### PR TITLE
Fix AxisItem with SIPrefix

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -801,22 +801,15 @@ class AxisItem(GraphicsWidget):
                     
                     rects.append(br)
                     textRects.append(rects[-1])
-
-            ## measure all text, make sure there's enough room
-            th = [r.height() for r in textRects]
-            tw = [r.width() for r in textRects]
-            if axis == 0:
-                if len(th)>0:
-                    textSize = np.sum(th)
-                if len(tw)>0:
-                    textSize2 = np.max(tw)
-            else:
-                if len(tw)>0:
-                    textSize = np.sum(tw)
-                if len(th)>0:
-                    textSize2 = np.max(th)
-
+            
             if i > 0:  ## always draw top level
+                ## measure all text, make sure there's enough room
+                if axis == 0:
+                    textSize = np.sum([r.height() for r in textRects])
+                    textSize2 = np.max([r.width() for r in textRects])
+                else:
+                    textSize = np.sum([r.width() for r in textRects])
+                    textSize2 = np.max([r.height() for r in textRects])
 
                 ## If the strings are too crowded, stop drawing text now.
                 ## We use three different crowding limits based on the number


### PR DESCRIPTION
Fix #4. The problem seems to be that the textWidth is not measured for first level ticks. Why this bug is only occurring when there is a SI prefix? I have no idea, but it's a good idea to measure textwidth of first level ticks.
