### PR TITLE
Faster import of PyQtGraph.

### DIFF
--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -178,7 +178,8 @@ def importAll(path, globals, locals, excludes=()):
                 globals[k] = getattr(mod, k)
 
 importAll('graphicsItems', globals(), locals())
-importAll('widgets', globals(), locals(), excludes=['MatplotlibWidget', 'RemoteGraphicsView'])
+importAll('widgets', globals(), locals(),
+          excludes=['MatplotlibWidget', 'RawImageWidget', 'RemoteGraphicsView'])
 
 from .imageview import *
 from .WidgetGroup import *

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -7,7 +7,6 @@ except:
     
 from scipy.fftpack import fft
 import numpy as np
-import scipy.stats
 from .GraphicsObject import GraphicsObject
 import pyqtgraph.functions as fn
 from pyqtgraph import debug
@@ -126,8 +125,8 @@ class PlotCurveItem(GraphicsObject):
         else:
             mask = np.isfinite(d)
             d = d[mask]
-            b = (scipy.stats.scoreatpercentile(d, 50 - (frac * 50)), scipy.stats.scoreatpercentile(d, 50 + (frac * 50)))
-        
+            b = np.percentile(d, [50 * (1 - frac), 50 * (1 + frac)])
+
         ## adjust for fill level
         if ax == 1 and self.opts['fillLevel'] is not None:
             b = (min(b[0], self.opts['fillLevel']), max(b[1], self.opts['fillLevel']))

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -4,7 +4,6 @@ import pyqtgraph.functions as fn
 from .GraphicsItem import GraphicsItem
 from .GraphicsObject import GraphicsObject
 import numpy as np
-import scipy.stats
 import weakref
 import pyqtgraph.debug as debug
 from pyqtgraph.pgcollections import OrderedDict
@@ -633,8 +632,8 @@ class ScatterPlotItem(GraphicsObject):
         else:
             mask = np.isfinite(d)
             d = d[mask]
-            return (scipy.stats.scoreatpercentile(d, 50 - (frac * 50)), scipy.stats.scoreatpercentile(d, 50 + (frac * 50)))
-            
+            return np.percentile(d, [50 * (1 - frac), 50 * (1 + frac)])
+
     def pixelPadding(self):
         return self._maxSpotPxWidth*0.7072
 


### PR DESCRIPTION
- RawImageWidget (and thus OpenGL) isn't imported by default anymore.
- scipy.stats.scoreatpercentile is replaced by numpy.percentile.

This commit has **not** been tested as the example runner is currently
broken.

See issues #9 and #10.
