### PR TITLE
PlotDataItem downsampling calculation fix

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -532,7 +532,8 @@ class PlotDataItem(GraphicsObject):
                     x0 = (range.left()-x[0]) / dx
                     x1 = (range.right()-x[0]) / dx
                     width = self.getViewBox().width()
-                    ds = int(max(1, int(0.2 * (x1-x0) / width)))
+                    if width != 0.0:
+                        ds = int(max(1, int(0.2 * (x1-x0) / width)))
                     ## downsampling is expensive; delay until after clipping.
             
             if self.opts['clipToView']:


### PR DESCRIPTION
There is a zero-division problem in PlotDataItem in case when automatic downsampling is enabled before a Plot and the corresponding ViewBox is properly set-up within it's container (in such case, the ViewBox.width is 0). This is the simplest fix.
