### PR TITLE
Fixed image scatterplot export bug Issue #16

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -102,8 +102,9 @@ class GraphicsItem(object):
         Extends deviceTransform to automatically determine the viewportTransform.
         """
         if self._exportOpts is not False and 'painter' in self._exportOpts: ## currently exporting; device transform may be different.
-            return self._exportOpts['painter'].deviceTransform() * self.sceneTransform()
-            
+            scaler = self._exportOpts['resolutionScale']
+            return self.sceneTransform() * QtGui.QTransform(scaler, 0, 0, scaler, 1, 1)
+
         if viewportTransform is None:
             view = self.getViewWidget()
             if view is None:

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -770,7 +770,7 @@ class ScatterPlotItem(GraphicsObject):
                 pts = pts[:,viewMask]
                 for i, rec in enumerate(data):
                     p.resetTransform()
-                    p.translate(pts[0,i] + rec['width'], pts[1,i] + rec['width'])
+                    p.translate(pts[0,i] + rec['width'], pts[1,i] + rec['width']/2)
                     drawSymbol(p, *self.getSpotOpts(rec, scale))
         else:
             if self.picture is None:


### PR DESCRIPTION
Exporting an image with a ScatterPlotItem in it does not scale correctly. This seems to be due to the QImage that is being exported to not having the expected scaling in its transform attribute.

Fix for https://github.com/pyqtgraph/pyqtgraph/issues/16
