### PR TITLE
Fix getGitVersion showing a clean repo as modified

### DIFF
--- a/tools/setupHelpers.py
+++ b/tools/setupHelpers.py
@@ -377,9 +377,9 @@ def getGitVersion(tagPrefix):
     
     # any uncommitted modifications?
     modified = False
-    status = check_output(['git', 'status', '-s'], universal_newlines=True).strip().split('\n')
+    status = check_output(['git', 'status', '--porcelain'], universal_newlines=True).strip().split('\n')
     for line in status:
-        if line[:2] != '??':
+        if line != '' and line[:2] != '??':
             modified = True
             break        
                 
@@ -558,5 +558,3 @@ class MergeTestCommand(Command):
     def finalize_options(self):
         pass
 
-    
-    


### PR DESCRIPTION
`split('\n')` on an empty string results in a list containing an empty string, not an empty list. This causes the version (`python setup.py --version`) to have a "+" at the end, even when the tree is clean.

Using `--porcelain` additionally protects against things like user color settings.
