### PR TITLE
FillBetweenItem fixes

### DIFF
--- a/pyqtgraph/graphicsItems/FillBetweenItem.py
+++ b/pyqtgraph/graphicsItems/FillBetweenItem.py
@@ -62,13 +62,17 @@ class FillBetweenItem(QtGui.QGraphicsPathItem):
                 paths.append(c.curve.getPath())
             elif isinstance(c, PlotCurveItem):
                 paths.append(c.getPath())
-            
+
         path = QtGui.QPainterPath()
         p1 = paths[0].toSubpathPolygons()
-        p2 = paths[1].toReversed().toSubpathPolygons()
-        if len(p1) == 0 or len(p2) == 0:
-            self.setPath(QtGui.QPainterPath())
-            return
-            
-        path.addPolygon(p1[0] + p2[0])
+        p2 = paths[1].toSubpathPolygons()
+
+        for sp1, sp2 in zip(p1, p2):
+            if len(sp1) == 0 or len(sp2) == 0:
+                continue
+            points = [p for p in sp2]
+            points.reverse()
+            rsp2 = QtGui.QPolygonF(points)
+            path.addPolygon(sp1 + rsp2)
+
         self.setPath(path)


### PR DESCRIPTION
Hi,

this patch modifies FillBetweenItem.py to

1) support disjoint paths at the input, which are present when using connect='pairs' plot option

2) disable the default black Pen, so it only fills the area between curves.
