### PR TITLE
Python3 related fixes

### DIFF
--- a/examples/__main__.py
+++ b/examples/__main__.py
@@ -8,6 +8,7 @@ if __name__ == "__main__" and (__package__ is None or __package__==''):
 
 from . import initExample
 from pyqtgraph.Qt import QtCore, QtGui, USE_PYSIDE
+from pyqtgraph.python2_3 import string_types
 import pyqtgraph as pg
 
 if USE_PYSIDE:
@@ -143,7 +144,7 @@ class ExampleLoader(QtGui.QMainWindow):
             self.itemCache.append(item) # PyQt 4.9.6 no longer keeps references to these wrappers,
                                         # so we need to make an explicit reference or else the .file
                                         # attribute will disappear.
-            if isinstance(val, basestring):
+            if isinstance(val, string_types):
                 item.file = val
             else:
                 self.populateTree(item, val)
@@ -218,7 +219,7 @@ def buildFileList(examples, files=None):
         files = []
     for key, val in examples.items():
         #item = QtGui.QTreeWidgetItem([key])
-        if isinstance(val, basestring):
+        if isinstance(val, string_types):
             #item.file = val
             files.append((key,val))
         else:

--- a/examples/crosshair.py
+++ b/examples/crosshair.py
@@ -31,7 +31,7 @@ p1.setAutoVisible(y=True)
 
 
 #create numpy arrays
-#make the numbers large to show that the xrange shows data from 10000 to all the way 0
+#make the numbers large to show that the range shows data from 10000 to all the way 0
 data1 = 10000 + 15000 * pg.gaussianFilter(np.random.random(size=10000), 10) + 3000 * np.random.random(size=10000)
 data2 = 15000 + 15000 * pg.gaussianFilter(np.random.random(size=10000), 10) + 3000 * np.random.random(size=10000)
 

--- a/examples/multiplePlotSpeedTest.py
+++ b/examples/multiplePlotSpeedTest.py
@@ -23,8 +23,8 @@ def plot():
     pts = 100
     x = np.linspace(0, 0.8, pts)
     y = np.random.random(size=pts)*0.8
-    for i in xrange(n):
-        for j in xrange(n):
+    for i in range(n):
+        for j in range(n):
             ## calling PlotWidget.plot() generates a PlotDataItem, which 
             ## has a bit more overhead than PlotCurveItem, which is all 
             ## we need here. This overhead adds up quickly and makes a big

--- a/examples/parallelize.py
+++ b/examples/parallelize.py
@@ -30,7 +30,7 @@ start = time.time()
 with pg.ProgressDialog('processing serially..', maximum=len(tasks)) as dlg:
     for i, x in enumerate(tasks):
         tot = 0
-        for j in xrange(size):
+        for j in range(size):
             tot += j * x
         results[i] = tot
         dlg += 1
@@ -44,7 +44,7 @@ start = time.time()
 with mp.Parallelize(enumerate(tasks), results=results2, workers=1, progressDialog='processing serially (using Parallelizer)..') as tasker:
     for i, x in tasker:
         tot = 0
-        for j in xrange(size):
+        for j in range(size):
             tot += j * x
         tasker.results[i] = tot
 print( "\nParallel time, 1 worker: %0.2f" % (time.time() - start))
@@ -55,7 +55,7 @@ start = time.time()
 with mp.Parallelize(enumerate(tasks), results=results3, progressDialog='processing in parallel..') as tasker:
     for i, x in tasker:
         tot = 0
-        for j in xrange(size):
+        for j in range(size):
             tot += j * x
         tasker.results[i] = tot
 print( "\nParallel time, %d workers: %0.2f" % (mp.Parallelize.suggestedWorkerCount(), time.time() - start))

--- a/examples/relativity/relativity.py
+++ b/examples/relativity/relativity.py
@@ -515,8 +515,7 @@ class Simulation:
         dt = self.dt
         tVals = np.linspace(0, dt*(nPts-1), nPts)
         for cl in self.clocks.itervalues():
-            for i in xrange(1,nPts):
-                nextT = tVals[i]
+            for i, nextT in enumerate(tVals[1:], 1):
                 while True:
                     tau1, tau2 = cl.accelLimits()
                     x = cl.x
@@ -561,10 +560,9 @@ class Simulation:
         ## These are the set of proper times (in the reference frame) that will be simulated
         ptVals = np.linspace(ref.pt, ref.pt + dt*(nPts-1), nPts)
         
-        for i in xrange(1,nPts):
-                
+        for i, nextPt in enumerate(ptVals[1:], 1):
             ## step reference clock ahead one time step in its proper time
-            nextPt = ptVals[i]  ## this is where (when) we want to end up
+            ## nextPt is where (when) we want to end up
             while True:
                 tau1, tau2 = ref.accelLimits()
                 dtau = min(nextPt-ref.pt, tau2-ref.pt)  ## do not step past the next command boundary

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -430,14 +430,14 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 continue
             if shape.contains(item.mapFromScene(point)):
                 items2.append(item)
-        
+
         ## Sort by descending Z-order (don't trust scene.itms() to do this either)
         ## use 'absolute' z value, which is the sum of all item/parent ZValues
-        return sorted(items2,
-                      key=lambda item: item.zValue() + absZValue(item.parentItem())
-                                       if item is not None else 0,
-                      reverse=True)
-        
+        def absZValue(item):
+            return (0 if item is None
+                    else item.zValue() + absZValue(item.parentItem()))
+        return sorted(items2, key=absZValue, reverse=True)
+
         #for item in items:
             ##seen.add(item)
 

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -1,5 +1,4 @@
 from ..Qt import QtCore, QtGui
-from ..python2_3 import sortList
 import weakref
 from ..Point import Point
 from .. import functions as fn
@@ -434,14 +433,10 @@ class GraphicsScene(QtGui.QGraphicsScene):
         
         ## Sort by descending Z-order (don't trust scene.itms() to do this either)
         ## use 'absolute' z value, which is the sum of all item/parent ZValues
-        def absZValue(item):
-            if item is None:
-                return 0
-            return item.zValue() + absZValue(item.parentItem())
-        
-        sortList(items2, lambda a,b: cmp(absZValue(b), absZValue(a)))
-        
-        return items2
+        return sorted(items2,
+                      key=lambda item: item.zValue() + absZValue(item.parentItem())
+                                       if item is not None else 0,
+                      reverse=True)
         
         #for item in items:
             ##seen.add(item)

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -326,7 +326,7 @@ def exit():
     
     ## close file handles
     if sys.platform == 'darwin':
-        for fd in xrange(3, 4096):
+        for fd in range(3, 4096):
             if fd not in [7]:  # trying to close 7 produces an illegal instruction on the Mac.
                 os.close(fd)
     else:

--- a/pyqtgraph/colormap.py
+++ b/pyqtgraph/colormap.py
@@ -1,5 +1,6 @@
 import numpy as np
 from .Qt import QtGui, QtCore
+from .python2_3 import string_types
 
 class ColorMap(object):
     """
@@ -83,7 +84,7 @@ class ColorMap(object):
         qcolor      Values are returned as an array of QColor objects.
         =========== ===============================================================
         """
-        if isinstance(mode, basestring):
+        if isinstance(mode, string_types):
             mode = self.enumMap[mode.lower()]
             
         if mode == self.QCOLOR:
@@ -160,7 +161,7 @@ class ColorMap(object):
     def getColors(self, mode=None):
         """Return list of all color stops converted to the specified mode.
         If mode is None, then no conversion is done."""
-        if isinstance(mode, basestring):
+        if isinstance(mode, string_types):
             mode = self.enumMap[mode.lower()]
         
         color = self.color
@@ -212,7 +213,7 @@ class ColorMap(object):
                           See :func:`map() <pyqtgraph.ColorMap.map>`.
         ===============   =============================================================================
         """
-        if isinstance(mode, basestring):
+        if isinstance(mode, string_types):
             mode = self.enumMap[mode.lower()]
         
         if alpha is None:

--- a/pyqtgraph/configfile.py
+++ b/pyqtgraph/configfile.py
@@ -13,7 +13,7 @@ import re, os, sys
 from .pgcollections import OrderedDict
 GLOBAL_PATH = None # so not thread safe.
 from . import units
-from .python2_3 import asUnicode
+from .python2_3 import asUnicode, string_types
 from .Qt import QtCore
 from .Point import Point
 from .colormap import ColorMap
@@ -98,7 +98,7 @@ def genString(data, indent=''):
 def parseString(lines, start=0):
     
     data = OrderedDict()
-    if isinstance(lines, basestring):
+    if isinstance(lines, string_types):
         lines = lines.split('\n')
         lines = [l for l in lines if re.search(r'\S', l) and not re.match(r'\s*#', l)]  ## remove empty lines
         

--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -1,5 +1,6 @@
 
 from ..Qt import QtCore, QtGui, USE_PYSIDE
+from ..python2_3 import string_types
 import sys, re, os, time, traceback, subprocess
 if USE_PYSIDE:
     from . import template_pyside as template
@@ -345,7 +346,7 @@ class ConsoleWidget(QtGui.QWidget):
         if filterStr != '':
             if isinstance(exc, Exception):
                 msg = exc.message
-            elif isinstance(exc, basestring):
+            elif isinstance(exc, string_types):
                 msg = exc
             else:
                 msg = repr(exc)

--- a/pyqtgraph/debug.py
+++ b/pyqtgraph/debug.py
@@ -723,7 +723,6 @@ class ObjTracker(object):
         for k in self.startCount:
             c1[k] = c1.get(k, 0) - self.startCount[k]
         typs = list(c1.keys())
-        #typs.sort(lambda a,b: cmp(c1[a], c1[b]))
         typs.sort(key=lambda a: c1[a])
         for t in typs:
             if c1[t] == 0:
@@ -824,7 +823,6 @@ class ObjTracker(object):
             c = count.get(typ, [0,0])
             count[typ] =  [c[0]+1, c[1]+objectSize(obj)]
         typs = list(count.keys())
-        #typs.sort(lambda a,b: cmp(count[a][1], count[b][1]))
         typs.sort(key=lambda a: count[a][1])
         
         for t in typs:

--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from ..Qt import QtCore, QtGui
+from ..python2_3 import string_types
 from .Container import *
 from .DockDrop import *
 from .Dock import Dock
@@ -64,7 +65,7 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
                 container = self.topContainer
                 neighbor = None
         else:
-            if isinstance(relativeTo, basestring):
+            if isinstance(relativeTo, string_types):
                 relativeTo = self.docks[relativeTo]
             container = self.getContainer(relativeTo)
             neighbor = relativeTo

--- a/pyqtgraph/exporters/Exporter.py
+++ b/pyqtgraph/exporters/Exporter.py
@@ -1,6 +1,6 @@
 from ..widgets.FileDialog import FileDialog
 from ..Qt import QtGui, QtCore, QtSvg
-from ..python2_3 import asUnicode
+from ..python2_3 import asUnicode, string_types
 from ..GraphicsScene import GraphicsScene
 import os, re
 LastExportDirectory = None
@@ -48,7 +48,7 @@ class Exporter(object):
         self.fileDialog.setFileMode(QtGui.QFileDialog.AnyFile)
         self.fileDialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
         if filter is not None:
-            if isinstance(filter, basestring):
+            if isinstance(filter, string_types):
                 self.fileDialog.setNameFilter(filter)
             elif isinstance(filter, list):
                 self.fileDialog.setNameFilters(filter)

--- a/pyqtgraph/flowchart/Flowchart.py
+++ b/pyqtgraph/flowchart/Flowchart.py
@@ -349,7 +349,8 @@ class Flowchart(Node):
             #tdeps[t] = lastNode
             if lastInd is not None:
                 dels.append((lastInd+1, t))
-        for i, t in sorted(dels, reverse=True):
+        dels.sort(key=lambda a: a[0], reverse=True)
+        for i, t in dels:
             ops.insert(i, ('d', t))
         return ops
         

--- a/pyqtgraph/flowchart/Flowchart.py
+++ b/pyqtgraph/flowchart/Flowchart.py
@@ -349,9 +349,7 @@ class Flowchart(Node):
             #tdeps[t] = lastNode
             if lastInd is not None:
                 dels.append((lastInd+1, t))
-        #dels.sort(lambda a,b: cmp(b[0], a[0]))
-        dels.sort(key=lambda a: a[0], reverse=True)
-        for i, t in dels:
+        for i, t in sorted(dels, reverse=True):
             ops.insert(i, ('d', t))
         return ops
         
@@ -464,7 +462,6 @@ class Flowchart(Node):
                 self.clear()
             Node.restoreState(self, state)
             nodes = state['nodes']
-            #nodes.sort(lambda a, b: cmp(a['pos'][0], b['pos'][0]))
             nodes.sort(key=lambda a: a['pos'][0])
             for n in nodes:
                 if n['name'] in self._nodes:

--- a/pyqtgraph/flowchart/library/Filters.py
+++ b/pyqtgraph/flowchart/library/Filters.py
@@ -321,7 +321,7 @@ class RemovePeriodic(CtrlNode):
         
         ## flatten spikes at f0 and harmonics
         f0 = self.ctrls['f0'].value()
-        for i in xrange(1, self.ctrls['harmonics'].value()+2):
+        for i in range(1, self.ctrls['harmonics'].value()+2):
             f = f0 * i # target frequency
             
             ## determine index range to check for this frequency

--- a/pyqtgraph/flowchart/library/functions.py
+++ b/pyqtgraph/flowchart/library/functions.py
@@ -305,7 +305,7 @@ def suggestDType(x):
         return float
     elif isinstance(x, int):
         return int
-    #elif isinstance(x, basestring):  ## don't try to guess correct string length; use object instead.
+    #elif isinstance(x, string_types):  ## don't try to guess correct string length; use object instead.
         #return '<U%d' % len(x)
     else:
         return object
@@ -328,7 +328,7 @@ def removePeriodic(data, f0=60.0, dt=None, harmonics=10, samples=4):
     freqs = np.linspace(0.0, (len(ft)-1) * df, len(ft))
     
     ## flatten spikes at f0 and harmonics
-    for i in xrange(1, harmonics + 2):
+    for i in range(1, harmonics + 2):
         f = f0 * i # target frequency
         
         ## determine index range to check for this frequency

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -6,7 +6,7 @@ Distributed under MIT/X11 license. See license.txt for more infomation.
 """
 
 from __future__ import division
-from .python2_3 import asUnicode
+from .python2_3 import asUnicode, string_types
 from .Qt import QtGui, QtCore, USE_PYSIDE
 Colors = {
     'b': QtGui.QColor(0,0,255,255),
@@ -161,7 +161,7 @@ def mkColor(*args):
     """
     err = 'Not sure how to make a color from "%s"' % str(args)
     if len(args) == 1:
-        if isinstance(args[0], basestring):
+        if isinstance(args[0], string_types):
             c = args[0]
             if c[0] == '#':
                 c = c[1:]
@@ -1417,9 +1417,9 @@ def arrayToQPath(x, y, connect='all'):
         #index = tetFields[0] + tetFields[1]*2 + tetFields[2]*4 + tetFields[3]*8
         
         ### add facets
-        #for i in xrange(index.shape[0]):                 # data x-axis
-            #for j in xrange(index.shape[1]):             # data y-axis
-                #for k in xrange(index.shape[2]):         # data z-axis
+        #for i in range(index.shape[0]):                 # data x-axis
+            #for j in range(index.shape[1]):             # data y-axis
+                #for k in range(index.shape[2]):         # data z-axis
                     #for f in indexFacets[index[i,j,k]]:  # faces to generate for this tet
                         #pts = []
                         #for l in [0,1,2]:      # points in this face

--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -1,5 +1,4 @@
 from ..Qt import QtGui, QtCore
-from ..python2_3 import sortList
 from .. import functions as fn
 from .GraphicsObject import GraphicsObject
 from .GraphicsWidget import GraphicsWidget
@@ -337,9 +336,7 @@ class TickSliderItem(GraphicsWidget):
     def listTicks(self):
         """Return a sorted list of all the Tick objects on the slider."""
         ## public
-        ticks = list(self.ticks.items())
-        sortList(ticks, lambda a,b: cmp(a[1], b[1]))  ## see pyqtgraph.python2_3.sortList
-        return ticks
+        return sorted(self.ticks.items(), key=lambda kv: kv[1])
 
 
 class GradientEditorItem(TickSliderItem):

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -1,5 +1,6 @@
 from .. import metaarray as metaarray
 from ..Qt import QtCore
+from ..python2_3 import string_types
 from .GraphicsObject import GraphicsObject
 from .PlotCurveItem import PlotCurveItem
 from .ScatterPlotItem import ScatterPlotItem
@@ -767,7 +768,7 @@ def isSequence(obj):
         ##print rec1, dtype
         #arr = np.empty(len(self), dtype=dtype)
         #arr[0] = tuple(rec1.values())
-        #for i in xrange(1, len(self)):
+        #for i in range(1, len(self)):
             #arr[i] = tuple(self[i].values())
         #return arr
             
@@ -778,7 +779,7 @@ def isSequence(obj):
             #return self.data[arg]
             
     #def __getitem__list(self, arg):
-        #if isinstance(arg, basestring):
+        #if isinstance(arg, string_types):
             #return [d.get(arg, None) for d in self.data]
         #elif isinstance(arg, int):
             #return self.data[arg]
@@ -789,7 +790,7 @@ def isSequence(obj):
             #raise TypeError(type(arg))
         
     #def __getitem__dict(self, arg):
-        #if isinstance(arg, basestring):
+        #if isinstance(arg, string_types):
             #return self.data[arg]
         #elif isinstance(arg, int):
             #return dict([(k, v[arg]) for k, v in self.data.iteritems()])
@@ -806,7 +807,7 @@ def isSequence(obj):
             #self.data[arg] = val
 
     #def __setitem__list(self, arg, val):
-        #if isinstance(arg, basestring):
+        #if isinstance(arg, string_types):
             #if len(val) != len(self.data):
                 #raise Exception("Values (%d) and data set (%d) are not the same length." % (len(val), len(self.data)))
             #for i, rec in enumerate(self.data):
@@ -820,7 +821,7 @@ def isSequence(obj):
             #raise TypeError(type(arg))
         
     #def __setitem__dict(self, arg, val):
-        #if isinstance(arg, basestring):
+        #if isinstance(arg, string_types):
             #if len(val) != len(self.data[arg]):
                 #raise Exception("Values (%d) and data set (%d) are not the same length." % (len(val), len(self.data[arg])))
             #self.data[arg] = val
@@ -835,13 +836,13 @@ def isSequence(obj):
 
     #def _orderArgs(self, args):
         ### return args in (int, str) order
-        #if isinstance(args[0], basestring):
+        #if isinstance(args[0], string_types):
             #return (args[1], args[0])
         #else:
             #return args
         
     #def __iter__(self):
-        #for i in xrange(len(self)):
+        #for i in range(len(self)):
             #yield self[i]
 
     #def __len__(self):

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -17,6 +17,7 @@ This class is very heavily featured:
     display, power spectrum, svg/png export, plot linking, and more.
 """
 from ...Qt import QtGui, QtCore, QtSvg, USE_PYSIDE
+from ...python2_3 import string_types
 from ... import pixmaps
 import sys
 
@@ -274,7 +275,7 @@ class PlotItem(GraphicsWidget):
                 labels[label] = kargs[label]
                 del kargs[label]
         for k in labels:
-            if isinstance(labels[k], basestring):
+            if isinstance(labels[k], string_types):
                 labels[k] = (labels[k],)
             self.setLabel(k, *labels[k])
                 
@@ -769,8 +770,8 @@ class PlotItem(GraphicsWidget):
                     
                     fh.write('<circle cx="%f" cy="%f" r="1" fill="#%s" stroke="none" fill-opacity="%f"/>\n' % (x, y, color, opacity))
                     #fh.write('<path fill="none" stroke="#%s" stroke-opacity="%f" stroke-width="1" d="M%f,%f ' % (color, opacity, x[0], y[0]))
-                    #for i in xrange(1, len(x)):
-                        #fh.write('L%f,%f ' % (x[i], y[i]))
+                    #for xi, yi in zip(x, y)
+                        #fh.write('L%f,%f ' % (xi, yi))
                     
                     #fh.write('"/>')
             
@@ -1148,7 +1149,7 @@ class PlotItem(GraphicsWidget):
             if k == 'title':
                 self.setTitle(v)
             else:
-                if isinstance(v, basestring):
+                if isinstance(v, string_types):
                     v = (v,)
                 self.setLabel(k, *v)
         

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -1,4 +1,5 @@
 from ..Qt import QtGui, QtCore, USE_PYSIDE
+from ..python2_3 import string_types
 from ..Point import Point
 from .. import functions as fn
 from .GraphicsItem import GraphicsItem
@@ -47,7 +48,7 @@ def drawSymbol(painter, symbol, size, pen, brush):
     painter.scale(size, size)
     painter.setPen(pen)
     painter.setBrush(brush)
-    if isinstance(symbol, basestring):
+    if isinstance(symbol, string_types):
         symbol = Symbols[symbol]
     if np.isscalar(symbol):
         symbol = list(Symbols.values())[symbol % len(Symbols)]
@@ -457,7 +458,7 @@ class ScatterPlotItem(GraphicsObject):
                 brushes = brushes[kargs['mask']]
             if len(brushes) != len(dataSet):
                 raise Exception("Number of brushes does not match number of points (%d != %d)" % (len(brushes), len(dataSet)))
-            #for i in xrange(len(brushes)):
+            #for i in range(len(brushes)):
                 #self.data[i]['brush'] = fn.mkBrush(brushes[i], **kargs)
             dataSet['brush'] = brushes
         else:
@@ -817,7 +818,7 @@ class ScatterPlotItem(GraphicsObject):
             #else:
                 #print "No hit:", (x, y), (sx, sy)
                 #print "       ", (sx-s2x, sy-s2y), (sx+s2x, sy+s2y)
-        #pts.sort(lambda a,b: cmp(b.zValue(), a.zValue()))
+        #pts.sort(key=lambda s: s.zValue(), reverse=True)
         return pts[::-1]
             
 

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1,5 +1,5 @@
 from ...Qt import QtGui, QtCore
-from ...python2_3 import sortList
+from ...python2_3 import string_types
 import numpy as np
 from ...Point import Point
 from ... import functions as fn
@@ -307,7 +307,7 @@ class ViewBox(GraphicsWidget):
         for v in state['linkedViews']:
             if isinstance(v, weakref.ref):
                 v = v()
-            if v is None or isinstance(v, basestring):
+            if v is None or isinstance(v, string_types):
                 views.append(v)
             else:
                 views.append(v.name)
@@ -930,7 +930,7 @@ class ViewBox(GraphicsWidget):
         Link X or Y axes of two views and unlink any previously connected axes. *axis* must be ViewBox.XAxis or ViewBox.YAxis.
         If view is None, the axis is left unlinked.
         """
-        if isinstance(view, basestring):
+        if isinstance(view, string_types):
             if view == '':
                 view = None
             else:
@@ -958,7 +958,7 @@ class ViewBox(GraphicsWidget):
                 pass
             
         
-        if view is None or isinstance(view, basestring):
+        if view is None or isinstance(view, string_types):
             self.state['linkedViews'][axis] = view
         else:
             self.state['linkedViews'][axis] = weakref.ref(view)
@@ -991,7 +991,7 @@ class ViewBox(GraphicsWidget):
         ## Return the linked view for axis *ax*.
         ## this method _always_ returns either a ViewBox or None.
         v = self.state['linkedViews'][ax]
-        if v is None or isinstance(v, basestring):
+        if v is None or isinstance(v, string_types):
             return None
         else:
             return v()  ## dereference weakref pointer. If the reference is dead, this returns None
@@ -1659,17 +1659,11 @@ class ViewBox(GraphicsWidget):
             self.window()
         except RuntimeError:  ## this view has already been deleted; it will probably be collected shortly.
             return
-            
-        def cmpViews(a, b):
-            wins = 100 * cmp(a.window() is self.window(), b.window() is self.window())
-            alpha = cmp(a.name, b.name)
-            return wins + alpha
-            
+
         ## make a sorted list of all named views
-        nv = list(ViewBox.NamedViews.values())
-        #print "new view list:", nv
-        sortList(nv, cmpViews) ## see pyqtgraph.python2_3.sortList
-        
+        nv = sorted(ViewBox.NamedViews.values(),
+                    key=lambda view: (view.window() is self.window(), view.name))
+
         if self in nv:
             nv.remove(self)
             
@@ -1677,7 +1671,7 @@ class ViewBox(GraphicsWidget):
         
         for ax in [0,1]:
             link = self.state['linkedViews'][ax]
-            if isinstance(link, basestring):     ## axis has not been linked yet; see if it's possible now
+            if isinstance(link, string_types):     ## axis has not been linked yet; see if it's possible now
                 for v in nv:
                     if link == v.name:
                         self.linkView(ax, v)

--- a/pyqtgraph/metaarray/MetaArray.py
+++ b/pyqtgraph/metaarray/MetaArray.py
@@ -26,6 +26,8 @@ except:
     USE_HDF5 = False
     HAVE_HDF5 = False
 
+from ..python2_3 import string_types
+
 
 def axis(name=None, cols=None, values=None, units=None):
     """Convenience function for generating axis descriptions when defining MetaArrays"""
@@ -113,7 +115,7 @@ class MetaArray(object):
     defaultCompression = None
     
     ## Types allowed as axis or column names
-    nameTypes = [basestring, tuple]
+    nameTypes = [string_types, tuple]
     @staticmethod
     def isNameType(var):
         return any([isinstance(var, t) for t in MetaArray.nameTypes])
@@ -441,7 +443,7 @@ class MetaArray(object):
         if type(axis) == int:
             ind = [slice(None)]*axis
             ind.append(order)
-        elif isinstance(axis, basestring):
+        elif isinstance(axis, string_types):
             ind = (slice(axis, order),)
         return self[tuple(ind)]
   
@@ -505,7 +507,7 @@ class MetaArray(object):
         return tuple(nInd)
       
     def _interpretAxis(self, axis):
-        if isinstance(axis, basestring) or isinstance(axis, tuple):
+        if isinstance(axis, (string_types, tuple)):
             return self._getAxis(axis)
         else:
             return axis
@@ -981,7 +983,7 @@ class MetaArray(object):
         ## Pull list of values from attributes and child objects
         for k in root.attrs:
             val = root.attrs[k]
-            if isinstance(val, basestring):  ## strings need to be re-evaluated to their original types
+            if isinstance(val, string_types):  ## strings need to be re-evaluated to their original types
                 try:
                     val = eval(val)
                 except:

--- a/pyqtgraph/multiprocess/parallelizer.py
+++ b/pyqtgraph/multiprocess/parallelizer.py
@@ -1,4 +1,5 @@
 import os, sys, time, multiprocessing, re
+from ..python2_3 import string_types
 from .processes import ForkedProcess
 from .remoteproxy import ClosedError
 
@@ -61,7 +62,7 @@ class Parallelize(object):
         self.showProgress = False
         if progressDialog is not None:
             self.showProgress = True
-            if isinstance(progressDialog, basestring):
+            if isinstance(progressDialog, string_types):
                 progressDialog = {'labelText': progressDialog}
             from ..widgets.ProgressDialog import ProgressDialog
             self.progressDlg = ProgressDialog(**progressDialog)
@@ -114,7 +115,7 @@ class Parallelize(object):
         
         ## break up tasks into one set per worker
         workers = self.workers
-        chunks = [[] for i in xrange(workers)]
+        chunks = [[] for i in range(workers)]
         i = 0
         for i in range(len(self.tasks)):
             chunks[i%workers].append(self.tasks[i])

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -1,4 +1,5 @@
 from ..Qt import QtGui, QtCore
+from ..python2_3 import string_types
 from .. import Transform3D
 from OpenGL.GL import *
 from OpenGL import GL
@@ -84,7 +85,7 @@ class GLGraphicsItem(QtCore.QObject):
             
         
         """
-        if isinstance(opts, basestring):
+        if isinstance(opts, string_types):
             opts = GLOptions[opts]
         self.__glOpts = opts.copy()
         self.update()
@@ -238,7 +239,7 @@ class GLGraphicsItem(QtCore.QObject):
         for k,v in self.__glOpts.items():
             if v is None:
                 continue
-            if isinstance(k, basestring):
+            if isinstance(k, string_types):
                 func = getattr(GL, k)
                 func(*v)
             else:

--- a/pyqtgraph/opengl/MeshData.py
+++ b/pyqtgraph/opengl/MeshData.py
@@ -207,7 +207,7 @@ class MeshData(object):
             faceNorms = self.faceNormals()
             vertFaces = self.vertexFaces()
             self._vertexNormals = np.empty(self._vertexes.shape, dtype=float)
-            for vindex in xrange(self._vertexes.shape[0]):
+            for vindex, faces in enumerate(vertFaces):
                 faces = vertFaces[vindex]
                 if len(faces) == 0:
                     self._vertexNormals[vindex] = (0,0,0)
@@ -316,10 +316,9 @@ class MeshData(object):
         self._vertexFaces = []
         self._faceNormals = None
         self._vertexNormals = None
-        for i in xrange(faces.shape[0]):
-            face = faces[i]
+        for i, face in enumerate(faces):
             inds = []
-            for j in range(face.shape[0]):
+            for j, pt in enumerate(face):
                 pt = face[j]
                 pt2 = tuple([round(x*1e14) for x in pt])  ## quantize to be sure that nearly-identical points will be merged
                 index = verts.get(pt2, None)
@@ -348,9 +347,8 @@ class MeshData(object):
         Return list mapping each vertex index to a list of face indexes that use the vertex.
         """
         if self._vertexFaces is None:
-            self._vertexFaces = [[] for i in xrange(len(self.vertexes()))]
-            for i in xrange(self._faces.shape[0]):
-                face = self._faces[i]
+            self._vertexFaces = [[] for _ in self.vertexes()]
+            for i, face in enumerate(self._faces):
                 for ind in face:
                     self._vertexFaces[ind].append(i)
         return self._vertexFaces

--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -1,7 +1,7 @@
 from ..Qt import QtGui, QtCore
 import os, weakref, re
 from ..pgcollections import OrderedDict
-from ..python2_3 import asUnicode
+from ..python2_3 import asUnicode, string_types
 from .ParameterItem import ParameterItem
 
 PARAM_TYPES = {}
@@ -175,7 +175,7 @@ class Parameter(QtCore.QObject):
         if 'value' not in self.opts:
             self.opts['value'] = None
         
-        if 'name' not in self.opts or not isinstance(self.opts['name'], basestring):
+        if 'name' not in self.opts or not isinstance(self.opts['name'], string_types):
             raise Exception("Parameter must have a string name specified in opts.")
         self.setName(opts['name'])
         
@@ -634,7 +634,7 @@ class Parameter(QtCore.QObject):
         
             param[('child', 'grandchild')] = value
         """
-        if isinstance(names, basestring):
+        if isinstance(names, string_types):
             names = (names,)
         return self.param(*names).setValue(value)
 

--- a/pyqtgraph/pixmaps/__init__.py
+++ b/pyqtgraph/pixmaps/__init__.py
@@ -19,7 +19,7 @@ def getPixmap(name):
     """
     key = name+'.png'
     data = pixmapData.pixmapData[key]
-    if isinstance(data, basestring) or isinstance(data, bytes):
+    if isinstance(data, (str, bytes)):
         pixmapData.pixmapData[key] = pickle.loads(data)
     arr = pixmapData.pixmapData[key]
     return QtGui.QPixmap(makeQImage(arr, alpha=True))

--- a/pyqtgraph/python2_3.py
+++ b/pyqtgraph/python2_3.py
@@ -3,58 +3,15 @@ Helper functions that smooth out the differences between python 2 and 3.
 """
 import sys
 
-def asUnicode(x):
-    if sys.version_info[0] == 2:
-        if isinstance(x, unicode):
-            return x
-        elif isinstance(x, str):
-            return x.decode('UTF-8')
+
+if sys.version_info < (3,):
+    def asUnicode(x):
+        if isinstance(x, str):
+            return x.decode("utf-8")
         else:
             return unicode(x)
-    else:
+    string_types = basestring
+else:
+    def asUnicode(x):
         return str(x)
-        
-def cmpToKey(mycmp):
-    'Convert a cmp= function into a key= function'
-    class K(object):
-        def __init__(self, obj, *args):
-            self.obj = obj
-        def __lt__(self, other):
-            return mycmp(self.obj, other.obj) < 0
-        def __gt__(self, other):
-            return mycmp(self.obj, other.obj) > 0
-        def __eq__(self, other):
-            return mycmp(self.obj, other.obj) == 0
-        def __le__(self, other):
-            return mycmp(self.obj, other.obj) <= 0
-        def __ge__(self, other):
-            return mycmp(self.obj, other.obj) >= 0
-        def __ne__(self, other):
-            return mycmp(self.obj, other.obj) != 0
-    return K
-
-def sortList(l, cmpFunc):
-    if sys.version_info[0] == 2:
-        l.sort(cmpFunc)
-    else:
-        l.sort(key=cmpToKey(cmpFunc))
-
-if sys.version_info[0] == 3:
-    import builtins
-    builtins.basestring = str
-    #builtins.asUnicode = asUnicode
-    #builtins.sortList = sortList
-    basestring = str
-    def cmp(a,b):
-        if a>b:
-            return 1
-        elif b > a:
-            return -1
-        else:
-            return 0
-    builtins.cmp = cmp
-    builtins.xrange = range
-#else:    ## don't use __builtin__  -- this confuses things like pyshell and ActiveState's lazy import recipe
-    #import __builtin__
-    #__builtin__.asUnicode = asUnicode
-    #__builtin__.sortList = sortList
+    string_types = str

--- a/pyqtgraph/util/cprint.py
+++ b/pyqtgraph/util/cprint.py
@@ -5,6 +5,7 @@ Based on colorama (see pyqtgraph/util/colorama/README.txt)
 """
 import sys, re
 
+from ..python2_3 import string_types
 from .colorama.winterm import WinTerm, WinColor, WinStyle
 from .colorama.win32 import windll
 
@@ -61,7 +62,7 @@ def cprint(stream, *args, **kwds):
         cprint('stderr', 1, 'This is in red.', -1)
 
     """
-    if isinstance(stream, basestring):
+    if isinstance(stream, string_types):
         stream = kwds.get('stream', 'stdout')
         err = stream == 'stderr'
         stream = getattr(sys, stream)
@@ -72,7 +73,7 @@ def cprint(stream, *args, **kwds):
         if _WIN:
             # convert to win32 calls
             for arg in args:
-                if isinstance(arg, basestring):
+                if isinstance(arg, string_types):
                     stream.write(arg)
                 else:
                     kwds = WIN[arg]
@@ -80,14 +81,14 @@ def cprint(stream, *args, **kwds):
         else:
             # convert to ANSI
             for arg in args:
-                if isinstance(arg, basestring):
+                if isinstance(arg, string_types):
                     stream.write(arg)
                 else:
                     stream.write(ANSI[arg])
     else:
         # ignore colors
         for arg in args:
-            if isinstance(arg, basestring):
+            if isinstance(arg, string_types):
                 stream.write(arg)
 
 def cout(*args):

--- a/pyqtgraph/widgets/ComboBox.py
+++ b/pyqtgraph/widgets/ComboBox.py
@@ -2,7 +2,7 @@ from ..Qt import QtGui, QtCore
 from ..SignalProxy import SignalProxy
 import sys
 from ..pgcollections import OrderedDict
-from ..python2_3 import asUnicode
+from ..python2_3 import asUnicode, string_types
 
 class ComboBox(QtGui.QComboBox):
     """Extends QComboBox to add extra functionality.
@@ -158,7 +158,7 @@ class ComboBox(QtGui.QComboBox):
     def addItem(self, *args, **kwds):
         # Need to handle two different function signatures for QComboBox.addItem
         try:
-            if isinstance(args[0], basestring):
+            if isinstance(args[0], string_types):
                 text = args[0]
                 if len(args) == 2:
                     value = args[1]

--- a/pyqtgraph/widgets/TableWidget.py
+++ b/pyqtgraph/widgets/TableWidget.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from ..Qt import QtGui, QtCore
-from ..python2_3 import asUnicode
+from ..python2_3 import asUnicode, string_types
 
 import numpy as np
 try:
@@ -173,7 +173,7 @@ class TableWidget(QtGui.QTableWidget):
         Added in version 0.9.9.
         
         """
-        if format is not None and not isinstance(format, basestring) and not callable(format):
+        if format is not None and not isinstance(format, string_types) and not callable(format):
             raise ValueError("Format argument must string, callable, or None. (got %s)" % format)
         
         self._formats[column] = format
@@ -417,7 +417,7 @@ class TableWidgetItem(QtGui.QTableWidgetItem):
         
         Added in version 0.9.9.
         """
-        if fmt is not None and not isinstance(fmt, basestring) and not callable(fmt):
+        if fmt is not None and not isinstance(fmt, string_types) and not callable(fmt):
             raise ValueError("Format argument must string, callable, or None. (got %s)" % fmt)
         self._format = fmt
         self._updateText()

--- a/pyqtgraph/widgets/TreeWidget.py
+++ b/pyqtgraph/widgets/TreeWidget.py
@@ -162,7 +162,7 @@ class TreeWidget(QtGui.QTreeWidget):
         if hasattr(item, 'treeWidgetChanged'):
             item.treeWidgetChanged()
         else:
-            for i in xrange(item.childCount()):
+            for i in range(item.childCount()):
                 TreeWidget.informTreeWidgetChange(item.child(i))
         
         
@@ -194,7 +194,7 @@ class TreeWidget(QtGui.QTreeWidget):
         return item
 
     def topLevelItems(self):
-        return map(self.topLevelItem, xrange(self.topLevelItemCount()))
+        return map(self.topLevelItem, range(self.topLevelItemCount()))
         
     def clear(self):
         items = self.topLevelItems()

--- a/tools/setupHelpers.py
+++ b/tools/setupHelpers.py
@@ -232,10 +232,8 @@ def unitTests():
     Return the exit code.
     """
     try:
-        if sys.version[0] == '3':
-            out = check_output('PYTHONPATH=. py.test-3', shell=True)
-        else:
-            out = check_output('PYTHONPATH=. py.test', shell=True)
+        out = check_output([sys.executable, "-mpy.test"],
+                           env=dict(os.environ, PYTHONPATH="."))
         ret = 0
     except Exception as e:
         out = e.output


### PR DESCRIPTION
Two fixes related to Python3:
- py.test for python3 is not necessarily called py.test3, and
- do not inject python2 builtins in the python3 builtins namespace.