### PR TITLE
Fix OpenGL shader/texture sharing on PySide

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -7,6 +7,8 @@ from .. import functions as fn
 
 ##Vector = QtGui.QVector3D
 
+ShareWidget = None
+
 class GLViewWidget(QtOpenGL.QGLWidget):
     """
     Basic widget for displaying 3D data
@@ -16,14 +18,14 @@ class GLViewWidget(QtOpenGL.QGLWidget):
 
     """
     
-    ShareWidget = None
-    
     def __init__(self, parent=None):
-        if GLViewWidget.ShareWidget is None:
+        global ShareWidget
+
+        if ShareWidget is None:
             ## create a dummy widget to allow sharing objects (textures, shaders, etc) between views
-            GLViewWidget.ShareWidget = QtOpenGL.QGLWidget()
+            ShareWidget = QtOpenGL.QGLWidget()
             
-        QtOpenGL.QGLWidget.__init__(self, parent, GLViewWidget.ShareWidget)
+        QtOpenGL.QGLWidget.__init__(self, parent, ShareWidget)
         
         self.setFocusPolicy(QtCore.Qt.ClickFocus)
         


### PR DESCRIPTION
For some reason, the `GLViewWidget.ShareWidget` class attribute stayed as `None` on PySide. That is, `ShareWidget` was created, but other instances of the `GLViewWidget` class just saw `None`. It works great on PyQt4.

This may be to a difference in the way PySide and PyQt4 bind `QtOpenGL.QGLWidget`. Maybe PySide is using some metaclass mumbo jumbo that erases class attributes.

I simply made `ShareWidget` a module-level declaration. I see no problem with this, since the shaders are themselves declared at the module level.

See [this thread](https://groups.google.com/forum/#!topic/pyqtgraph/AOj_oRoN_fk) on the mailing list for more information.
