### PR TITLE
Fix memory leak in GLScatterPlotItem

### DIFF
--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -66,7 +66,8 @@ class GLScatterPlotItem(GLGraphicsItem):
         #print pData.shape, pData.min(), pData.max()
         pData = pData.astype(np.ubyte)
         
-        self.pointTexture = glGenTextures(1)
+        if getattr(self, "pointTexture", None) is None:
+            self.pointTexture = glGenTextures(1)
         glActiveTexture(GL_TEXTURE0)
         glEnable(GL_TEXTURE_2D)
         glBindTexture(GL_TEXTURE_2D, self.pointTexture)


### PR DESCRIPTION
Fixes #103. If a ScatterPlotItem was removed from a plot and added again, glGenTetures was called again unneccesarily. Each time it is called, it eats up a little more space.

We agreed that this solution was fine, since `pyqtgraph.opengl` items should't be used in multiple contexts.

Thanks!
