### PR TITLE
Add recursive submenu support for node library.

### DIFF
--- a/pyqtgraph/flowchart/Flowchart.py
+++ b/pyqtgraph/flowchart/Flowchart.py
@@ -836,7 +836,7 @@ class FlowchartWidget(dockarea.DockArea):
                     act.pos = pos
         self.nodeMenu = QtGui.QMenu()
         self.subMenus = []       
-        buildSubMenu(library.getNodeTree(), self.nodeMenu, self.subMenus, pos=pos)
+        buildSubMenu(self.chart.library.getNodeTree(), self.nodeMenu, self.subMenus, pos=pos)
         self.nodeMenu.triggered.connect(self.nodeMenuTriggered)
         return self.nodeMenu
     


### PR DESCRIPTION
Added support for arbitrarily deep nested submenus.  The address of a menu item is specified in the paths argument to pyqtgraph.flowchart.library.registerNodeType().  This arg contains a list of tuples where each element of a tuple is a containing menu.

For example `pyqtgraph.flowchart.library.registerNodeType(newNode, paths=[('menu1', 'menu2'),('menu3'),))` would build this menu:

```
├─── menu1
│    └─── menu2
│         └─── newNode
└─── menu3 
     └─── newNode
```

We can test that example with this script:

``` python
from pyqtgraph import flowchart
from pyqtgraph.flowchart.Node import Node
import pyqtgraph.flowchart.library as fclib
from PyQt4 import QtGui

__dialogs = list()

class newNode(Node):
    nodeName = 'newNode'

def subMenuTest(fc):
    fclib.registerNodeType(newNode, [('menu1','menu2'), ('menu3',)])

def startGui():
    global __dialogs
    window = QtGui.QMainWindow()
    fc = flowchart.Flowchart()
    subMenuTest(fc)
    window.setCentralWidget(fc.widget())
    window.show()
    __dialogs.append(window)

if __name__ == '__main__':
    import sys
    QtGui.QApplication.setDesktopSettingsAware(False)
    app = QtGui.QApplication(sys.argv)
    startGui()
    sys.exit(app.exec_())
```

Gives us:
![pyqtgraph_submenus](https://cloud.githubusercontent.com/assets/6343590/4727743/6f769d82-596f-11e4-9354-5744d8c47ad9.png)
