### PR TITLE
Update GLViewWidget.py

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -304,7 +304,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         if ev.buttons() == QtCore.Qt.LeftButton:
             self.orbit(-diff.x(), diff.y())
             #print self.opts['azimuth'], self.opts['elevation']
-        elif ev.buttons() == QtCore.Qt.MidButton:
+        elif ev.buttons() == QtCore.Qt.RightButton:
             if (ev.modifiers() & QtCore.Qt.ControlModifier):
                 self.pan(diff.x(), 0, diff.y(), relative=True)
             else:


### PR DESCRIPTION
Change mouseMoveEvent to use the right mouse button for panning. 
Event is currently set to the middle mouse button. This causes erratic bevhavior when trying to click and drag since the wheel usually gets activated to and the graphic starts zooming at the same time. The right button is not currently used for anything.
I have tested this and it works in all of the demos.
