### PR TITLE
Add tickAlpha setting to AxisItem style

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -57,6 +57,7 @@ class AxisItem(GraphicsWidget):
             'tickLength': maxTickLength,
             'maxTickLevel': 2,
             'maxTextLevel': 2,
+            'tickAlpha': None,  ## If not none, use this alpha for all ticks.
         }
         
         self.textWidth = 30  ## Keeps track of maximum width / height of tick text 
@@ -133,6 +134,10 @@ class AxisItem(GraphicsWidget):
                                 
         showValues          (bool) indicates whether text is displayed adjacent
                             to ticks.
+        tickAlpha           (float or None) If not None, all ticks will be drawn
+                            with the same alpha (this one), regardless of their
+                            level. tickAlpha can be in the range [0,1] or
+                            [0 .. 255].
         =================== =======================================================
         
         Added in version 0.9.9
@@ -862,10 +867,17 @@ class AxisItem(GraphicsWidget):
             ## length of tick
             tickLength = self.style['tickLength'] / ((i*0.5)+1.0)
                 
-            lineAlpha = 255 / (i+1)
-            if self.grid is not False:
-                lineAlpha *= self.grid/255. * np.clip((0.05  * lengthInPixels / (len(ticks)+1)), 0., 1.)
-            
+            lineAlpha = self.style["tickAlpha"]
+            if lineAlpha is None:
+                lineAlpha = 255 / (i+1)
+                if self.grid is not False:
+                    lineAlpha *= self.grid/255. * np.clip((0.05  * lengthInPixels / (len(ticks)+1)), 0., 1.)
+            else:
+                if lineAlpha < 1:
+                    lineAlpha *= 255
+                elif lineAlpha == 1:
+                    lineAlpha = lineAlpha if isinstance(lineAlpha, int) else 255
+
             for v in ticks:
                 ## determine actual position to draw this tick
                 x = (v * xScale) - offset


### PR DESCRIPTION
In the AxisItem class, ticks are arranged in a hierarchy (major, minor, subminor). When you have a plot with gridlines, the higher ticks are drawn with heavier lines. I needed to produce a plot where the gridlines all look the same, but could not find a straightforward way of doing so. I could have subclassed the AxisItem class and used the custom class in my code, but I felt that other people might find this added functionality useful, so I instead created this pull request.
