### PR TITLE
Don't create extraneous AxisItems

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,14 @@
-pyqtgraph-0.9.10
+pyqtgraph-0.9.11  Unreleased
+
+  Bugfixes:
+    - Fixed extraneous axis being drawn when providing a custom AxisItem to a
+      PlotItem
+
+pyqtgraph-0.9.10  2014-12-24
 
   Fixed installation issues with more recent pip versions.
 
-pyqtgraph-0.9.9
+pyqtgraph-0.9.9  2014-12-13
 
   API / behavior changes:
     - Dynamic import system abandoned; pg now uses static imports throughout.

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -168,7 +168,9 @@ class PlotItem(GraphicsWidget):
             axisItems = {}
         self.axes = {}
         for k, pos in (('top', (1,1)), ('bottom', (3,1)), ('left', (2,0)), ('right', (2,2))):
-            axis = axisItems.get(k, AxisItem(orientation=k, parent=self))
+            axis = axisItems.get(k)
+            if axis is None:
+                axis = AxisItem(orientation=k, parent=self)
             axis.linkToView(self.vb)
             self.axes[k] = {'item': axis, 'pos': pos}
             self.layout.addItem(axis, *pos)


### PR DESCRIPTION
Fixes a bug introduced in 0.9.10.