### PR TITLE
bugfix: don't attach spurious AxisItem to plot

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -168,7 +168,9 @@ class PlotItem(GraphicsWidget):
             axisItems = {}
         self.axes = {}
         for k, pos in (('top', (1,1)), ('bottom', (3,1)), ('left', (2,0)), ('right', (2,2))):
-            axis = axisItems.get(k, AxisItem(orientation=k, parent=self))
+            axis = axisItems.get(k, None)
+            if axis is None:
+                axis = AxisItem(orientation=k, parent=self)
             axis.linkToView(self.vb)
             self.axes[k] = {'item': axis, 'pos': pos}
             self.layout.addItem(axis, *pos)


### PR DESCRIPTION
Bug description: when PlotItem is given a custom axis in constructor:
PlotItem(axisItems={'bottom': myAxis})
the result is a plot with _2_ bottom axes visible instead of just user's custom axis.

Cause: axisItems.get(k, AxisItem(orientation=k, parent=self)) attaches an axis to the parent via "parent=self" directive, even if custom axis is present in 'axisItems'.

Fix: create and attach default AxisItem to parent _only_ after verifying that no custom AxisItem is available.

Fixes regression in f6ded808efc89cb65d51edd2257c5a204b856317
"Fixed a few exit crashes, added unit tests to cover them"
(where parent=self was added)

Signed-off-by: Picket G
