### PR TITLE
Bugfix: PlotCurveItem.sigClicked emits MouseClickEvent

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -567,7 +567,7 @@ class PlotCurveItem(GraphicsObject):
             return
         if self.mouseShape().contains(ev.pos()):
             ev.accept()
-            self.sigClicked.emit(self)
+            self.sigClicked.emit(ev)
             
 
 


### PR DESCRIPTION
Hi all,

currently `PlotCurveItem.sigClicked` emits `self`, a `PlotCurveItem`:

```
def mouseClickEvent(self, ev):
    if not self.clickable or ev.button() != QtCore.Qt.LeftButton:
        return
    if self.mouseShape().contains(ev.pos()):
        ev.accept()
        self.sigClicked.emit(self)
```

Since it can be useful to get the MouseClickEvent in the GraphicsView I suggest to either emit
            `self.sigClicked.emit(ev)`
or
            `self.sigClicked.emit(self, ev)`

cheers!
