### PR TITLE
Make ViewBox update matrix for invertX and setState

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -326,7 +326,7 @@ class ViewBox(GraphicsWidget):
         del state['linkedViews']
         
         self.state.update(state)
-        #self.updateMatrix()
+        self._matrixNeedsUpdate = True  # updateViewRange won't detect this for us
         self.updateViewRange()
         self.sigStateChanged.emit(self)
 
@@ -1091,7 +1091,7 @@ class ViewBox(GraphicsWidget):
             return
         
         self.state['xInverted'] = b
-        #self.updateMatrix(changed=(False, True))
+        self._matrixNeedsUpdate = True  # updateViewRange won't detect this for us
         self.updateViewRange()
         self.sigStateChanged.emit(self)
         self.sigXRangeChanged.emit(self, tuple(self.state['viewRange'][0]))


### PR DESCRIPTION
I couldn't figure out why these updateMatrix calls were commented out, but they seem to be necessary (or equivalently as in invertY, _matrixNeedsUpdate can be set to True).
