### PR TITLE
Remove ScatterPlotItem's SpotItems during addItem call

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -339,6 +339,9 @@ class ScatterPlotItem(GraphicsObject):
             kargs['x'] = []
             kargs['y'] = []
             numPts = 0
+
+        ## Clear current SpotItems since the data references they contain will no longer be current
+        self.data['item'][...] = None
         
         ## Extend record array
         oldData = self.data


### PR DESCRIPTION
After addItem is called and a new data array is constructed, any previously created SpotItems will have obsolete references to the old data array.  This clears these SpotItems so that new ones can be created with up-to-date array references.
