### PR TITLE
Do not create an axis if a custom one is specified

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -170,7 +170,13 @@ class PlotItem(GraphicsWidget):
             axisItems = {}
         self.axes = {}
         for k, pos in (('top', (1,1)), ('bottom', (3,1)), ('left', (2,0)), ('right', (2,2))):
-            axis = axisItems.get(k, AxisItem(orientation=k, parent=self))
+            try:
+                axis = axisItems[k]
+                assert(axis.orientation == k)
+                axis.setParent(self)
+            except KeyError:
+                axis = AxisItem(orientation=k, parent=self)
+
             axis.linkToView(self.vb)
             self.axes[k] = {'item': axis, 'pos': pos}
             self.layout.addItem(axis, *pos)


### PR DESCRIPTION
Because get(key, default) creates the default object unconditionally,
and the default axis gets linked with the PlotItem, a bogus axis
ends up displayed in the top left corner when a custom axis is used.

Change-Id: I7bfd5e126cc7bd150122edd8436348f0c74ff947