### PR TITLE
Properly remove select box when export dialog is closed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ pyqtgraph-0.9.11  [unreleased]
     - DockArea:
         - Fixed adding Docks to DockArea after all Docks have been removed
         - Fixed DockArea save/restoreState when area is empty
+    - Properly remove select box when export dialog is closed using window decorations
 
   New Features:
     - Preliminary PyQt5 support

--- a/pyqtgraph/GraphicsScene/exportDialog.py
+++ b/pyqtgraph/GraphicsScene/exportDialog.py
@@ -139,5 +139,6 @@ class ExportDialog(QtGui.QWidget):
         self.selectBox.setVisible(False)
         self.setVisible(False)
 
-
-    
+    def closeEvent(self, event):
+        self.close()
+        QtGui.QWidget.closeEvent(self, event)


### PR DESCRIPTION
Previously, only clicking the "Close" button would remove it,
but it would stay behind when directly closing the window.