### PR TITLE
Fix clickRadius feature

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -426,7 +426,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
         #self.searchRect.setRect(rgn)
 
 
-        items = self.items(point, selMode, sortOrder, tr)
+        items = self.items(rgn, selMode, sortOrder, tr)
         
         ## remove items whose shape does not contain point (scene.items() apparently sucks at this)
         items2 = []
@@ -436,8 +436,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
             shape = item.shape() # Note: default shape() returns boundingRect()
             if shape is None:
                 continue
-            if shape.contains(item.mapFromScene(point)):
-                items2.append(item)
+            items2.append(item)
         
         ## Sort by descending Z-order (don't trust scene.itms() to do this either)
         ## use 'absolute' z value, which is the sum of all item/parent ZValues


### PR DESCRIPTION
Hi. The current version of PyQtGraph do not support anymore the setClickRadius feature. The code was broken somewhen.

To support again the clickRadius feature (which allow to select an item anyway the mouse is over it or not):
- `items` list must come from the `rgn` shape (computed from `_clickRadius`)
- `shape contains point` must be removed cause that's especially what must allow the clickRadius feature.

This patch does that.

Thanks a lot.
