### PR TITLE
Log scale and fft transform fix

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -523,6 +523,10 @@ class PlotDataItem(GraphicsObject):
                 #y = y[::ds]
             if self.opts['fftMode']:
                 x,y = self._fourierTransform(x, y)
+                # Ignore the first bin for fft data if we have a logx scale
+                if self.opts['logMode'][0]:
+                    x=x[1:]
+                    y=y[1:]                
             if self.opts['logMode'][0]:
                 x = np.log10(x)
             if self.opts['logMode'][1]:


### PR DESCRIPTION
If the plotted data is fourier transformed and an x log scale is chosen, the first bin causes an error because np.log10(0) doesn't make any sense.