### PR TITLE
trying to fix error in log scale Issue  #144

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -530,7 +530,7 @@ class PlotDataItem(GraphicsObject):
             if self.opts['logMode'][0]:
                 x = np.log10(x)
             if self.opts['logMode'][1]:
-                y = np.log10(y)
+                y = np.log10(1.0+y)
             #if any(self.opts['logMode']):  ## re-check for NANs after log
                 #nanMask = np.isinf(x) | np.isinf(y) | np.isnan(x) | np.isnan(y)
                 #if any(nanMask):


### PR DESCRIPTION
Trying to fix the error in log scaling in issue 144.
Running the example code in that issue i get:

 "RuntimeWarning: divide by zero encountered in log10"

going from np.log10(y) to np.log10(1.0+y) fixes the issue