### PR TITLE
prevent divide-by-zero in PlotDataItem downsample

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -547,7 +547,7 @@ class PlotDataItem(GraphicsObject):
             if self.opts['autoDownsample']:
                 # this option presumes that x-values have uniform spacing
                 range = self.viewRect()
-                if range is not None:
+                if range is not None and len(x) > 1:
                     dx = float(x[-1]-x[0]) / (len(x)-1)
                     x0 = (range.left()-x[0]) / dx
                     x1 = (range.right()-x[0]) / dx

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -175,7 +175,7 @@ class PlotDataItem(GraphicsObject):
             'autoDownsample': False,
             'downsampleMethod': 'peak',
             'autoDownsampleFactor': 5.,  # draw ~5 samples per pixel
-            'quantizedDownsample': True, #ensures downsample points align across scrolls
+            'quantizedDownsample': False, #ensures downsample points align across scrolls
             'clipToView': False,
             
             'data': None,
@@ -587,11 +587,12 @@ class PlotDataItem(GraphicsObject):
                         indices = np.arange(i0, n*ds, ds)
                     else:
                         indices = [0]
+                    """use midpoint of x downsample points"""
+                    x = x[indices] + float(x[-1]-x[0]) / (len(x)-1)
                 else: 
                     indices = np.arange(0, n*ds, ds)
-                
-                """use midpoint of x downsample points"""
-                x = x[indices] + float(x[-1]-x[0]) / (len(x)-1)
+                    x = x[indices]
+
                 if self.opts['downsampleMethod'] == 'subsample':
                     y = y[indices]
                 elif self.opts['downsampleMethod'] in ['mean', 'max', 'min']:

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -155,8 +155,7 @@ class ViewBox(GraphicsWidget):
             'mouseEnabled': [enableMouse, enableMouse],
             'mouseMode': ViewBox.PanMode if getConfigOption('leftButtonPan') else ViewBox.RectMode,  
             'enableMenu': enableMenu,
-            'wheelScaleFactor': -1.0 / 8.0,
-
+            'wheelScaleFactor': [-1.0 / 8.0, -1.0/8.0], #wheel scale factor for each axis or None to disable for that axis
             'background': None,
             
             # Limits
@@ -696,8 +695,6 @@ class ViewBox(GraphicsWidget):
             self.updateViewRange()
                     
             
-            
-            
     def scaleBy(self, s=None, center=None, x=None, y=None):
         """
         Scale by *s* around given center point (or center of view).
@@ -847,6 +844,9 @@ class ViewBox(GraphicsWidget):
         
         if x is not None or y is not None:
             self.updateAutoRange()
+
+    def setWheelScaleFactor(self, x=None, y=None):
+        self.state['wheelScaleFactor'] = (x, y)
 
     def updateAutoRange(self):
         ## Break recursive loops when auto-ranging.
@@ -1208,13 +1208,17 @@ class ViewBox(GraphicsWidget):
             mv = mask[axis]
             mask[:] = 0
             mask[axis] = mv
-        s = ((mask * 0.02) + 1) ** (ev.delta() * self.state['wheelScaleFactor']) # actual scaling factor
+        
+        xfactor = self.state['wheelScaleFactor'][0]
+        xs = ((mask[0] * 0.02) + 1) ** (ev.delta() * xfactor) if xfactor is not None else None
+        yfactor = self.state['wheelScaleFactor'][1]
+        ys = ((mask[1] * 0.02) + 1) ** (ev.delta() * yfactor) if yfactor is not None else None
         
         center = Point(fn.invertQTransform(self.childGroup.transform()).map(ev.pos()))
         #center = ev.pos()
         
         self._resetTarget()
-        self.scaleBy(s, center)
+        self.scaleBy(x=xs, y=ys, center=center)
         self.sigRangeChangedManually.emit(self.state['mouseEnabled'])
         ev.accept()
 


### PR DESCRIPTION
In the edge case of a PlotDataItem with only a single data point,
don't downsample since this leads to a divide by zero exception