### PR TITLE
do not close non-closable docks that are floating

### DIFF
--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -18,6 +18,7 @@ class Dock(QtGui.QWidget, DockDrop):
         self.label = DockLabel(name, self, closable)
         if closable:
             self.label.sigCloseClicked.connect(self.close)
+        self.closable = closable
         self.labelHidden = False
         self.moveLabel = True  ## If false, the dock is no longer allowed to move the label.
         self.autoOrient = autoOrientation

--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -306,7 +306,10 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
     def clear(self):
         docks = self.findAll()[1]
         for dock in docks.values():
-            dock.close()
+            if dock.closable:
+                dock.close()
+            else:
+                self.home.moveDock(dock, "top", None)
             
     ## PySide bug: We need to explicitly redefine these methods
     ## or else drag/drop events will not be delivered.


### PR DESCRIPTION
Non-closable docks that are floating can still be closed by closing their window. This is a pretty serious bug as it may render the application completely unusable when the improperly closed docks contain important widgets.

This patch fixes the problem by moving non-closable docks to the home area when they are floating and their window is closed.
