### PR TITLE
Ignore wheel events in GraphicsView if mouse disabled

### DIFF
--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -324,6 +324,7 @@ class GraphicsView(QtGui.QGraphicsView):
     def wheelEvent(self, ev):
         QtGui.QGraphicsView.wheelEvent(self, ev)
         if not self.mouseEnabled:
+            ev.ignore()
             return
         sc = 1.001 ** ev.delta()
         #self.scale *= sc


### PR DESCRIPTION
This allows parent dialogs to receive these events
if needed.