### PR TITLE
Fix import of OrderedDict for old python API

### DIFF
--- a/pyqtgraph/parametertree/SystemSolver.py
+++ b/pyqtgraph/parametertree/SystemSolver.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from pyqtgraph.pgcollections import OrderedDict
 import numpy as np
 
 class SystemSolver(object):


### PR DESCRIPTION
Hi,

This file do not use your backport of OrderedDict (which is already part of pyqtgraph). This fix only use your default way to import OrderedDict.

The file ./examples/relativity/relativity.py should also be fixed in the same way.

We are using pyqtgraph tag 0.9.10 in production to have something stable. This bug is also part of this tag.

Thanks a lot.