### PR TITLE
invalid slice fix

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -347,8 +347,8 @@ class ImageItem(GraphicsObject):
         if self.image is None:
             return None,None
         if step == 'auto':
-            step = (np.ceil(self.image.shape[0] / targetImageSize),
-                    np.ceil(self.image.shape[1] / targetImageSize))
+            step = (int(np.ceil(self.image.shape[0] / targetImageSize)),
+                    int(np.ceil(self.image.shape[1] / targetImageSize)))
         if np.isscalar(step):
             step = (step, step)
         stepData = self.image[::step[0], ::step[1]]


### PR DESCRIPTION
I don't understand why this line used to work without problems. But for the last few days it was crashing my HistogramLUTItem because np.ceil(self.image.shape[0] / targetImageSize) returned a float