### PR TITLE
Multiprocess cleanup

### DIFF
--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -156,14 +156,14 @@ class Process(RemoteEventHandler):
                 time.sleep(0.05)
         self.debugMsg('Child process exited. (%d)' % self.proc.returncode)
 
-    def debugMsg(self, msg):
+    def debugMsg(self, msg, *args):
         if hasattr(self, '_stdoutForwarder'):
             ## Lock output from subprocess to make sure we do not get line collisions
             with self._stdoutForwarder.lock:
                 with self._stderrForwarder.lock:
-                    RemoteEventHandler.debugMsg(self, msg)
+                    RemoteEventHandler.debugMsg(self, msg, *args)
         else:
-            RemoteEventHandler.debugMsg(self, msg)
+            RemoteEventHandler.debugMsg(self, msg, *args)
 
         
 def startEventLoop(name, port, authkey, ppid, debug=False):

--- a/pyqtgraph/multiprocess/remoteproxy.py
+++ b/pyqtgraph/multiprocess/remoteproxy.py
@@ -69,6 +69,11 @@ class RemoteEventHandler(object):
             'deferGetattr': False,   ## True, False
             'noProxyTypes': [ type(None), str, int, float, tuple, list, dict, LocalObjectProxy, ObjectProxy ],
         }
+        if int(sys.version[0]) < 3:
+            self.proxyOptions['noProxyTypes'].append(unicode)
+        else:
+            self.proxyOptions['noProxyTypes'].append(bytes)
+        
         self.optsLock = threading.RLock()
         
         self.nextRequestId = 0


### PR DESCRIPTION
Minor updates to multiprocessing system:
* Debugging messages now avoid expensive string processing if debugging is disabled
* Unicode and bytes types added to the default no-proxy list (these types are serialized and passed by value instead of by proxy)
* Check for invalid arguments to `ObjectProxy._setProxyOptions`
* Fix error messages caused by trying to delete proxy objects after connection has closed