### PR TITLE
Remove trailing spaces

### DIFF
--- a/doc/extensions/qt_doc.py
+++ b/doc/extensions/qt_doc.py
@@ -13,10 +13,10 @@ Extension for building Qt-like documentation.
 def setup(app):
     # probably we will be making a wrapper around autodoc
     app.setup_extension('sphinx.ext.autodoc')
-    
+
     # would it be useful to define a new domain?
-    #app.add_domain(QtDomain) 
-    
+    #app.add_domain(QtDomain)
+
     ## Add new configuration options
     app.add_config_value('todo_include_todos', False, False)
 
@@ -31,11 +31,11 @@ def setup(app):
     ## New directives like ".. todo:"
     app.add_directive('todo', TodoDirective)
     app.add_directive('todolist', TodolistDirective)
-    
+
     ## Connect callbacks to specific hooks in the build process
     app.connect('doctree-resolved', process_todo_nodes)
     app.connect('env-purge-doc', purge_todos)
-    
+
 
 from docutils import nodes
 from sphinx.util.compat import Directive
@@ -63,7 +63,7 @@ def visit_todo_node(self, node):
     self.visit_admonition(node)
 
 def depart_todo_node(self, node):
-    self.depart_admonition(node)    
+    self.depart_admonition(node)
 
 class TodoDirective(Directive):
 
@@ -72,7 +72,7 @@ class TodoDirective(Directive):
 
     def run(self):
         env = self.state.document.settings.env
-    
+
         # create a new target node for linking to
         targetid = "todo-%d" % env.new_serialno('todo')
         targetnode = nodes.target('', '', ids=[targetid])
@@ -102,7 +102,7 @@ def purge_todos(app, env, docname):
         return
     env.todo_all_todos = [todo for todo in env.todo_all_todos
                           if todo['docname'] != docname]
-                          
+
 
 # called at the end of resolving phase; we will convert temporary nodes
 # into finalized nodes
@@ -146,4 +146,3 @@ def process_todo_nodes(app, doctree, fromdocname):
             content.append(para)
 
         node.replace_self(content)
-        

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -216,4 +216,3 @@ man_pages = [
     ('index', 'pyqtgraph', 'pyqtgraph Documentation',
      ['Luke Campagnola'], 1)
 ]
-

--- a/examples/CLIexample.py
+++ b/examples/CLIexample.py
@@ -1,5 +1,5 @@
 """
-Display a plot and an image with minimal setup. 
+Display a plot and an image with minimal setup.
 
 pg.plot() and pg.image() are indended to be used from an interactive prompt
 to allow easy data inspection (but note that PySide unfortunately does not

--- a/examples/ConsoleWidget.py
+++ b/examples/ConsoleWidget.py
@@ -20,8 +20,8 @@ namespace = {'pg': pg, 'np': np}
 
 ## initial text to display in the console
 text = """
-This is an interactive python console. The numpy and pyqtgraph modules have already been imported 
-as 'np' and 'pg'. 
+This is an interactive python console. The numpy and pyqtgraph modules have already been imported
+as 'np' and 'pg'.
 
 Go, play.
 """

--- a/examples/CustomGraphItem.py
+++ b/examples/CustomGraphItem.py
@@ -24,7 +24,7 @@ class Graph(pg.GraphItem):
         self.textItems = []
         pg.GraphItem.__init__(self)
         self.scatter.sigClicked.connect(self.clicked)
-        
+
     def setData(self, **kwds):
         self.text = kwds.pop('text', [])
         self.data = kwds
@@ -34,7 +34,7 @@ class Graph(pg.GraphItem):
             self.data['data']['index'] = np.arange(npts)
         self.setTexts(self.text)
         self.updateGraph()
-        
+
     def setTexts(self, text):
         for i in self.textItems:
             i.scene().removeItem(i)
@@ -43,21 +43,21 @@ class Graph(pg.GraphItem):
             item = pg.TextItem(t)
             self.textItems.append(item)
             item.setParentItem(self)
-        
+
     def updateGraph(self):
         pg.GraphItem.setData(self, **self.data)
         for i,item in enumerate(self.textItems):
             item.setPos(*self.data['pos'][i])
-        
-        
+
+
     def mouseDragEvent(self, ev):
         if ev.button() != QtCore.Qt.LeftButton:
             ev.ignore()
             return
-        
+
         if ev.isStart():
             # We are already one step into the drag.
-            # Find the point(s) at the mouse cursor when the button was first 
+            # Find the point(s) at the mouse cursor when the button was first
             # pressed:
             pos = ev.buttonDownPos()
             pts = self.scatter.pointsAt(pos)
@@ -74,12 +74,12 @@ class Graph(pg.GraphItem):
             if self.dragPoint is None:
                 ev.ignore()
                 return
-        
+
         ind = self.dragPoint.data()[0]
         self.data['pos'][ind] = ev.pos() + self.dragOffset
         self.updateGraph()
         ev.accept()
-        
+
     def clicked(self, pts):
         print("clicked: %s" % pts)
 
@@ -96,7 +96,7 @@ pos = np.array([
     [5,5],
     [15,5]
     ], dtype=float)
-    
+
 ## Define the set of connections in the graph
 adj = np.array([
     [0,1],
@@ -106,7 +106,7 @@ adj = np.array([
     [1,5],
     [3,5],
     ])
-    
+
 ## Define the symbol to use for each node (this is optional)
 symbols = ['o','o','o','o','t','+']
 

--- a/examples/DataSlicing.py
+++ b/examples/DataSlicing.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-Demonstrate a simple data-slicing task: given 3D data (displayed at top), select 
-a 2D plane and interpolate data along that plane to generate a slice image 
-(displayed at bottom). 
+Demonstrate a simple data-slicing task: given 3D data (displayed at top), select
+a 2D plane and interpolate data along that plane to generate a slice image
+(displayed at bottom).
 
 
 """
@@ -46,7 +46,7 @@ def update():
     global data, imv1, imv2
     d2 = roi.getArrayRegion(data, imv1.imageItem, axes=(1,2))
     imv2.setImage(d2)
-    
+
 roi.sigRegionChanged.connect(update)
 
 

--- a/examples/FillBetweenItem.py
+++ b/examples/FillBetweenItem.py
@@ -30,7 +30,7 @@ def update():
     a = 5 / abs(np.random.normal(loc=1, scale=0.2))
     y1 = -np.abs(a*gauss + np.random.normal(size=len(x)))
     y2 =  np.abs(a*gauss + np.random.normal(size=len(x)))
-    
+
     s = 0.01
     mn = np.where(y1<mn, y1, mn) * (1-s) + y1 * s
     mx = np.where(y2>mx, y2, mx) * (1-s) + y2 * s
@@ -38,7 +38,7 @@ def update():
     curves[1].setData(x, y1)
     curves[2].setData(x, y2)
     curves[3].setData(x, mx)
-    
+
 
 timer = QtCore.QTimer()
 timer.timeout.connect(update)

--- a/examples/Flowchart.py
+++ b/examples/Flowchart.py
@@ -32,7 +32,7 @@ cw.setLayout(layout)
 ## Create flowchart, define input/output terminals
 fc = Flowchart(terminals={
     'dataIn': {'io': 'in'},
-    'dataOut': {'io': 'out'}    
+    'dataOut': {'io': 'out'}
 })
 w = fc.widget()
 
@@ -56,7 +56,7 @@ data = metaarray.MetaArray(data, info=[{'name': 'Time', 'values': np.linspace(0,
 ## Feed data into the input terminal of the flowchart
 fc.setInput(dataIn=data)
 
-## populate the flowchart with a basic set of processing nodes. 
+## populate the flowchart with a basic set of processing nodes.
 ## (usually we let the user do this)
 plotList = {'Top Plot': pw1, 'Bottom Plot': pw2}
 

--- a/examples/FlowchartCustomNode.py
+++ b/examples/FlowchartCustomNode.py
@@ -26,7 +26,7 @@ cw.setLayout(layout)
 ## Create an empty flowchart with a single input and output
 fc = Flowchart(terminals={
     'dataIn': {'io': 'in'},
-    'dataOut': {'io': 'out'}    
+    'dataOut': {'io': 'out'}
 })
 w = fc.widget()
 
@@ -55,26 +55,26 @@ fc.setInput(dataIn=data)
 
 
 ## At this point, we need some custom Node classes since those provided in the library
-## are not sufficient. Each node will define a set of input/output terminals, a 
-## processing function, and optionally a control widget (to be displayed in the 
+## are not sufficient. Each node will define a set of input/output terminals, a
+## processing function, and optionally a control widget (to be displayed in the
 ## flowchart control panel)
 
 class ImageViewNode(Node):
     """Node that displays image data in an ImageView widget"""
     nodeName = 'ImageView'
-    
+
     def __init__(self, name):
         self.view = None
         ## Initialize node with only a single input terminal
         Node.__init__(self, name, terminals={'data': {'io':'in'}})
-        
+
     def setView(self, view):  ## setView must be called by the program
         self.view = view
-        
+
     def process(self, data, display=True):
         ## if process is called with display=False, then the flowchart is being operated
         ## in batch processing mode, so we should skip displaying to improve performance.
-        
+
         if display and self.view is not None:
             ## the 'data' argument is the value given to the 'data' terminal
             if data is None:
@@ -84,7 +84,7 @@ class ImageViewNode(Node):
 
 
 
-        
+
 ## We will define an unsharp masking filter node as a subclass of CtrlNode.
 ## CtrlNode is just a convenience class that automatically creates its
 ## control widget based on a simple data structure.
@@ -102,9 +102,9 @@ class UnsharpMaskNode(CtrlNode):
             'dataOut': dict(io='out'),  # to specify whether it is input or output
         }                              # other more advanced options are available
                                        # as well..
-        
+
         CtrlNode.__init__(self, name, terminals=terminals)
-        
+
     def process(self, dataIn, display=True):
         # CtrlNode has created self.ctrls, which is a dict containing {ctrlName: widget}
         sigma = self.ctrls['sigma'].value()
@@ -117,19 +117,19 @@ class UnsharpMaskNode(CtrlNode):
 ## we can either register them with the default node library or make a
 ## new library.
 
-        
+
 ## Method 1: Register to global default library:
 #fclib.registerNodeType(ImageViewNode, [('Display',)])
 #fclib.registerNodeType(UnsharpMaskNode, [('Image',)])
 
 ## Method 2: If we want to make our custom node available only to this flowchart,
-## then instead of registering the node type globally, we can create a new 
+## then instead of registering the node type globally, we can create a new
 ## NodeLibrary:
 library = fclib.LIBRARY.copy() # start with the default node set
 library.addNodeType(ImageViewNode, [('Display',)])
 # Add the unsharp mask node to two locations in the menu to demonstrate
 # that we can create arbitrary menu structures
-library.addNodeType(UnsharpMaskNode, [('Image',), 
+library.addNodeType(UnsharpMaskNode, [('Image',),
                                       ('Submenu_test','submenu2','submenu3')])
 fc.setLibrary(library)
 

--- a/examples/GLImageItem.py
+++ b/examples/GLImageItem.py
@@ -2,7 +2,7 @@
 """
 Use GLImageItem to display image data on rectangular planes.
 
-In this example, the image data is sampled from a volume and the image planes 
+In this example, the image data is sampled from a volume and the image planes
 placed as if they slice through the volume.
 """
 ## Add path to library (just for examples; you do not need this)

--- a/examples/GLIsosurface.py
+++ b/examples/GLIsosurface.py
@@ -35,10 +35,10 @@ def psi(i, j, k, offset=(25, 25, 50)):
     a0 = 1
     #ps = (1./81.) * (2./np.pi)**0.5 * (1./a0)**(3/2) * (6 - r/a0) * (r/a0) * np.exp(-r/(3*a0)) * np.cos(th)
     ps = (1./81.) * 1./(6.*np.pi)**0.5 * (1./a0)**(3/2) * (r/a0)**2 * np.exp(-r/(3*a0)) * (3 * np.cos(th)**2 - 1)
-    
+
     return ps
-    
-    #return ((1./81.) * (1./np.pi)**0.5 * (1./a0)**(3/2) * (r/a0)**2 * (r/a0) * np.exp(-r/(3*a0)) * np.sin(th) * np.cos(th) * np.exp(2 * 1j * phi))**2 
+
+    #return ((1./81.) * (1./np.pi)**0.5 * (1./a0)**(3/2) * (r/a0)**2 * (r/a0) * np.exp(-r/(3*a0)) * np.sin(th) * np.cos(th) * np.exp(2 * 1j * phi))**2
 
 
 print("Generating scalar field..")
@@ -65,7 +65,7 @@ m2.setGLOptions('additive')
 
 w.addItem(m2)
 m2.translate(-25, -25, -50)
-    
+
 
 
 ## Start Qt event loop unless running in interactive mode.

--- a/examples/GLLinePlotItem.py
+++ b/examples/GLLinePlotItem.py
@@ -42,7 +42,7 @@ for i in range(n):
     pts = np.vstack([x,yi,z]).transpose()
     plt = gl.GLLinePlotItem(pos=pts, color=pg.glColor((i,n*1.3)), width=(i+1)/10., antialias=True)
     w.addItem(plt)
-    
+
 
 
 ## Start Qt event loop unless running in interactive mode.

--- a/examples/GLMeshItem.py
+++ b/examples/GLMeshItem.py
@@ -61,10 +61,10 @@ theta = np.linspace(0, 2*np.pi, 37)[:-1]
 verts[:,0] = np.vstack([2*np.cos(theta), 2*np.sin(theta), [0]*36]).T
 verts[:,1] = np.vstack([4*np.cos(theta+0.2), 4*np.sin(theta+0.2), [-1]*36]).T
 verts[:,2] = np.vstack([4*np.cos(theta-0.2), 4*np.sin(theta-0.2), [1]*36]).T
-    
+
 ## Colors are specified per-vertex
 colors = np.random.random(size=(verts.shape[0], 3, 4))
-m2 = gl.GLMeshItem(vertexes=verts, vertexColors=colors, smooth=False, shader='balloon', 
+m2 = gl.GLMeshItem(vertexes=verts, vertexColors=colors, smooth=False, shader='balloon',
                    drawEdges=True, edgeColor=(1, 1, 0, 1))
 m2.translate(-5, 5, 0)
 w.addItem(m2)
@@ -119,7 +119,7 @@ w.addItem(m6)
 
 
 
-    
+
 
 
 ## Start Qt event loop unless running in interactive mode.

--- a/examples/GLScatterPlotItem.py
+++ b/examples/GLScatterPlotItem.py
@@ -23,8 +23,8 @@ w.addItem(g)
 
 ##
 ##  First example is a set of points with pxMode=False
-##  These demonstrate the ability to have points with real size down to a very small scale 
-## 
+##  These demonstrate the ability to have points with real size down to a very small scale
+##
 pos = np.empty((53, 3))
 size = np.empty((53))
 color = np.empty((53, 4))
@@ -40,7 +40,7 @@ for i in range(3,53):
     color[i] = (0.0, 1.0, 0.0, 0.5)
     z *= 0.5
     d *= 2.0
-    
+
 sp1 = gl.GLScatterPlotItem(pos=pos, size=size, color=color, pxMode=False)
 sp1.translate(5,5,0)
 w.addItem(sp1)
@@ -89,7 +89,7 @@ def update():
     color[:,2] = np.clip(s ** 3, 0, 1)
     sp2.setData(color=color)
     phase -= 0.1
-    
+
     ## update surface positions and colors
     global sp3, d3, pos3
     z = -np.cos(d3*2+phase)
@@ -100,7 +100,7 @@ def update():
     color[:,1] = np.clip(z * 1.0, 0, 1)
     color[:,2] = np.clip(z ** 3, 0, 1)
     sp3.setData(pos=pos3, color=color)
-    
+
 t = QtCore.QTimer()
 t.timeout.connect(update)
 t.start(50)

--- a/examples/GLSurfacePlot.py
+++ b/examples/GLSurfacePlot.py
@@ -75,7 +75,7 @@ z = np.sin(d[np.newaxis,...] + phi.reshape(phi.shape[0], 1, 1)) / d2[np.newaxis,
 
 
 ## create a surface plot, tell it to use the 'heightColor' shader
-## since this does not require normal vectors to render (thus we 
+## since this does not require normal vectors to render (thus we
 ## can set computeNormals=False to save time when the mesh updates)
 p4 = gl.GLSurfacePlotItem(x=x[:,0], y = y[0,:], shader='heightColor', computeNormals=False, smooth=False)
 p4.shader()['colorMap'] = np.array([0.2, 2, 0.5, 0.2, 1, 1, 0.2, 0, 2])
@@ -87,7 +87,7 @@ def update():
     global p4, z, index
     index -= 1
     p4.setData(z=z[index%z.shape[0]])
-    
+
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(30)

--- a/examples/GLVolumeItem.py
+++ b/examples/GLVolumeItem.py
@@ -34,10 +34,10 @@ def psi(i, j, k, offset=(50,50,100)):
     a0 = 2
     #ps = (1./81.) * (2./np.pi)**0.5 * (1./a0)**(3/2) * (6 - r/a0) * (r/a0) * np.exp(-r/(3*a0)) * np.cos(th)
     ps = (1./81.) * 1./(6.*np.pi)**0.5 * (1./a0)**(3/2) * (r/a0)**2 * np.exp(-r/(3*a0)) * (3 * np.cos(th)**2 - 1)
-    
+
     return ps
-    
-    #return ((1./81.) * (1./np.pi)**0.5 * (1./a0)**(3/2) * (r/a0)**2 * (r/a0) * np.exp(-r/(3*a0)) * np.sin(th) * np.cos(th) * np.exp(2 * 1j * phi))**2 
+
+    #return ((1./81.) * (1./np.pi)**0.5 * (1./a0)**(3/2) * (r/a0)**2 * (r/a0) * np.exp(-r/(3*a0)) * np.sin(th) * np.cos(th) * np.exp(2 * 1j * phi))**2
 
 
 data = np.fromfunction(psi, (100,100,200))

--- a/examples/GLshaders.py
+++ b/examples/GLshaders.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Demonstration of some of the shader programs included with pyqtgraph that can be 
+Demonstration of some of the shader programs included with pyqtgraph that can be
 used to affect the appearance of a surface.
 """
 
@@ -72,17 +72,17 @@ w.addItem(m6)
     #a0 = 1
     ##ps = (1./81.) * (2./np.pi)**0.5 * (1./a0)**(3/2) * (6 - r/a0) * (r/a0) * np.exp(-r/(3*a0)) * np.cos(th)
     #ps = (1./81.) * 1./(6.*np.pi)**0.5 * (1./a0)**(3/2) * (r/a0)**2 * np.exp(-r/(3*a0)) * (3 * np.cos(th)**2 - 1)
-    
+
     #return ps
-    
-    ##return ((1./81.) * (1./np.pi)**0.5 * (1./a0)**(3/2) * (r/a0)**2 * (r/a0) * np.exp(-r/(3*a0)) * np.sin(th) * np.cos(th) * np.exp(2 * 1j * phi))**2 
+
+    ##return ((1./81.) * (1./np.pi)**0.5 * (1./a0)**(3/2) * (r/a0)**2 * (r/a0) * np.exp(-r/(3*a0)) * np.sin(th) * np.cos(th) * np.exp(2 * 1j * phi))**2
 
 
 #print("Generating scalar field..")
 #data = np.abs(np.fromfunction(psi, (50,50,100)))
 
 
-##data = np.fromfunction(lambda i,j,k: np.sin(0.2*((i-25)**2+(j-15)**2+k**2)**0.5), (50,50,50)); 
+##data = np.fromfunction(lambda i,j,k: np.sin(0.2*((i-25)**2+(j-15)**2+k**2)**0.5), (50,50,50));
 #print("Generating isosurface..")
 #verts = pg.isosurface(data, data.max()/4.)
 
@@ -100,7 +100,7 @@ w.addItem(m6)
 
 #w.addItem(m2)
 #m2.translate(-25, -25, -50)
-    
+
 
 
 ## Start Qt event loop unless running in interactive mode.

--- a/examples/GradientEditor.py
+++ b/examples/GradientEditor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-## Add path to library (just for examples; you do not need this)                                                                           
+## Add path to library (just for examples; you do not need this)
 import initExample
 
 import numpy as np

--- a/examples/GradientWidget.py
+++ b/examples/GradientWidget.py
@@ -50,6 +50,3 @@ if __name__ == '__main__':
     import sys
     if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
         QtGui.QApplication.instance().exec_()
-
-
-

--- a/examples/GraphItem.py
+++ b/examples/GraphItem.py
@@ -30,7 +30,7 @@ pos = np.array([
     [5,5],
     [15,5]
     ])
-    
+
 ## Define the set of connections in the graph
 adj = np.array([
     [0,1],
@@ -40,7 +40,7 @@ adj = np.array([
     [1,5],
     [3,5],
     ])
-    
+
 ## Define the symbol to use for each node (this is optional)
 symbols = ['o','o','o','o','t','+']
 

--- a/examples/GraphicsScene.py
+++ b/examples/GraphicsScene.py
@@ -15,27 +15,27 @@ class Obj(QtGui.QGraphicsObject):
     def __init__(self):
         QtGui.QGraphicsObject.__init__(self)
         GraphicsScene.registerObject(self)
-        
+
     def paint(self, p, *args):
         p.setPen(pg.mkPen(200,200,200))
         p.drawRect(self.boundingRect())
-        
+
     def boundingRect(self):
         return QtCore.QRectF(0, 0, 20, 20)
-        
+
     def mouseClickEvent(self, ev):
         if ev.double():
             print("double click")
         else:
             print("click")
         ev.accept()
-        
+
     #def mouseDragEvent(self, ev):
         #print "drag"
         #ev.accept()
         #self.setPos(self.pos() + ev.pos()-ev.lastPos())
-        
-        
+
+
 
 vb = pg.ViewBox()
 win.setCentralItem(vb)

--- a/examples/HistogramLUT.py
+++ b/examples/HistogramLUT.py
@@ -3,7 +3,7 @@
 Use a HistogramLUTWidget to control the contrast / coloration of an image.
 """
 
-## Add path to library (just for examples; you do not need this)                                                                           
+## Add path to library (just for examples; you do not need this)
 import initExample
 
 import numpy as np

--- a/examples/ImageItem.py
+++ b/examples/ImageItem.py
@@ -48,9 +48,9 @@ def updateData():
     fps2 = 1.0 / (now-updateTime)
     updateTime = now
     fps = fps * 0.9 + fps2 * 0.1
-    
+
     #print "%0.1f fps" % fps
-    
+
 
 updateData()
 

--- a/examples/ImageView.py
+++ b/examples/ImageView.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-This example demonstrates the use of ImageView, which is a high-level widget for 
+This example demonstrates the use of ImageView, which is a high-level widget for
 displaying and analyzing 2D and 3D data. ImageView provides:
 
   1. A zoomable region (ViewBox) for displaying the image

--- a/examples/JoystickButton.py
+++ b/examples/JoystickButton.py
@@ -2,7 +2,7 @@
 """
 JoystickButton is a button with x/y values. When the button is depressed and the
 mouse dragged, the x/y values change to follow the mouse.
-When the mouse button is released, the x/y values change to 0,0 (rather like 
+When the mouse button is released, the x/y values change to 0,0 (rather like
 letting go of the joystick).
 """
 
@@ -45,8 +45,8 @@ def update():
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(30)
-    
-    
+
+
 
 
 ## Start Qt event loop unless running in interactive mode or using pyside.

--- a/examples/MouseSelection.py
+++ b/examples/MouseSelection.py
@@ -16,7 +16,7 @@ curves = [
     pg.PlotCurveItem(y=np.sin(np.linspace(1, 21, 1000)), pen='g', clickable=True),
     pg.PlotCurveItem(y=np.sin(np.linspace(2, 22, 1000)), pen='b', clickable=True),
     ]
-              
+
 def plotClicked(curve):
     global curves
     for i,c in enumerate(curves):
@@ -24,8 +24,8 @@ def plotClicked(curve):
             c.setPen('rgb'[i], width=3)
         else:
             c.setPen('rgb'[i], width=1)
-            
-    
+
+
 for c in curves:
     win.addItem(c)
     c.sigClicked.connect(plotClicked)

--- a/examples/MultiPlotSpeedTest.py
+++ b/examples/MultiPlotSpeedTest.py
@@ -19,7 +19,7 @@ app = QtGui.QApplication([])
 
 p = pg.plot()
 p.setWindowTitle('pyqtgraph example: MultiPlotSpeedTest')
-#p.setRange(QtCore.QRectF(0, -10, 5000, 20)) 
+#p.setRange(QtCore.QRectF(0, -10, 5000, 20))
 p.setLabel('bottom', 'Index', units='B')
 
 nPlots = 100
@@ -51,7 +51,7 @@ def update():
     #print "---------", count
     for i in range(nPlots):
         curves[i].setData(data[(ptr+i)%data.shape[0]])
-        
+
     #print "   setData done."
     ptr += nPlots
     now = time()
@@ -67,7 +67,7 @@ def update():
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(0)
-    
+
 
 
 ## Start Qt event loop unless running in interactive mode.

--- a/examples/MultiPlotWidget.py
+++ b/examples/MultiPlotWidget.py
@@ -25,10 +25,10 @@ mw.show()
 data = random.normal(size=(3, 1000)) * np.array([[0.1], [1e-5], [1]])
 ma = MetaArray(data, info=[
     {'name': 'Signal', 'cols': [
-        {'name': 'Col1', 'units': 'V'}, 
-        {'name': 'Col2', 'units': 'A'}, 
+        {'name': 'Col1', 'units': 'V'},
+        {'name': 'Col2', 'units': 'A'},
         {'name': 'Col3'},
-        ]}, 
+        ]},
     {'name': 'Time', 'values': linspace(0., 1., 1000), 'units': 's'}
     ])
 pw.plot(ma)
@@ -38,4 +38,3 @@ if __name__ == '__main__':
     import sys
     if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
         QtGui.QApplication.instance().exec_()
-

--- a/examples/MultiplePlotAxes.py
+++ b/examples/MultiplePlotAxes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Demonstrates a way to put multiple axes around a single plot. 
+Demonstrates a way to put multiple axes around a single plot.
 
 (This will eventually become a built-in feature of PlotItem)
 
@@ -27,7 +27,7 @@ p1.getAxis('right').linkToView(p2)
 p2.setXLink(p1)
 p1.getAxis('right').setLabel('axis2', color='#0000ff')
 
-## create third ViewBox. 
+## create third ViewBox.
 ## this time we need to create a new axis as well.
 p3 = pg.ViewBox()
 ax3 = pg.AxisItem('right')
@@ -39,13 +39,13 @@ ax3.setZValue(-10000)
 ax3.setLabel('axis 3', color='#ff0000')
 
 
-## Handle view resizing 
+## Handle view resizing
 def updateViews():
     ## view has resized; update auxiliary views to match
     global p1, p2, p3
     p2.setGeometry(p1.vb.sceneBoundingRect())
     p3.setGeometry(p1.vb.sceneBoundingRect())
-    
+
     ## need to re-update linked axes since this was called
     ## incorrectly while views had different shapes.
     ## (probably this should be handled in ViewBox.resizeEvent)

--- a/examples/PlotAutoRange.py
+++ b/examples/PlotAutoRange.py
@@ -31,12 +31,12 @@ p2.setAutoPan(y=True)
 curve = p2.plot()
 def update():
     t = pg.time()
-    
+
     data = np.ones(100) * np.sin(t)
     data[50:60] += np.sin(t)
     global curve
     curve.setData(data)
-    
+
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(50)
@@ -47,4 +47,3 @@ if __name__ == '__main__':
     import sys
     if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
         QtGui.QApplication.instance().exec_()
-

--- a/examples/PlotSpeedTest.py
+++ b/examples/PlotSpeedTest.py
@@ -16,7 +16,7 @@ app = QtGui.QApplication([])
 
 p = pg.plot()
 p.setWindowTitle('pyqtgraph example: PlotSpeedTest')
-p.setRange(QtCore.QRectF(0, -10, 5000, 20)) 
+p.setRange(QtCore.QRectF(0, -10, 5000, 20))
 p.setLabel('bottom', 'Index', units='B')
 curve = p.plot()
 
@@ -47,7 +47,7 @@ def update():
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(0)
-    
+
 
 
 ## Start Qt event loop unless running in interactive mode.

--- a/examples/PlotWidget.py
+++ b/examples/PlotWidget.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Demonstrates use of PlotWidget class. This is little more than a 
+Demonstrates use of PlotWidget class. This is little more than a
 GraphicsView with a PlotItem placed in its center.
 """
 
@@ -53,7 +53,7 @@ def rand(n):
     data[int(n*0.18)] *= 20
     data *= 1e-12
     return data, np.arange(n, n+len(data)) / float(n)
-    
+
 
 def updateData():
     yd, xd = rand(10000)

--- a/examples/Plotting.py
+++ b/examples/Plotting.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 This example demonstrates many of the 2D plotting capabilities
-in pyqtgraph. All of the plots may be panned/scaled by dragging with 
+in pyqtgraph. All of the plots may be panned/scaled by dragging with
 the left/right mouse buttons. Right click on any plot to show a context menu.
 """
 

--- a/examples/ROIExamples.py
+++ b/examples/ROIExamples.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
 Demonstrates a variety of uses for ROI. This class provides a user-adjustable
-region of interest marker. It is possible to customize the layout and 
-function of the scale/rotate handles in very flexible ways. 
+region of interest marker. It is possible to customize the layout and
+function of the scale/rotate handles in very flexible ways.
 """
 
 import initExample ## Add path to library (just for examples; you do not need this)
@@ -61,13 +61,13 @@ rois.append(pg.PolyLineROI([[80, 60], [90, 30], [60, 40]], pen=(6,9), closed=Tru
 def update(roi):
     img1b.setImage(roi.getArrayRegion(arr, img1a), levels=(0, arr.max()))
     v1b.autoRange()
-    
+
 for roi in rois:
     roi.sigRegionChanged.connect(update)
     v1a.addItem(roi)
 
 update(rois[-1])
-    
+
 
 
 text = """User-Modifiable ROIs<br>

--- a/examples/ROItypes.py
+++ b/examples/ROItypes.py
@@ -37,7 +37,7 @@ arr[:, 75] = 5
 arr[50, :] = 10
 arr[:, 50] = 10
 
-## Create image items, add to scene and set position 
+## Create image items, add to scene and set position
 im1 = pg.ImageItem(arr)
 im2 = pg.ImageItem(arr)
 v.addItem(im1)
@@ -82,7 +82,7 @@ def updateRoi(roi):
     arr2 = roi.getArrayRegion(im2.image, img=im2)
     im4.setImage(arr2)
     updateRoiPlot(roi, arr1)
-    
+
 def updateRoiPlot(roi, data=None):
     if data is None:
         data = roi.getArrayRegion(im1.image, img=im1)
@@ -114,8 +114,8 @@ def updateImage():
     updateRoi(lastRoi)
     for r in rois:
         updateRoiPlot(r)
-    
-## Rapidly update one of the images with random noise    
+
+## Rapidly update one of the images with random noise
 t = QtCore.QTimer()
 t.timeout.connect(updateImage)
 t.start(50)

--- a/examples/RemoteGraphicsView.py
+++ b/examples/RemoteGraphicsView.py
@@ -2,7 +2,7 @@
 """
 Very simple example demonstrating RemoteGraphicsView.
 
-This allows graphics to be rendered in a child process and displayed in the 
+This allows graphics to be rendered in a child process and displayed in the
 parent, which can improve CPU usage on multi-core processors.
 """
 import initExample ## Add path to library (just for examples; you do not need this)
@@ -18,7 +18,7 @@ v = RemoteGraphicsView(debug=False)  # setting debug=True causes both processes 
 v.show()
 v.setWindowTitle('pyqtgraph example: RemoteGraphicsView')
 
-## v.pg is a proxy to the remote process' pyqtgraph module. All attribute 
+## v.pg is a proxy to the remote process' pyqtgraph module. All attribute
 ## requests and function calls made with this object are forwarded to the
 ## remote process and executed there. See pyqtgraph.multiprocess.remoteproxy
 ## for more inormation.

--- a/examples/RemoteSpeedTest.py
+++ b/examples/RemoteSpeedTest.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 """
 This example demonstrates the use of RemoteGraphicsView to improve performance in
-applications with heavy load. It works by starting a second process to handle 
+applications with heavy load. It works by starting a second process to handle
 all graphics rendering, thus freeing up the main process to do its work.
 
 In this example, the update() function is very expensive and is called frequently.
 After update() generates a new set of data, it can either plot directly to a local
 plot (bottom) or remotely via a RemoteGraphicsView (top), allowing speed comparison
-between the two cases. IF you have a multi-core CPU, it should be obvious that the 
+between the two cases. IF you have a multi-core CPU, it should be obvious that the
 remote case is much faster.
 """
 
@@ -21,7 +21,7 @@ app = pg.mkQApp()
 
 view = pg.widgets.RemoteGraphicsView.RemoteGraphicsView()
 pg.setConfigOptions(antialias=True)  ## this will be expensive for the local plot
-view.pg.setConfigOptions(antialias=True)  ## prettier plots at no cost to the main process! 
+view.pg.setConfigOptions(antialias=True)  ## prettier plots at no cost to the main process!
 view.setWindowTitle('pyqtgraph example: RemoteSpeedTest')
 
 label = QtGui.QLabel()
@@ -50,22 +50,22 @@ def update():
     global check, label, plt, lastUpdate, avgFps, rpltfunc
     data = np.random.normal(size=(10000,50)).sum(axis=1)
     data += 5 * np.sin(np.linspace(0, 10, data.shape[0]))
-    
+
     if rcheck.isChecked():
         rplt.plot(data, clear=True, _callSync='off')  ## We do not expect a return value.
                                                       ## By turning off callSync, we tell
-                                                      ## the proxy that it does not need to 
+                                                      ## the proxy that it does not need to
                                                       ## wait for a reply from the remote
                                                       ## process.
     if lcheck.isChecked():
         lplt.plot(data, clear=True)
-        
+
     now = pg.ptime.time()
     fps = 1.0 / (now - lastUpdate)
     lastUpdate = now
     avgFps = avgFps * 0.8 + fps * 0.2
     label.setText("Generating %0.2f fps" % avgFps)
-        
+
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(0)

--- a/examples/ScatterPlot.py
+++ b/examples/ScatterPlot.py
@@ -32,8 +32,8 @@ print("Generating data, this takes a few seconds...")
 ## There are a few different ways we can draw scatter plots; each is optimized for different types of data:
 
 
-## 1) All spots identical and transform-invariant (top-left plot). 
-## In this case we can get a huge performance boost by pre-rendering the spot 
+## 1) All spots identical and transform-invariant (top-left plot).
+## In this case we can get a huge performance boost by pre-rendering the spot
 ## image and just drawing that image repeatedly.
 
 n = 300
@@ -57,9 +57,9 @@ s1.sigClicked.connect(clicked)
 
 
 
-## 2) Spots are transform-invariant, but not identical (top-right plot). 
-## In this case, drawing is almsot as fast as 1), but there is more startup 
-## overhead and memory usage since each spot generates its own pre-rendered 
+## 2) Spots are transform-invariant, but not identical (top-right plot).
+## In this case, drawing is almsot as fast as 1), but there is more startup
+## overhead and memory usage since each spot generates its own pre-rendered
 ## image.
 
 s2 = pg.ScatterPlotItem(size=10, pen=pg.mkPen('w'), pxMode=True)
@@ -70,8 +70,8 @@ w2.addItem(s2)
 s2.sigClicked.connect(clicked)
 
 
-## 3) Spots are not transform-invariant, not identical (bottom-left). 
-## This is the slowest case, since all spots must be completely re-drawn 
+## 3) Spots are not transform-invariant, not identical (bottom-left).
+## This is the slowest case, since all spots must be completely re-drawn
 ## every time because their apparent transformation may have changed.
 
 s3 = pg.ScatterPlotItem(pxMode=False)   ## Set pxMode=False to allow spots to transform with the view
@@ -99,4 +99,3 @@ if __name__ == '__main__':
     import sys
     if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
         QtGui.QApplication.instance().exec_()
-

--- a/examples/ScatterPlotSpeedTest.py
+++ b/examples/ScatterPlotSpeedTest.py
@@ -48,8 +48,8 @@ def update():
         size = sizeArray
     else:
         size = ui.sizeSpin.value()
-    curve = pg.ScatterPlotItem(x=data[ptr%50], y=data[(ptr+1)%50], 
-                               pen='w', brush='b', size=size, 
+    curve = pg.ScatterPlotItem(x=data[ptr%50], y=data[(ptr+1)%50],
+                               pen='w', brush='b', size=size,
                                pxMode=ui.pixelModeCheck.isChecked())
     p.addItem(curve)
     ptr += 1
@@ -67,7 +67,7 @@ def update():
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(0)
-    
+
 
 
 ## Start Qt event loop unless running in interactive mode.

--- a/examples/ScatterPlotWidget.py
+++ b/examples/ScatterPlotWidget.py
@@ -6,11 +6,11 @@ The widget consists of four components:
 
 1) A list of column names from which the user may select 1 or 2 columns
     to plot. If one column is selected, the data for that column will be
-    plotted in a histogram-like manner by using pg.pseudoScatter(). 
+    plotted in a histogram-like manner by using pg.pseudoScatter().
     If two columns are selected, then the
     scatter plot will be generated with x determined by the first column
     that was selected and y by the second.
-2) A DataFilter that allows the user to select a subset of the data by 
+2) A DataFilter that allows the user to select a subset of the data by
     specifying multiple selection criteria.
 3) A ColorMap that allows the user to determine how points are colored by
     specifying multiple criteria.
@@ -26,8 +26,8 @@ import numpy as np
 pg.mkQApp()
 
 # Make up some tabular data with structure
-data = np.empty(1000, dtype=[('x_pos', float), ('y_pos', float), 
-                             ('count', int), ('amplitude', float), 
+data = np.empty(1000, dtype=[('x_pos', float), ('y_pos', float),
+                             ('count', int), ('amplitude', float),
                              ('decay', float), ('type', 'S10')])
 strings = ['Type-A', 'Type-B', 'Type-C', 'Type-D', 'Type-E']
 typeInds = np.random.randint(5, size=1000)
@@ -55,10 +55,10 @@ spw.setFields([
     ('y_pos', {'units': 'm'}),
     ('count', {}),
     ('amplitude', {'units': 'V'}),
-    ('decay', {'units': 's'}),    
+    ('decay', {'units': 's'}),
     ('type', {'mode': 'enum', 'values': strings}),
     ])
-    
+
 spw.setData(data)
 spw.show()
 

--- a/examples/SpinBox.py
+++ b/examples/SpinBox.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-This example demonstrates the SpinBox widget, which is an extension of 
+This example demonstrates the SpinBox widget, which is an extension of
 QDoubleSpinBox providing some advanced features:
 
   * SI-prefixed units
@@ -19,17 +19,17 @@ app = QtGui.QApplication([])
 
 
 spins = [
-    ("Floating-point spin box, min=0, no maximum.", 
+    ("Floating-point spin box, min=0, no maximum.",
      pg.SpinBox(value=5.0, bounds=[0, None])),
-    ("Integer spin box, dec stepping<br>(1-9, 10-90, 100-900, etc), decimals=4", 
+    ("Integer spin box, dec stepping<br>(1-9, 10-90, 100-900, etc), decimals=4",
      pg.SpinBox(value=10, int=True, dec=True, minStep=1, step=1, decimals=4)),
-    ("Float with SI-prefixed units<br>(n, u, m, k, M, etc)", 
+    ("Float with SI-prefixed units<br>(n, u, m, k, M, etc)",
      pg.SpinBox(value=0.9, suffix='V', siPrefix=True)),
-    ("Float with SI-prefixed units,<br>dec step=0.1, minStep=0.1", 
+    ("Float with SI-prefixed units,<br>dec step=0.1, minStep=0.1",
      pg.SpinBox(value=1.0, suffix='V', siPrefix=True, dec=True, step=0.1, minStep=0.1)),
-    ("Float with SI-prefixed units,<br>dec step=0.5, minStep=0.01", 
+    ("Float with SI-prefixed units,<br>dec step=0.5, minStep=0.01",
      pg.SpinBox(value=1.0, suffix='V', siPrefix=True, dec=True, step=0.5, minStep=0.01)),
-    ("Float with SI-prefixed units,<br>dec step=1.0, minStep=0.001", 
+    ("Float with SI-prefixed units,<br>dec step=1.0, minStep=0.001",
      pg.SpinBox(value=1.0, suffix='V', siPrefix=True, dec=True, step=1.0, minStep=0.001)),
 ]
 
@@ -59,7 +59,7 @@ def valueChanged(sb):
 def valueChanging(sb, value):
     changingLabel.setText("Value changing: %s" % str(sb.value()))
 
-    
+
 for text, spin in spins:
     label = QtGui.QLabel(text)
     labels.append(label)

--- a/examples/TableWidget.py
+++ b/examples/TableWidget.py
@@ -16,14 +16,14 @@ w.show()
 w.resize(500,500)
 w.setWindowTitle('pyqtgraph example: TableWidget')
 
-    
+
 data = np.array([
     (1,   1.6,   'x'),
     (3,   5.4,   'y'),
     (8,   12.5,  'z'),
     (443, 1e-12, 'w'),
     ], dtype=[('Column 1', int), ('Column 2', float), ('Column 3', object)])
-    
+
 w.setData(data)
 
 

--- a/examples/VideoSpeedTest.py
+++ b/examples/VideoSpeedTest.py
@@ -21,7 +21,7 @@ elif USE_PYQT5:
     import VideoTemplate_pyqt5 as VideoTemplate
 else:
     import VideoTemplate_pyqt as VideoTemplate
-    
+
 
 #QtGui.QApplication.setGraphicsSystem('raster')
 app = QtGui.QApplication([])
@@ -69,7 +69,7 @@ def updateScale():
         for s in spins[2:]:
             s.setEnabled(False)
 ui.rgbLevelsCheck.toggled.connect(updateScale)
-    
+
 cache = {}
 def mkData():
     with pg.BusyCursor():
@@ -93,7 +93,7 @@ def mkData():
                 dt = np.float
                 loc = 1.0
                 scale = 0.1
-            
+
             if ui.rgbCheck.isChecked():
                 data = np.random.normal(size=(frames,width,height,3), loc=loc, scale=scale)
                 data = pg.gaussianFilter(data, (0, 6, 6, 0))
@@ -104,7 +104,7 @@ def mkData():
                 data = np.clip(data, 0, mx)
             data = data.astype(dt)
             cache = {dtype: data} # clear to save memory (but keep one to prevent unnecessary regeneration)
-            
+
         data = cache[dtype]
         updateLUT()
         updateSize()
@@ -117,7 +117,7 @@ def updateSize():
     dtype = np.dtype(str(ui.dtypeCombo.currentText()))
     rgb = 3 if ui.rgbCheck.isChecked() else 1
     ui.sizeLabel.setText('%d MB' % (frames * width * height * rgb * dtype.itemsize / 1e6))
-    
+
 
 mkData()
 
@@ -143,14 +143,14 @@ def update():
         useLut = LUT
     else:
         useLut = None
-        
+
     downsample = ui.downsampleCheck.isChecked()
 
     if ui.scaleCheck.isChecked():
         if ui.rgbLevelsCheck.isChecked():
             useScale = [
-                [ui.minSpin1.value(), ui.maxSpin1.value()], 
-                [ui.minSpin2.value(), ui.maxSpin2.value()], 
+                [ui.minSpin1.value(), ui.maxSpin1.value()],
+                [ui.minSpin2.value(), ui.maxSpin2.value()],
                 [ui.minSpin3.value(), ui.maxSpin3.value()]]
         else:
             useScale = [ui.minSpin1.value(), ui.maxSpin1.value()]
@@ -167,7 +167,7 @@ def update():
         img.setImage(data[ptr%data.shape[0]], autoLevels=False, levels=useScale, lut=useLut, autoDownsample=downsample)
         ui.stack.setCurrentIndex(0)
         #img.setImage(data[ptr%data.shape[0]], autoRange=False)
-        
+
     ptr += 1
     now = ptime.time()
     dt = now - lastTime
@@ -182,7 +182,7 @@ def update():
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(0)
-    
+
 
 
 ## Start Qt event loop unless running in interactive mode or using pyside.

--- a/examples/ViewBox.py
+++ b/examples/ViewBox.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
-ViewBox is the general-purpose graphical container that allows the user to 
-zoom / pan to inspect any area of a 2D coordinate system. 
+ViewBox is the general-purpose graphical container that allows the user to
+zoom / pan to inspect any area of a 2D coordinate system.
 
 This unimaginative example demonstrates the constrution of a ViewBox-based
 plot area with axes, very similar to the way PlotItem is built.
@@ -52,10 +52,10 @@ class movableRect(QtGui.QGraphicsRectItem):
             ev.accept()
             self.pressDelta = self.mapToParent(ev.pos()) - self.pos()
         else:
-            ev.ignore()     
+            ev.ignore()
     def mouseMoveEvent(self, ev):
         self.setPos(self.mapToParent(ev.pos()) - self.pressDelta)
-        
+
 rect = movableRect(QtCore.QRectF(0, 0, 1, 1))
 rect.setPen(pg.mkPen(100, 200, 100))
 vb.addItem(rect)
@@ -79,7 +79,7 @@ def rand(n):
     data[int(n*0.1):int(n*0.13)] *= 5
     data[int(n*0.18)] *= 20
     return data, np.arange(n, n+len(data)) / float(n)
-    
+
 
 def updateData():
     yd, xd = rand(10000)

--- a/examples/ViewBoxFeatures.py
+++ b/examples/ViewBoxFeatures.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-ViewBox is the general-purpose graphical container that allows the user to 
-zoom / pan to inspect any area of a 2D coordinate system. 
+ViewBox is the general-purpose graphical container that allows the user to
+zoom / pan to inspect any area of a 2D coordinate system.
 
 This example demonstrates many of the features ViewBox provides.
 """
@@ -14,7 +14,7 @@ import numpy as np
 
 x = np.arange(1000, dtype=float)
 y = np.random.normal(size=1000)
-y += 5 * np.sin(x/100) 
+y += 5 * np.sin(x/100)
 
 win = pg.GraphicsWindow()
 win.setWindowTitle('pyqtgraph example: ____')
@@ -51,8 +51,8 @@ sub4 = win.addLayout()
 sub4.addLabel("<b>View limits:</b><br>prevent panning or zooming past limits.")
 sub4.nextRow()
 v4 = sub4.addViewBox()
-v4.setLimits(xMin=-100, xMax=1100, 
-             minXRange=20, maxXRange=500, 
+v4.setLimits(xMin=-100, xMax=1100,
+             minXRange=20, maxXRange=500,
              yMin=-10, yMax=10,
              minYRange=1, maxYRange=10)
 l4 = pg.PlotDataItem(y)

--- a/examples/__main__.py
+++ b/examples/__main__.py
@@ -120,11 +120,11 @@ def run():
 if __name__ == '__main__':
 
     args = sys.argv[1:]
-        
+
     if '--test' in args:
         # get rid of orphaned cache files first
         pg.renamePyc(path)
-        
+
         files = buildFileList(examples)
         if '--pyside' in args:
             lib = 'PySide'
@@ -134,10 +134,10 @@ if __name__ == '__main__':
             lib = 'PyQt5'
         else:
             lib = ''
-            
+
         exe = sys.executable
         print("Running tests:", lib, sys.executable)
         for f in files:
             testFile(f[0], f[1], exe, lib)
-    else: 
+    else:
         run()

--- a/examples/contextMenu.py
+++ b/examples/contextMenu.py
@@ -3,9 +3,9 @@
 Demonstrates adding a custom context menu to a GraphicsItem
 and extending the context menu of a ViewBox.
 
-PyQtGraph implements a system that allows each item in a scene to implement its 
-own context menu, and for the menus of its parent items to be automatically 
-displayed as well. 
+PyQtGraph implements a system that allows each item in a scene to implement its
+own context menu, and for the menus of its parent items to be automatically
+displayed as well.
 
 """
 import initExample ## Add path to library (just for examples; you do not need this)
@@ -41,30 +41,30 @@ class MenuBox(pg.GraphicsObject):
     """
     This class draws a rectangular area. Right-clicking inside the area will
     raise a custom context menu which also includes the context menus of
-    its parents.    
+    its parents.
     """
     def __init__(self, name):
         self.name = name
         self.pen = pg.mkPen('r')
-        
+
         # menu creation is deferred because it is expensive and often
         # the user will never see the menu anyway.
         self.menu = None
-        
-        # note that the use of super() is often avoided because Qt does not 
-        # allow to inherit from multiple QObject subclasses.
-        pg.GraphicsObject.__init__(self) 
 
-    
+        # note that the use of super() is often avoided because Qt does not
+        # allow to inherit from multiple QObject subclasses.
+        pg.GraphicsObject.__init__(self)
+
+
     # All graphics items must have paint() and boundingRect() defined.
     def boundingRect(self):
         return QtCore.QRectF(0, 0, 10, 10)
-    
+
     def paint(self, p, *args):
         p.setPen(self.pen)
         p.drawRect(self.boundingRect())
-    
-    
+
+
     # On right-click, raise the context menu
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.RightButton:
@@ -73,11 +73,11 @@ class MenuBox(pg.GraphicsObject):
 
     def raiseContextMenu(self, ev):
         menu = self.getContextMenus()
-        
+
         # Let the scene add on to the end of our context menu
         # (this is optional)
         menu = self.scene().addParentContextMenus(self, menu, ev)
-        
+
         pos = ev.screenPos()
         menu.popup(QtCore.QPoint(pos.x(), pos.y()))
         return True
@@ -88,17 +88,17 @@ class MenuBox(pg.GraphicsObject):
         if self.menu is None:
             self.menu = QtGui.QMenu()
             self.menu.setTitle(self.name+ " options..")
-            
+
             green = QtGui.QAction("Turn green", self.menu)
             green.triggered.connect(self.setGreen)
             self.menu.addAction(green)
             self.menu.green = green
-            
+
             blue = QtGui.QAction("Turn blue", self.menu)
             blue.triggered.connect(self.setBlue)
             self.menu.addAction(blue)
             self.menu.green = blue
-            
+
             alpha = QtGui.QWidgetAction(self.menu)
             alphaSlider = QtGui.QSlider()
             alphaSlider.setOrientation(QtCore.Qt.Horizontal)

--- a/examples/crosshair.py
+++ b/examples/crosshair.py
@@ -1,5 +1,5 @@
 """
-Demonstrates some customized mouse interaction by drawing a crosshair that follows 
+Demonstrates some customized mouse interaction by drawing a crosshair that follows
 the mouse.
 
 
@@ -22,7 +22,7 @@ p2 = win.addPlot(row=2, col=0)
 
 region = pg.LinearRegionItem()
 region.setZValue(10)
-# Add the LinearRegionItem to the ViewBox, but tell the ViewBox to exclude this 
+# Add the LinearRegionItem to the ViewBox, but tell the ViewBox to exclude this
 # item when doing auto-range calculations.
 p2.addItem(region, ignoreBounds=True)
 
@@ -43,7 +43,7 @@ p2.plot(data1, pen="w")
 def update():
     region.setZValue(10)
     minX, maxX = region.getRegion()
-    p1.setXRange(minX, maxX, padding=0)    
+    p1.setXRange(minX, maxX, padding=0)
 
 region.sigRegionChanged.connect(update)
 

--- a/examples/customGraphicsItem.py
+++ b/examples/customGraphicsItem.py
@@ -8,16 +8,16 @@ import pyqtgraph as pg
 from pyqtgraph import QtCore, QtGui
 
 ## Create a subclass of GraphicsObject.
-## The only required methods are paint() and boundingRect() 
+## The only required methods are paint() and boundingRect()
 ## (see QGraphicsItem documentation)
 class CandlestickItem(pg.GraphicsObject):
     def __init__(self, data):
         pg.GraphicsObject.__init__(self)
         self.data = data  ## data must have fields: time, open, close, min, max
         self.generatePicture()
-    
+
     def generatePicture(self):
-        ## pre-computing a QPicture object allows paint() to run much more quickly, 
+        ## pre-computing a QPicture object allows paint() to run much more quickly,
         ## rather than re-drawing the shapes every time.
         self.picture = QtGui.QPicture()
         p = QtGui.QPainter(self.picture)
@@ -31,10 +31,10 @@ class CandlestickItem(pg.GraphicsObject):
                 p.setBrush(pg.mkBrush('g'))
             p.drawRect(QtCore.QRectF(t-w, open, w*2, close-open))
         p.end()
-    
+
     def paint(self, p, *args):
         p.drawPicture(0, 0, self.picture)
-    
+
     def boundingRect(self):
         ## boundingRect _must_ indicate the entire area that will be drawn on
         ## or else we will get artifacts and possibly crashing.

--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 This example demonstrates the creation of a plot with a customized
-AxisItem and ViewBox. 
+AxisItem and ViewBox.
 """
 
 
@@ -50,12 +50,12 @@ class CustomViewBox(pg.ViewBox):
     def __init__(self, *args, **kwds):
         pg.ViewBox.__init__(self, *args, **kwds)
         self.setMouseMode(self.RectMode)
-        
+
     ## reimplement right-click to zoom out
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.RightButton:
             self.autoRange()
-            
+
     def mouseDragEvent(self, ev):
         if ev.button() == QtCore.Qt.RightButton:
             ev.ignore()

--- a/examples/cx_freeze/plotTest.py
+++ b/examples/cx_freeze/plotTest.py
@@ -2,7 +2,7 @@ import sys
 from PyQt4 import QtGui
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems import TextItem
-# For packages that require scipy, these may be needed: 
+# For packages that require scipy, these may be needed:
 #   from scipy.stats import futil
 #   from scipy.sparse.csgraph import _validation
 
@@ -13,7 +13,7 @@ app = QtGui.QApplication(sys.argv)
 
 pw = pg.plot(x = [0, 1, 2, 4], y = [4, 5, 9, 6])
 pw.showGrid(x=True,y=True)
-text = pg.TextItem(html='<div style="text-align: center"><span style="color: #000000;"> %s</span></div>' % "here",anchor=(0.0, 0.0)) 
+text = pg.TextItem(html='<div style="text-align: center"><span style="color: #000000;"> %s</span></div>' % "here",anchor=(0.0, 0.0))
 text.setPos(1.0, 5.0)
 pw.addItem(text)
 status = app.exec_()

--- a/examples/cx_freeze/setup.py
+++ b/examples/cx_freeze/setup.py
@@ -32,5 +32,3 @@ setup(name = "cx_freeze plot test",
       description = "cx_freeze plot test",
       options = {"build_exe": build_exe_options},
       executables = [Executable("plotTest.py", base=base)])
-
-

--- a/examples/designerExample.py
+++ b/examples/designerExample.py
@@ -3,7 +3,7 @@
 Simple example of loading UI template created with Qt Designer.
 
 This example uses uic.loadUiType to parse and load the ui at runtime. It is also
-possible to pre-compile the .ui file using pyuic (see VideoSpeedTest and 
+possible to pre-compile the .ui file using pyuic (see VideoSpeedTest and
 ScatterPlotSpeedTest examples; these .ui files have been compiled with the
 tools/rebuildUi.py script).
 """
@@ -21,21 +21,21 @@ path = os.path.dirname(os.path.abspath(__file__))
 uiFile = os.path.join(path, 'designerExample.ui')
 WindowTemplate, TemplateBaseClass = pg.Qt.loadUiType(uiFile)
 
-class MainWindow(TemplateBaseClass):  
+class MainWindow(TemplateBaseClass):
     def __init__(self):
         TemplateBaseClass.__init__(self)
         self.setWindowTitle('pyqtgraph example: Qt Designer')
-        
+
         # Create the main window
         self.ui = WindowTemplate()
         self.ui.setupUi(self)
         self.ui.plotBtn.clicked.connect(self.plot)
-        
+
         self.show()
-        
+
     def plot(self):
         self.ui.plot.plot(np.random.normal(size=100), clear=True)
-        
+
 win = MainWindow()
 
 

--- a/examples/dockarea.py
+++ b/examples/dockarea.py
@@ -4,11 +4,11 @@ This example demonstrates the use of pyqtgraph's dock widget system.
 
 The dockarea system allows the design of user interfaces which can be rearranged by
 the user at runtime. Docks can be moved, resized, stacked, and torn out of the main
-window. This is similar in principle to the docking system built into Qt, but 
-offers a more deterministic dock placement API (in Qt it is very difficult to 
-programatically generate complex dock arrangements). Additionally, Qt's docks are 
-designed to be used as small panels around the outer edge of a window. Pyqtgraph's 
-docks were created with the notion that the entire window (or any portion of it) 
+window. This is similar in principle to the docking system built into Qt, but
+offers a more deterministic dock placement API (in Qt it is very difficult to
+programatically generate complex dock arrangements). Additionally, Qt's docks are
+designed to be used as small panels around the outer edge of a window. Pyqtgraph's
+docks were created with the notion that the entire window (or any portion of it)
 would consist of dockable components.
 
 """
@@ -57,9 +57,9 @@ area.moveDock(d5, 'top', d2)     ## move d5 to top edge of d2
 
 ## first dock gets save/restore buttons
 w1 = pg.LayoutWidget()
-label = QtGui.QLabel(""" -- DockArea Example -- 
+label = QtGui.QLabel(""" -- DockArea Example --
 This window has 6 Dock widgets in it. Each dock can be dragged
-by its title bar to occupy a different space within the window 
+by its title bar to occupy a different space within the window
 but note that one dock has its title bar hidden). Additionally,
 the borders between docks may be dragged to resize. Docks that are dragged on top
 of one another are stacked in a tabbed layout. Double-click a dock title

--- a/examples/exampleLoaderTemplate_pyqt.py
+++ b/examples/exampleLoaderTemplate_pyqt.py
@@ -103,4 +103,3 @@ class Ui_Form(object):
         self.label_2.setText(_translate("Form", "Graphics System:", None))
         self.label.setText(_translate("Form", "Qt Library:", None))
         self.loadBtn.setText(_translate("Form", "Run Example", None))
-

--- a/examples/exampleLoaderTemplate_pyqt5.py
+++ b/examples/exampleLoaderTemplate_pyqt5.py
@@ -90,4 +90,3 @@ class Ui_Form(object):
         self.label_2.setText(_translate("Form", "Graphics System:"))
         self.label.setText(_translate("Form", "Qt Library:"))
         self.loadBtn.setText(_translate("Form", "Run Example"))
-

--- a/examples/exampleLoaderTemplate_pyside.py
+++ b/examples/exampleLoaderTemplate_pyside.py
@@ -89,4 +89,3 @@ class Ui_Form(object):
         self.label_2.setText(QtGui.QApplication.translate("Form", "Graphics System:", None, QtGui.QApplication.UnicodeUTF8))
         self.label.setText(QtGui.QApplication.translate("Form", "Qt Library:", None, QtGui.QApplication.UnicodeUTF8))
         self.loadBtn.setText(QtGui.QApplication.translate("Form", "Run Example", None, QtGui.QApplication.UnicodeUTF8))
-

--- a/examples/hdf5.py
+++ b/examples/hdf5.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 """
-In this example we create a subclass of PlotCurveItem for displaying a very large 
-data set from an HDF5 file that does not fit in memory. 
+In this example we create a subclass of PlotCurveItem for displaying a very large
+data set from an HDF5 file that does not fit in memory.
 
 The basic approach is to override PlotCurveItem.viewRangeChanged such that it
 reads only the portion of the HDF5 data that is necessary to display the visible
-portion of the data. This is further downsampled to reduce the number of samples 
+portion of the data. This is further downsampled to reduce the number of samples
 being displayed.
 
-A more clever implementation of this class would employ some kind of caching 
+A more clever implementation of this class would employ some kind of caching
 to avoid re-reading the entire visible waveform at every update.
 """
 
@@ -33,79 +33,79 @@ class HDF5Plot(pg.PlotCurveItem):
         self.hdf5 = None
         self.limit = 10000 # maximum number of samples to be plotted
         pg.PlotCurveItem.__init__(self, *args, **kwds)
-        
+
     def setHDF5(self, data):
         self.hdf5 = data
         self.updateHDF5Plot()
-        
+
     def viewRangeChanged(self):
         self.updateHDF5Plot()
-        
+
     def updateHDF5Plot(self):
         if self.hdf5 is None:
             self.setData([])
             return
-        
+
         vb = self.getViewBox()
         if vb is None:
             return  # no ViewBox yet
-        
+
         # Determine what data range must be read from HDF5
         xrange = vb.viewRange()[0]
         start = max(0,int(xrange[0])-1)
         stop = min(len(self.hdf5), int(xrange[1]+2))
-        
-        # Decide by how much we should downsample 
+
+        # Decide by how much we should downsample
         ds = int((stop-start) / self.limit) + 1
-        
+
         if ds == 1:
             # Small enough to display with no intervention.
             visible = self.hdf5[start:stop]
             scale = 1
         else:
             # Here convert data into a down-sampled array suitable for visualizing.
-            # Must do this piecewise to limit memory usage.        
+            # Must do this piecewise to limit memory usage.
             samples = 1 + ((stop-start) // ds)
             visible = np.zeros(samples*2, dtype=self.hdf5.dtype)
             sourcePtr = start
             targetPtr = 0
-            
+
             # read data in chunks of ~1M samples
             chunkSize = (1000000//ds) * ds
-            while sourcePtr < stop-1: 
+            while sourcePtr < stop-1:
                 chunk = self.hdf5[sourcePtr:min(stop,sourcePtr+chunkSize)]
                 sourcePtr += len(chunk)
-                
+
                 # reshape chunk to be integral multiple of ds
                 chunk = chunk[:(len(chunk)//ds) * ds].reshape(len(chunk)//ds, ds)
-                
+
                 # compute max and min
                 chunkMax = chunk.max(axis=1)
                 chunkMin = chunk.min(axis=1)
-                
+
                 # interleave min and max into plot data to preserve envelope shape
                 visible[targetPtr:targetPtr+chunk.shape[0]*2:2] = chunkMin
                 visible[1+targetPtr:1+targetPtr+chunk.shape[0]*2:2] = chunkMax
                 targetPtr += chunk.shape[0]*2
-            
+
             visible = visible[:targetPtr]
             scale = ds * 0.5
-            
+
         self.setData(visible) # update the plot
         self.setPos(start, 0) # shift to match starting index
         self.resetTransform()
         self.scale(scale, 1)  # scale to match downsampling
 
-        
+
 
 
 def createFile(finalSize=2000000000):
     """Create a large HDF5 data file for testing.
     Data consists of 1M random samples tiled through the end of the array.
     """
-    
+
     chunk = np.random.normal(size=1000000).astype(np.float32)
-    
+
     f = h5py.File('test.hdf5', 'w')
     f.create_dataset('data', data=chunk, chunks=True, maxshape=(None,))
     data = f['data']
@@ -123,7 +123,7 @@ def createFile(finalSize=2000000000):
                 sys.exit()
         dlg += 1
     f.close()
-    
+
 if len(sys.argv) > 1:
     fileName = sys.argv[1]
 else:
@@ -144,12 +144,8 @@ plt.addItem(curve)
 
 ## Start Qt event loop unless running in interactive mode or using pyside.
 if __name__ == '__main__':
-    
-    
+
+
     import sys
     if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
         QtGui.QApplication.instance().exec_()
-
-
-
-

--- a/examples/imageAnalysis.py
+++ b/examples/imageAnalysis.py
@@ -72,7 +72,7 @@ img.scale(0.2, 0.2)
 img.translate(-50, 0)
 
 # zoom to fit imageo
-p1.autoRange()  
+p1.autoRange()
 
 
 # Callbacks for handling user interaction

--- a/examples/initExample.py
+++ b/examples/initExample.py
@@ -20,17 +20,17 @@ if not hasattr(sys, 'frozen'):
                 sys.path.insert(0, p)
 
 ## should force example to use PySide instead of PyQt
-if 'pyside' in sys.argv:  
+if 'pyside' in sys.argv:
     from PySide import QtGui
-elif 'pyqt' in sys.argv: 
+elif 'pyqt' in sys.argv:
     from PyQt4 import QtGui
-elif 'pyqt5' in sys.argv: 
+elif 'pyqt5' in sys.argv:
     from PyQt5 import QtGui
 else:
     from pyqtgraph.Qt import QtGui
 
-import pyqtgraph as pg    
-    
+import pyqtgraph as pg
+
 ## Force use of a specific graphics system
 use_gs = 'default'
 for gs in ['raster', 'native', 'opengl']:
@@ -41,7 +41,7 @@ for gs in ['raster', 'native', 'opengl']:
 
 print("Using %s (%s graphics system)" % (pg.Qt.QT_LIB, use_gs))
 
-## Enable fault handling to give more helpful error messages on crash. 
+## Enable fault handling to give more helpful error messages on crash.
 ## Only available in python 3.3+
 try:
     import faulthandler

--- a/examples/isocurve.py
+++ b/examples/isocurve.py
@@ -52,7 +52,7 @@ def update():
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(50)
-    
+
 ## Start Qt event loop unless running in interactive mode or using pyside.
 if __name__ == '__main__':
     import sys

--- a/examples/linkedViews.py
+++ b/examples/linkedViews.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 This example demonstrates the ability to link the axes of views together
-Views can be linked manually using the context menu, but only if they are given 
+Views can be linked manually using the context menu, but only if they are given
 names.
 """
 
@@ -47,4 +47,3 @@ if __name__ == '__main__':
     import sys
     if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
         QtGui.QApplication.instance().exec_()
-

--- a/examples/multiplePlotSpeedTest.py
+++ b/examples/multiplePlotSpeedTest.py
@@ -11,7 +11,7 @@ plt = pg.PlotWidget()
 app.processEvents()
 
 ## Putting this at the beginning or end does not have much effect
-plt.show()   
+plt.show()
 
 ## The auto-range is recomputed after each item is added,
 ## so disabling it before plotting helps
@@ -25,19 +25,19 @@ def plot():
     y = np.random.random(size=pts)*0.8
     for i in range(n):
         for j in range(n):
-            ## calling PlotWidget.plot() generates a PlotDataItem, which 
-            ## has a bit more overhead than PlotCurveItem, which is all 
+            ## calling PlotWidget.plot() generates a PlotDataItem, which
+            ## has a bit more overhead than PlotCurveItem, which is all
             ## we need here. This overhead adds up quickly and makes a big
             ## difference in speed.
-            
+
             #plt.plot(x=x+i, y=y+j)
             plt.addItem(pg.PlotCurveItem(x=x+i, y=y+j))
-            
+
             #path = pg.arrayToQPath(x+i, y+j)
             #item = QtGui.QGraphicsPathItem(path)
             #item.setPen(pg.mkPen('w'))
             #plt.addItem(item)
-            
+
     dt = pg.ptime.time() - start
     print("Create plots took: %0.3fms" % (dt*1000))
 
@@ -70,7 +70,7 @@ def fastPlot():
     item = QtGui.QGraphicsPathItem(path)
     item.setPen(pg.mkPen('w'))
     plt.addItem(item)
-    
+
     dt = pg.ptime.time() - start
     print("Create plots took: %0.3fms" % (dt*1000))
 

--- a/examples/optics_demos.py
+++ b/examples/optics_demos.py
@@ -46,7 +46,7 @@ for y in np.linspace(-10, 10, 21):
 
 for o in optics:
     view.addItem(o)
-    
+
 t1 = Tracer(allRays, optics)
 
 
@@ -130,14 +130,14 @@ IROptics2 = [m1a, m2a, l3a, l4a, obja]
 
 for o in set(IROptics+IROptics2):
     view.addItem(o)
-    
+
 IRRays = []
 IRRays2 = []
 
 for dy in [-0.4, -0.15, 0, 0.15, 0.4]:
     IRRays.append(Ray(start=Point(-50, dy), dir=(1, 0), wl=780))
     IRRays2.append(Ray(start=Point(-50, dy+2*scany), dir=(1, 0), wl=780))
-    
+
 for r in set(IRRays+IRRays2):
     view.addItem(r)
 
@@ -154,7 +154,7 @@ def update():
         m2['angle'] = 135 + 1.5*np.sin(phase)
         m2a['angle'] = 135 + 1.5*np.sin(phase)
     phase += 0.2
-    
+
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(40)

--- a/examples/parallelize.py
+++ b/examples/parallelize.py
@@ -9,7 +9,7 @@ from pyqtgraph.python2_3 import xrange
 
 print( "\n=================\nParallelize")
 
-## Do a simple task: 
+## Do a simple task:
 ##   for x in range(N):
 ##      sum([x*i for i in range(M)])
 ##
@@ -62,4 +62,3 @@ with mp.Parallelize(enumerate(tasks), results=results3, progressDialog='processi
         tasker.results[i] = tot
 print( "\nParallel time, %d workers: %0.2f" % (mp.Parallelize.suggestedWorkerCount(), time.time() - start))
 print( "Results match serial:      %s" % str(results3 == results))
-

--- a/examples/parametertree.py
+++ b/examples/parametertree.py
@@ -26,14 +26,14 @@ class ComplexParameter(pTypes.GroupParameter):
         opts['type'] = 'bool'
         opts['value'] = True
         pTypes.GroupParameter.__init__(self, **opts)
-        
+
         self.addChild({'name': 'A = 1/B', 'type': 'float', 'value': 7, 'suffix': 'Hz', 'siPrefix': True})
         self.addChild({'name': 'B = 1/A', 'type': 'float', 'value': 1/7., 'suffix': 's', 'siPrefix': True})
         self.a = self.param('A = 1/B')
         self.b = self.param('B = 1/A')
         self.a.sigValueChanged.connect(self.aChanged)
         self.b.sigValueChanged.connect(self.bChanged)
-        
+
     def aChanged(self):
         self.b.setValue(1.0 / self.a.value(), blockSignal=self.bChanged)
 
@@ -49,7 +49,7 @@ class ScalableGroup(pTypes.GroupParameter):
         opts['addText'] = "Add"
         opts['addList'] = ['str', 'float', 'int']
         pTypes.GroupParameter.__init__(self, **opts)
-    
+
     def addNew(self, typ):
         val = {
             'str': '',
@@ -82,7 +82,7 @@ params = [
         {'name': 'Units + SI prefix', 'type': 'float', 'value': 1.2e-6, 'step': 1e-6, 'siPrefix': True, 'suffix': 'V'},
         {'name': 'Limits (min=7;max=15)', 'type': 'int', 'value': 11, 'limits': (7, 15), 'default': -6},
         {'name': 'DEC stepping', 'type': 'float', 'value': 1.2e6, 'dec': True, 'step': 1, 'siPrefix': True, 'suffix': 'Hz'},
-        
+
     ]},
     {'name': 'Save/Restore functionality', 'type': 'group', 'children': [
         {'name': 'Save State', 'type': 'action'},
@@ -119,25 +119,25 @@ def change(param, changes):
         print('  change:    %s'% change)
         print('  data:      %s'% str(data))
         print('  ----------')
-    
+
 p.sigTreeStateChanged.connect(change)
 
 
 def valueChanging(param, value):
     print("Value changing (not finalized): %s %s" % (param, value))
-    
+
 # Too lazy for recursion:
 for child in p.children():
     child.sigValueChanging.connect(valueChanging)
     for ch2 in child.children():
         ch2.sigValueChanging.connect(valueChanging)
-        
+
 
 
 def save():
     global state
     state = p.saveState()
-    
+
 def restore():
     global state
     add = p['Save/Restore functionality', 'Restore State', 'Add missing items']

--- a/examples/py2exe/plotTest.py
+++ b/examples/py2exe/plotTest.py
@@ -2,7 +2,7 @@ import sys
 from PyQt4 import QtGui
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems import TextItem
-# For packages that require scipy, these may be needed: 
+# For packages that require scipy, these may be needed:
 #   from scipy.stats import futil
 #   from scipy.sparse.csgraph import _validation
 
@@ -13,7 +13,7 @@ app = QtGui.QApplication(sys.argv)
 
 pw = pg.plot(x = [0, 1, 2, 4], y = [4, 5, 9, 6])
 pw.showGrid(x=True,y=True)
-text = pg.TextItem(html='<div style="text-align: center"><span style="color: #000000;"> %s</span></div>' % "here",anchor=(0.0, 0.0)) 
+text = pg.TextItem(html='<div style="text-align: center"><span style="color: #000000;"> %s</span></div>' % "here",anchor=(0.0, 0.0))
 text.setPos(1.0, 5.0)
 pw.addItem(text)
 status = app.exec_()

--- a/examples/py2exe/setup.py
+++ b/examples/py2exe/setup.py
@@ -33,4 +33,4 @@ setup(
                       "compressed": 2,
                       "bundle_files": 1}},
   zipfile=None,
-) 
+)

--- a/examples/relativity_demo.py
+++ b/examples/relativity_demo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Special relativity simulation 
+Special relativity simulation
 
 
 

--- a/examples/scrollingPlots.py
+++ b/examples/scrollingPlots.py
@@ -26,14 +26,14 @@ def update1():
                             # (see also: np.roll)
     data1[-1] = np.random.normal()
     curve1.setData(data1)
-    
+
     ptr1 += 1
     curve2.setData(data1)
     curve2.setPos(ptr1, 0)
-    
+
 
 # 2) Allow data to accumulate. In these examples, the array doubles in length
-#    whenever it is full. 
+#    whenever it is full.
 win.nextRow()
 p3 = win.addPlot()
 p4 = win.addPlot()
@@ -81,13 +81,13 @@ def update3():
     now = pg.ptime.time()
     for c in curves:
         c.setPos(-(now-startTime), 0)
-    
+
     i = ptr5 % chunkSize
     if i == 0:
         curve = p5.plot()
         curves.append(curve)
         last = data5[-1]
-        data5 = np.empty((chunkSize+1,2))        
+        data5 = np.empty((chunkSize+1,2))
         data5[0] = last
         while len(curves) > maxChunks:
             c = curves.pop(0)

--- a/examples/text.py
+++ b/examples/text.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-This example shows how to insert text into a scene using TextItem. This class 
+This example shows how to insert text into a scene using TextItem. This class
 is for displaying text that is anchored to a particular location in the data
-coordinate system, but which is always displayed unscaled. 
+coordinate system, but which is always displayed unscaled.
 
-For text that scales with the data, use QTextItem. 
+For text that scales with the data, use QTextItem.
 For text that can be placed in a layout, use LabelItem.
 """
 
@@ -48,7 +48,7 @@ def update():
     curvePoint.setPos(float(index)/(len(x)-1))
     #text2.viewRangeChanged()
     text2.setText('[%0.1f, %0.1f]' % (x[index], y[index]))
-    
+
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(10)

--- a/examples/verlet_chain/chain.py
+++ b/examples/verlet_chain/chain.py
@@ -5,17 +5,17 @@ from . import relax
 
 
 class ChainSim(pg.QtCore.QObject):
-    
+
     stepped = pg.QtCore.Signal()
     relaxed = pg.QtCore.Signal()
-    
+
     def __init__(self):
         pg.QtCore.QObject.__init__(self)
-        
+
         self.damping = 0.1  # 0=full damping, 1=no damping
         self.relaxPerStep = 10
         self.maxTimeStep = 0.01
-        
+
         self.pos = None      # (Npts, 2) float
         self.mass = None     # (Npts) float
         self.fixed = None    # (Npts) bool
@@ -23,25 +23,25 @@ class ChainSim(pg.QtCore.QObject):
         self.lengths = None  # (Nlinks), float
         self.push = None     # (Nlinks), bool
         self.pull = None     # (Nlinks), bool
-        
+
         self.initialized = False
         self.lasttime = None
         self.lastpos = None
-        
+
     def init(self):
         if self.initialized:
             return
-        
+
         assert None not in [self.pos, self.mass, self.links, self.lengths]
-        
+
         if self.fixed is None:
             self.fixed = np.zeros(self.pos.shape[0], dtype=bool)
         if self.push is None:
             self.push = np.ones(self.links.shape[0], dtype=bool)
         if self.pull is None:
             self.pull = np.ones(self.links.shape[0], dtype=bool)
-            
-        
+
+
         # precompute relative masses across links
         l1 = self.links[:,0]
         l2 = self.links[:,1]
@@ -54,9 +54,9 @@ class ChainSim(pg.QtCore.QObject):
 
         for i in range(10):
             self.relax(n=10)
-        
+
         self.initialized = True
-        
+
     def makeGraph(self):
         #g1 = pg.GraphItem(pos=self.pos, adj=self.links[self.rope], pen=0.2, symbol=None)
         brushes = np.where(self.fixed, pg.mkBrush(0,0,0,255), pg.mkBrush(50,50,200,255))
@@ -65,17 +65,17 @@ class ChainSim(pg.QtCore.QObject):
         #p.addItem(g1)
         p.addItem(g2)
         return p
-    
+
     def update(self):
         # approximate physics with verlet integration
-        
+
         now = pg.ptime.time()
         if self.lasttime is None:
             dt = 0
         else:
             dt = now - self.lasttime
         self.lasttime = now
-        
+
         # limit amount of work to be done between frames
         if not relax.COMPILED:
             dt = self.maxTimeStep
@@ -85,31 +85,28 @@ class ChainSim(pg.QtCore.QObject):
 
         # remember fixed positions
         fixedpos = self.pos[self.fixed]
-        
+
         while dt > 0:
             dt1 = min(self.maxTimeStep, dt)
             dt -= dt1
-            
+
             # compute motion since last timestep
             dx = self.pos - self.lastpos
             self.lastpos = self.pos
-            
+
             # update positions for gravity and inertia
             acc = np.array([[0, -5]]) * dt1
             inertia = dx * (self.damping**(dt1/self.mass))[:,np.newaxis]  # with mass-dependent damping
             self.pos = self.pos + inertia + acc
 
             self.pos[self.fixed] = fixedpos  # fixed point constraint
-            
+
             # correct for link constraints
             self.relax(self.relaxPerStep)
         self.stepped.emit()
-        
-        
+
+
     def relax(self, n=50):
         # speed up with C magic if possible
         relax.relax(self.pos, self.links, self.mrel1, self.mrel2, self.lengths, self.push, self.pull, n)
         self.relaxed.emit()
-        
-        
-

--- a/examples/verlet_chain/relax.py
+++ b/examples/verlet_chain/relax.py
@@ -25,7 +25,7 @@ if COMPILED:
     def relax(pos, links, mrel1, mrel2, lengths, push, pull, iters):
         nlinks = links.shape[0]
         lib.relax(pos.ctypes, links.ctypes, mrel1.ctypes, mrel2.ctypes, lengths.ctypes, push.ctypes, pull.ctypes, nlinks, iters)
-        
+
 else:
     def relax(pos, links, mrel1, mrel2, lengths, push, pull, iters):
         lengths2 = lengths**2
@@ -34,34 +34,34 @@ else:
             #p2 = links[:, 1]
             #x1 = pos[p1]
             #x2 = pos[p2]
-            
+
             #dx = x2 - x1
-            
+
             #dist = (dx**2).sum(axis=1)**0.5
-            
+
             #mask = (npush & (dist < lengths)) | (npull & (dist > lengths))
             ##dist[mask] = lengths[mask]
             #change = (lengths-dist) / dist
             #change[mask] = 0
-            
+
             #dx *= change[:, np.newaxis]
             #print dx
-            
+
             ##pos[p1] -= mrel2 * dx
             ##pos[p2] += mrel1 * dx
             #for j in range(links.shape[0]):
                 #pos[links[j,0]] -= mrel2[j] * dx[j]
                 #pos[links[j,1]] += mrel1[j] * dx[j]
-                
-            
+
+
             for l in range(links.shape[0]):
                 p1, p2 = links[l];
                 x1 = pos[p1]
                 x2 = pos[p2]
-                
+
                 dx = x2 - x1
                 dist2 = (dx**2).sum()
-               
+
                 if (push[l] and dist2 < lengths2[l]) or (pull[l] and dist2 > lengths2[l]):
                     dist = dist2 ** 0.5
                     change = (lengths[l]-dist) / dist

--- a/examples/verlet_chain_demo.py
+++ b/examples/verlet_chain_demo.py
@@ -4,7 +4,7 @@ Mechanical simulation of a chain using verlet integration.
 Use the mouse to interact with one of the chains.
 
 By default, this uses a slow, pure-python integrator to solve the chain link
-positions. Unix users may compile a small math library to speed this up by 
+positions. Unix users may compile a small math library to speed this up by
 running the `examples/verlet_chain/make` script.
 
 """
@@ -28,7 +28,7 @@ else:
     chlen1 = 10
     chlen2 = 8
     linklen = 8
-    
+
 npts = chlen1 + chlen2
 
 sim.mass = np.ones(npts)
@@ -77,12 +77,12 @@ def display():
     global view, sim
     view.clear()
     view.addItem(sim.makeGraph())
-    
+
 def relaxed():
     global app
     display()
     app.processEvents()
-    
+
 def mouse(pos):
     global mousepos
     pos = view.mapSceneToView(pos)
@@ -118,7 +118,7 @@ timer = pg.QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(16)
 
-    
+
 ## Start Qt event loop unless running in interactive mode or using pyside.
 if __name__ == '__main__':
     import sys

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -23,12 +23,12 @@ __all__ = ['GraphicsScene']
 class GraphicsScene(QtGui.QGraphicsScene):
     """
     Extension of QGraphicsScene that implements a complete, parallel mouse event system.
-    (It would have been preferred to just alter the way QGraphicsScene creates and delivers 
+    (It would have been preferred to just alter the way QGraphicsScene creates and delivers
     events, but this turned out to be impossible because the constructor for QGraphicsMouseEvent
     is private)
-    
-    *  Generates MouseClicked events in addition to the usual press/move/release events. 
-       (This works around a problem where it is impossible to have one item respond to a 
+
+    *  Generates MouseClicked events in addition to the usual press/move/release events.
+       (This works around a problem where it is impossible to have one item respond to a
        drag if another is watching for a click.)
     *  Adjustable radius around click that will catch objects so you don't have to click *exactly* over small/thin objects
     *  Global context menu--if an item implements a context menu, then its parent(s) may also add items to the menu.
@@ -36,44 +36,44 @@ class GraphicsScene(QtGui.QGraphicsScene):
        This lets us indicate unambiguously to the user which item they are about to click/drag on
     *  Eats mouseMove events that occur too soon after a mouse press.
     *  Reimplements items() and itemAt() to circumvent PyQt bug
-    
+
     Mouse interaction is as follows:
-    
-    1) Every time the mouse moves, the scene delivers both the standard hoverEnter/Move/LeaveEvents 
-       as well as custom HoverEvents. 
-    2) Items are sent HoverEvents in Z-order and each item may optionally call event.acceptClicks(button), 
-       acceptDrags(button) or both. If this method call returns True, this informs the item that _if_ 
-       the user clicks/drags the specified mouse button, the item is guaranteed to be the 
+
+    1) Every time the mouse moves, the scene delivers both the standard hoverEnter/Move/LeaveEvents
+       as well as custom HoverEvents.
+    2) Items are sent HoverEvents in Z-order and each item may optionally call event.acceptClicks(button),
+       acceptDrags(button) or both. If this method call returns True, this informs the item that _if_
+       the user clicks/drags the specified mouse button, the item is guaranteed to be the
        recipient of click/drag events (the item may wish to change its appearance to indicate this).
        If the call to acceptClicks/Drags returns False, then the item is guaranteed to *not* receive
-       the requested event (because another item has already accepted it). 
+       the requested event (because another item has already accepted it).
     3) If the mouse is clicked, a mousePressEvent is generated as usual. If any items accept this press event, then
        No click/drag events will be generated and mouse interaction proceeds as defined by Qt. This allows
        items to function properly if they are expecting the usual press/move/release sequence of events.
        (It is recommended that items do NOT accept press events, and instead use click/drag events)
-       Note: The default implementation of QGraphicsItem.mousePressEvent will *accept* the event if the 
+       Note: The default implementation of QGraphicsItem.mousePressEvent will *accept* the event if the
        item is has its Selectable or Movable flags enabled. You may need to override this behavior.
     4) If no item accepts the mousePressEvent, then the scene will begin delivering mouseDrag and/or mouseClick events.
-       If the mouse is moved a sufficient distance (or moved slowly enough) before the button is released, 
+       If the mouse is moved a sufficient distance (or moved slowly enough) before the button is released,
        then a mouseDragEvent is generated.
-       If no drag events are generated before the button is released, then a mouseClickEvent is generated. 
+       If no drag events are generated before the button is released, then a mouseClickEvent is generated.
     5) Click/drag events are delivered to the item that called acceptClicks/acceptDrags on the HoverEvent
-       in step 1. If no such items exist, then the scene attempts to deliver the events to items near the event. 
+       in step 1. If no such items exist, then the scene attempts to deliver the events to items near the event.
        ClickEvents may be delivered in this way even if no
        item originally claimed it could accept the click. DragEvents may only be delivered this way if it is the initial
        move in a drag.
     """
-    
+
     sigMouseHover = QtCore.Signal(object)   ## emits a list of objects hovered over
     sigMouseMoved = QtCore.Signal(object)   ## emits position of mouse on every move
     sigMouseClicked = QtCore.Signal(object)   ## emitted when mouse is clicked. Check for event.isAccepted() to see whether the event has already been acted on.
-    
+
     sigPrepareForPaint = QtCore.Signal()  ## emitted immediately before the scene is about to be rendered
-    
+
     _addressCache = weakref.WeakValueDictionary()
-    
+
     ExportDirectory = None
-    
+
     @classmethod
     def registerObject(cls, obj):
         """
@@ -83,14 +83,14 @@ class GraphicsScene(QtGui.QGraphicsScene):
         """
         if HAVE_SIP and isinstance(obj, sip.wrapper):
             cls._addressCache[sip.unwrapinstance(sip.cast(obj, QtGui.QGraphicsItem))] = obj
-            
-            
+
+
     def __init__(self, clickRadius=2, moveDistance=5, parent=None):
         QtGui.QGraphicsScene.__init__(self, parent)
         self.setClickRadius(clickRadius)
         self.setMoveDistance(moveDistance)
         self.exportDirectory = None
-        
+
         self.clickEvents = []
         self.dragButtons = []
         self.mouseGrabber = None
@@ -98,12 +98,12 @@ class GraphicsScene(QtGui.QGraphicsScene):
         self.lastDrag = None
         self.hoverItems = weakref.WeakKeyDictionary()
         self.lastHoverEvent = None
-        
+
         self.contextMenu = [QtGui.QAction("Export...", self)]
         self.contextMenu[0].triggered.connect(self.showExportDialog)
-        
+
         self.exportDialog = None
-        
+
     def render(self, *args):
         self.prepareForPaint()
         return QtGui.QGraphicsScene.render(self, *args)
@@ -111,20 +111,20 @@ class GraphicsScene(QtGui.QGraphicsScene):
     def prepareForPaint(self):
         """Called before every render. This method will inform items that the scene is about to
         be rendered by emitting sigPrepareForPaint.
-        
+
         This allows items to delay expensive processing until they know a paint will be required."""
         self.sigPrepareForPaint.emit()
-    
+
 
     def setClickRadius(self, r):
         """
         Set the distance away from mouse clicks to search for interacting items.
         When clicking, the scene searches first for items that directly intersect the click position
-        followed by any other items that are within a rectangle that extends r pixels away from the 
-        click position. 
+        followed by any other items that are within a rectangle that extends r pixels away from the
+        click position.
         """
         self._clickRadius = r
-        
+
     def setMoveDistance(self, d):
         """
         Set the distance the mouse must move after a press before mouseMoveEvents will be delivered.
@@ -142,25 +142,25 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 # This can happen if a context menu is open while the mouse is moving.
                 if ev.scenePos() != self.lastHoverEvent.scenePos():
                     self.sendHoverEvents(ev)
-            
+
             self.clickEvents.append(MouseClickEvent(ev))
-            
+
             ## set focus on the topmost focusable item under this click
             items = self.items(ev.scenePos())
             for i in items:
                 if i.isEnabled() and i.isVisible() and int(i.flags() & i.ItemIsFocusable) > 0:
                     i.setFocus(QtCore.Qt.MouseFocusReason)
                     break
-        
+
     def mouseMoveEvent(self, ev):
         self.sigMouseMoved.emit(ev.scenePos())
-        
+
         ## First allow QGraphicsScene to deliver hoverEnter/Move/ExitEvents
         QtGui.QGraphicsScene.mouseMoveEvent(self, ev)
-        
+
         ## Next deliver our own HoverEvents
         self.sendHoverEvents(ev)
-        
+
         if int(ev.buttons()) != 0:  ## button is pressed; send mouseMoveEvents and mouseDragEvents
             QtGui.QGraphicsScene.mouseMoveEvent(self, ev)
             if self.mouseGrabberItem() is None:
@@ -177,17 +177,17 @@ class GraphicsScene(QtGui.QGraphicsScene):
                             continue
                         init = init or (len(self.dragButtons) == 0)  ## If this is the first button to be dragged, then init=True
                         self.dragButtons.append(int(btn))
-                        
+
                 ## If we have dragged buttons, deliver a drag event
                 if len(self.dragButtons) > 0:
                     if self.sendDragEvent(ev, init=init):
                         ev.accept()
-                
+
     def leaveEvent(self, ev):  ## inform items that mouse is gone
         if len(self.dragButtons) == 0:
             self.sendHoverEvents(ev, exitOnly=True)
-        
-                
+
+
     def mouseReleaseEvent(self, ev):
         #print 'sceneRelease'
         if self.mouseGrabberItem() is None:
@@ -202,24 +202,24 @@ class GraphicsScene(QtGui.QGraphicsScene):
                     #print "sent click event"
                     ev.accept()
                 self.clickEvents.remove(cev[0])
-                
+
         if int(ev.buttons()) == 0:
             self.dragItem = None
             self.dragButtons = []
             self.clickEvents = []
             self.lastDrag = None
         QtGui.QGraphicsScene.mouseReleaseEvent(self, ev)
-        
+
         self.sendHoverEvents(ev)  ## let items prepare for next click/drag
 
     def mouseDoubleClickEvent(self, ev):
         QtGui.QGraphicsScene.mouseDoubleClickEvent(self, ev)
         if self.mouseGrabberItem() is None:  ## nobody claimed press; we are free to generate drag/click events
             self.clickEvents.append(MouseClickEvent(ev, double=True))
-        
+
     def sendHoverEvents(self, ev, exitOnly=False):
         ## if exitOnly, then just inform all previously hovered items that the mouse has left.
-        
+
         if exitOnly:
             acceptable=False
             items = []
@@ -229,9 +229,9 @@ class GraphicsScene(QtGui.QGraphicsScene):
             event = HoverEvent(ev, acceptable)
             items = self.itemsNearEvent(event, hoverable=True)
             self.sigMouseHover.emit(items)
-            
+
         prevItems = list(self.hoverItems.keys())
-            
+
         #print "hover prev items:", prevItems
         #print "hover test items:", items
         for item in items:
@@ -243,12 +243,12 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 else:
                     prevItems.remove(item)
                     event.enter = False
-                    
+
                 try:
                     item.hoverEvent(event)
                 except:
                     debug.printExc("Error sending hover event:")
-                    
+
         event.enter = False
         event.exit = True
         #print "hover exit items:", prevItems
@@ -260,17 +260,17 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 debug.printExc("Error sending hover exit event:")
             finally:
                 del self.hoverItems[item]
-        
+
         # Update last hover event unless:
         #   - mouse is dragging (move+buttons); in this case we want the dragged
         #     item to continue receiving events until the drag is over
         #   - event is not a mouse event (QEvent.Leave sometimes appears here)
-        if (ev.type() == ev.GraphicsSceneMousePress or 
+        if (ev.type() == ev.GraphicsSceneMousePress or
             (ev.type() == ev.GraphicsSceneMouseMove and int(ev.buttons()) == 0)):
             self.lastHoverEvent = event  ## save this so we can ask about accepted events later.
 
     def sendDragEvent(self, ev, init=False, final=False):
-        ## Send a MouseDragEvent to the current dragItem or to 
+        ## Send a MouseDragEvent to the current dragItem or to
         ## items near the beginning of the drag
         event = MouseDragEvent(ev, self.clickEvents[0], self.lastDrag, start=init, finish=final)
         #print "dragEvent: init=", init, 'final=', final, 'self.dragItem=', self.dragItem
@@ -279,7 +279,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 acceptedItem = self.lastHoverEvent.dragItems().get(event.button(), None)
             else:
                 acceptedItem = None
-                
+
             if acceptedItem is not None:
                 #print "Drag -> pre-selected item:", acceptedItem
                 self.dragItem = acceptedItem
@@ -288,7 +288,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
                     self.dragItem.mouseDragEvent(event)
                 except:
                     debug.printExc("Error sending drag event:")
-                    
+
             else:
                 #print "drag -> new item"
                 for item in self.itemsNearEvent(event):
@@ -313,18 +313,18 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 self.dragItem.mouseDragEvent(event)
             except:
                 debug.printExc("Error sending hover exit event:")
-            
+
         self.lastDrag = event
-        
+
         return event.isAccepted()
-            
-        
+
+
     def sendClickEvent(self, ev):
         ## if we are in mid-drag, click events may only go to the dragged item.
         if self.dragItem is not None and hasattr(self.dragItem, 'mouseClickEvent'):
             ev.currentItem = self.dragItem
             self.dragItem.mouseClickEvent(ev)
-            
+
         ## otherwise, search near the cursor
         else:
             if self.lastHoverEvent is not None:
@@ -347,14 +347,14 @@ class GraphicsScene(QtGui.QGraphicsScene):
                             item.mouseClickEvent(ev)
                         except:
                             debug.printExc("Error sending click event:")
-                            
+
                         if ev.isAccepted():
                             if int(item.flags() & item.ItemIsFocusable) > 0:
                                 item.setFocus(QtCore.Qt.MouseFocusReason)
                             break
         self.sigMouseClicked.emit(ev)
         return ev.isAccepted()
-        
+
     def items(self, *args):
         #print 'args:', args
         items = QtGui.QGraphicsScene.items(self, *args)
@@ -370,7 +370,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 #items2.append(i2)
         #print 'items:', items
         return items2
-    
+
     def selectedItems(self, *args):
         items = QtGui.QGraphicsScene.selectedItems(self, *args)
         ## PyQt bug: items() returns a list of QGraphicsItem instances. If the item is subclassed from QGraphicsObject,
@@ -389,7 +389,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
 
     def itemAt(self, *args):
         item = QtGui.QGraphicsScene.itemAt(self, *args)
-        
+
         ## PyQt bug: items() returns a list of QGraphicsItem instances. If the item is subclassed from QGraphicsObject,
         ## then the object returned will be different than the actual item that was originally added to the scene
         #if HAVE_SIP and isinstance(self, sip.wrapper):
@@ -408,7 +408,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
         tr = view.viewportTransform()
         r = self._clickRadius
         rect = view.mapToScene(QtCore.QRect(0, 0, 2*r, 2*r)).boundingRect()
-        
+
         seen = set()
         if hasattr(event, 'buttonDownScenePos'):
             point = event.buttonDownScenePos()
@@ -421,7 +421,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
 
 
         items = self.items(point, selMode, sortOrder, tr)
-        
+
         ## remove items whose shape does not contain point (scene.items() apparently sucks at this)
         items2 = []
         for item in items:
@@ -432,18 +432,18 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 continue
             if shape.contains(item.mapFromScene(point)):
                 items2.append(item)
-        
+
         ## Sort by descending Z-order (don't trust scene.itms() to do this either)
         ## use 'absolute' z value, which is the sum of all item/parent ZValues
         def absZValue(item):
             if item is None:
                 return 0
             return item.zValue() + absZValue(item.parentItem())
-        
+
         sortList(items2, lambda a,b: cmp(absZValue(b), absZValue(a)))
-        
+
         return items2
-        
+
         #for item in items:
             ##seen.add(item)
 
@@ -454,10 +454,10 @@ class GraphicsScene(QtGui.QGraphicsScene):
         #for item in self.items(rgn, selMode, sortOrder, tr):
             ##if item not in seen:
             #yield item
-        
+
     def getViewWidget(self):
         return self.views()[0]
-    
+
     #def getViewWidget(self, widget):
         ### same pyqt bug -- mouseEvent.widget() doesn't give us the original python object.
         ### [[doesn't seem to work correctly]]
@@ -478,9 +478,9 @@ class GraphicsScene(QtGui.QGraphicsScene):
         Parents may implement getContextMenus to add new menus / actions to the existing menu.
         getContextMenus must accept 1 argument (the event that generated the original menu) and
         return a single QMenu or a list of QMenus.
-        
+
         The final menu will look like:
-        
+
             |    Original Item 1
             |    Original Item 2
             |    ...
@@ -491,11 +491,11 @@ class GraphicsScene(QtGui.QGraphicsScene):
             |    ...
             |    Grandparent Item 1
             |    ...
-            
-        
+
+
         ==============  ==================================================
         **Arguments:**
-        item            The item that initially created the context menu 
+        item            The item that initially created the context menu
                         (This is probably the item making the call to this function)
         menu            The context menu being shown by the item
         event           The original event that triggered the menu to appear.
@@ -525,7 +525,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 menu.addAction(m)
             else:
                 raise Exception("Cannot add object %s (type=%s) to QMenu." % (str(m), str(type(m))))
-            
+
         return menu
 
     def getContextMenus(self, event):
@@ -549,6 +549,3 @@ class GraphicsScene(QtGui.QGraphicsScene):
     @staticmethod
     def translateGraphicsItems(items):
         return list(map(GraphicsScene.translateGraphicsItem, items))
-
-
-

--- a/pyqtgraph/GraphicsScene/exportDialog.py
+++ b/pyqtgraph/GraphicsScene/exportDialog.py
@@ -20,21 +20,21 @@ class ExportDialog(QtGui.QWidget):
         self.shown = False
         self.currentExporter = None
         self.scene = scene
-            
+
         self.selectBox = QtGui.QGraphicsRectItem()
         self.selectBox.setPen(fn.mkPen('y', width=3, style=QtCore.Qt.DashLine))
         self.selectBox.hide()
         self.scene.addItem(self.selectBox)
-        
+
         self.ui = exportDialogTemplate.Ui_Form()
         self.ui.setupUi(self)
-        
+
         self.ui.closeBtn.clicked.connect(self.close)
         self.ui.exportBtn.clicked.connect(self.exportClicked)
         self.ui.copyBtn.clicked.connect(self.copyClicked)
         self.ui.itemTree.currentItemChanged.connect(self.exportItemChanged)
         self.ui.formatList.currentItemChanged.connect(self.exportFormatChanged)
-        
+
 
     def show(self, item=None):
         if item is not None:
@@ -49,12 +49,12 @@ class ExportDialog(QtGui.QWidget):
         self.activateWindow()
         self.raise_()
         self.selectBox.setVisible(True)
-        
+
         if not self.shown:
             self.shown = True
             vcenter = self.scene.getViewWidget().geometry().center()
             self.setGeometry(vcenter.x()-self.width()/2, vcenter.y()-self.height()/2, self.width(), self.height())
-        
+
     def updateItemList(self, select=None):
         self.ui.itemTree.clear()
         si = QtGui.QTreeWidgetItem(["Entire Scene"])
@@ -65,25 +65,25 @@ class ExportDialog(QtGui.QWidget):
         for child in self.scene.items():
             if child.parentItem() is None:
                 self.updateItemTree(child, si, select=select)
-                
+
     def updateItemTree(self, item, treeItem, select=None):
         si = None
         if isinstance(item, ViewBox):
             si = QtGui.QTreeWidgetItem(['ViewBox'])
         elif isinstance(item, PlotItem):
             si = QtGui.QTreeWidgetItem(['Plot'])
-            
+
         if si is not None:
             si.gitem = item
             treeItem.addChild(si)
             treeItem = si
             if si.gitem is select:
                 self.ui.itemTree.setCurrentItem(si)
-            
+
         for ch in item.childItems():
             self.updateItemTree(ch, treeItem, select=select)
-        
-            
+
+
     def exportItemChanged(self, item, prev):
         if item is None:
             return
@@ -94,7 +94,7 @@ class ExportDialog(QtGui.QWidget):
         self.selectBox.setRect(newBounds)
         self.selectBox.show()
         self.updateFormatList()
-        
+
     def updateFormatList(self):
         current = self.ui.formatList.currentItem()
         if current is not None:
@@ -108,10 +108,10 @@ class ExportDialog(QtGui.QWidget):
             if exp.Name == current:
                 self.ui.formatList.setCurrentRow(self.ui.formatList.count()-1)
                 gotCurrent = True
-                
+
         if not gotCurrent:
             self.ui.formatList.setCurrentRow(0)
-        
+
     def exportFormatChanged(self, item, prev):
         if item is None:
             self.currentExporter = None
@@ -126,15 +126,15 @@ class ExportDialog(QtGui.QWidget):
             self.ui.paramTree.setParameters(params)
         self.currentExporter = exp
         self.ui.copyBtn.setEnabled(exp.allowCopy)
-        
+
     def exportClicked(self):
         self.selectBox.hide()
         self.currentExporter.export()
-        
+
     def copyClicked(self):
         self.selectBox.hide()
         self.currentExporter.export(copy=True)
-        
+
     def close(self):
         self.selectBox.setVisible(False)
         self.setVisible(False)

--- a/pyqtgraph/GraphicsScene/mouseEvents.py
+++ b/pyqtgraph/GraphicsScene/mouseEvents.py
@@ -5,12 +5,12 @@ from .. import ptime as ptime
 
 class MouseDragEvent(object):
     """
-    Instances of this class are delivered to items in a :class:`GraphicsScene <pyqtgraph.GraphicsScene>` via their mouseDragEvent() method when the item is being mouse-dragged. 
-    
+    Instances of this class are delivered to items in a :class:`GraphicsScene <pyqtgraph.GraphicsScene>` via their mouseDragEvent() method when the item is being mouse-dragged.
+
     """
-    
-    
-    
+
+
+
     def __init__(self, moveEvent, pressEvent, lastEvent, start=False, finish=False):
         self.start = start
         self.finish = finish
@@ -33,27 +33,27 @@ class MouseDragEvent(object):
         self._button = pressEvent.button()
         self._modifiers = moveEvent.modifiers()
         self.acceptedItem = None
-        
+
     def accept(self):
         """An item should call this method if it can handle the event. This will prevent the event being delivered to any other items."""
         self.accepted = True
         self.acceptedItem = self.currentItem
-        
+
     def ignore(self):
         """An item should call this method if it cannot handle the event. This will allow the event to be delivered to other items."""
         self.accepted = False
-    
+
     def isAccepted(self):
         return self.accepted
-    
+
     def scenePos(self):
         """Return the current scene position of the mouse."""
         return Point(self._scenePos)
-    
+
     def screenPos(self):
         """Return the current screen position (pixels relative to widget) of the mouse."""
         return Point(self._screenPos)
-    
+
     def buttonDownScenePos(self, btn=None):
         """
         Return the scene position of the mouse at the time *btn* was pressed.
@@ -62,7 +62,7 @@ class MouseDragEvent(object):
         if btn is None:
             btn = self.button()
         return Point(self._buttonDownScenePos[int(btn)])
-    
+
     def buttonDownScreenPos(self, btn=None):
         """
         Return the screen position (pixels relative to widget) of the mouse at the time *btn* was pressed.
@@ -71,47 +71,47 @@ class MouseDragEvent(object):
         if btn is None:
             btn = self.button()
         return Point(self._buttonDownScreenPos[int(btn)])
-    
+
     def lastScenePos(self):
         """
         Return the scene position of the mouse immediately prior to this event.
         """
         return Point(self._lastScenePos)
-    
+
     def lastScreenPos(self):
         """
         Return the screen position of the mouse immediately prior to this event.
         """
         return Point(self._lastScreenPos)
-    
+
     def buttons(self):
         """
         Return the buttons currently pressed on the mouse.
         (see QGraphicsSceneMouseEvent::buttons in the Qt documentation)
         """
         return self._buttons
-        
+
     def button(self):
         """Return the button that initiated the drag (may be different from the buttons currently pressed)
         (see QGraphicsSceneMouseEvent::button in the Qt documentation)
-        
+
         """
         return self._button
-        
+
     def pos(self):
         """
         Return the current position of the mouse in the coordinate system of the item
         that the event was delivered to.
         """
         return Point(self.currentItem.mapFromScene(self._scenePos))
-    
+
     def lastPos(self):
         """
         Return the previous position of the mouse in the coordinate system of the item
         that the event was delivered to.
         """
         return Point(self.currentItem.mapFromScene(self._lastScenePos))
-        
+
     def buttonDownPos(self, btn=None):
         """
         Return the position of the mouse at the time the drag was initiated
@@ -120,11 +120,11 @@ class MouseDragEvent(object):
         if btn is None:
             btn = self.button()
         return Point(self.currentItem.mapFromScene(self._buttonDownScenePos[int(btn)]))
-    
+
     def isStart(self):
         """Returns True if this event is the first since a drag was initiated."""
         return self.start
-        
+
     def isFinish(self):
         """Returns False if this is the last event in a drag. Note that this
         event will have the same position as the previous one."""
@@ -138,11 +138,11 @@ class MouseDragEvent(object):
             lp = self.lastPos()
             p = self.pos()
         return "<MouseDragEvent (%g,%g)->(%g,%g) buttons=%d start=%s finish=%s>" % (lp.x(), lp.y(), p.x(), p.y(), int(self.buttons()), str(self.isStart()), str(self.isFinish()))
-        
+
     def modifiers(self):
         """Return any keyboard modifiers currently pressed.
         (see QGraphicsSceneMouseEvent::modifiers in the Qt documentation)
-        
+
         """
         return self._modifiers
 
@@ -150,11 +150,11 @@ class MouseDragEvent(object):
 
 class MouseClickEvent(object):
     """
-    Instances of this class are delivered to items in a :class:`GraphicsScene <pyqtgraph.GraphicsScene>` via their mouseClickEvent() method when the item is clicked. 
-    
-    
+    Instances of this class are delivered to items in a :class:`GraphicsScene <pyqtgraph.GraphicsScene>` via their mouseClickEvent() method when the item is clicked.
+
+
     """
-    
+
     def __init__(self, pressEvent, double=False):
         self.accepted = False
         self.currentItem = None
@@ -166,40 +166,40 @@ class MouseClickEvent(object):
         self._modifiers = pressEvent.modifiers()
         self._time = ptime.time()
         self.acceptedItem = None
-        
+
     def accept(self):
         """An item should call this method if it can handle the event. This will prevent the event being delivered to any other items."""
         self.accepted = True
         self.acceptedItem = self.currentItem
-        
+
     def ignore(self):
         """An item should call this method if it cannot handle the event. This will allow the event to be delivered to other items."""
         self.accepted = False
-    
+
     def isAccepted(self):
         return self.accepted
-    
+
     def scenePos(self):
         """Return the current scene position of the mouse."""
         return Point(self._scenePos)
-    
+
     def screenPos(self):
         """Return the current screen position (pixels relative to widget) of the mouse."""
         return Point(self._screenPos)
-    
+
     def buttons(self):
         """
         Return the buttons currently pressed on the mouse.
         (see QGraphicsSceneMouseEvent::buttons in the Qt documentation)
         """
         return self._buttons
-    
+
     def button(self):
         """Return the mouse button that generated the click event.
         (see QGraphicsSceneMouseEvent::button in the Qt documentation)
         """
         return self._button
-    
+
     def double(self):
         """Return True if this is a double-click."""
         return self._double
@@ -210,17 +210,17 @@ class MouseClickEvent(object):
         that the event was delivered to.
         """
         return Point(self.currentItem.mapFromScene(self._scenePos))
-    
+
     def lastPos(self):
         """
         Return the previous position of the mouse in the coordinate system of the item
         that the event was delivered to.
         """
         return Point(self.currentItem.mapFromScene(self._lastScenePos))
-        
+
     def modifiers(self):
         """Return any keyboard modifiers currently pressed.
-        (see QGraphicsSceneMouseEvent::modifiers in the Qt documentation)        
+        (see QGraphicsSceneMouseEvent::modifiers in the Qt documentation)
         """
         return self._modifiers
 
@@ -242,21 +242,21 @@ class MouseClickEvent(object):
 class HoverEvent(object):
     """
     Instances of this class are delivered to items in a :class:`GraphicsScene <pyqtgraph.GraphicsScene>` via their hoverEvent() method when the mouse is hovering over the item.
-    This event class both informs items that the mouse cursor is nearby and allows items to 
-    communicate with one another about whether each item will accept *potential* mouse events. 
-    
-    It is common for multiple overlapping items to receive hover events and respond by changing 
+    This event class both informs items that the mouse cursor is nearby and allows items to
+    communicate with one another about whether each item will accept *potential* mouse events.
+
+    It is common for multiple overlapping items to receive hover events and respond by changing
     their appearance. This can be misleading to the user since, in general, only one item will
-    respond to mouse events. To avoid this, items make calls to event.acceptClicks(button) 
+    respond to mouse events. To avoid this, items make calls to event.acceptClicks(button)
     and/or acceptDrags(button).
-    
-    Each item may make multiple calls to acceptClicks/Drags, each time for a different button. 
+
+    Each item may make multiple calls to acceptClicks/Drags, each time for a different button.
     If the method returns True, then the item is guaranteed to be
     the recipient of the claimed event IF the user presses the specified mouse button before
     moving. If claimEvent returns False, then this item is guaranteed NOT to get the specified
-    event (because another has already claimed it) and the item should change its appearance 
+    event (because another has already claimed it) and the item should change its appearance
     accordingly.
-    
+
     event.isEnter() returns True if the mouse has just entered the item's shape;
     event.isExit() returns True if the mouse has just left.
     """
@@ -276,22 +276,22 @@ class HoverEvent(object):
             self._modifiers = moveEvent.modifiers()
         else:
             self.exit = True
-            
-        
-        
+
+
+
     def isEnter(self):
         """Returns True if the mouse has just entered the item's shape"""
         return self.enter
-        
+
     def isExit(self):
         """Returns True if the mouse has just exited the item's shape"""
         return self.exit
-        
+
     def acceptClicks(self, button):
         """Inform the scene that the item (that the event was delivered to)
         would accept a mouse click event if the user were to click before
         moving the mouse again.
-        
+
         Returns True if the request is successful, otherwise returns False (indicating
         that some other item would receive an incoming click).
         """
@@ -301,12 +301,12 @@ class HoverEvent(object):
             self.__clickItems[button] = self.currentItem
             return True
         return False
-        
+
     def acceptDrags(self, button):
         """Inform the scene that the item (that the event was delivered to)
         would accept a mouse drag event if the user were to drag before
         the next hover event.
-        
+
         Returns True if the request is successful, otherwise returns False (indicating
         that some other item would receive an incoming drag event).
         """
@@ -316,37 +316,37 @@ class HoverEvent(object):
             self.__dragItems[button] = self.currentItem
             return True
         return False
-        
+
     def scenePos(self):
         """Return the current scene position of the mouse."""
         return Point(self._scenePos)
-    
+
     def screenPos(self):
         """Return the current screen position of the mouse."""
         return Point(self._screenPos)
-    
+
     def lastScenePos(self):
         """Return the previous scene position of the mouse."""
         return Point(self._lastScenePos)
-    
+
     def lastScreenPos(self):
         """Return the previous screen position of the mouse."""
         return Point(self._lastScreenPos)
-    
+
     def buttons(self):
         """
         Return the buttons currently pressed on the mouse.
         (see QGraphicsSceneMouseEvent::buttons in the Qt documentation)
         """
         return self._buttons
-        
+
     def pos(self):
         """
         Return the current position of the mouse in the coordinate system of the item
         that the event was delivered to.
         """
         return Point(self.currentItem.mapFromScene(self._scenePos))
-    
+
     def lastPos(self):
         """
         Return the previous position of the mouse in the coordinate system of the item
@@ -357,7 +357,7 @@ class HoverEvent(object):
     def __repr__(self):
         if self.exit:
             return "<HoverEvent exit=True>"
-        
+
         if self.currentItem is None:
             lp = self._lastScenePos
             p = self._scenePos
@@ -365,18 +365,15 @@ class HoverEvent(object):
             lp = self.lastPos()
             p = self.pos()
         return "<HoverEvent (%g,%g)->(%g,%g) buttons=%d enter=%s exit=%s>" % (lp.x(), lp.y(), p.x(), p.y(), int(self.buttons()), str(self.isEnter()), str(self.isExit()))
-        
+
     def modifiers(self):
         """Return any keyboard modifiers currently pressed.
-        (see QGraphicsSceneMouseEvent::modifiers in the Qt documentation)        
+        (see QGraphicsSceneMouseEvent::modifiers in the Qt documentation)
         """
         return self._modifiers
-    
+
     def clickItems(self):
         return self.__clickItems
-        
+
     def dragItems(self):
         return self.__dragItems
-        
-    
-    

--- a/pyqtgraph/PlotData.py
+++ b/pyqtgraph/PlotData.py
@@ -6,12 +6,12 @@ class PlotData(object):
       - allows data sharing between multiple graphics items (curve, scatter, graph..)
       - each item may define the columns it needs
       - column groupings ('pos' or x, y, z)
-      - efficiently appendable 
+      - efficiently appendable
       - log, fft transformations
       - color mode conversion (float/byte/qcolor)
       - pen/brush conversion
       - per-field cached masking
-        - allows multiple masking fields (different graphics need to mask on different criteria) 
+        - allows multiple masking fields (different graphics need to mask on different criteria)
         - removal of nan/inf values
       - option for single value shared by entire column
       - cached downsampling
@@ -19,7 +19,7 @@ class PlotData(object):
     """
     def __init__(self):
         self.fields = {}
-        
+
         self.maxVals = {}  ## cache for max/min
         self.minVals = {}
 
@@ -33,24 +33,20 @@ class PlotData(object):
 
     def __getitem__(self, field):
         return self.fields[field]
-    
+
     def __setitem__(self, field, val):
         self.fields[field] = val
-    
+
     def max(self, field):
         mx = self.maxVals.get(field, None)
         if mx is None:
             mx = np.max(self[field])
             self.maxVals[field] = mx
         return mx
-    
+
     def min(self, field):
         mn = self.minVals.get(field, None)
         if mn is None:
             mn = np.min(self[field])
             self.minVals[field] = mn
         return mn
-    
-    
-    
-    

--- a/pyqtgraph/Point.py
+++ b/pyqtgraph/Point.py
@@ -17,7 +17,7 @@ def clip(x, mn, mx):
 
 class Point(QtCore.QPointF):
     """Extension of QPointF which adds a few missing methods."""
-    
+
     def __init__(self, *args):
         if len(args) == 1:
             if isinstance(args[0], QtCore.QSizeF):
@@ -33,13 +33,13 @@ class Point(QtCore.QPointF):
             QtCore.QPointF.__init__(self, args[0], args[1])
             return
         QtCore.QPointF.__init__(self, *args)
-        
+
     def __len__(self):
         return 2
-        
+
     def __reduce__(self):
         return (Point, (self.x(), self.y()))
-        
+
     def __getitem__(self, i):
         if i == 0:
             return self.x()
@@ -47,7 +47,7 @@ class Point(QtCore.QPointF):
             return self.y()
         else:
             raise IndexError("Point has no index %s" % str(i))
-        
+
     def __setitem__(self, i, x):
         if i == 0:
             return self.setX(x)
@@ -55,43 +55,43 @@ class Point(QtCore.QPointF):
             return self.setY(x)
         else:
             raise IndexError("Point has no index %s" % str(i))
-        
+
     def __radd__(self, a):
         return self._math_('__radd__', a)
-    
+
     def __add__(self, a):
         return self._math_('__add__', a)
-    
+
     def __rsub__(self, a):
         return self._math_('__rsub__', a)
-    
+
     def __sub__(self, a):
         return self._math_('__sub__', a)
-    
+
     def __rmul__(self, a):
         return self._math_('__rmul__', a)
-    
+
     def __mul__(self, a):
         return self._math_('__mul__', a)
-    
+
     def __rdiv__(self, a):
         return self._math_('__rdiv__', a)
-    
+
     def __div__(self, a):
         return self._math_('__div__', a)
-    
+
     def __truediv__(self, a):
         return self._math_('__truediv__', a)
-    
+
     def __rtruediv__(self, a):
         return self._math_('__rtruediv__', a)
-    
+
     def __rpow__(self, a):
         return self._math_('__rpow__', a)
-    
+
     def __pow__(self, a):
         return self._math_('__pow__', a)
-    
+
     def _math_(self, op, x):
         #print "point math:", op
         #try:
@@ -102,15 +102,15 @@ class Point(QtCore.QPointF):
         #except AttributeError:
         x = Point(x)
         return Point(getattr(self[0], op)(x[0]), getattr(self[1], op)(x[1]))
-    
+
     def length(self):
         """Returns the vector length of this Point."""
         return (self[0]**2 + self[1]**2) ** 0.5
-    
+
     def norm(self):
         """Returns a vector in the same direction with unit length."""
         return self / self.length()
-    
+
     def angle(self, a):
         """Returns the angle in degrees between this vector and the vector a."""
         n1 = self.length()
@@ -123,33 +123,33 @@ class Point(QtCore.QPointF):
         if c > 0:
             ang *= -1.
         return ang * 180. / np.pi
-    
+
     def dot(self, a):
         """Returns the dot product of a and this Point."""
         a = Point(a)
         return self[0]*a[0] + self[1]*a[1]
-    
+
     def cross(self, a):
         a = Point(a)
         return self[0]*a[1] - self[1]*a[0]
-        
+
     def proj(self, b):
         """Return the projection of this vector onto the vector b"""
         b1 = b / b.length()
         return self.dot(b1) * b1
-    
+
     def __repr__(self):
         return "Point(%f, %f)" % (self[0], self[1])
-    
-    
+
+
     def min(self):
         return min(self[0], self[1])
-    
+
     def max(self):
         return max(self[0], self[1])
-        
+
     def copy(self):
         return Point(self)
-        
+
     def toQPoint(self):
         return QtCore.QPoint(*self)

--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -64,11 +64,11 @@ if QT_LIB == PYSIDE:
                 return False
             else:
                 return True
-    
+
     VERSION_INFO = 'PySide ' + PySide.__version__
-    
+
     # Make a loadUiType function like PyQt has
-    
+
     # Credit:
     # http://stackoverflow.com/questions/4442286/python-code-genration-with-pyside-uic/14195313#14195313
 
@@ -76,13 +76,13 @@ if QT_LIB == PYSIDE:
         """Alternative to built-in StringIO needed to circumvent unicode/ascii issues"""
         def __init__(self):
             self.data = []
-        
+
         def write(self, data):
             self.data.append(data)
-            
+
         def getvalue(self):
             return ''.join(map(asUnicode, self.data)).encode('utf8')
-        
+
     def loadUiType(uiFile):
         """
         Pyside "loadUiType" command like PyQt4 has one, so we have to convert
@@ -98,11 +98,11 @@ if QT_LIB == PYSIDE:
         import pysideuic
         import xml.etree.ElementTree as xml
         #from io import StringIO
-        
+
         parsed = xml.parse(uiFile)
         widget_class = parsed.find('widget').get('class')
         form_class = parsed.find('class').text
-        
+
         with open(uiFile, 'r') as f:
             o = StringIO()
             frame = {}
@@ -136,7 +136,7 @@ elif QT_LIB == PYQT4:
     VERSION_INFO = 'PyQt4 ' + QtCore.PYQT_VERSION_STR + ' Qt ' + QtCore.QT_VERSION_STR
 
 elif QT_LIB == PYQT5:
-    
+
     # We're using PyQt5 which has a different structure so we're going to use a shim to
     # recreate the Qt4 structure for Qt5
     from PyQt5 import QtGui, QtCore, QtWidgets, Qt, uic
@@ -176,19 +176,19 @@ elif QT_LIB == PYQT5:
         self.setSectionResizeMode(mode)
     QtWidgets.QHeaderView.setResizeMode = setResizeMode
 
-    
+
     QtGui.QApplication = QtWidgets.QApplication
     QtGui.QGraphicsScene = QtWidgets.QGraphicsScene
     QtGui.QGraphicsObject = QtWidgets.QGraphicsObject
     QtGui.QGraphicsWidget = QtWidgets.QGraphicsWidget
 
     QtGui.QApplication.setGraphicsSystem = None
-    
+
     # Import all QtWidgets objects into QtGui
     for o in dir(QtWidgets):
         if o.startswith('Q'):
             setattr(QtGui, o, getattr(QtWidgets,o) )
-    
+
     VERSION_INFO = 'PyQt5 ' + QtCore.PYQT_VERSION_STR + ' Qt ' + QtCore.QT_VERSION_STR
 
 # Common to PyQt4 and 5
@@ -199,9 +199,9 @@ if QT_LIB.startswith('PyQt'):
     loadUiType = uic.loadUiType
 
     QtCore.Signal = QtCore.pyqtSignal
-    
 
-    
+
+
 ## Make sure we have Qt >= 4.7
 versionReq = [4, 7]
 USE_PYSIDE = QT_LIB == PYSIDE

--- a/pyqtgraph/SRTTransform.py
+++ b/pyqtgraph/SRTTransform.py
@@ -10,7 +10,7 @@ class SRTTransform(QtGui.QTransform):
     def __init__(self, init=None):
         QtGui.QTransform.__init__(self)
         self.reset()
-        
+
         if init is None:
             return
         elif isinstance(init, dict):
@@ -29,20 +29,20 @@ class SRTTransform(QtGui.QTransform):
         else:
             raise Exception("Cannot create SRTTransform from input type: %s" % str(type(init)))
 
-        
+
     def getScale(self):
         return self._state['scale']
-        
-    def getAngle(self):  
+
+    def getAngle(self):
         ## deprecated; for backward compatibility
         return self.getRotation()
-        
+
     def getRotation(self):
         return self._state['angle']
-        
+
     def getTranslation(self):
         return self._state['pos']
-    
+
     def reset(self):
         self._state = {
             'pos': Point(0,0),
@@ -50,15 +50,15 @@ class SRTTransform(QtGui.QTransform):
             'angle': 0.0  ## in degrees
         }
         self.update()
-        
+
     def setFromQTransform(self, tr):
         p1 = Point(tr.map(0., 0.))
         p2 = Point(tr.map(1., 0.))
         p3 = Point(tr.map(0., 1.))
-        
+
         dp2 = Point(p2-p1)
         dp3 = Point(p3-p1)
-        
+
         ## detect flipped axes
         if dp2.angle(dp3) > 0:
             #da = 180
@@ -67,14 +67,14 @@ class SRTTransform(QtGui.QTransform):
         else:
             da = 0
             sy = 1.0
-            
+
         self._state = {
             'pos': Point(p1),
             'scale': Point(dp2.length(), dp3.length() * sy),
             'angle': (np.arctan2(dp2[1], dp2[0]) * 180. / np.pi) + da
         }
         self.update()
-        
+
     def setFromMatrix4x4(self, m):
         m = SRTTransform3D(m)
         angle, axis = m.getRotation()
@@ -87,43 +87,43 @@ class SRTTransform(QtGui.QTransform):
             'angle': angle
         }
         self.update()
-        
+
     def translate(self, *args):
-        """Acceptable arguments are: 
+        """Acceptable arguments are:
            x, y
            [x, y]
            Point(x,y)"""
         t = Point(*args)
         self.setTranslate(self._state['pos']+t)
-        
+
     def setTranslate(self, *args):
-        """Acceptable arguments are: 
+        """Acceptable arguments are:
            x, y
            [x, y]
            Point(x,y)"""
         self._state['pos'] = Point(*args)
         self.update()
-        
+
     def scale(self, *args):
-        """Acceptable arguments are: 
+        """Acceptable arguments are:
            x, y
            [x, y]
            Point(x,y)"""
         s = Point(*args)
         self.setScale(self._state['scale'] * s)
-        
+
     def setScale(self, *args):
-        """Acceptable arguments are: 
+        """Acceptable arguments are:
            x, y
            [x, y]
            Point(x,y)"""
         self._state['scale'] = Point(*args)
         self.update()
-        
+
     def rotate(self, angle):
         """Rotate the transformation by angle (in degrees)"""
         self.setRotate(self._state['angle'] + angle)
-        
+
     def setRotate(self, angle):
         """Set the transformation rotation to angle (in degrees)"""
         self._state['angle'] = angle
@@ -133,10 +133,10 @@ class SRTTransform(QtGui.QTransform):
         """A / B  ==  B^-1 * A"""
         dt = t.inverted()[0] * self
         return SRTTransform(dt)
-        
+
     def __div__(self, t):
         return self.__truediv__(t)
-        
+
     def __mul__(self, t):
         return SRTTransform(QtGui.QTransform.__mul__(self, t))
 
@@ -162,10 +162,10 @@ class SRTTransform(QtGui.QTransform):
 
     def __repr__(self):
         return str(self.saveState())
-        
+
     def matrix(self):
         return np.array([[self.m11(), self.m12(), self.m13()],[self.m21(), self.m22(), self.m23()],[self.m31(), self.m32(), self.m33()]])
-        
+
 if __name__ == '__main__':
     from . import widgets
     import GraphicsView
@@ -174,14 +174,14 @@ if __name__ == '__main__':
     win = QtGui.QMainWindow()
     win.show()
     cw = GraphicsView.GraphicsView()
-    #cw.enableMouse()  
+    #cw.enableMouse()
     win.setCentralWidget(cw)
     s = QtGui.QGraphicsScene()
     cw.setScene(s)
     win.resize(600,600)
     cw.enableMouse()
     cw.setRange(QtCore.QRectF(-100., -100., 200., 200.))
-    
+
     class Item(QtGui.QGraphicsItem):
         def __init__(self):
             QtGui.QGraphicsItem.__init__(self)
@@ -198,7 +198,7 @@ if __name__ == '__main__':
             return QtCore.QRectF()
         def paint(self, *args):
             pass
-            
+
     #s.addItem(b)
     #s.addItem(t1)
     item = Item()
@@ -209,30 +209,30 @@ if __name__ == '__main__':
     l2.setPen(QtGui.QPen(mkPen('r')))
     s.addItem(l1)
     s.addItem(l2)
-    
+
     tr1 = SRTTransform()
     tr2 = SRTTransform()
     tr3 = QtGui.QTransform()
     tr3.translate(20, 0)
     tr3.rotate(45)
     print("QTransform -> Transform:", SRTTransform(tr3))
-    
+
     print("tr1:", tr1)
-    
+
     tr2.translate(20, 0)
     tr2.rotate(45)
     print("tr2:", tr2)
-    
+
     dt = tr2/tr1
     print("tr2 / tr1 = ", dt)
-    
+
     print("tr2 * tr1 = ", tr2*tr1)
-    
+
     tr4 = SRTTransform()
     tr4.scale(-1, 1)
     tr4.rotate(30)
     print("tr1 * tr4 = ", tr1*tr4)
-    
+
     w1 = widgets.TestROI((19,19), (22, 22), invertible=True)
     #w2 = widgets.TestROI((0,0), (150, 150))
     w1.setZValue(10)
@@ -244,15 +244,15 @@ if __name__ == '__main__':
         tr1 = w1.getGlobalTransform(w1Base)
         #tr2 = w2.getGlobalTransform(w2Base)
         item.setTransform(tr1)
-        
+
     #def update2():
         #tr1 = w1.getGlobalTransform(w1Base)
         #tr2 = w2.getGlobalTransform(w2Base)
         #t1.setTransform(tr1)
         #w1.setState(w1Base)
         #w1.applyGlobalTransform(tr2)
-        
+
     w1.sigRegionChanged.connect(update)
     #w2.sigRegionChanged.connect(update2)
-    
+
 from .SRTTransform3D import SRTTransform3D

--- a/pyqtgraph/SRTTransform3D.py
+++ b/pyqtgraph/SRTTransform3D.py
@@ -16,7 +16,7 @@ class SRTTransform3D(Transform3D):
             return
         if init.__class__ is QtGui.QTransform:
             init = SRTTransform(init)
-        
+
         if isinstance(init, dict):
             self.restoreState(init)
         elif isinstance(init, SRTTransform3D):
@@ -41,17 +41,17 @@ class SRTTransform3D(Transform3D):
         else:
             raise Exception("Cannot build SRTTransform3D from argument type:", type(init))
 
-        
+
     def getScale(self):
         return Vector(self._state['scale'])
-        
+
     def getRotation(self):
         """Return (angle, axis) of rotation"""
         return self._state['angle'], Vector(self._state['axis'])
-        
+
     def getTranslation(self):
         return Vector(self._state['pos'])
-    
+
     def reset(self):
         self._state = {
             'pos': Vector(0,0,0),
@@ -60,17 +60,17 @@ class SRTTransform3D(Transform3D):
             'axis': (0, 0, 1)
         }
         self.update()
-        
+
     def translate(self, *args):
         """Adjust the translation of this transform"""
         t = Vector(*args)
         self.setTranslate(self._state['pos']+t)
-        
+
     def setTranslate(self, *args):
         """Set the translation of this transform"""
         self._state['pos'] = Vector(*args)
         self.update()
-        
+
     def scale(self, *args):
         """adjust the scale of this transform"""
         ## try to prevent accidentally setting 0 scale on z axis
@@ -78,10 +78,10 @@ class SRTTransform3D(Transform3D):
             args = args[0]
         if len(args) == 2:
             args = args + (1,)
-            
+
         s = Vector(*args)
         self.setScale(self._state['scale'] * s)
-        
+
     def setScale(self, *args):
         """Set the scale of this transform"""
         if len(args) == 1 and hasattr(args[0], '__len__'):
@@ -90,7 +90,7 @@ class SRTTransform3D(Transform3D):
             args = args + (1,)
         self._state['scale'] = Vector(*args)
         self.update()
-        
+
     def rotate(self, angle, axis=(0,0,1)):
         """Adjust the rotation of this transform"""
         origAxis = self._state['axis']
@@ -103,14 +103,14 @@ class SRTTransform3D(Transform3D):
             m.rotate(angle, *axis)
             m.scale(*self._state['scale'])
             self.setFromMatrix(m)
-        
+
     def setRotate(self, angle, axis=(0,0,1)):
         """Set the transformation rotation to angle (in degrees)"""
-        
+
         self._state['angle'] = angle
         self._state['axis'] = Vector(axis)
         self.update()
-    
+
     def setFromMatrix(self, m):
         """
         Set this transform mased on the elements of *m*
@@ -123,7 +123,7 @@ class SRTTransform3D(Transform3D):
         m = self.matrix().reshape(4,4)
         ## translation is 4th column
         self._state['pos'] = m[:3,3]
-        
+
         ## scale is vector-length of first three columns
         scale = (m[:3,:3]**2).sum(axis=0)**0.5
         ## see whether there is an inversion
@@ -131,7 +131,7 @@ class SRTTransform3D(Transform3D):
         if np.dot(z, m[2, :3]) < 0:
             scale[1] *= -1  ## doesn't really matter which axis we invert
         self._state['scale'] = scale
-        
+
         ## rotation axis is the eigenvector with eigenvalue=1
         r = m[:3, :3] / scale[np.newaxis, :]
         try:
@@ -150,24 +150,24 @@ class SRTTransform3D(Transform3D):
         axis = evecs[:,eigIndex[0,0]].real
         axis /= ((axis**2).sum())**0.5
         self._state['axis'] = axis
-        
+
         ## trace(r) == 2 cos(angle) + 1, so:
         cos = (r.trace()-1)*0.5  ## this only gets us abs(angle)
-        
-        ## The off-diagonal values can be used to correct the angle ambiguity, 
+
+        ## The off-diagonal values can be used to correct the angle ambiguity,
         ## but we need to figure out which element to use:
         axisInd = np.argmax(np.abs(axis))
         rInd,sign = [((1,2), -1), ((0,2), 1), ((0,1), -1)][axisInd]
-        
+
         ## Then we have r-r.T = sin(angle) * 2 * sign * axis[axisInd];
         ## solve for sin(angle)
         sin = (r-r.T)[rInd] / (2. * sign * axis[axisInd])
-        
+
         ## finally, we get the complete angle from arctan(sin/cos)
         self._state['angle'] = np.arctan2(sin, cos) * 180 / np.pi
         if self._state['angle'] == 0:
             self._state['axis'] = (0,0,1)
-        
+
     def as2D(self):
         """Return a QTransform representing the x,y portion of this transform (if possible)"""
         return SRTTransform(self)
@@ -176,7 +176,7 @@ class SRTTransform3D(Transform3D):
         #"""A / B  ==  B^-1 * A"""
         #dt = t.inverted()[0] * self
         #return SRTTransform(dt)
-        
+
     #def __mul__(self, t):
         #return SRTTransform(QtGui.QTransform.__mul__(self, t))
 
@@ -187,9 +187,9 @@ class SRTTransform3D(Transform3D):
         #if s[0] == 0:
             #raise Exception('Invalid scale: %s' % str(s))
         return {
-            'pos': (p[0], p[1], p[2]), 
-            'scale': (s[0], s[1], s[2]), 
-            'angle': self._state['angle'], 
+            'pos': (p[0], p[1], p[2]),
+            'scale': (s[0], s[1], s[2]),
+            'angle': self._state['angle'],
             'axis': (ax[0], ax[1], ax[2])
         }
 
@@ -211,7 +211,7 @@ class SRTTransform3D(Transform3D):
 
     def __repr__(self):
         return str(self.saveState())
-        
+
     def matrix(self, nd=3):
         if nd == 3:
             return np.array(self.copyDataTo()).reshape(4,4)
@@ -222,7 +222,7 @@ class SRTTransform3D(Transform3D):
             return m[:3,:3]
         else:
             raise Exception("Argument 'nd' must be 2 or 3")
-        
+
 if __name__ == '__main__':
     import widgets
     import GraphicsView
@@ -231,14 +231,14 @@ if __name__ == '__main__':
     win = QtGui.QMainWindow()
     win.show()
     cw = GraphicsView.GraphicsView()
-    #cw.enableMouse()  
+    #cw.enableMouse()
     win.setCentralWidget(cw)
     s = QtGui.QGraphicsScene()
     cw.setScene(s)
     win.resize(600,600)
     cw.enableMouse()
     cw.setRange(QtCore.QRectF(-100., -100., 200., 200.))
-    
+
     class Item(QtGui.QGraphicsItem):
         def __init__(self):
             QtGui.QGraphicsItem.__init__(self)
@@ -255,7 +255,7 @@ if __name__ == '__main__':
             return QtCore.QRectF()
         def paint(self, *args):
             pass
-            
+
     #s.addItem(b)
     #s.addItem(t1)
     item = Item()
@@ -266,30 +266,30 @@ if __name__ == '__main__':
     l2.setPen(QtGui.QPen(mkPen('r')))
     s.addItem(l1)
     s.addItem(l2)
-    
+
     tr1 = SRTTransform()
     tr2 = SRTTransform()
     tr3 = QtGui.QTransform()
     tr3.translate(20, 0)
     tr3.rotate(45)
     print("QTransform -> Transform: %s" % str(SRTTransform(tr3)))
-    
+
     print("tr1: %s" % str(tr1))
-    
+
     tr2.translate(20, 0)
     tr2.rotate(45)
     print("tr2: %s" % str(tr2))
-    
+
     dt = tr2/tr1
     print("tr2 / tr1 = %s" % str(dt))
-    
+
     print("tr2 * tr1 = %s" % str(tr2*tr1))
-    
+
     tr4 = SRTTransform()
     tr4.scale(-1, 1)
     tr4.rotate(30)
     print("tr1 * tr4 = %s" % str(tr1*tr4))
-    
+
     w1 = widgets.TestROI((19,19), (22, 22), invertible=True)
     #w2 = widgets.TestROI((0,0), (150, 150))
     w1.setZValue(10)
@@ -301,15 +301,15 @@ if __name__ == '__main__':
         tr1 = w1.getGlobalTransform(w1Base)
         #tr2 = w2.getGlobalTransform(w2Base)
         item.setTransform(tr1)
-        
+
     #def update2():
         #tr1 = w1.getGlobalTransform(w1Base)
         #tr2 = w2.getGlobalTransform(w2Base)
         #t1.setTransform(tr1)
         #w1.setState(w1Base)
         #w1.applyGlobalTransform(tr2)
-        
+
     w1.sigRegionChanged.connect(update)
     #w2.sigRegionChanged.connect(update2)
-    
+
 from .SRTTransform import SRTTransform

--- a/pyqtgraph/ThreadsafeTimer.py
+++ b/pyqtgraph/ThreadsafeTimer.py
@@ -4,11 +4,11 @@ class ThreadsafeTimer(QtCore.QObject):
     """
     Thread-safe replacement for QTimer.
     """
-    
+
     timeout = QtCore.Signal()
     sigTimerStopRequested = QtCore.Signal()
     sigTimerStartRequested = QtCore.Signal(object)
-    
+
     def __init__(self):
         QtCore.QObject.__init__(self)
         self.timer = QtCore.QTimer()
@@ -17,8 +17,8 @@ class ThreadsafeTimer(QtCore.QObject):
         self.moveToThread(QtCore.QCoreApplication.instance().thread())
         self.sigTimerStopRequested.connect(self.stop, QtCore.Qt.QueuedConnection)
         self.sigTimerStartRequested.connect(self.start, QtCore.Qt.QueuedConnection)
-        
-        
+
+
     def start(self, timeout):
         isGuiThread = QtCore.QThread.currentThread() == QtCore.QCoreApplication.instance().thread()
         if isGuiThread:
@@ -27,7 +27,7 @@ class ThreadsafeTimer(QtCore.QObject):
         else:
             #print "start timer", self, "from remote thread"
             self.sigTimerStartRequested.emit(timeout)
-        
+
     def stop(self):
         isGuiThread = QtCore.QThread.currentThread() == QtCore.QCoreApplication.instance().thread()
         if isGuiThread:
@@ -36,6 +36,6 @@ class ThreadsafeTimer(QtCore.QObject):
         else:
             #print "stop timer", self, "from remote thread"
             self.sigTimerStopRequested.emit()
-        
+
     def timerFinished(self):
         self.timeout.emit()

--- a/pyqtgraph/Transform3D.py
+++ b/pyqtgraph/Transform3D.py
@@ -9,7 +9,7 @@ class Transform3D(QtGui.QMatrix4x4):
     """
     def __init__(self, *args):
         QtGui.QMatrix4x4.__init__(self, *args)
-        
+
     def matrix(self, nd=3):
         if nd == 3:
             return np.array(self.copyDataTo()).reshape(4,4)
@@ -20,7 +20,7 @@ class Transform3D(QtGui.QMatrix4x4):
             return m[:3,:3]
         else:
             raise Exception("Argument 'nd' must be 2 or 3")
-        
+
     def map(self, obj):
         """
         Extends QMatrix4x4.map() to allow mapping (3, ...) arrays of coordinates
@@ -29,7 +29,7 @@ class Transform3D(QtGui.QMatrix4x4):
             return fn.transformCoordinates(self, obj)
         else:
             return QtGui.QMatrix4x4.map(self, obj)
-            
+
     def inverted(self):
         inv, b = QtGui.QMatrix4x4.inverted(self)
         return Transform3D(inv), b

--- a/pyqtgraph/Vector.py
+++ b/pyqtgraph/Vector.py
@@ -10,7 +10,7 @@ import numpy as np
 
 class Vector(QtGui.QVector3D):
     """Extension of QVector3D which adds a few helpful methods."""
-    
+
     def __init__(self, *args):
         if len(args) == 1:
             if isinstance(args[0], QtCore.QSizeF):
@@ -39,10 +39,10 @@ class Vector(QtGui.QVector3D):
         if USE_PYSIDE and isinstance(b, QtGui.QVector3D):
             b = Vector(b)
         return QtGui.QVector3D.__add__(self, b)
-    
+
     #def __reduce__(self):
         #return (Point, (self.x(), self.y()))
-        
+
     def __getitem__(self, i):
         if i == 0:
             return self.x()
@@ -52,7 +52,7 @@ class Vector(QtGui.QVector3D):
             return self.z()
         else:
             raise IndexError("Point has no index %s" % str(i))
-        
+
     def __setitem__(self, i, x):
         if i == 0:
             return self.setX(x)
@@ -62,7 +62,7 @@ class Vector(QtGui.QVector3D):
             return self.setZ(x)
         else:
             raise IndexError("Point has no index %s" % str(i))
-        
+
     def __iter__(self):
         yield(self.x())
         yield(self.y())
@@ -83,5 +83,3 @@ class Vector(QtGui.QVector3D):
 
     def __abs__(self):
         return Vector(abs(self.x()), abs(self.y()), abs(self.z()))
-        
-        

--- a/pyqtgraph/WidgetGroup.py
+++ b/pyqtgraph/WidgetGroup.py
@@ -5,7 +5,7 @@ Copyright 2010  Luke Campagnola
 Distributed under MIT/X11 license. See license.txt for more infomation.
 
 This class addresses the problem of having to save and restore the state
-of a large group of widgets. 
+of a large group of widgets.
 """
 
 from .Qt import QtCore, QtGui, USE_PYQT5
@@ -18,7 +18,7 @@ __all__ = ['WidgetGroup']
 def splitterState(w):
     s = str(w.saveState().toPercentEncoding())
     return s
-    
+
 def restoreSplitter(w, s):
     if type(s) is list:
         w.setSizes(s)
@@ -31,7 +31,7 @@ def restoreSplitter(w, s):
             if i > 0:
                 return
         w.setSizes([50] * w.count())
-        
+
 def comboState(w):
     ind = w.currentIndex()
     data = w.itemData(ind)
@@ -48,7 +48,7 @@ def comboState(w):
         return asUnicode(w.itemText(ind))
     else:
         return data
-    
+
 def setComboState(w, v):
     if type(v) is int:
         #ind = w.findData(QtCore.QVariant(v))
@@ -57,37 +57,37 @@ def setComboState(w, v):
             w.setCurrentIndex(ind)
             return
     w.setCurrentIndex(w.findText(str(v)))
-        
+
 
 class WidgetGroup(QtCore.QObject):
     """This class takes a list of widgets and keeps an internal record of their
-    state that is always up to date. 
-    
+    state that is always up to date.
+
     Allows reading and writing from groups of widgets simultaneously.
     """
-    
+
     ## List of widget types that can be handled by WidgetGroup.
     ## The value for each type is a tuple (change signal function, get function, set function, [auto-add children])
-    ## The change signal function that takes an object and returns a signal that is emitted any time the state of the widget changes, not just 
+    ## The change signal function that takes an object and returns a signal that is emitted any time the state of the widget changes, not just
     ##   when it is changed by user interaction. (for example, 'clicked' is not a valid signal here)
     ## If the change signal is None, the value of the widget is not cached.
     ## Custom widgets not in this list can be made to work with WidgetGroup by giving them a 'widgetGroupInterface' method
     ##   which returns the tuple.
     classes = {
-        QtGui.QSpinBox: 
-            (lambda w: w.valueChanged, 
-            QtGui.QSpinBox.value, 
+        QtGui.QSpinBox:
+            (lambda w: w.valueChanged,
+            QtGui.QSpinBox.value,
             QtGui.QSpinBox.setValue),
-        QtGui.QDoubleSpinBox: 
-            (lambda w: w.valueChanged, 
-            QtGui.QDoubleSpinBox.value, 
+        QtGui.QDoubleSpinBox:
+            (lambda w: w.valueChanged,
+            QtGui.QDoubleSpinBox.value,
             QtGui.QDoubleSpinBox.setValue),
-        QtGui.QSplitter: 
-            (None, 
+        QtGui.QSplitter:
+            (None,
             splitterState,
             restoreSplitter,
             True),
-        QtGui.QCheckBox: 
+        QtGui.QCheckBox:
             (lambda w: w.stateChanged,
             QtGui.QCheckBox.isChecked,
             QtGui.QCheckBox.setChecked),
@@ -113,17 +113,17 @@ class WidgetGroup(QtCore.QObject):
             QtGui.QSlider.value,
             QtGui.QSlider.setValue),
     }
-    
+
     sigChanged = QtCore.Signal(str, object)
-    
-    
+
+
     def __init__(self, widgetList=None):
         """Initialize WidgetGroup, adding specified widgets into this group.
-        widgetList can be: 
+        widgetList can be:
          - a list of widget specifications (widget, [name], [scale])
          - a dict of name: widget pairs
          - any QObject, and all compatible child widgets will be added recursively.
-        
+
         The 'scale' parameter for each widget allows QSpinBox to display a different value than the value recorded
         in the group state (for example, the program may set a spin box value to 100e-6 and have it displayed as 100 to the user)
         """
@@ -144,7 +144,7 @@ class WidgetGroup(QtCore.QObject):
             return
         else:
             raise Exception("Wrong argument type %s" % type(widgetList))
-        
+
     def addWidget(self, w, name=None, scale=None):
         if not self.acceptsType(w):
             raise Exception("Widget type %s not supported by WidgetGroup" % type(w))
@@ -155,25 +155,25 @@ class WidgetGroup(QtCore.QObject):
         self.widgetList[w] = name
         self.scales[w] = scale
         self.readWidget(w)
-            
+
         if type(w) in WidgetGroup.classes:
             signal = WidgetGroup.classes[type(w)][0]
         else:
             signal = w.widgetGroupInterface()[0]
-            
+
         if signal is not None:
             if inspect.isfunction(signal) or inspect.ismethod(signal):
                 signal = signal(w)
             signal.connect(self.mkChangeCallback(w))
         else:
             self.uncachedWidgets[w] = None
-       
+
     def findWidget(self, name):
         for w in self.widgetList:
             if self.widgetList[w] == name:
                 return w
         return None
-       
+
     def interface(self, obj):
         t = type(obj)
         if t in WidgetGroup.classes:
@@ -185,14 +185,14 @@ class WidgetGroup(QtCore.QObject):
         """Return true if we should automatically search the children of this object for more."""
         iface = self.interface(obj)
         return (len(iface) > 3 and iface[3])
-       
+
     def autoAdd(self, obj):
         ## Find all children of this object and add them if possible.
         accepted = self.acceptsType(obj)
         if accepted:
             #print "%s  auto add %s" % (self.objectName(), obj.objectName())
             self.addWidget(obj)
-            
+
         if not accepted or self.checkForChildren(obj):
             for c in obj.children():
                 self.autoAdd(c)
@@ -212,7 +212,7 @@ class WidgetGroup(QtCore.QObject):
 
     def mkChangeCallback(self, w):
         return lambda *args: self.widgetChanged(w, *args)
-        
+
     def widgetChanged(self, w, *args):
         n = self.widgetList[w]
         v1 = self.cache[n]
@@ -222,7 +222,7 @@ class WidgetGroup(QtCore.QObject):
                 # Old signal kept for backward compatibility.
                 self.emit(QtCore.SIGNAL('changed'), self.widgetList[w], v2)
             self.sigChanged.emit(self.widgetList[w], v2)
-        
+
     def state(self):
         for w in self.uncachedWidgets:
             self.readWidget(w)
@@ -240,18 +240,18 @@ class WidgetGroup(QtCore.QObject):
             getFunc = WidgetGroup.classes[type(w)][1]
         else:
             getFunc = w.widgetGroupInterface()[1]
-        
+
         if getFunc is None:
             return None
-            
+
         ## if the getter function provided in the interface is a bound method,
         ## then just call the method directly. Otherwise, pass in the widget as the first arg
         ## to the function.
-        if inspect.ismethod(getFunc) and getFunc.__self__ is not None:  
+        if inspect.ismethod(getFunc) and getFunc.__self__ is not None:
             val = getFunc()
         else:
             val = getFunc(w)
-            
+
         if self.scales[w] is not None:
             val /= self.scales[w]
         #if isinstance(val, QtCore.QString):
@@ -264,23 +264,20 @@ class WidgetGroup(QtCore.QObject):
         v1 = v
         if self.scales[w] is not None:
             v *= self.scales[w]
-        
+
         if type(w) in WidgetGroup.classes:
             setFunc = WidgetGroup.classes[type(w)][2]
         else:
             setFunc = w.widgetGroupInterface()[2]
-            
+
         ## if the setter function provided in the interface is a bound method,
         ## then just call the method directly. Otherwise, pass in the widget as the first arg
         ## to the function.
-        if inspect.ismethod(setFunc) and setFunc.__self__ is not None:  
+        if inspect.ismethod(setFunc) and setFunc.__self__ is not None:
             setFunc(v)
         else:
             setFunc(w, v)
-            
+
         #name = self.widgetList[w]
         #if name in self.cache and (self.cache[name] != v1):
             #print "%s: Cached value %s != set value %s" % (name, str(self.cache[name]), str(v1))
-
-        
-        

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -42,10 +42,10 @@ elif 'darwin' in sys.platform: ## openGL can have a major impact on mac, but als
     if QtGui.QApplication.instance() is not None:
         print('Warning: QApplication was created before pyqtgraph was imported; there may be problems (to avoid bugs, call QApplication.setGraphicsSystem("raster") before the QApplication is created).')
     if QtGui.QApplication.setGraphicsSystem:
-        QtGui.QApplication.setGraphicsSystem('raster')  ## work around a variety of bugs in the native graphics system 
+        QtGui.QApplication.setGraphicsSystem('raster')  ## work around a variety of bugs in the native graphics system
 else:
-    useOpenGL = False  ## on windows there's a more even performance / bugginess tradeoff. 
-                
+    useOpenGL = False  ## on windows there's a more even performance / bugginess tradeoff.
+
 CONFIG_OPTIONS = {
     'useOpenGL': useOpenGL, ## by default, this is platform-dependent (see widgets/GraphicsView). Set to True or False to explicitly enable/disable opengl.
     'leftButtonPan': True,  ## if false, left button drags a rubber band for zooming in viewbox
@@ -59,7 +59,7 @@ CONFIG_OPTIONS = {
     'exitCleanup': True,    ## Attempt to work around some exit crash bugs in PyQt and PySide
     'enableExperimental': False, ## Enable experimental features (the curious can search for this key in the code)
     'crashWarning': False,  # If True, print warnings about situations that may result in a crash
-} 
+}
 
 
 def setConfigOption(opt, value):
@@ -77,14 +77,14 @@ def systemInfo():
     print("sys.version: %s" % sys.version)
     from .Qt import VERSION_INFO
     print("qt bindings: %s" % VERSION_INFO)
-    
+
     global __version__
     rev = None
     if __version__ is None:  ## this code was probably checked out from bzr; look up the last-revision file
         lastRevFile = os.path.join(os.path.dirname(__file__), '..', '.bzr', 'branch', 'last-revision')
         if os.path.exists(lastRevFile):
             rev = open(lastRevFile, 'r').read().strip()
-    
+
     print("pyqtgraph: %s; %s" % (__version__, rev))
     print("config:")
     import pprint
@@ -92,16 +92,16 @@ def systemInfo():
 
 ## Rename orphaned .pyc files. This is *probably* safe :)
 ## We only do this if __version__ is None, indicating the code was probably pulled
-## from the repository. 
+## from the repository.
 def renamePyc(startDir):
     ### Used to rename orphaned .pyc files
     ### When a python file changes its location in the repository, usually the .pyc file
-    ### is left behind, possibly causing mysterious and difficult to track bugs. 
+    ### is left behind, possibly causing mysterious and difficult to track bugs.
 
     ### Note that this is no longer necessary for python 3.2; from PEP 3147:
-    ### "If the py source file is missing, the pyc file inside __pycache__ will be ignored. 
+    ### "If the py source file is missing, the pyc file inside __pycache__ will be ignored.
     ### This eliminates the problem of accidental stale pyc file imports."
-    
+
     printed = False
     startDir = os.path.abspath(startDir)
     for path, dirs, files in os.walk(startDir):
@@ -124,7 +124,7 @@ def renamePyc(startDir):
                 print("  " + fileName + "  ==>")
                 print("  " + name2)
                 os.rename(fileName, name2)
-                
+
 path = os.path.split(__file__)[0]
 if __version__ is None and not hasattr(sys, 'frozen') and sys.version_info[0] == 2: ## If we are frozen, there's a good chance we don't have the original .py files anymore.
     renamePyc(path)
@@ -136,8 +136,8 @@ if __version__ is None and not hasattr(sys, 'frozen') and sys.version_info[0] ==
 #from . import frozenSupport
 #def importModules(path, globals, locals, excludes=()):
     #"""Import all modules residing within *path*, return a dict of name: module pairs.
-    
-    #Note that *path* MUST be relative to the module doing the import.    
+
+    #Note that *path* MUST be relative to the module doing the import.
     #"""
     #d = os.path.join(os.path.split(globals['__file__'])[0], path)
     #files = set()
@@ -148,7 +148,7 @@ if __version__ is None and not hasattr(sys, 'frozen') and sys.version_info[0] ==
             #files.add(f[:-3])
         #elif f[-4:] == '.pyc' and f != '__init__.pyc':
             #files.add(f[:-4])
-        
+
     #mods = {}
     #path = path.replace(os.sep, '.')
     #for modName in files:
@@ -165,7 +165,7 @@ if __version__ is None and not hasattr(sys, 'frozen') and sys.version_info[0] ==
             #traceback.print_stack()
             #sys.excepthook(*sys.exc_info())
             #print("[Error importing module: %s]" % modName)
-            
+
     #return mods
 
 #def importAll(path, globals, locals, excludes=()):
@@ -185,66 +185,66 @@ if __version__ is None and not hasattr(sys, 'frozen') and sys.version_info[0] ==
 #importAll('widgets', globals(), locals(),
           #excludes=['MatplotlibWidget', 'RawImageWidget', 'RemoteGraphicsView'])
 
-from .graphicsItems.VTickGroup import * 
-from .graphicsItems.GraphicsWidget import * 
-from .graphicsItems.ScaleBar import * 
-from .graphicsItems.PlotDataItem import * 
-from .graphicsItems.GraphItem import * 
-from .graphicsItems.TextItem import * 
-from .graphicsItems.GraphicsLayout import * 
-from .graphicsItems.UIGraphicsItem import * 
-from .graphicsItems.GraphicsObject import * 
-from .graphicsItems.PlotItem import * 
-from .graphicsItems.ROI import * 
-from .graphicsItems.InfiniteLine import * 
-from .graphicsItems.HistogramLUTItem import * 
-from .graphicsItems.GridItem import * 
-from .graphicsItems.GradientLegend import * 
-from .graphicsItems.GraphicsItem import * 
-from .graphicsItems.BarGraphItem import * 
-from .graphicsItems.ViewBox import * 
-from .graphicsItems.ArrowItem import * 
-from .graphicsItems.ImageItem import * 
-from .graphicsItems.AxisItem import * 
-from .graphicsItems.LabelItem import * 
-from .graphicsItems.CurvePoint import * 
-from .graphicsItems.GraphicsWidgetAnchor import * 
-from .graphicsItems.PlotCurveItem import * 
-from .graphicsItems.ButtonItem import * 
-from .graphicsItems.GradientEditorItem import * 
-from .graphicsItems.MultiPlotItem import * 
-from .graphicsItems.ErrorBarItem import * 
-from .graphicsItems.IsocurveItem import * 
-from .graphicsItems.LinearRegionItem import * 
-from .graphicsItems.FillBetweenItem import * 
-from .graphicsItems.LegendItem import * 
-from .graphicsItems.ScatterPlotItem import * 
-from .graphicsItems.ItemGroup import * 
+from .graphicsItems.VTickGroup import *
+from .graphicsItems.GraphicsWidget import *
+from .graphicsItems.ScaleBar import *
+from .graphicsItems.PlotDataItem import *
+from .graphicsItems.GraphItem import *
+from .graphicsItems.TextItem import *
+from .graphicsItems.GraphicsLayout import *
+from .graphicsItems.UIGraphicsItem import *
+from .graphicsItems.GraphicsObject import *
+from .graphicsItems.PlotItem import *
+from .graphicsItems.ROI import *
+from .graphicsItems.InfiniteLine import *
+from .graphicsItems.HistogramLUTItem import *
+from .graphicsItems.GridItem import *
+from .graphicsItems.GradientLegend import *
+from .graphicsItems.GraphicsItem import *
+from .graphicsItems.BarGraphItem import *
+from .graphicsItems.ViewBox import *
+from .graphicsItems.ArrowItem import *
+from .graphicsItems.ImageItem import *
+from .graphicsItems.AxisItem import *
+from .graphicsItems.LabelItem import *
+from .graphicsItems.CurvePoint import *
+from .graphicsItems.GraphicsWidgetAnchor import *
+from .graphicsItems.PlotCurveItem import *
+from .graphicsItems.ButtonItem import *
+from .graphicsItems.GradientEditorItem import *
+from .graphicsItems.MultiPlotItem import *
+from .graphicsItems.ErrorBarItem import *
+from .graphicsItems.IsocurveItem import *
+from .graphicsItems.LinearRegionItem import *
+from .graphicsItems.FillBetweenItem import *
+from .graphicsItems.LegendItem import *
+from .graphicsItems.ScatterPlotItem import *
+from .graphicsItems.ItemGroup import *
 
-from .widgets.MultiPlotWidget import * 
-from .widgets.ScatterPlotWidget import * 
-from .widgets.ColorMapWidget import * 
-from .widgets.FileDialog import * 
-from .widgets.ValueLabel import * 
-from .widgets.HistogramLUTWidget import * 
-from .widgets.CheckTable import * 
-from .widgets.BusyCursor import * 
-from .widgets.PlotWidget import * 
-from .widgets.ComboBox import * 
-from .widgets.GradientWidget import * 
-from .widgets.DataFilterWidget import * 
-from .widgets.SpinBox import * 
-from .widgets.JoystickButton import * 
-from .widgets.GraphicsLayoutWidget import * 
-from .widgets.TreeWidget import * 
-from .widgets.PathButton import * 
-from .widgets.VerticalLabel import * 
-from .widgets.FeedbackButton import * 
-from .widgets.ColorButton import * 
-from .widgets.DataTreeWidget import * 
-from .widgets.GraphicsView import * 
-from .widgets.LayoutWidget import * 
-from .widgets.TableWidget import * 
+from .widgets.MultiPlotWidget import *
+from .widgets.ScatterPlotWidget import *
+from .widgets.ColorMapWidget import *
+from .widgets.FileDialog import *
+from .widgets.ValueLabel import *
+from .widgets.HistogramLUTWidget import *
+from .widgets.CheckTable import *
+from .widgets.BusyCursor import *
+from .widgets.PlotWidget import *
+from .widgets.ComboBox import *
+from .widgets.GradientWidget import *
+from .widgets.DataFilterWidget import *
+from .widgets.SpinBox import *
+from .widgets.JoystickButton import *
+from .widgets.GraphicsLayoutWidget import *
+from .widgets.TreeWidget import *
+from .widgets.PathButton import *
+from .widgets.VerticalLabel import *
+from .widgets.FeedbackButton import *
+from .widgets.ColorButton import *
+from .widgets.DataTreeWidget import *
+from .widgets.GraphicsView import *
+from .widgets.LayoutWidget import *
+from .widgets.TableWidget import *
 from .widgets.ProgressDialog import *
 
 from .imageview import *
@@ -263,7 +263,7 @@ from .Qt import isQObjectAlive
 
 
 ##############################################################
-## PyQt and PySide both are prone to crashing on exit. 
+## PyQt and PySide both are prone to crashing on exit.
 ## There are two general approaches to dealing with this:
 ##  1. Install atexit handlers that assist in tearing down to avoid crashes.
 ##     This helps, but is never perfect.
@@ -277,12 +277,12 @@ def cleanup():
     global _cleanupCalled
     if _cleanupCalled:
         return
-    
+
     if not getConfigOption('exitCleanup'):
         return
-    
+
     ViewBox.quit()  ## tell ViewBox that it doesn't need to deregister views anymore.
-    
+
     ## Workaround for Qt exit crash:
     ## ALL QGraphicsItems must have a scene before they are deleted.
     ## This is potentially very expensive, but preferred over crashing.
@@ -298,7 +298,7 @@ def cleanup():
                     sys.stderr.write('Error: graphics item without scene. '
                         'Make sure ViewBox.close() and GraphicsView.close() '
                         'are properly called before app shutdown (%s)\n' % (o,))
-                
+
                 s.addItem(o)
         except RuntimeError:  ## occurs if a python wrapper no longer has its underlying C++ object
             continue
@@ -323,28 +323,28 @@ def _connectCleanup():
 def exit():
     """
     Causes python to exit without garbage-collecting any objects, and thus avoids
-    calling object destructor methods. This is a sledgehammer workaround for 
+    calling object destructor methods. This is a sledgehammer workaround for
     a variety of bugs in PyQt and Pyside that cause crashes on exit.
-    
+
     This function does the following in an attempt to 'safely' terminate
     the process:
-    
+
     * Invoke atexit callbacks
     * Close all open file handles
     * os._exit()
-    
+
     Note: there is some potential for causing damage with this function if you
     are using objects that _require_ their destructors to be called (for example,
     to properly terminate log files, disconnect from devices, etc). Situations
     like this are probably quite rare, but use at your own risk.
     """
-    
+
     ## first disable our own cleanup function; won't be needing it.
     setConfigOptions(exitCleanup=False)
-    
+
     ## invoke atexit callbacks
     atexit._run_exitfuncs()
-    
+
     ## close file handles
     if sys.platform == 'darwin':
         for fd in range(3, 4096):
@@ -354,7 +354,7 @@ def exit():
         os.closerange(3, 4096) ## just guessing on the maximum descriptor count..
 
     os._exit(0)
-    
+
 
 
 ## Convenience functions for command-line use
@@ -365,7 +365,7 @@ QAPP = None
 
 def plot(*args, **kargs):
     """
-    Create and return a :class:`PlotWindow <pyqtgraph.PlotWindow>` 
+    Create and return a :class:`PlotWindow <pyqtgraph.PlotWindow>`
     (this is just a window with :class:`PlotWidget <pyqtgraph.PlotWidget>` inside), plot data in it.
     Accepts a *title* argument to set the title of the window.
     All other arguments are used to plot data. (see :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>`)
@@ -378,7 +378,7 @@ def plot(*args, **kargs):
         #w = PlotWindow()
     #if len(args)+len(kargs) > 0:
         #w.plot(*args, **kargs)
-        
+
     pwArgList = ['title', 'labels', 'name', 'left', 'right', 'top', 'bottom', 'background']
     pwArgs = {}
     dataArgs = {}
@@ -387,17 +387,17 @@ def plot(*args, **kargs):
             pwArgs[k] = kargs[k]
         else:
             dataArgs[k] = kargs[k]
-        
+
     w = PlotWindow(**pwArgs)
     if len(args) > 0 or len(dataArgs) > 0:
         w.plot(*args, **dataArgs)
     plots.append(w)
     w.show()
     return w
-    
+
 def image(*args, **kargs):
     """
-    Create and return an :class:`ImageWindow <pyqtgraph.ImageWindow>` 
+    Create and return an :class:`ImageWindow <pyqtgraph.ImageWindow>`
     (this is just a window with :class:`ImageView <pyqtgraph.ImageView>` widget inside), show image data inside.
     Will show 2D or 3D image data.
     Accepts a *title* argument to set the title of the window.
@@ -413,7 +413,7 @@ show = image  ## for backward compatibility
 def dbg(*args, **kwds):
     """
     Create a console window and begin watching for exceptions.
-    
+
     All arguments are passed to :func:`ConsoleWidget.__init__() <pyqtgraph.console.ConsoleWidget.__init__>`.
     """
     mkQApp()
@@ -427,8 +427,8 @@ def dbg(*args, **kwds):
     except NameError:
         consoles = [c]
     return c
-    
-    
+
+
 def mkQApp():
     global QAPP
     inst = QtGui.QApplication.instance()
@@ -437,4 +437,3 @@ def mkQApp():
     else:
         QAPP = inst
     return QAPP
-        

--- a/pyqtgraph/canvas/Canvas.py
+++ b/pyqtgraph/canvas/Canvas.py
@@ -13,7 +13,7 @@ if USE_PYSIDE:
     from .CanvasTemplate_pyside import *
 else:
     from .CanvasTemplate_pyqt import *
-    
+
 import numpy as np
 from .. import debug
 import weakref
@@ -21,11 +21,11 @@ from .CanvasManager import CanvasManager
 from .CanvasItem import CanvasItem, GroupCanvasItem
 
 class Canvas(QtGui.QWidget):
-    
+
     sigSelectionChanged = QtCore.Signal(object, object)
     sigItemTransformChanged = QtCore.Signal(object, object)
     sigItemTransformChangeFinished = QtCore.Signal(object, object)
-    
+
     def __init__(self, parent=None, allowTransforms=True, hideCtrl=False, name=None):
         QtGui.QWidget.__init__(self, parent)
         self.ui = Ui_Form()
@@ -43,18 +43,18 @@ class Canvas(QtGui.QWidget):
         self.ui.mirrorSelectionBtn.hide()
         self.ui.reflectSelectionBtn.hide()
         self.ui.resetTransformsBtn.hide()
-        
+
         self.redirect = None  ## which canvas to redirect items to
         self.items = []
-        
+
         #self.view.enableMouse()
         self.view.setAspectLocked(True)
         #self.view.invertY()
-        
+
         grid = GridItem()
         self.grid = CanvasItem(grid, name='Grid', movable=False)
         self.addItem(self.grid)
-        
+
         self.hideBtn = QtGui.QPushButton('>', self)
         self.hideBtn.setFixedWidth(20)
         self.hideBtn.setFixedHeight(20)
@@ -62,7 +62,7 @@ class Canvas(QtGui.QWidget):
         self.sizeApplied = False
         self.hideBtn.clicked.connect(self.hideBtnClicked)
         self.ui.splitter.splitterMoved.connect(self.splitterMoved)
-        
+
         self.ui.itemList.itemChanged.connect(self.treeItemChanged)
         self.ui.itemList.sigItemMoved.connect(self.treeItemMoved)
         self.ui.itemList.itemSelectionChanged.connect(self.treeItemSelected)
@@ -76,15 +76,15 @@ class Canvas(QtGui.QWidget):
         self.ui.mirrorSelectionBtn.clicked.connect(self.mirrorSelectionClicked)
         self.ui.reflectSelectionBtn.clicked.connect(self.reflectSelectionClicked)
         self.ui.resetTransformsBtn.clicked.connect(self.resetTransformsClicked)
-        
+
         self.resizeEvent()
         if hideCtrl:
             self.hideBtnClicked()
-            
+
         if name is not None:
             self.registeredName = CanvasManager.instance().registerCanvas(self, name)
             self.ui.redirectCombo.setHostName(self.registeredName)
-            
+
         self.menu = QtGui.QMenu()
         #self.menu.setTitle("Image")
         remAct = QtGui.QAction("Remove item", self.menu)
@@ -92,7 +92,7 @@ class Canvas(QtGui.QWidget):
         self.menu.addAction(remAct)
         self.menu.remAct = remAct
         self.ui.itemList.contextMenuEvent = self.itemListContextMenuEvent
-            
+
 
     #def storeSvg(self):
         #from pyqtgraph.GraphicsScene.exportDialog import ExportDialog
@@ -127,14 +127,14 @@ class Canvas(QtGui.QWidget):
         if ev is not None:
             QtGui.QWidget.resizeEvent(self, ev)
         self.hideBtn.move(self.ui.view.size().width() - self.hideBtn.width(), 0)
-        
+
         if not self.sizeApplied:
             self.sizeApplied = True
             s = min(self.width(), max(100, min(200, self.width()*0.25)))
             s2 = self.width()-s
             self.ui.splitter.setSizes([s2, s])
 
-    
+
     def updateRedirect(self, *args):
         ### Decide whether/where to redirect items and make it so
         cname = str(self.ui.redirectCombo.currentText())
@@ -143,17 +143,17 @@ class Canvas(QtGui.QWidget):
             redirect = man.getCanvas(cname)
         else:
             redirect = None
-            
+
         if self.redirect is redirect:
             return
-            
+
         self.redirect = redirect
         if redirect is None:
             self.reclaimItems()
         else:
             self.redirectItems(redirect)
 
-    
+
     def redirectItems(self, canvas):
         for i in self.items:
             if i is self.grid:
@@ -169,7 +169,7 @@ class Canvas(QtGui.QWidget):
             else:
                 parent.removeChild(li)
             canvas.addItem(i)
-            
+
 
     def reclaimItems(self):
         items = self.items
@@ -177,7 +177,7 @@ class Canvas(QtGui.QWidget):
         #del items['Grid']
         self.items = [self.grid]
         items.remove(self.grid)
-        
+
         for i in items:
             i.canvas.removeItem(i)
             self.addItem(i)
@@ -206,17 +206,17 @@ class Canvas(QtGui.QWidget):
             #if hasattr(listItem, 'canvasItem') and listItem.canvasItem is not None:
                 #sel.append(listItem.canvasItem)
         #sel = [self.items[item.name] for item in sel]
-        
+
         if len(sel) == 0:
             #self.selectWidget.hide()
             return
-            
+
         multi = len(sel) > 1
         for i in self.items:
             #i.ctrlWidget().hide()
             ## updated the selected state of every item
             i.selectionChanged(i in sel, multi)
-            
+
         if len(sel)==1:
             #item = sel[0]
             #item.ctrlWidget().show()
@@ -226,23 +226,23 @@ class Canvas(QtGui.QWidget):
             self.ui.resetTransformsBtn.hide()
         elif len(sel) > 1:
             self.showMultiSelectBox()
-        
+
         #if item.isMovable():
             #self.selectBox.setPos(item.item.pos())
             #self.selectBox.setSize(item.item.sceneBoundingRect().size())
             #self.selectBox.show()
         #else:
             #self.selectBox.hide()
-        
+
         #self.emit(QtCore.SIGNAL('itemSelected'), self, item)
         self.sigSelectionChanged.emit(self, sel)
-        
+
     def selectedItems(self):
         """
         Return list of all selected canvasItems
         """
         return [item.canvasItem() for item in self.itemList.selectedItems() if item.canvasItem() is not None]
-        
+
     #def selectedItem(self):
         #sel = self.itemList.selectedItems()
         #if sel is None or len(sel) < 1:
@@ -255,27 +255,27 @@ class Canvas(QtGui.QWidget):
         #print "select", li
         self.itemList.setCurrentItem(li)
 
-        
-        
+
+
     def showMultiSelectBox(self):
         ## Get list of selected canvas items
         items = self.selectedItems()
-        
+
         rect = self.view.itemBoundingRect(items[0].graphicsItem())
         for i in items:
             if not i.isMovable():  ## all items in selection must be movable
                 return
             br = self.view.itemBoundingRect(i.graphicsItem())
             rect = rect|br
-            
+
         self.multiSelectBox.blockSignals(True)
         self.multiSelectBox.setPos([rect.x(), rect.y()])
         self.multiSelectBox.setSize(rect.size())
         self.multiSelectBox.setAngle(0)
         self.multiSelectBox.blockSignals(False)
-        
+
         self.multiSelectBox.show()
-        
+
         self.ui.mirrorSelectionBtn.show()
         self.ui.reflectSelectionBtn.show()
         self.ui.resetTransformsBtn.show()
@@ -290,7 +290,7 @@ class Canvas(QtGui.QWidget):
         for ci in self.selectedItems():
             ci.mirrorXY()
         self.showMultiSelectBox()
-            
+
     def resetTransformsClicked(self):
         for i in self.selectedItems():
             i.resetTransformClicked()
@@ -298,18 +298,18 @@ class Canvas(QtGui.QWidget):
 
     def multiSelectBoxChanged(self):
         self.multiSelectBoxMoved()
-        
+
     def multiSelectBoxChangeFinished(self):
         for ci in self.selectedItems():
             ci.applyTemporaryTransform()
             ci.sigTransformChangeFinished.emit(ci)
-        
+
     def multiSelectBoxMoved(self):
         transform = self.multiSelectBox.getGlobalTransform()
         for ci in self.selectedItems():
             ci.setTemporaryTransform(transform)
             ci.sigTransformChanged.emit(ci)
-        
+
 
     def addGraphicsItem(self, item, **opts):
         """Add a new GraphicsItem to the scene at pos.
@@ -319,19 +319,19 @@ class Canvas(QtGui.QWidget):
         item._canvasItem = citem
         self.addItem(citem)
         return citem
-            
+
 
     def addGroup(self, name, **kargs):
         group = GroupCanvasItem(name=name)
         self.addItem(group, **kargs)
         return group
-        
+
 
     def addItem(self, citem):
         """
-        Add an item to the canvas. 
+        Add an item to the canvas.
         """
-        
+
         ## Check for redirections
         if self.redirect is not None:
             name = self.redirect.addItem(citem)
@@ -345,7 +345,7 @@ class Canvas(QtGui.QWidget):
         citem.sigTransformChangeFinished.connect(self.itemTransformChangeFinished)
         citem.sigVisibilityChanged.connect(self.itemVisibilityChanged)
 
-        
+
         ## Determine name to use in the item list
         name = citem.opts['name']
         if name is None:
@@ -359,20 +359,20 @@ class Canvas(QtGui.QWidget):
             #c += 1
             #newname = name + '_%03d' %c
         #name = newname
-            
+
         ## find parent and add item to tree
         #currentNode = self.itemList.invisibleRootItem()
         insertLocation = 0
         #print "Inserting node:", name
-        
-            
+
+
         ## determine parent list item where this item should be inserted
         parent = citem.parentItem()
         if parent in (None, self.view.childGroup):
             parent = self.itemList.invisibleRootItem()
         else:
             parent = parent.listItem
-        
+
         ## set Z value above all other siblings if none was specified
         siblings = [parent.child(i).canvasItem() for i in range(parent.childCount())]
         z = citem.zValue()
@@ -389,7 +389,7 @@ class Canvas(QtGui.QWidget):
                 else:
                     z = max(zvals)+1
             citem.setZValue(z)
-            
+
         ## determine location to insert item relative to its siblings
         for i in range(parent.childCount()):
             ch = parent.child(i)
@@ -399,7 +399,7 @@ class Canvas(QtGui.QWidget):
                 break
             else:
                 insertLocation = i+1
-                
+
         node = QtGui.QTreeWidgetItem([name])
         flags = node.flags() | QtCore.Qt.ItemIsUserCheckable | QtCore.Qt.ItemIsDragEnabled
         if not isinstance(citem, GroupCanvasItem):
@@ -409,14 +409,14 @@ class Canvas(QtGui.QWidget):
             node.setCheckState(0, QtCore.Qt.Checked)
         else:
             node.setCheckState(0, QtCore.Qt.Unchecked)
-        
+
         node.name = name
         #if citem.opts['parent'] != None:
             ## insertLocation is incorrect in this case
         parent.insertChild(insertLocation, node)
-        #else:    
+        #else:
             #root.insertChild(insertLocation, node)
-        
+
         citem.name = name
         citem.listItem = node
         node.canvasItem = weakref.ref(citem)
@@ -425,15 +425,15 @@ class Canvas(QtGui.QWidget):
         ctrl = citem.ctrlWidget()
         ctrl.hide()
         self.ui.ctrlLayout.addWidget(ctrl)
-        
+
         ## inform the canvasItem that its parent canvas has changed
         citem.setCanvas(self)
 
         ## Autoscale to fit the first item added (not including the grid).
         if len(self.items) == 2:
             self.autoRange()
-            
-        
+
+
         #for n in name:
             #nextnode = None
             #for x in range(currentNode.childCount()):
@@ -453,15 +453,15 @@ class Canvas(QtGui.QWidget):
                 ### Add node to correct position in list by Z-value
                 ###print "  ==>", insertLocation
                 #currentNode.insertChild(insertLocation, nextnode)
-                
+
                 #if n == name[-1]:   ## This is the leaf; add some extra properties.
                     #nextnode.name = name
-                
+
                 #if n == name[0]:   ## This is the root; make the item movable
                     #nextnode.setFlags(nextnode.flags() | QtCore.Qt.ItemIsDragEnabled)
                 #else:
                     #nextnode.setFlags(nextnode.flags() & ~QtCore.Qt.ItemIsDragEnabled)
-                    
+
             #currentNode = nextnode
         return citem
 
@@ -472,27 +472,27 @@ class Canvas(QtGui.QWidget):
         else:
             item.canvasItem().setParentItem(parent.canvasItem())
         siblings = [parent.child(i).canvasItem() for i in range(parent.childCount())]
-        
+
         zvals = [i.zValue() for i in siblings]
         zvals.sort(reverse=True)
-        
+
         for i in range(len(siblings)):
             item = siblings[i]
             item.setZValue(zvals[i])
             #item = self.itemList.topLevelItem(i)
-            
+
             ##ci = self.items[item.name]
             #ci = item.canvasItem
             #if ci is None:
                 #continue
             #if ci.zValue() != zvals[i]:
                 #ci.setZValue(zvals[i])
-        
+
         #if self.itemList.topLevelItemCount() < 2:
             #return
         #name = item.name
         #gi = self.items[name]
-        #if index == 0:   
+        #if index == 0:
             #next = self.itemList.topLevelItem(1)
             #z = self.items[next.name].zValue()+1
         #else:
@@ -504,7 +504,7 @@ class Canvas(QtGui.QWidget):
 
 
 
-        
+
     def itemVisibilityChanged(self, item):
         listItem = item.listItem
         checked = listItem.checkState(0) == QtCore.Qt.Checked
@@ -518,8 +518,8 @@ class Canvas(QtGui.QWidget):
     def removeItem(self, item):
         if isinstance(item, QtGui.QTreeWidgetItem):
             item = item.canvasItem()
-            
-            
+
+
         if isinstance(item, CanvasItem):
             item.setCanvas(None)
             listItem = item.listItem
@@ -535,43 +535,43 @@ class Canvas(QtGui.QWidget):
                 self.removeItem(item._canvasItem)
             else:
                 self.view.removeItem(item)
-        
+
         ## disconnect signals, remove from list, etc..
-        
+
     def clear(self):
         while len(self.items) > 0:
             self.removeItem(self.items[0])
-        
+
 
     def addToScene(self, item):
         self.view.addItem(item)
-        
+
     def removeFromScene(self, item):
         self.view.removeItem(item)
 
-    
+
     def listItems(self):
         """Return a dictionary of name:item pairs"""
         return self.items
-        
+
     def getListItem(self, name):
         return self.items[name]
-        
+
     #def scene(self):
         #return self.view.scene()
-        
+
     def itemTransformChanged(self, item):
         #self.emit(QtCore.SIGNAL('itemTransformChanged'), self, item)
         self.sigItemTransformChanged.emit(self, item)
-    
+
     def itemTransformChangeFinished(self, item):
         #self.emit(QtCore.SIGNAL('itemTransformChangeFinished'), self, item)
         self.sigItemTransformChangeFinished.emit(self, item)
-        
+
     def itemListContextMenuEvent(self, ev):
         self.menuItem = self.itemList.itemAt(ev.pos())
         self.menu.popup(ev.globalPos())
-        
+
     def removeClicked(self):
         #self.removeItem(self.menuItem)
         for item in self.selectedItems():
@@ -585,20 +585,9 @@ class SelectBox(ROI):
         #QtGui.QGraphicsRectItem.__init__(self, 0, 0, size[0], size[1])
         ROI.__init__(self, [0,0], [1,1])
         center = [0.5, 0.5]
-            
+
         if scalable:
             self.addScaleHandle([1, 1], center, lockAspect=True)
             self.addScaleHandle([0, 0], center, lockAspect=True)
         self.addRotateHandle([0, 1], center)
         self.addRotateHandle([1, 0], center)
-
-
-
-
-
-
-
-
-
-
-    

--- a/pyqtgraph/canvas/CanvasItem.py
+++ b/pyqtgraph/canvas/CanvasItem.py
@@ -14,7 +14,7 @@ class SelectBox(ROI):
         #QtGui.QGraphicsRectItem.__init__(self, 0, 0, size[0], size[1])
         ROI.__init__(self, [0,0], [1,1], invertible=True)
         center = [0.5, 0.5]
-            
+
         if scalable:
             self.addScaleHandle([1, 1], center, lockAspect=True)
             self.addScaleHandle([0, 0], center, lockAspect=True)
@@ -23,34 +23,34 @@ class SelectBox(ROI):
             self.addRotateHandle([1, 0], center)
 
 class CanvasItem(QtCore.QObject):
-    
+
     sigResetUserTransform = QtCore.Signal(object)
     sigTransformChangeFinished = QtCore.Signal(object)
     sigTransformChanged = QtCore.Signal(object)
-    
+
     """CanvasItem takes care of managing an item's state--alpha, visibility, z-value, transformations, etc. and
     provides a control widget"""
-    
+
     sigVisibilityChanged = QtCore.Signal(object)
     transformCopyBuffer = None
-    
+
     def __init__(self, item, **opts):
         defOpts = {'name': None, 'z': None, 'movable': True, 'scalable': False, 'rotatable': True, 'visible': True, 'parent':None} #'pos': [0,0], 'scale': [1,1], 'angle':0,
         defOpts.update(opts)
         self.opts = defOpts
         self.selectedAlone = False  ## whether this item is the only one selected
-        
+
         QtCore.QObject.__init__(self)
         self.canvas = None
         self._graphicsItem = item
-        
+
         parent = self.opts['parent']
         if parent is not None:
             self._graphicsItem.setParentItem(parent.graphicsItem())
             self._parentItem = parent
         else:
             self._parentItem = None
-        
+
         z = self.opts['z']
         if z is not None:
             item.setZValue(z)
@@ -60,7 +60,7 @@ class CanvasItem(QtCore.QObject):
         self.layout.setSpacing(0)
         self.layout.setContentsMargins(0,0,0,0)
         self.ctrl.setLayout(self.layout)
-        
+
         self.alphaLabel = QtGui.QLabel("Alpha")
         self.alphaSlider = QtGui.QSlider()
         self.alphaSlider.setMaximum(1023)
@@ -71,14 +71,14 @@ class CanvasItem(QtCore.QObject):
         self.resetTransformBtn = QtGui.QPushButton('Reset Transform')
         self.copyBtn = QtGui.QPushButton('Copy')
         self.pasteBtn = QtGui.QPushButton('Paste')
-        
+
         self.transformWidget = QtGui.QWidget()
         self.transformGui = TransformGuiTemplate.Ui_Form()
         self.transformGui.setupUi(self.transformWidget)
         self.layout.addWidget(self.transformWidget, 3, 0, 1, 2)
         self.transformGui.mirrorImageBtn.clicked.connect(self.mirrorY)
         self.transformGui.reflectImageBtn.clicked.connect(self.mirrorXY)
-        
+
         self.layout.addWidget(self.resetTransformBtn, 1, 0, 1, 2)
         self.layout.addWidget(self.copyBtn, 2, 0, 1, 1)
         self.layout.addWidget(self.pasteBtn, 2, 1, 1, 1)
@@ -89,7 +89,7 @@ class CanvasItem(QtCore.QObject):
         self.resetTransformBtn.clicked.connect(self.resetTransformClicked)
         self.copyBtn.clicked.connect(self.copyClicked)
         self.pasteBtn.clicked.connect(self.pasteClicked)
-        
+
         self.setMovable(self.opts['movable'])  ## update gui to reflect this option
 
 
@@ -108,8 +108,8 @@ class CanvasItem(QtCore.QObject):
         tr = self.baseTransform.saveState()
         if 'scalable' not in opts and tr['scale'] == (1,1):
             self.opts['scalable'] = True
-            
-        ## every CanvasItem implements its own individual selection box 
+
+        ## every CanvasItem implements its own individual selection box
         ## so that subclasses are free to make their own.
         self.selectBox = SelectBox(scalable=self.opts['scalable'], rotatable=self.opts['rotatable'])
         #self.canvas.scene().addItem(self.selectBox)
@@ -123,24 +123,24 @@ class CanvasItem(QtCore.QObject):
         self.itemRotation = QtGui.QGraphicsRotation()
         self.itemScale = QtGui.QGraphicsScale()
         self._graphicsItem.setTransformations([self.itemRotation, self.itemScale])
-        
+
         self.tempTransform = SRTTransform() ## holds the additional transform that happens during a move - gets added to the userTransform when move is done.
         self.userTransform = SRTTransform() ## stores the total transform of the object
-        self.resetUserTransform() 
-        
+        self.resetUserTransform()
+
         ## now happens inside resetUserTransform -> selectBoxToItem
         # self.selectBoxBase = self.selectBox.getState().copy()
-        
-                
+
+
         #print "Created canvas item", self
         #print "  base:", self.baseTransform
         #print "  user:", self.userTransform
         #print "  temp:", self.tempTransform
         #print "  bounds:", self.item.sceneBoundingRect()
-        
+
     def setMovable(self, m):
         self.opts['movable'] = m
-        
+
         if m:
             self.resetTransformBtn.show()
             self.copyBtn.show()
@@ -153,11 +153,11 @@ class CanvasItem(QtCore.QObject):
     def setCanvas(self, canvas):
         ## Called by canvas whenever the item is added.
         ## It is our responsibility to add all graphicsItems to the canvas's scene
-        ## The canvas will automatically add our graphicsitem, 
+        ## The canvas will automatically add our graphicsitem,
         ## so we just need to take care of the selectbox.
         if canvas is self.canvas:
             return
-            
+
         if canvas is None:
             self.canvas.removeFromScene(self._graphicsItem)
             self.canvas.removeFromScene(self.selectBox)
@@ -169,7 +169,7 @@ class CanvasItem(QtCore.QObject):
     def graphicsItem(self):
         """Return the graphicsItem for this canvasItem."""
         return self._graphicsItem
-        
+
     def parentItem(self):
         return self._parentItem
 
@@ -182,24 +182,24 @@ class CanvasItem(QtCore.QObject):
 
     #def name(self):
         #return self.opts['name']
-    
+
     def copyClicked(self):
         CanvasItem.transformCopyBuffer = self.saveTransform()
-        
+
     def pasteClicked(self):
         t = CanvasItem.transformCopyBuffer
         if t is None:
             return
         else:
             self.restoreTransform(t)
-            
+
     def mirrorY(self):
         if not self.isMovable():
             return
-        
+
         #flip = self.transformGui.mirrorImageCheck.isChecked()
         #tr = self.userTransform.saveState()
-        
+
         inv = SRTTransform()
         inv.scale(-1, 1)
         self.userTransform = self.userTransform * inv
@@ -237,23 +237,23 @@ class CanvasItem(QtCore.QObject):
         # s=self.updateTransform()
         # self.setTranslate(-2*s['pos'][0], -2*s['pos'][1])
         # self.selectBoxFromUser()
-        
- 
+
+
     def hasUserTransform(self):
         #print self.userRotate, self.userTranslate
         return not self.userTransform.isIdentity()
 
     def ctrlWidget(self):
         return self.ctrl
-        
+
     def alphaChanged(self, val):
         alpha = val / 1023.
         self._graphicsItem.setOpacity(alpha)
-        
+
     def isMovable(self):
         return self.opts['movable']
-        
-        
+
+
     def selectBoxMoved(self):
         """The selection box has moved; get its transformation information and pass to the graphics item"""
         self.userTransform = self.selectBox.getGlobalTransform(relativeTo=self.selectBoxBase)
@@ -263,37 +263,37 @@ class CanvasItem(QtCore.QObject):
         self.userTransform.scale(x, y)
         self.selectBoxFromUser()
         self.updateTransform()
-        
+
     def rotate(self, ang):
         self.userTransform.rotate(ang)
         self.selectBoxFromUser()
         self.updateTransform()
-        
+
     def translate(self, x, y):
         self.userTransform.translate(x, y)
         self.selectBoxFromUser()
         self.updateTransform()
-        
+
     def setTranslate(self, x, y):
         self.userTransform.setTranslate(x, y)
         self.selectBoxFromUser()
         self.updateTransform()
-        
+
     def setRotate(self, angle):
         self.userTransform.setRotate(angle)
         self.selectBoxFromUser()
         self.updateTransform()
-        
+
     def setScale(self, x, y):
         self.userTransform.setScale(x, y)
         self.selectBoxFromUser()
         self.updateTransform()
-        
+
 
     def setTemporaryTransform(self, transform):
         self.tempTransform = transform
         self.updateTransform()
-    
+
     def applyTemporaryTransform(self):
         """Collapses tempTransform into UserTransform, resets tempTransform"""
         self.userTransform = self.userTransform * self.tempTransform ## order is important!
@@ -301,14 +301,14 @@ class CanvasItem(QtCore.QObject):
         self.selectBoxFromUser()  ## update the selection box to match the new userTransform
 
         #st = self.userTransform.saveState()
-        
+
         #self.userTransform = self.userTransform * self.tempTransform ## order is important!
-        
+
         #### matrix multiplication affects the scale factors, need to reset
         #if st['scale'][0] < 0 or st['scale'][1] < 0:
             #nst = self.userTransform.saveState()
             #self.userTransform.setScale([-nst['scale'][0], -nst['scale'][1]])
-        
+
         #self.resetTemporaryTransform()
         #self.selectBoxFromUser()
         #self.selectBoxChangeFinished()
@@ -318,8 +318,8 @@ class CanvasItem(QtCore.QObject):
     def resetTemporaryTransform(self):
         self.tempTransform = SRTTransform()  ## don't use Transform.reset()--this transform might be used elsewhere.
         self.updateTransform()
-        
-    def transform(self): 
+
+    def transform(self):
         return self._graphicsItem.transform()
 
     def updateTransform(self):
@@ -327,19 +327,19 @@ class CanvasItem(QtCore.QObject):
         transform = self.baseTransform * self.userTransform * self.tempTransform ## order is important
         s = transform.saveState()
         self._graphicsItem.setPos(*s['pos'])
-        
+
         self.itemRotation.setAngle(s['angle'])
         self.itemScale.setXScale(s['scale'][0])
         self.itemScale.setYScale(s['scale'][1])
 
         self.displayTransform(transform)
         return(s) # return the transform state
-        
+
     def displayTransform(self, transform):
         """Updates transform numbers in the ctrl widget."""
-        
+
         tr = transform.saveState()
-        
+
         self.transformGui.translateLabel.setText("Translate: (%f, %f)" %(tr['pos'][0], tr['pos'][1]))
         self.transformGui.rotateLabel.setText("Rotate: %f degrees" %tr['angle'])
         self.transformGui.scaleLabel.setText("Scale: (%f, %f)" %(tr['scale'][0], tr['scale'][1]))
@@ -353,24 +353,24 @@ class CanvasItem(QtCore.QObject):
         #self.userTranslate = pg.Point(0,0)
         self.userTransform.reset()
         self.updateTransform()
-        
+
         self.selectBox.blockSignals(True)
         self.selectBoxToItem()
         self.selectBox.blockSignals(False)
         self.sigTransformChanged.emit(self)
         self.sigTransformChangeFinished.emit(self)
-       
+
     def resetTransformClicked(self):
         self.resetUserTransform()
         self.sigResetUserTransform.emit(self)
-        
+
     def restoreTransform(self, tr):
         try:
             #self.userTranslate = pg.Point(tr['trans'])
             #self.userRotate = tr['rot']
             self.userTransform = SRTTransform(tr)
             self.updateTransform()
-            
+
             self.selectBoxFromUser() ## move select box to match
             self.sigTransformChanged.emit(self)
             self.sigTransformChangeFinished.emit(self)
@@ -380,29 +380,29 @@ class CanvasItem(QtCore.QObject):
             self.userTransform = SRTTransform()
             debug.printExc("Failed to load transform:")
         #print "set transform", self, self.userTranslate
-        
+
     def saveTransform(self):
         """Return a dict containing the current user transform"""
         #print "save transform", self, self.userTranslate
         #return {'trans': list(self.userTranslate), 'rot': self.userRotate}
         return self.userTransform.saveState()
-        
+
     def selectBoxFromUser(self):
         """Move the selection box to match the current userTransform"""
         ## user transform
         #trans = QtGui.QTransform()
         #trans.translate(*self.userTranslate)
         #trans.rotate(-self.userRotate)
-        
+
         #x2, y2 = trans.map(*self.selectBoxBase['pos'])
-        
+
         self.selectBox.blockSignals(True)
         self.selectBox.setState(self.selectBoxBase)
         self.selectBox.applyGlobalTransform(self.userTransform)
         #self.selectBox.setAngle(self.userRotate)
         #self.selectBox.setPos([x2, y2])
         self.selectBox.blockSignals(False)
-        
+
 
     def selectBoxToItem(self):
         """Move/scale the selection box so it fits the item's bounding rect. (assumes item is not rotated)"""
@@ -417,24 +417,24 @@ class CanvasItem(QtCore.QObject):
 
     def zValue(self):
         return self.opts['z']
-        
+
     def setZValue(self, z):
         self.opts['z'] = z
         if z is not None:
             self._graphicsItem.setZValue(z)
-        
+
     #def selectionChanged(self, canvas, items):
-        #self.selected = len(items) == 1 and (items[0] is self) 
+        #self.selected = len(items) == 1 and (items[0] is self)
         #self.showSelectBox()
-           
-           
+
+
     def selectionChanged(self, sel, multi):
         """
-        Inform the item that its selection state has changed. 
+        Inform the item that its selection state has changed.
         ============== =========================================================
         **Arguments:**
         sel            (bool) whether the item is currently selected
-        multi          (bool) whether there are multiple items currently 
+        multi          (bool) whether there are multiple items currently
                        selected
         ============== =========================================================
         """
@@ -444,24 +444,24 @@ class CanvasItem(QtCore.QObject):
             self.ctrlWidget().show()
         else:
             self.ctrlWidget().hide()
-        
+
     def showSelectBox(self):
         """Display the selection box around this item if it is selected and movable"""
         if self.selectedAlone and self.isMovable() and self.isVisible():  #and len(self.canvas.itemList.selectedItems())==1:
             self.selectBox.show()
         else:
             self.selectBox.hide()
-        
+
     def hideSelectBox(self):
         self.selectBox.hide()
-        
-                
+
+
     def selectBoxChanged(self):
         self.selectBoxMoved()
         #self.updateTransform(self.selectBox)
         #self.emit(QtCore.SIGNAL('transformChanged'), self)
         self.sigTransformChanged.emit(self)
-        
+
     def selectBoxChangeFinished(self):
         #self.emit(QtCore.SIGNAL('transformChangeFinished'), self)
         self.sigTransformChangeFinished.emit(self)
@@ -469,10 +469,10 @@ class CanvasItem(QtCore.QObject):
     def alphaPressed(self):
         """Hide selection box while slider is moving"""
         self.hideSelectBox()
-        
+
     def alphaReleased(self):
         self.showSelectBox()
-        
+
     def show(self):
         if self.opts['visible']:
             return
@@ -480,7 +480,7 @@ class CanvasItem(QtCore.QObject):
         self._graphicsItem.show()
         self.showSelectBox()
         self.sigVisibilityChanged.emit(self)
-        
+
     def hide(self):
         if not self.opts['visible']:
             return
@@ -503,10 +503,9 @@ class GroupCanvasItem(CanvasItem):
     """
     Canvas item used for grouping others
     """
-    
+
     def __init__(self, **opts):
         defOpts = {'movable': False, 'scalable': False}
         defOpts.update(opts)
         item = ItemGroup()
         CanvasItem.__init__(self, item, **defOpts)
-    

--- a/pyqtgraph/canvas/CanvasManager.py
+++ b/pyqtgraph/canvas/CanvasManager.py
@@ -6,9 +6,9 @@ import weakref
 
 class CanvasManager(QtCore.QObject):
     SINGLETON = None
-    
+
     sigCanvasListChanged = QtCore.Signal()
-    
+
     def __init__(self):
         if CanvasManager.SINGLETON is not None:
             raise Exception("Can only create one canvas manager.")
@@ -19,7 +19,7 @@ class CanvasManager(QtCore.QObject):
     @classmethod
     def instance(cls):
         return CanvasManager.SINGLETON
-        
+
     def registerCanvas(self, canvas, name):
         n2 = name
         i = 0
@@ -29,19 +29,19 @@ class CanvasManager(QtCore.QObject):
         self.canvases[n2] = canvas
         self.sigCanvasListChanged.emit()
         return n2
-        
+
     def unregisterCanvas(self, name):
         c = self.canvases[name]
         del self.canvases[name]
         self.sigCanvasListChanged.emit()
-        
+
     def listCanvases(self):
         return list(self.canvases.keys())
-        
+
     def getCanvas(self, name):
         return self.canvases[name]
-        
-    
+
+
 manager = CanvasManager()
 
 
@@ -52,13 +52,13 @@ class CanvasCombo(QtGui.QComboBox):
         man.sigCanvasListChanged.connect(self.updateCanvasList)
         self.hostName = None
         self.updateCanvasList()
-        
+
     def updateCanvasList(self):
         canvases = CanvasManager.instance().listCanvases()
         canvases.insert(0, "")
         if self.hostName in canvases:
             canvases.remove(self.hostName)
-            
+
         sel = self.currentText()
         if sel in canvases:
             self.blockSignals(True)  ## change does not affect current selection; block signals during update
@@ -67,10 +67,9 @@ class CanvasCombo(QtGui.QComboBox):
             self.addItem(i)
             if i == sel:
                 self.setCurrentIndex(self.count())
-            
+
         self.blockSignals(False)
-        
+
     def setHostName(self, name):
         self.hostName = name
         self.updateCanvasList()
-

--- a/pyqtgraph/canvas/TransformGuiTemplate_pyqt.py
+++ b/pyqtgraph/canvas/TransformGuiTemplate_pyqt.py
@@ -66,4 +66,3 @@ class Ui_Form(object):
         self.scaleLabel.setText(_translate("Form", "Scale:", None))
         self.mirrorImageBtn.setText(_translate("Form", "Mirror", None))
         self.reflectImageBtn.setText(_translate("Form", "Reflect", None))
-

--- a/pyqtgraph/canvas/TransformGuiTemplate_pyqt5.py
+++ b/pyqtgraph/canvas/TransformGuiTemplate_pyqt5.py
@@ -53,4 +53,3 @@ class Ui_Form(object):
         self.scaleLabel.setText(_translate("Form", "Scale:"))
         self.mirrorImageBtn.setText(_translate("Form", "Mirror"))
         self.reflectImageBtn.setText(_translate("Form", "Reflect"))
-

--- a/pyqtgraph/canvas/TransformGuiTemplate_pyside.py
+++ b/pyqtgraph/canvas/TransformGuiTemplate_pyside.py
@@ -52,4 +52,3 @@ class Ui_Form(object):
         self.scaleLabel.setText(QtGui.QApplication.translate("Form", "Scale:", None, QtGui.QApplication.UnicodeUTF8))
         self.mirrorImageBtn.setText(QtGui.QApplication.translate("Form", "Mirror", None, QtGui.QApplication.UnicodeUTF8))
         self.reflectImageBtn.setText(QtGui.QApplication.translate("Form", "Reflect", None, QtGui.QApplication.UnicodeUTF8))
-

--- a/pyqtgraph/colormap.py
+++ b/pyqtgraph/colormap.py
@@ -5,40 +5,40 @@ from .python2_3 import basestring
 
 class ColorMap(object):
     """
-    A ColorMap defines a relationship between a scalar value and a range of colors. 
-    ColorMaps are commonly used for false-coloring monochromatic images, coloring 
-    scatter-plot points, and coloring surface plots by height. 
-    
+    A ColorMap defines a relationship between a scalar value and a range of colors.
+    ColorMaps are commonly used for false-coloring monochromatic images, coloring
+    scatter-plot points, and coloring surface plots by height.
+
     Each color map is defined by a set of colors, each corresponding to a
     particular scalar value. For example:
-    
+
         | 0.0  -> black
         | 0.2  -> red
         | 0.6  -> yellow
         | 1.0  -> white
-        
-    The colors for intermediate values are determined by interpolating between 
+
+    The colors for intermediate values are determined by interpolating between
     the two nearest colors in either RGB or HSV color space.
-    
+
     To provide user-defined color mappings, see :class:`GradientWidget <pyqtgraph.GradientWidget>`.
     """
-    
-    
+
+
     ## color interpolation modes
     RGB = 1
     HSV_POS = 2
     HSV_NEG = 3
-    
+
     ## boundary modes
     CLIP = 1
     REPEAT = 2
     MIRROR = 3
-    
+
     ## return types
     BYTE = 1
     FLOAT = 2
     QCOLOR = 3
-    
+
     enumMap = {
         'rgb': RGB,
         'hsv+': HSV_POS,
@@ -50,7 +50,7 @@ class ColorMap(object):
         'float': FLOAT,
         'qcolor': QCOLOR,
     }
-    
+
     def __init__(self, pos, color, mode=None):
         """
         ===============     ==============================================================
@@ -71,31 +71,31 @@ class ColorMap(object):
             mode = np.ones(len(pos))
         self.mode = mode
         self.stopsCache = {}
-        
+
     def map(self, data, mode='byte'):
         """
-        Return an array of colors corresponding to the values in *data*. 
+        Return an array of colors corresponding to the values in *data*.
         Data must be either a scalar position or an array (any shape) of positions.
-        
+
         The *mode* argument determines the type of data returned:
-        
+
         =========== ===============================================================
         byte        (default) Values are returned as 0-255 unsigned bytes.
-        float       Values are returned as 0.0-1.0 floats. 
+        float       Values are returned as 0.0-1.0 floats.
         qcolor      Values are returned as an array of QColor objects.
         =========== ===============================================================
         """
         if isinstance(mode, basestring):
             mode = self.enumMap[mode.lower()]
-            
+
         if mode == self.QCOLOR:
             pos, color = self.getStops(self.BYTE)
         else:
             pos, color = self.getStops(mode)
-            
+
         # don't need this--np.interp takes care of it.
         #data = np.clip(data, pos.min(), pos.max())
-            
+
         # Interpolate
         # TODO: is griddata faster?
         #          interp = scipy.interpolate.griddata(pos, color, data)
@@ -116,7 +116,7 @@ class ColorMap(object):
                 return [QtGui.QColor(*x) for x in interp]
         else:
             return interp
-        
+
     def mapToQColor(self, data):
         """Convenience function; see :func:`map() <pyqtgraph.ColorMap.map>`."""
         return self.map(data, mode=self.QCOLOR)
@@ -128,7 +128,7 @@ class ColorMap(object):
     def mapToFloat(self, data):
         """Convenience function; see :func:`map() <pyqtgraph.ColorMap.map>`."""
         return self.map(data, mode=self.FLOAT)
-    
+
     def getGradient(self, p1=None, p2=None):
         """Return a QLinearGradient object spanning from QPoints p1 to p2."""
         if p1 == None:
@@ -136,11 +136,11 @@ class ColorMap(object):
         if p2 == None:
             p2 = QtCore.QPointF(self.pos.max()-self.pos.min(),0)
         g = QtGui.QLinearGradient(p1, p2)
-        
+
         pos, color = self.getStops(mode=self.BYTE)
         color = [QtGui.QColor(*x) for x in color]
         g.setStops(zip(pos, color))
-        
+
         #if self.colorMode == 'rgb':
             #ticks = self.listTicks()
             #g.setStops([(x, QtGui.QColor(t.color)) for t,x in ticks])
@@ -158,24 +158,24 @@ class ColorMap(object):
                 #stops.append((x2, self.getColor(x2)))
             #g.setStops(stops)
         return g
-    
+
     def getColors(self, mode=None):
         """Return list of all color stops converted to the specified mode.
         If mode is None, then no conversion is done."""
         if isinstance(mode, basestring):
             mode = self.enumMap[mode.lower()]
-        
+
         color = self.color
         if mode in [self.BYTE, self.QCOLOR] and color.dtype.kind == 'f':
             color = (color * 255).astype(np.ubyte)
         elif mode == self.FLOAT and color.dtype.kind != 'f':
             color = color.astype(float) / 255.
-            
+
         if mode == self.QCOLOR:
             color = [QtGui.QColor(*x) for x in color]
-            
+
         return color
-        
+
     def getStops(self, mode):
         ## Get fully-expanded set of RGBA stops in either float or byte mode.
         if mode not in self.stopsCache:
@@ -184,25 +184,25 @@ class ColorMap(object):
                 color = (color * 255).astype(np.ubyte)
             elif mode == self.FLOAT and color.dtype.kind != 'f':
                 color = color.astype(float) / 255.
-        
+
             ## to support HSV mode, we need to do a little more work..
             #stops = []
             #for i in range(len(self.pos)):
                 #pos = self.pos[i]
                 #color = color[i]
-                
+
                 #imode = self.mode[i]
                 #if imode == self.RGB:
-                    #stops.append((x,color)) 
+                    #stops.append((x,color))
                 #else:
-                    #ns = 
+                    #ns =
             self.stopsCache[mode] = (self.pos, color)
         return self.stopsCache[mode]
-        
+
     def getLookupTable(self, start=0.0, stop=1.0, nPts=512, alpha=None, mode='byte'):
         """
-        Return an RGB(A) lookup table (ndarray). 
-        
+        Return an RGB(A) lookup table (ndarray).
+
         ===============   =============================================================================
         **Arguments:**
         start             The starting value in the lookup table (default=0.0)
@@ -216,23 +216,23 @@ class ColorMap(object):
         """
         if isinstance(mode, basestring):
             mode = self.enumMap[mode.lower()]
-        
+
         if alpha is None:
             alpha = self.usesAlpha()
-            
+
         x = np.linspace(start, stop, nPts)
         table = self.map(x, mode)
-        
+
         if not alpha:
             return table[:,:3]
         else:
             return table
-    
+
     def usesAlpha(self):
         """Return True if any stops have an alpha < 255"""
         max = 1.0 if self.color.dtype.kind == 'f' else 255
         return np.any(self.color[:,3] != max)
-            
+
     def isMapTrivial(self):
         """
         Return True if the gradient has exactly two stops in it: black at 0.0 and white at 1.0.

--- a/pyqtgraph/configfile.py
+++ b/pyqtgraph/configfile.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-configfile.py - Human-readable text configuration file library 
+configfile.py - Human-readable text configuration file library
 Copyright 2010  Luke Campagnola
 Distributed under MIT/X11 license. See license.txt for more infomation.
 
@@ -27,7 +27,7 @@ class ParseError(Exception):
         #self.message = message
         self.fileName = fileName
         Exception.__init__(self, message)
-        
+
     def __str__(self):
         if self.fileName is None:
             msg = "Error parsing string at line %d:\n" % self.lineNum
@@ -36,14 +36,14 @@ class ParseError(Exception):
         msg += "%s\n%s" % (self.line, self.message)
         return msg
         #raise Exception()
-        
+
 
 def writeConfigFile(data, fname):
     s = genString(data)
     fd = open(fname, 'w')
     fd.write(s)
     fd.close()
-    
+
 def readConfigFile(fname):
     #cwd = os.getcwd()
     global GLOBAL_PATH
@@ -53,7 +53,7 @@ def readConfigFile(fname):
             fname = fname2
 
     GLOBAL_PATH = os.path.dirname(os.path.abspath(fname))
-        
+
     try:
         #os.chdir(newDir)  ## bad.
         fd = open(fname)
@@ -95,30 +95,30 @@ def genString(data, indent=''):
         else:
             s += indent + sk + ': ' + repr(data[k]) + '\n'
     return s
-    
+
 def parseString(lines, start=0):
-    
+
     data = OrderedDict()
     if isinstance(lines, basestring):
         lines = lines.split('\n')
         lines = [l for l in lines if re.search(r'\S', l) and not re.match(r'\s*#', l)]  ## remove empty lines
-        
+
     indent = measureIndent(lines[start])
     ln = start - 1
-    
+
     try:
         while True:
             ln += 1
             #print ln
             if ln >= len(lines):
                 break
-            
+
             l = lines[ln]
-            
+
             ## Skip blank lines or lines starting with #
             if re.match(r'\s*#', l) or not re.search(r'\S', l):
                 continue
-            
+
             ## Measure line indentation, make sure it is correct for this level
             lineInd = measureIndent(l)
             if lineInd < indent:
@@ -127,15 +127,15 @@ def parseString(lines, start=0):
             if lineInd > indent:
                 #print lineInd, indent
                 raise ParseError('Indentation is incorrect. Expected %d, got %d' % (indent, lineInd), ln+1, l)
-            
-            
+
+
             if ':' not in l:
                 raise ParseError('Missing colon', ln+1, l)
-            
+
             (k, p, v) = l.partition(':')
             k = k.strip()
             v = v.strip()
-            
+
             ## set up local variables to use for eval
             local = units.allUnits.copy()
             local['OrderedDict'] = OrderedDict
@@ -145,12 +145,12 @@ def parseString(lines, start=0):
             local['ColorMap'] = ColorMap
             # Needed for reconstructing numpy arrays
             local['array'] = numpy.array
-            for dtype in ['int8', 'uint8', 
+            for dtype in ['int8', 'uint8',
                           'int16', 'uint16', 'float16',
                           'int32', 'uint32', 'float32',
                           'int64', 'uint64', 'float64']:
                 local[dtype] = getattr(numpy, dtype)
-                
+
             if len(k) < 1:
                 raise ParseError('Missing name preceding colon', ln+1, l)
             if k[0] == '(' and k[-1] == ')':  ## If the key looks like a tuple, try evaluating it.
@@ -182,15 +182,15 @@ def parseString(lines, start=0):
         raise ParseError("%s: %s" % (ex.__class__.__name__, str(ex)), ln+1, l)
     #print "Returning shallower..", ln+1
     return (ln, data)
-    
+
 def measureIndent(s):
     n = 0
     while n < len(s) and s[n] == ' ':
         n += 1
     return n
-    
-    
-    
+
+
+
 if __name__ == '__main__':
     import tempfile
     fn = tempfile.mktemp()

--- a/pyqtgraph/console/CmdInput.py
+++ b/pyqtgraph/console/CmdInput.py
@@ -2,16 +2,16 @@ from ..Qt import QtCore, QtGui
 from ..python2_3 import asUnicode
 
 class CmdInput(QtGui.QLineEdit):
-    
+
     sigExecuteCmd = QtCore.Signal(object)
-    
+
     def __init__(self, parent):
         QtGui.QLineEdit.__init__(self, parent)
         self.history = [""]
         self.ptr = 0
         #self.lastCmd = None
         #self.setMultiline(False)
-    
+
     def keyPressEvent(self, ev):
         #print "press:", ev.key(), QtCore.Qt.Key_Up, QtCore.Qt.Key_Down, QtCore.Qt.Key_Enter
         if ev.key() == QtCore.Qt.Key_Up and self.ptr < len(self.history) - 1:
@@ -27,7 +27,7 @@ class CmdInput(QtGui.QLineEdit):
         else:
             QtGui.QLineEdit.keyPressEvent(self, ev)
             self.history[0] = asUnicode(self.text())
-        
+
     def execCmd(self):
         cmd = asUnicode(self.text())
         if len(self.history) == 1 or cmd != self.history[1]:
@@ -36,11 +36,11 @@ class CmdInput(QtGui.QLineEdit):
         self.history[0] = ""
         self.setHistory(0)
         self.sigExecuteCmd.emit(cmd)
-        
+
     def setHistory(self, num):
         self.ptr = num
         self.setText(self.history[self.ptr])
-        
+
     #def setMultiline(self, m):
         #height = QtGui.QFontMetrics(self.font()).lineSpacing()
         #if m:
@@ -49,14 +49,10 @@ class CmdInput(QtGui.QLineEdit):
             #self.setFixedHeight(height+15)
             #self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             #self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-            
-       
+
+
     #def sizeHint(self):
         #hint = QtGui.QPlainTextEdit.sizeHint(self)
         #height = QtGui.QFontMetrics(self.font()).lineSpacing()
         #hint.setHeight(height)
         #return hint
-
-        
-        
-        

--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -17,21 +17,21 @@ class ConsoleWidget(QtGui.QWidget):
     """
     Widget displaying console output and accepting command input.
     Implements:
-        
+
     - eval python expressions / exec python statements
     - storable history of commands
     - exception handling allowing commands to be interpreted in the context of any level in the exception stack frame
-    
+
     Why not just use python in an interactive shell (or ipython) ? There are a few reasons:
-       
+
     - pyside does not yet allow Qt event processing and interactive shell at the same time
-    - on some systems, typing in the console _blocks_ the qt event loop until the user presses enter. This can 
+    - on some systems, typing in the console _blocks_ the qt event loop until the user presses enter. This can
       be baffling and frustrating to users since it would appear the program has frozen.
     - some terminals (eg windows cmd.exe) have notoriously unfriendly interfaces
     - ability to add extra features like exception stack introspection
     - ability to have multiple interactive prompts, including for spawned sub-processes
     """
-    
+
     def __init__(self, parent=None, namespace=None, historyFile=None, text=None, editor=None):
         """
         ==============  ============================================================================
@@ -39,9 +39,9 @@ class ConsoleWidget(QtGui.QWidget):
         namespace       dictionary containing the initial variables present in the default namespace
         historyFile     optional file for storing command history
         text            initial text to display in the console window
-        editor          optional string for invoking code editor (called when stack trace entries are 
-                        double-clicked). May contain {fileName} and {lineNum} format keys. Example:: 
-                      
+        editor          optional string for invoking code editor (called when stack trace entries are
+                        double-clicked). May contain {fileName} and {lineNum} format keys. Example::
+
                             editorCommand --loadfile {fileName} --gotoline {lineNum}
         ==============  =============================================================================
         """
@@ -52,60 +52,60 @@ class ConsoleWidget(QtGui.QWidget):
         self.editor = editor
         self.multiline = None
         self.inCmd = False
-        
+
         self.ui = template.Ui_Form()
         self.ui.setupUi(self)
         self.output = self.ui.output
         self.input = self.ui.input
         self.input.setFocus()
-        
+
         if text is not None:
             self.output.setPlainText(text)
 
         self.historyFile = historyFile
-        
+
         history = self.loadHistory()
         if history is not None:
             self.input.history = [""] + history
             self.ui.historyList.addItems(history[::-1])
         self.ui.historyList.hide()
         self.ui.exceptionGroup.hide()
-        
+
         self.input.sigExecuteCmd.connect(self.runCmd)
         self.ui.historyBtn.toggled.connect(self.ui.historyList.setVisible)
         self.ui.historyList.itemClicked.connect(self.cmdSelected)
         self.ui.historyList.itemDoubleClicked.connect(self.cmdDblClicked)
         self.ui.exceptionBtn.toggled.connect(self.ui.exceptionGroup.setVisible)
-        
+
         self.ui.catchAllExceptionsBtn.toggled.connect(self.catchAllExceptions)
         self.ui.catchNextExceptionBtn.toggled.connect(self.catchNextException)
         self.ui.clearExceptionBtn.clicked.connect(self.clearExceptionClicked)
         self.ui.exceptionStackList.itemClicked.connect(self.stackItemClicked)
         self.ui.exceptionStackList.itemDoubleClicked.connect(self.stackItemDblClicked)
         self.ui.onlyUncaughtCheck.toggled.connect(self.updateSysTrace)
-        
+
         self.currentTraceback = None
-        
+
     def loadHistory(self):
         """Return the list of previously-invoked command strings (or None)."""
         if self.historyFile is not None:
             return pickle.load(open(self.historyFile, 'rb'))
-        
+
     def saveHistory(self, history):
         """Store the list of previously-invoked command strings."""
         if self.historyFile is not None:
             pickle.dump(open(self.historyFile, 'wb'), history)
-        
+
     def runCmd(self, cmd):
         #cmd = str(self.input.lastCmd)
         self.stdout = sys.stdout
         self.stderr = sys.stderr
         encCmd = re.sub(r'>', '&gt;', re.sub(r'<', '&lt;', cmd))
         encCmd = re.sub(r' ', '&nbsp;', encCmd)
-        
+
         self.ui.historyList.addItem(cmd)
         self.saveHistory(self.input.history[1:100])
-        
+
         try:
             sys.stdout = self
             sys.stderr = self
@@ -116,33 +116,33 @@ class ConsoleWidget(QtGui.QWidget):
                 self.write("<br><div style='background-color: #CCF'><b>%s</b>\n"%encCmd, html=True)
                 self.inCmd = True
                 self.execSingle(cmd)
-            
+
             if not self.inCmd:
                 self.write("</div>\n", html=True)
-                
+
         finally:
             sys.stdout = self.stdout
             sys.stderr = self.stderr
-            
+
             sb = self.output.verticalScrollBar()
             sb.setValue(sb.maximum())
             sb = self.ui.historyList.verticalScrollBar()
             sb.setValue(sb.maximum())
-            
+
     def globals(self):
         frame = self.currentFrame()
         if frame is not None and self.ui.runSelectedFrameCheck.isChecked():
             return self.currentFrame().tb_frame.f_globals
         else:
             return globals()
-        
+
     def locals(self):
         frame = self.currentFrame()
         if frame is not None and self.ui.runSelectedFrameCheck.isChecked():
             return self.currentFrame().tb_frame.f_locals
         else:
             return self.localNamespace
-            
+
     def currentFrame(self):
         ## Return the currently selected exception stack frame (or None if there is no exception)
         if self.currentTraceback is None:
@@ -152,7 +152,7 @@ class ConsoleWidget(QtGui.QWidget):
         for i in range(index):
             tb = tb.tb_next
         return tb
-        
+
     def execSingle(self, cmd):
         try:
             output = eval(cmd, self.globals(), self.locals())
@@ -169,8 +169,8 @@ class ConsoleWidget(QtGui.QWidget):
                 self.displayException()
         except:
             self.displayException()
-            
-            
+
+
     def execMulti(self, nextLine):
         #self.stdout.write(nextLine+"\n")
         if nextLine.strip() != '':
@@ -178,7 +178,7 @@ class ConsoleWidget(QtGui.QWidget):
             return
         else:
             cmd = self.multiline
-            
+
         try:
             output = eval(cmd, self.globals(), self.locals())
             self.write(str(output) + '\n')
@@ -211,7 +211,7 @@ class ConsoleWidget(QtGui.QWidget):
                 #self.stdout.write("</div><br><div style='font-weight: normal; background-color: #FFF;'>")
             self.output.insertPlainText(strn)
         #self.stdout.write(strn)
-    
+
     def displayException(self):
         """
         Display the current exception and stack.
@@ -219,22 +219,22 @@ class ConsoleWidget(QtGui.QWidget):
         tb = traceback.format_exc()
         lines = []
         indent = 4
-        prefix = '' 
+        prefix = ''
         for l in tb.split('\n'):
             lines.append(" "*indent + prefix + l)
         self.write('\n'.join(lines))
         self.exceptionHandler(*sys.exc_info())
-        
+
     def cmdSelected(self, item):
         index = -(self.ui.historyList.row(item)+1)
         self.input.setHistory(index)
         self.input.setFocus()
-        
+
     def cmdDblClicked(self, item):
         index = -(self.ui.historyList.row(item)+1)
         self.input.setHistory(index)
         self.input.execCmd()
-        
+
     def flush(self):
         pass
 
@@ -250,7 +250,7 @@ class ConsoleWidget(QtGui.QWidget):
             self.ui.exceptionBtn.setChecked(True)
         else:
             self.disableExceptionHandling()
-        
+
     def catchNextException(self, catch=True):
         """
         If True, the console will catch the next unhandled exception and display the stack
@@ -263,24 +263,24 @@ class ConsoleWidget(QtGui.QWidget):
             self.ui.exceptionBtn.setChecked(True)
         else:
             self.disableExceptionHandling()
-        
+
     def enableExceptionHandling(self):
         exceptionHandling.register(self.exceptionHandler)
         self.updateSysTrace()
-        
+
     def disableExceptionHandling(self):
         exceptionHandling.unregister(self.exceptionHandler)
         self.updateSysTrace()
-        
+
     def clearExceptionClicked(self):
         self.currentTraceback = None
         self.ui.exceptionInfoLabel.setText("[No current exception]")
         self.ui.exceptionStackList.clear()
         self.ui.clearExceptionBtn.setEnabled(False)
-        
+
     def stackItemClicked(self, item):
         pass
-    
+
     def stackItemDblClicked(self, item):
         editor = self.editor
         if editor is None:
@@ -291,23 +291,23 @@ class ConsoleWidget(QtGui.QWidget):
         lineNum = tb.tb_lineno
         fileName = tb.tb_frame.f_code.co_filename
         subprocess.Popen(self.editor.format(fileName=fileName, lineNum=lineNum), shell=True)
-        
-    
+
+
     #def allExceptionsHandler(self, *args):
         #self.exceptionHandler(*args)
-    
+
     #def nextExceptionHandler(self, *args):
         #self.ui.catchNextExceptionBtn.setChecked(False)
         #self.exceptionHandler(*args)
 
     def updateSysTrace(self):
-        ## Install or uninstall  sys.settrace handler 
-        
+        ## Install or uninstall  sys.settrace handler
+
         if not self.ui.catchNextExceptionBtn.isChecked() and not self.ui.catchAllExceptionsBtn.isChecked():
             if sys.gettrace() == self.systrace:
                 sys.settrace(None)
             return
-        
+
         if self.ui.onlyUncaughtCheck.isChecked():
             if sys.gettrace() == self.systrace:
                 sys.settrace(None)
@@ -317,33 +317,33 @@ class ConsoleWidget(QtGui.QWidget):
                 raise Exception("sys.settrace is in use; cannot monitor for caught exceptions.")
             else:
                 sys.settrace(self.systrace)
-        
+
     def exceptionHandler(self, excType, exc, tb):
         if self.ui.catchNextExceptionBtn.isChecked():
             self.ui.catchNextExceptionBtn.setChecked(False)
         elif not self.ui.catchAllExceptionsBtn.isChecked():
             return
-        
+
         self.ui.clearExceptionBtn.setEnabled(True)
         self.currentTraceback = tb
-        
+
         excMessage = ''.join(traceback.format_exception_only(excType, exc))
         self.ui.exceptionInfoLabel.setText(excMessage)
         self.ui.exceptionStackList.clear()
         for index, line in enumerate(traceback.extract_tb(tb)):
             self.ui.exceptionStackList.addItem('File "%s", line %s, in %s()\n  %s' % line)
-    
+
     def systrace(self, frame, event, arg):
         if event == 'exception' and self.checkException(*arg):
             self.exceptionHandler(*arg)
         return self.systrace
-        
+
     def checkException(self, excType, exc, tb):
         ## Return True if the exception is interesting; False if it should be ignored.
-        
+
         filename = tb.tb_frame.f_code.co_filename
         function = tb.tb_frame.f_code.co_name
-        
+
         filterStr = str(self.ui.filterText.text())
         if filterStr != '':
             if isinstance(exc, Exception):
@@ -384,6 +384,5 @@ class ConsoleWidget(QtGui.QWidget):
         if excType is ZeroDivisionError:
             if filename.endswith('python2.7/traceback.py'):
                 return False
-            
+
         return True
-    

--- a/pyqtgraph/debug.py
+++ b/pyqtgraph/debug.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-debug.py - Functions to aid in debugging 
+debug.py - Functions to aid in debugging
 Copyright 2010  Luke Campagnola
 Distributed under MIT/X11 license. See license.txt for more infomation.
 """
@@ -43,19 +43,19 @@ class Tracer(object):
 
     def trace(self, frame, event, arg):
         self.count += 1
-        # If it has been a long time since we saw the top of the stack, 
+        # If it has been a long time since we saw the top of the stack,
         # print a reminder
         if self.count % 1000 == 0:
             print("----- current stack: -----")
             for line in self.stack:
                 print(line)
         if event == 'call':
-            line = "  " * len(self.stack) + ">> " + self.frameInfo(frame) 
+            line = "  " * len(self.stack) + ">> " + self.frameInfo(frame)
             print(line)
             self.stack.append(line)
         elif event == 'return':
             self.stack.pop()
-            line = "  " * len(self.stack) + "<< " + self.frameInfo(frame) 
+            line = "  " * len(self.stack) + "<< " + self.frameInfo(frame)
             print(line)
             if len(self.stack) == 0:
                 self.count = 0
@@ -93,8 +93,8 @@ def warnOnException(func):
     return w
 
 def getExc(indent=4, prefix='|  ', skip=1):
-    lines = (traceback.format_stack()[:-skip] 
-            + ["  ---- exception caught ---->\n"] 
+    lines = (traceback.format_stack()[:-skip]
+            + ["  ---- exception caught ---->\n"]
             + traceback.format_tb(sys.exc_info()[2])
             + traceback.format_exception_only(*sys.exc_info()[:2]))
     lines2 = []
@@ -112,7 +112,7 @@ def printExc(msg='', indent=4, prefix='|'):
     print(" "*indent + prefix + '='*30 + '>>')
     print(exc)
     print(" "*indent + prefix + '='*30 + '<<')
-    
+
 def printTrace(msg='', indent=4, prefix='|'):
     """Print an error message followed by an indented stack trace"""
     trace = backtrace(1)
@@ -122,12 +122,12 @@ def printTrace(msg='', indent=4, prefix='|'):
     for line in trace.split('\n'):
         print(" "*indent + prefix + " " + line)
     print(" "*indent + prefix + '='*30 + '<<')
-    
+
 
 def backtrace(skip=0):
-    return ''.join(traceback.format_stack()[:-(skip+1)])    
-    
-    
+    return ''.join(traceback.format_stack()[:-(skip+1)])
+
+
 def listObjs(regex='Q', typ=None):
     """List all objects managed by python gc with class name matching regex.
     Finds 'Q...' classes by default."""
@@ -135,9 +135,9 @@ def listObjs(regex='Q', typ=None):
         return [x for x in gc.get_objects() if isinstance(x, typ)]
     else:
         return [x for x in gc.get_objects() if re.match(regex, type(x).__name__)]
-        
 
-    
+
+
 def findRefPath(startObj, endObj, maxLen=8, restart=True, seen={}, path=None, ignore=None):
     """Determine all paths of object references from startObj to endObj"""
     refs = []
@@ -164,8 +164,8 @@ def findRefPath(startObj, endObj, maxLen=8, restart=True, seen={}, path=None, ig
             #if r not in fo:
                 #newRefs.append(r)
         #except:
-            #newRefs.append(r)            
-        
+            #newRefs.append(r)
+
     for r in newRefs:
         #print prefix+"->"+str(type(r))
         if type(r).__name__ in ['frame', 'function', 'listiterator']:
@@ -197,7 +197,7 @@ def findRefPath(startObj, endObj, maxLen=8, restart=True, seen={}, path=None, ig
                     print(refPathString(p+path))
         except KeyError:
             pass
-        
+
         ignore[id(tree)] = None
         if tree is None:
             tree = findRefPath(startObj, r, maxLen-1, restart=False, path=[r]+path, ignore=ignore)
@@ -293,41 +293,41 @@ def refPathString(chain):
         sys.stdout.flush()
     return s
 
-    
+
 def objectSize(obj, ignore=None, verbose=False, depth=0, recursive=False):
     """Guess how much memory an object is using"""
     ignoreTypes = ['MethodType', 'UnboundMethodType', 'BuiltinMethodType', 'FunctionType', 'BuiltinFunctionType']
     ignoreTypes = [getattr(types, key) for key in ignoreTypes if hasattr(types, key)]
     ignoreRegex = re.compile('(method-wrapper|Flag|ItemChange|Option|Mode)')
-    
-    
+
+
     if ignore is None:
         ignore = {}
-        
+
     indent = '  '*depth
-    
+
     try:
         hash(obj)
         hsh = obj
     except:
         hsh = "%s:%d" % (str(type(obj)), id(obj))
-        
+
     if hsh in ignore:
         return 0
     ignore[hsh] = 1
-    
+
     try:
         size = sys.getsizeof(obj)
     except TypeError:
         size = 0
-        
+
     if isinstance(obj, ndarray):
         try:
             size += len(obj.data)
         except:
             pass
-            
-        
+
+
     if recursive:
         if type(obj) in [list, tuple]:
             if verbose:
@@ -355,7 +355,7 @@ def objectSize(obj, ignore=None, verbose=False, depth=0, recursive=False):
                     #size += s
                     #if verbose:
                         #print indent + '  +', ch.objectName(), s
-                    
+
             #except:
                 #pass
     #if isinstance(obj, types.InstanceType):
@@ -373,7 +373,7 @@ def objectSize(obj, ignore=None, verbose=False, depth=0, recursive=False):
                 continue
             #if isinstance(o, types.ObjectType) and strtyp == "<type 'method-wrapper'>":
                 #continue
-            
+
             #if verbose:
                 #print indent, k, '?'
             refs = [r for r in gc.get_referrers(o) if type(r) != types.FrameType]
@@ -391,26 +391,26 @@ class GarbageWatcher(object):
     """
     Convenient dictionary for holding weak references to objects.
     Mainly used to check whether the objects have been collect yet or not.
-    
+
     Example:
         gw = GarbageWatcher()
         gw['objName'] = obj
         gw['objName2'] = obj2
-        gw.check()  
-        
-    
+        gw.check()
+
+
     """
     def __init__(self):
         self.objs = weakref.WeakValueDictionary()
         self.allNames = []
-        
+
     def add(self, obj, name):
         self.objs[name] = obj
         self.allNames.append(name)
-        
+
     def __setitem__(self, name, obj):
         self.add(obj, name)
-        
+
     def check(self):
         """Print a list of all watched objects and whether they have been collected."""
         gc.collect()
@@ -421,11 +421,11 @@ class GarbageWatcher(object):
             alive.append(k)
         print("Deleted objects:", dead)
         print("Live objects:", alive)
-        
+
     def __getitem__(self, item):
         return self.objs[item]
 
-    
+
 
 
 class Profiler(object):
@@ -460,11 +460,11 @@ class Profiler(object):
 
     _profilers = os.environ.get("PYQTGRAPHPROFILE", None)
     _profilers = _profilers.split(",") if _profilers is not None else []
-    
+
     _depth = 0
     _msgs = []
     disable = False  # set this flag to disable all or individual profilers at runtime
-    
+
     class DisabledProfiler(object):
         def __init__(self, *args, **kwds):
             pass
@@ -475,13 +475,13 @@ class Profiler(object):
         def mark(self, msg=None):
             pass
     _disabledProfiler = DisabledProfiler()
-        
+
     def __new__(cls, msg=None, disabled='env', delayed=True):
         """Optionally create a new profiler based on caller's qualname.
         """
         if disabled is True or (disabled == 'env' and len(cls._profilers) == 0):
             return cls._disabledProfiler
-                        
+
         # determine the qualified name of the caller function
         caller_frame = sys._getframe(1)
         try:
@@ -513,10 +513,10 @@ class Profiler(object):
             msg = str(self._markCount)
         self._markCount += 1
         newTime = ptime.time()
-        self._newMsg("  %s: %0.4f ms", 
+        self._newMsg("  %s: %0.4f ms",
                      msg, (newTime - self._lastTime) * 1000)
         self._lastTime = newTime
-        
+
     def mark(self, msg=None):
         self(msg)
 
@@ -530,21 +530,21 @@ class Profiler(object):
 
     def __del__(self):
         self.finish()
-    
+
     def finish(self, msg=None):
         """Add a final message; flush the message list if no parent profiler.
         """
         if self._finished or self.disable:
-            return        
+            return
         self._finished = True
         if msg is not None:
             self(msg)
-        self._newMsg("< Exiting %s, total time: %0.4f ms", 
+        self._newMsg("< Exiting %s, total time: %0.4f ms",
                      self._name, (ptime.time() - self._firstTime) * 1000)
         type(self)._depth -= 1
         if self._depth < 1:
             self.flush()
-        
+
     def flush(self):
         if self._msgs:
             print("\n".join([m[0]%m[1] for m in self._msgs]))
@@ -558,18 +558,18 @@ def profile(code, name='profile_run', sort='cumulative', num=30):
     stats.sort_stats(sort)
     stats.print_stats(num)
     return stats
-        
-        
-  
+
+
+
 #### Code for listing (nearly) all objects in the known universe
 #### http://utcc.utoronto.ca/~cks/space/blog/python/GetAllObjects
 # Recursively expand slist's objects
 # into olist, using seen to track
 # already processed objects.
 def _getr(slist, olist, first=True):
-    i = 0 
+    i = 0
     for e in slist:
-        
+
         oid = id(e)
         typ = type(e)
         if oid in olist or typ is int:    ## or e in olist:     ## since we're excluding all ints, there is no longer a need to check for olist keys
@@ -580,7 +580,7 @@ def _getr(slist, olist, first=True):
         tl = gc.get_referents(e)
         if tl:
             _getr(tl, olist, first=False)
-        i += 1        
+        i += 1
 # The public function.
 def get_all_objects():
     """Return a list of all live Python objects (excluding int and long), not including the list itself."""
@@ -588,7 +588,7 @@ def get_all_objects():
     gcl = gc.get_objects()
     olist = {}
     _getr(gcl, olist)
-    
+
     del olist[id(olist)]
     del olist[id(gcl)]
     del olist[id(sys._getframe())]
@@ -600,16 +600,16 @@ def lookup(oid, objects=None):
     if objects is None:
         objects = get_all_objects()
     return objects[oid]
-        
-        
-                    
-        
+
+
+
+
 class ObjTracker(object):
     """
     Tracks all objects under the sun, reporting the changes between snapshots: what objects are created, deleted, and persistent.
-    This class is very useful for tracking memory leaks. The class goes to great (but not heroic) lengths to avoid tracking 
+    This class is very useful for tracking memory leaks. The class goes to great (but not heroic) lengths to avoid tracking
     its own internal objects.
-    
+
     Example:
         ot = ObjTracker()   # takes snapshot of currently existing objects
            ... do stuff ...
@@ -618,42 +618,42 @@ class ObjTracker(object):
         ot.diff()           # prints lists of objects created and deleted since last call to ot.diff()
                             # also prints list of items that were created since initialization AND have not been deleted yet
                             #   (if done correctly, this list can tell you about objects that were leaked)
-           
+
         arrays = ot.findPersistent('ndarray')  ## returns all objects matching 'ndarray' (string match, not instance checking)
                                                ## that were considered persistent when the last diff() was run
-                                               
+
         describeObj(arrays[0])    ## See if we can determine who has references to this array
     """
-    
-    
+
+
     allObjs = {} ## keep track of all objects created and stored within class instances
     allObjs[id(allObjs)] = None
-    
+
     def __init__(self):
         self.startRefs = {}        ## list of objects that exist when the tracker is initialized {oid: weakref}
                                    ##   (If it is not possible to weakref the object, then the value is None)
-        self.startCount = {}       
+        self.startCount = {}
         self.newRefs = {}          ## list of objects that have been created since initialization
         self.persistentRefs = {}   ## list of objects considered 'persistent' when the last diff() was called
         self.objTypes = {}
-            
+
         ObjTracker.allObjs[id(self)] = None
         self.objs = [self.__dict__, self.startRefs, self.startCount, self.newRefs, self.persistentRefs, self.objTypes]
         self.objs.append(self.objs)
         for v in self.objs:
             ObjTracker.allObjs[id(v)] = None
-            
+
         self.start()
 
     def findNew(self, regex):
         """Return all objects matching regex that were considered 'new' when the last diff() was run."""
         return self.findTypes(self.newRefs, regex)
-    
+
     def findPersistent(self, regex):
         """Return all objects matching regex that were considered 'persistent' when the last diff() was run."""
         return self.findTypes(self.persistentRefs, regex)
-        
-    
+
+
     def start(self):
         """
         Remember the current set of objects as the comparison for all future calls to diff()
@@ -677,7 +677,7 @@ class ObjTracker(object):
         Print a set of reports for created, deleted, and persistent objects
         """
         refs, count, objs = self.collect()   ## refs contains the list of ALL objects
-        
+
         ## Which refs have disappeared since call to start()  (these are only displayed once, then forgotten.)
         delRefs = {}
         for i in list(self.startRefs.keys()):
@@ -691,18 +691,18 @@ class ObjTracker(object):
                 del self.newRefs[i]
                 self.forgetRef(delRefs[i])
         #print "deleted:", len(delRefs)
-                
+
         ## Which refs have appeared since call to start() or diff()
         persistentRefs = {}      ## created since start(), but before last diff()
         createRefs = {}          ## created since last diff()
         for o in refs:
-            if o not in self.startRefs:       
-                if o not in self.newRefs:     
+            if o not in self.startRefs:
+                if o not in self.newRefs:
                     createRefs[o] = refs[o]          ## object has been created since last diff()
                 else:
                     persistentRefs[o] = refs[o]      ## object has been created since start(), but before last diff() (persistent)
         #print "new:", len(newRefs)
-                
+
         ## self.newRefs holds the entire set of objects created since start()
         for r in self.newRefs:
             self.forgetRef(self.newRefs[r])
@@ -712,12 +712,12 @@ class ObjTracker(object):
         for r in self.newRefs:
             self.rememberRef(self.newRefs[r])
         #print "created:", len(createRefs)
-        
+
         ## self.persistentRefs holds all objects considered persistent.
         self.persistentRefs.clear()
         self.persistentRefs.update(persistentRefs)
-        
-                
+
+
         print("----------- Count changes since start: ----------")
         c1 = count.copy()
         for k in self.startCount:
@@ -729,37 +729,37 @@ class ObjTracker(object):
                 continue
             num = "%d" % c1[t]
             print("  " + num + " "*(10-len(num)) + str(t))
-            
+
         print("-----------  %d Deleted since last diff: ------------" % len(delRefs))
         self.report(delRefs, objs, **kargs)
         print("-----------  %d Created since last diff: ------------" % len(createRefs))
         self.report(createRefs, objs, **kargs)
         print("-----------  %d Created since start (persistent): ------------" % len(persistentRefs))
         self.report(persistentRefs, objs, **kargs)
-        
-        
+
+
     def __del__(self):
         self.startRefs.clear()
         self.startCount.clear()
         self.newRefs.clear()
         self.persistentRefs.clear()
-        
+
         del ObjTracker.allObjs[id(self)]
         for v in self.objs:
             del ObjTracker.allObjs[id(v)]
-            
+
     @classmethod
     def isObjVar(cls, o):
         return type(o) is cls or id(o) in cls.allObjs
-            
+
     def collect(self):
         print("Collecting list of all objects...")
         gc.collect()
         objs = get_all_objects()
         frame = sys._getframe()
-        del objs[id(frame)]  ## ignore the current frame 
+        del objs[id(frame)]  ## ignore the current frame
         del objs[id(frame.f_code)]
-        
+
         ignoreTypes = [int]
         refs = {}
         count = {}
@@ -769,7 +769,7 @@ class ObjTracker(object):
             oid = id(o)
             if ObjTracker.isObjVar(o) or typ in ignoreTypes:
                 continue
-            
+
             try:
                 ref = weakref.ref(obj)
             except:
@@ -780,20 +780,20 @@ class ObjTracker(object):
             self.objTypes[oid] = typStr
             ObjTracker.allObjs[id(typStr)] = None
             count[typ] = count.get(typ, 0) + 1
-            
+
         print("All objects: %d   Tracked objects: %d" % (len(objs), len(refs)))
         return refs, count, objs
-        
+
     def forgetRef(self, ref):
         if ref is not None:
             del ObjTracker.allObjs[id(ref)]
-        
+
     def rememberRef(self, ref):
         ## Record the address of the weakref object so it is not included in future object counts.
         if ref is not None:
             ObjTracker.allObjs[id(ref)] = None
-            
-        
+
+
     def lookup(self, oid, ref, objs=None):
         if ref is None or ref() is None:
             try:
@@ -803,12 +803,12 @@ class ObjTracker(object):
         else:
             obj = ref()
         return obj
-                    
-                    
+
+
     def report(self, refs, allobjs=None, showIDs=False):
         if allobjs is None:
             allobjs = get_all_objects()
-        
+
         count = {}
         rev = {}
         for oid in refs:
@@ -824,13 +824,13 @@ class ObjTracker(object):
             count[typ] =  [c[0]+1, c[1]+objectSize(obj)]
         typs = list(count.keys())
         typs.sort(key=lambda a: count[a][1])
-        
+
         for t in typs:
             line = "  %d\t%d\t%s" % (count[t][0], count[t][1], t)
             if showIDs:
                 line += "\t"+",".join(map(str,rev[t]))
             print(line)
-        
+
     def findTypes(self, refs, regex):
         allObjs = get_all_objects()
         ids = {}
@@ -840,10 +840,10 @@ class ObjTracker(object):
             if r.search(self.objTypes[k]):
                 objs.append(self.lookup(k, refs[k], allObjs))
         return objs
-        
 
-    
-    
+
+
+
 def describeObj(obj, depth=4, path=None, ignore=None):
     """
     Trace all reference paths backward, printing a list of different ways this object can be accessed.
@@ -877,9 +877,9 @@ def describeObj(obj, depth=4, path=None, ignore=None):
             printed = True
     if not printed:
         print("Dead end: " + refPathString(path))
-        
-    
-    
+
+
+
 def typeStr(obj):
     """Create a more useful type string by making <instance> types report their class."""
     typ = type(obj)
@@ -887,11 +887,11 @@ def typeStr(obj):
         return "<instance of %s>" % obj.__class__.__name__
     else:
         return str(typ)
-    
+
 def searchRefs(obj, *args):
     """Pseudo-interactive function for tracing references backward.
     **Arguments:**
-    
+
         obj:   The initial object from which to start searching
         args:  A set of string or int arguments.
                each integer selects one of obj's referrers to be the new 'obj'
@@ -902,14 +902,14 @@ def searchRefs(obj, *args):
                   o:  print obj
                   ro: return obj
                   rr: return list of obj's referrers
-    
+
     Examples::
-    
+
        searchRefs(obj, 't')                    ## Print types of all objects referring to obj
        searchRefs(obj, 't', 0, 't')            ##   ..then select the first referrer and print the types of its referrers
        searchRefs(obj, 't', 0, 't', 'l')       ##   ..also print lengths of the last set of referrers
        searchRefs(obj, 0, 1, 'ro')             ## Select index 0 from obj's referrer, then select index 1 from the next set of referrers, then return that object
-       
+
     """
     ignore = {id(sys._getframe()): None}
     gc.collect()
@@ -917,10 +917,10 @@ def searchRefs(obj, *args):
     ignore[id(refs)] = None
     refs = [r for r in refs if id(r) not in ignore]
     for a in args:
-        
+
         #fo = allFrameObjs()
         #refs = [r for r in refs if r not in fo]
-        
+
         if type(a) is int:
             obj = refs[a]
             gc.collect()
@@ -944,7 +944,7 @@ def searchRefs(obj, *args):
             return obj
         elif a == 'rr':
             return refs
-    
+
 def allFrameObjs():
     """Return list of frame objects in current stack. Useful if you want to ignore these objects in refernece searches"""
     f = sys._getframe()
@@ -957,8 +957,8 @@ def allFrameObjs():
         #objs.append(f.f_builtins)
         f = f.f_back
     return objs
-        
-    
+
+
 def findObj(regex):
     """Return a list of objects whose typeStr matches regex"""
     allObjs = get_all_objects()
@@ -969,7 +969,7 @@ def findObj(regex):
         if r.search(typeStr(obj)):
             objs.append(obj)
     return objs
-    
+
 
 
 def listRedundantModules():
@@ -985,7 +985,7 @@ def listRedundantModules():
             print("module at %s has 2 names: %s, %s" % (mfile, name, mods[mfile]))
         else:
             mods[mfile] = name
-            
+
 
 def walkQObjectTree(obj, counts=None, verbose=False, depth=0):
     """
@@ -994,7 +994,7 @@ def walkQObjectTree(obj, counts=None, verbose=False, depth=0):
     immediately rather than stumbling upon them later.
     Prints a count of the objects encountered, for fun. (or is it?)
     """
-    
+
     if verbose:
         print("  "*depth + typeStr(obj))
     report = False
@@ -1008,7 +1008,7 @@ def walkQObjectTree(obj, counts=None, verbose=False, depth=0):
         counts[typ] = 1
     for child in obj.children():
         walkQObjectTree(child, counts, verbose, depth+1)
-        
+
     return counts
 
 QObjCache = {}
@@ -1029,29 +1029,29 @@ def qObjectReport(verbose=False):
             print("check obj", oid, str(QObjCache[oid]))
             if obj.parent() is None:
                 walkQObjectTree(obj, count, verbose)
-            
+
     typs = list(count.keys())
     typs.sort()
     for t in typs:
         print(count[t], "\t", t)
-        
+
 
 class PrintDetector(object):
     """Find code locations that print to stdout."""
     def __init__(self):
         self.stdout = sys.stdout
         sys.stdout = self
-    
+
     def remove(self):
         sys.stdout = self.stdout
-        
+
     def __del__(self):
         self.remove()
-    
+
     def write(self, x):
         self.stdout.write(x)
         traceback.print_stack()
-        
+
     def flush(self):
         self.stdout.flush()
 
@@ -1096,8 +1096,8 @@ def pretty(data, indent=''):
 
 
 class ThreadTrace(object):
-    """ 
-    Used to debug freezing by starting a new thread that reports on the 
+    """
+    Used to debug freezing by starting a new thread that reports on the
     location of other threads periodically.
     """
     def __init__(self, interval=10.0):
@@ -1123,7 +1123,7 @@ class ThreadTrace(object):
             with self.lock:
                 if self._stop is True:
                     return
-                    
+
             print("\n=============  THREAD FRAMES:  ================")
             for id, frame in sys._current_frames().items():
                 if id == threading.current_thread().ident:
@@ -1131,7 +1131,7 @@ class ThreadTrace(object):
                 print("<< thread %d >>" % id)
                 traceback.print_stack(frame)
             print("===============================================\n")
-            
+
             time.sleep(self.interval)
 
 

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -5,10 +5,10 @@ from ..widgets.VerticalLabel import VerticalLabel
 from ..python2_3 import asUnicode
 
 class Dock(QtGui.QWidget, DockDrop):
-    
+
     sigStretchChanged = QtCore.Signal()
     sigClosed = QtCore.Signal(object)
-    
+
     def __init__(self, name, area=None, size=(10, 10), widget=None, hideTitle=False, autoOrientation=True, closable=False):
         QtGui.QWidget.__init__(self)
         DockDrop.__init__(self)
@@ -67,9 +67,9 @@ class Dock(QtGui.QWidget, DockDrop):
         }"""
         self.setAutoFillBackground(False)
         self.widgetArea.setStyleSheet(self.hStyle)
-        
+
         self.setStretch(*size)
-        
+
         if widget is not None:
             self.addWidget(widget)
 
@@ -81,7 +81,7 @@ class Dock(QtGui.QWidget, DockDrop):
             return ['dock']
         else:
             return name == 'dock'
-        
+
     def setStretch(self, x=None, y=None):
         """
         Set the 'target' size for this Dock.
@@ -101,12 +101,12 @@ class Dock(QtGui.QWidget, DockDrop):
         self._stretch = (x, y)
         self.sigStretchChanged.emit()
         #print "setStretch", self, x, y, self.stretch()
-        
+
     def stretch(self):
         #policy = self.sizePolicy()
         #return policy.horizontalStretch(), policy.verticalStretch()
         return self._stretch
-        
+
     #def stretch(self):
         #return self._stretch
 
@@ -120,7 +120,7 @@ class Dock(QtGui.QWidget, DockDrop):
         if 'center' in self.allowedAreas:
             self.allowedAreas.remove('center')
         self.updateStyle()
-        
+
     def showTitleBar(self):
         """
         Show the title bar for this Dock.
@@ -141,7 +141,7 @@ class Dock(QtGui.QWidget, DockDrop):
         Sets the text displayed in title bar for this Dock.
         """
         self.label.setText(text)
-        
+
     def setOrientation(self, o='auto', force=False):
         """
         Sets the orientation of the title bar for this Dock.
@@ -161,7 +161,7 @@ class Dock(QtGui.QWidget, DockDrop):
             self.orientation = o
             self.label.setOrientation(o)
             self.updateStyle()
-        
+
     def updateStyle(self):
         ## updates orientation and appearance of title bar
         #print self.name(), "update style:", self.orientation, self.moveLabel, self.label.isVisible()
@@ -201,8 +201,8 @@ class Dock(QtGui.QWidget, DockDrop):
         self.widgets.append(widget)
         self.layout.addWidget(widget, row, col, rowspan, colspan)
         self.raiseOverlay()
-        
-        
+
+
     def startDrag(self):
         self.drag = QtGui.QDrag(self)
         mime = QtCore.QMimeData()
@@ -212,10 +212,10 @@ class Dock(QtGui.QWidget, DockDrop):
         self.update()
         action = self.drag.exec_()
         self.updateStyle()
-        
+
     def float(self):
         self.area.floatDock(self)
-            
+
     def containerChanged(self, c):
         #print self.name(), "container changed"
         self._container = c
@@ -224,13 +224,13 @@ class Dock(QtGui.QWidget, DockDrop):
             self.label.setDim(False)
         else:
             self.moveLabel = False
-            
+
         self.setOrientation(force=True)
-        
+
     def raiseDock(self):
         """If this Dock is stacked underneath others, raise it to the top."""
         self.container().raiseDock(self)
-        
+
 
     def close(self):
         """Remove this dock from the DockArea it lives inside."""
@@ -259,10 +259,10 @@ class Dock(QtGui.QWidget, DockDrop):
 
 
 class DockLabel(VerticalLabel):
-    
+
     sigClicked = QtCore.Signal(object, object)
     sigCloseClicked = QtCore.Signal()
-    
+
     def __init__(self, text, dock, showCloseButton):
         self.dim = False
         self.fixedWidth = False
@@ -289,7 +289,7 @@ class DockLabel(VerticalLabel):
             fg = '#fff'
             bg = '#66c'
             border = '#55B'
-        
+
         if self.orientation == 'vertical':
             self.vStyle = """DockLabel {
                 background-color : %s;
@@ -323,7 +323,7 @@ class DockLabel(VerticalLabel):
         if self.dim != d:
             self.dim = d
             self.updateStyle()
-    
+
     def setOrientation(self, o):
         VerticalLabel.setOrientation(self, o)
         self.updateStyle()
@@ -333,21 +333,21 @@ class DockLabel(VerticalLabel):
             self.pressPos = ev.pos()
             self.startedDrag = False
             ev.accept()
-        
+
     def mouseMoveEvent(self, ev):
         if not self.startedDrag and (ev.pos() - self.pressPos).manhattanLength() > QtGui.QApplication.startDragDistance():
             self.dock.startDrag()
         ev.accept()
-            
+
     def mouseReleaseEvent(self, ev):
         if not self.startedDrag:
             self.sigClicked.emit(self, ev)
         ev.accept()
-        
+
     def mouseDoubleClickEvent(self, ev):
         if ev.button() == QtCore.Qt.LeftButton:
             self.dock.float()
-            
+
     def resizeEvent (self, ev):
         if self.closeButton:
             if self.orientation == 'vertical':

--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -23,31 +23,31 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
         self.temporary = temporary
         self.tempAreas = []
         self.home = home
-        
+
     def type(self):
         return "top"
-        
+
     def addDock(self, dock=None, position='bottom', relativeTo=None, **kwds):
         """Adds a dock to this area.
-        
+
         ============== =================================================================
         **Arguments:**
-        dock           The new Dock object to add. If None, then a new Dock will be 
+        dock           The new Dock object to add. If None, then a new Dock will be
                        created.
         position       'bottom', 'top', 'left', 'right', 'above', or 'below'
-        relativeTo     If relativeTo is None, then the new Dock is added to fill an 
-                       entire edge of the window. If relativeTo is another Dock, then 
-                       the new Dock is placed adjacent to it (or in a tabbed 
-                       configuration for 'above' and 'below'). 
+        relativeTo     If relativeTo is None, then the new Dock is added to fill an
+                       entire edge of the window. If relativeTo is another Dock, then
+                       the new Dock is placed adjacent to it (or in a tabbed
+                       configuration for 'above' and 'below').
         ============== =================================================================
-        
+
         All extra keyword arguments are passed to Dock.__init__() if *dock* is
-        None.        
+        None.
         """
         if dock is None:
             dock = Dock(**kwds)
-        
-        
+
+
         ## Determine the container to insert this dock into.
         ## If there is no neighbor, then the container is the top.
         if relativeTo is None or relativeTo is self:
@@ -62,7 +62,7 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
                 relativeTo = self.docks[relativeTo]
             container = self.getContainer(relativeTo)
             neighbor = relativeTo
-        
+
         ## what container type do we need?
         neededContainer = {
             'bottom': 'vertical',
@@ -72,12 +72,12 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
             'above': 'tab',
             'below': 'tab'
         }[position]
-        
+
         ## Can't insert new containers into a tab container; insert outside instead.
         if neededContainer != container.type() and container.type() == 'tab':
             neighbor = container
             container = container.container()
-            
+
         ## Decide if the container we have is suitable.
         ## If not, insert a new container inside.
         if neededContainer != container.type():
@@ -85,7 +85,7 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
                 container = self.addContainer(neededContainer, self.topContainer)
             else:
                 container = self.addContainer(neededContainer, neighbor)
-            
+
         ## Insert the new dock before/after its neighbor
         insertPos = {
             'bottom': 'after',
@@ -102,23 +102,23 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
         self.docks[dock.name()] = dock
         if old is not None:
             old.apoptose()
-        
+
         return dock
-        
+
     def moveDock(self, dock, position, neighbor):
         """
-        Move an existing Dock to a new location. 
+        Move an existing Dock to a new location.
         """
         ## Moving to the edge of a tabbed dock causes a drop outside the tab box
         if position in ['left', 'right', 'top', 'bottom'] and neighbor is not None and neighbor.container() is not None and neighbor.container().type() == 'tab':
             neighbor = neighbor.container()
         self.addDock(dock, position, neighbor)
-        
+
     def getContainer(self, obj):
         if obj is None:
             return self
         return obj.container()
-        
+
     def makeContainer(self, typ):
         if typ == 'vertical':
             new = VContainer(self)
@@ -127,11 +127,11 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
         elif typ == 'tab':
             new = TContainer(self)
         return new
-        
+
     def addContainer(self, typ, obj):
         """Add a new container around obj"""
         new = self.makeContainer(typ)
-        
+
         container = self.getContainer(obj)
         container.insert(new, 'before', obj)
         #print "Add container:", new, " -> ", container
@@ -139,7 +139,7 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
             new.insert(obj)
         self.raiseOverlay()
         return new
-    
+
     def insert(self, new, pos=None, neighbor=None):
         if self.topContainer is not None:
             self.topContainer.containerChanged(None)
@@ -149,19 +149,19 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
         new._container = self
         self.raiseOverlay()
         #print "Insert top:", new
-        
+
     def count(self):
         if self.topContainer is None:
             return 0
         return 1
-        
-        
+
+
     #def paintEvent(self, ev):
         #self.drawDockOverlay()
-        
+
     def resizeEvent(self, ev):
         self.resizeOverlay(self.size())
-        
+
     def addTempArea(self):
         if self.home is None:
             area = DockArea(temporary=True, home=self)
@@ -173,19 +173,19 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
             area = self.home.addTempArea()
         #print "added temp area", area, area.window()
         return area
-        
+
     def floatDock(self, dock):
         """Removes *dock* from this DockArea and places it in a new window."""
         area = self.addTempArea()
         area.win.resize(dock.size())
         area.moveDock(dock, 'top', None)
-        
-        
+
+
     def removeTempArea(self, area):
         self.tempAreas.remove(area)
         #print "close window", area.window()
         area.window().close()
-        
+
     def saveState(self):
         """
         Return a serialized (storable) representation of the state of
@@ -202,7 +202,7 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
             geo = (geo.x(), geo.y(), geo.width(), geo.height())
             state['float'].append((a.saveState(), geo))
         return state
-        
+
     def childState(self, obj):
         if isinstance(obj, Dock):
             return ('dock', obj.name(), {})
@@ -211,36 +211,36 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
             for i in range(obj.count()):
                 childs.append(self.childState(obj.widget(i)))
             return (obj.type(), childs, obj.saveState())
-        
-        
+
+
     def restoreState(self, state):
         """
         Restore Dock configuration as generated by saveState.
-        
-        Note that this function does not create any Docks--it will only 
+
+        Note that this function does not create any Docks--it will only
         restore the arrangement of an existing set of Docks.
-        
+
         """
-        
+
         ## 1) make dict of all docks and list of existing containers
         containers, docks = self.findAll()
         oldTemps = self.tempAreas[:]
         #print "found docks:", docks
-        
+
         ## 2) create container structure, move docks into new containers
         if state['main'] is not None:
             self.buildFromState(state['main'], docks, self)
-        
+
         ## 3) create floating areas, populate
         for s in state['float']:
             a = self.addTempArea()
             a.buildFromState(s[0]['main'], docks, a)
             a.win.setGeometry(*s[1])
-        
+
         ## 4) Add any remaining docks to the bottom
         for d in docks.values():
             self.moveDock(d, 'below', None)
-        
+
         #print "\nKill old containers:"
         ## 5) kill old containers
         for c in containers:
@@ -260,21 +260,21 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
                 raise Exception('Cannot restore dock state; no dock with name "%s"' % contents)
         else:
             obj = self.makeContainer(typ)
-            
+
         root.insert(obj, 'after')
         #print pfx+"Add:", obj, " -> ", root
-        
+
         if typ != 'dock':
             for o in contents:
                 self.buildFromState(o, docks, obj, depth+1)
             obj.apoptose(propagate=False)
             obj.restoreState(state)  ## this has to be done later?
-        
+
 
     def findAll(self, obj=None, c=None, d=None):
         if obj is None:
             obj = self.topContainer
-        
+
         ## check all temp areas first
         if c is None:
             c = []
@@ -283,7 +283,7 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
                 c1, d1 = a.findAll()
                 c.extend(c1)
                 d.update(d1)
-        
+
         if isinstance(obj, Dock):
             d[obj.name()] = obj
         elif obj is not None:
@@ -307,7 +307,7 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
         docks = self.findAll()[1]
         for dock in docks.values():
             dock.close()
-            
+
     ## PySide bug: We need to explicitly redefine these methods
     ## or else drag/drop events will not be delivered.
     def dragEnterEvent(self, *args):

--- a/pyqtgraph/dockarea/DockDrop.py
+++ b/pyqtgraph/dockarea/DockDrop.py
@@ -12,13 +12,13 @@ class DockDrop(object):
         self.dropArea = None
         self.overlay = DropAreaOverlay(self)
         self.overlay.raise_()
-    
+
     def resizeOverlay(self, size):
         self.overlay.resize(size)
-        
+
     def raiseOverlay(self):
         self.overlay.raise_()
-    
+
     def dragEnterEvent(self, ev):
         src = ev.source()
         if hasattr(src, 'implements') and src.implements('dock'):
@@ -27,14 +27,14 @@ class DockDrop(object):
         else:
             #print "drag enter ignore"
             ev.ignore()
-        
+
     def dragMoveEvent(self, ev):
         #print "drag move"
         ld = ev.pos().x()
         rd = self.width() - ld
         td = ev.pos().y()
         bd = self.height() - td
-        
+
         mn = min(ld, rd, td, bd)
         if mn > 30:
             self.dropArea = "center"
@@ -42,7 +42,7 @@ class DockDrop(object):
             self.dropArea = "center"
         elif (rd == mn or ld == mn) and mn > self.width()/3.:
             self.dropArea = "center"
-            
+
         elif rd == mn:
             self.dropArea = "right"
         elif ld == mn:
@@ -51,7 +51,7 @@ class DockDrop(object):
             self.dropArea = "top"
         elif bd == mn:
             self.dropArea = "bottom"
-            
+
         if ev.source() is self and self.dropArea == 'center':
             #print "  no self-center"
             self.dropArea = None
@@ -64,11 +64,11 @@ class DockDrop(object):
             #print "  ok"
             ev.accept()
         self.overlay.setDropArea(self.dropArea)
-            
+
     def dragLeaveEvent(self, ev):
         self.dropArea = None
         self.overlay.setDropArea(self.dropArea)
-    
+
     def dropEvent(self, ev):
         area = self.dropArea
         if area is None:
@@ -79,17 +79,17 @@ class DockDrop(object):
         self.dropArea = None
         self.overlay.setDropArea(self.dropArea)
 
-        
+
 
 class DropAreaOverlay(QtGui.QWidget):
     """Overlay widget that draws drop areas during a drag-drop operation"""
-    
+
     def __init__(self, parent):
         QtGui.QWidget.__init__(self, parent)
         self.dropArea = None
         self.hide()
         self.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
-        
+
     def setDropArea(self, area):
         self.dropArea = area
         if area is None:
@@ -101,7 +101,7 @@ class DropAreaOverlay(QtGui.QWidget):
             rgn = QtCore.QRect(prgn)
             w = min(30, prgn.width()/3.)
             h = min(30, prgn.height()/3.)
-            
+
             if self.dropArea == 'left':
                 rgn.setWidth(w)
             elif self.dropArea == 'right':
@@ -116,7 +116,7 @@ class DropAreaOverlay(QtGui.QWidget):
             self.show()
 
         self.update()
-    
+
     def paintEvent(self, ev):
         if self.dropArea is None:
             return

--- a/pyqtgraph/exceptionHandling.py
+++ b/pyqtgraph/exceptionHandling.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 """This module installs a wrapper around sys.excepthook which allows multiple
-new exception handlers to be registered. 
+new exception handlers to be registered.
 
-Optionally, the wrapper also stops exceptions from causing long-term storage 
+Optionally, the wrapper also stops exceptions from causing long-term storage
 of local stack frames. This has two major effects:
   - Unhandled exceptions will no longer cause memory leaks
-    (If an exception occurs while a lot of data is present on the stack, 
+    (If an exception occurs while a lot of data is present on the stack,
     such as when loading large files, the data would ordinarily be kept
-    until the next exception occurs. We would rather release this memory 
+    until the next exception occurs. We would rather release this memory
     as soon as possible.)
   - Some debuggers may have a hard time handling uncaught exceptions
- 
-The module also provides a callback mechanism allowing others to respond 
+
+The module also provides a callback mechanism allowing others to respond
 to exceptions.
 """
 
@@ -32,7 +32,7 @@ def register(fn):
     Multiple callbacks will be invoked in the order they were registered.
     """
     callbacks.append(fn)
-    
+
 def unregister(fn):
     """Unregister a previously registered callback."""
     callbacks.remove(fn)
@@ -41,21 +41,21 @@ def setTracebackClearing(clear=True):
     """
     Enable or disable traceback clearing.
     By default, clearing is disabled and Python will indefinitely store unhandled exception stack traces.
-    This function is provided since Python's default behavior can cause unexpected retention of 
+    This function is provided since Python's default behavior can cause unexpected retention of
     large memory-consuming objects.
     """
     global clear_tracebacks
     clear_tracebacks = clear
-    
+
 class ExceptionHandler(object):
     def __call__(self, *args):
-        ## Start by extending recursion depth just a bit. 
+        ## Start by extending recursion depth just a bit.
         ## If the error we are catching is due to recursion, we don't want to generate another one here.
         recursionLimit = sys.getrecursionlimit()
         try:
             sys.setrecursionlimit(recursionLimit+100)
-        
-        
+
+
             ## call original exception handler first (prints exception)
             global original_excepthook, callbacks, clear_tracebacks
             try:
@@ -65,7 +65,7 @@ class ExceptionHandler(object):
                 sys.stdout = sys.stderr
 
             ret = original_excepthook(*args)
-                
+
             for cb in callbacks:
                 try:
                     cb(*args)
@@ -74,33 +74,30 @@ class ExceptionHandler(object):
                     print("      Error occurred during exception callback %s" % str(cb))
                     print("   --------------------------------------------------------------")
                     traceback.print_exception(*sys.exc_info())
-                
-            
+
+
             ## Clear long-term storage of last traceback to prevent memory-hogging.
-            ## (If an exception occurs while a lot of data is present on the stack, 
+            ## (If an exception occurs while a lot of data is present on the stack,
             ## such as when loading large files, the data would ordinarily be kept
-            ## until the next exception occurs. We would rather release this memory 
+            ## until the next exception occurs. We would rather release this memory
             ## as soon as possible.)
             if clear_tracebacks is True:
                 sys.last_traceback = None
-        
+
         finally:
-            sys.setrecursionlimit(recursionLimit)            
-            
-            
+            sys.setrecursionlimit(recursionLimit)
+
+
     def implements(self, interface=None):
         ## this just makes it easy for us to detect whether an ExceptionHook is already installed.
         if interface is None:
             return ['ExceptionHandler']
         else:
             return interface == 'ExceptionHandler'
-    
+
 
 
 ## replace built-in excepthook only if this has not already been done
 if not (hasattr(sys.excepthook, 'implements') and sys.excepthook.implements('ExceptionHandler')):
     original_excepthook = sys.excepthook
     sys.excepthook = ExceptionHandler()
-
-
-

--- a/pyqtgraph/exporters/CSVExporter.py
+++ b/pyqtgraph/exporters/CSVExporter.py
@@ -4,8 +4,8 @@ from ..parametertree import Parameter
 from .. import PlotItem
 
 __all__ = ['CSVExporter']
-    
-    
+
+
 class CSVExporter(Exporter):
     Name = "CSV from plot data"
     windows = []
@@ -16,15 +16,15 @@ class CSVExporter(Exporter):
             {'name': 'precision', 'type': 'int', 'value': 10, 'limits': [0, None]},
             {'name': 'columnMode', 'type': 'list', 'values': ['(x,y) per plot', '(x,y,y,y) for all plots']}
         ])
-        
+
     def parameters(self):
         return self.params
-    
+
     def export(self, fileName=None):
-        
+
         if not isinstance(self.item, PlotItem):
             raise Exception("Must have a PlotItem selected for CSV export.")
-        
+
         if fileName is None:
             self.fileSaveDialog(filter=["*.csv", "*.tsv"])
             return
@@ -55,22 +55,22 @@ class CSVExporter(Exporter):
             sep = ','
         else:
             sep = '\t'
-            
+
         fd.write(sep.join(header) + '\n')
         i = 0
         numFormat = '%%0.%dg' % self.params['precision']
         numRows = max([len(d[0]) for d in data])
         for i in range(numRows):
             for j, d in enumerate(data):
-                # write x value if this is the first column, or if we want x 
+                # write x value if this is the first column, or if we want x
                 # for all rows
                 if appendAllX or j == 0:
                     if d is not None and i < len(d[0]):
                         fd.write(numFormat % d[0][i] + sep)
                     else:
                         fd.write(' %s' % sep)
-                
-                # write y value 
+
+                # write y value
                 if d is not None and i < len(d[1]):
                     fd.write(numFormat % d[1][i] + sep)
                 else:
@@ -78,6 +78,4 @@ class CSVExporter(Exporter):
             fd.write('\n')
         fd.close()
 
-CSVExporter.register()        
-                
-        
+CSVExporter.register()

--- a/pyqtgraph/exporters/Exporter.py
+++ b/pyqtgraph/exporters/Exporter.py
@@ -9,17 +9,17 @@ LastExportDirectory = None
 class Exporter(object):
     """
     Abstract class used for exporting graphics to file / printer / whatever.
-    """    
+    """
     allowCopy = False  # subclasses set this to True if they can use the copy buffer
     Exporters = []
-    
+
     @classmethod
     def register(cls):
         """
         Used to register Exporter classes to appear in the export dialog.
         """
         Exporter.Exporters.append(cls)
-    
+
     def __init__(self, item):
         """
         Initialize with the item to be exported.
@@ -27,11 +27,11 @@ class Exporter(object):
         """
         object.__init__(self)
         self.item = item
-        
+
     def parameters(self):
         """Return the parameters used to configure this exporter."""
         raise Exception("Abstract method must be overridden in subclass.")
-        
+
     def export(self, fileName=None, toBytes=False, copy=False):
         """
         If *fileName* is None, pop-up a file dialog.
@@ -60,12 +60,12 @@ class Exporter(object):
         self.fileDialog.opts = opts
         self.fileDialog.fileSelected.connect(self.fileSaveFinished)
         return
-        
+
     def fileSaveFinished(self, fileName):
         fileName = asUnicode(fileName)
         global LastExportDirectory
         LastExportDirectory = os.path.split(fileName)[0]
-        
+
         ## If file name does not match selected extension, append it now
         ext = os.path.splitext(fileName)[1].lower().lstrip('.')
         selectedExt = re.search(r'\*\.(\w+)\b', asUnicode(self.fileDialog.selectedNameFilter()))
@@ -73,36 +73,36 @@ class Exporter(object):
             selectedExt = selectedExt.groups()[0].lower()
             if ext != selectedExt:
                 fileName = fileName + '.' + selectedExt.lstrip('.')
-        
+
         self.export(fileName=fileName, **self.fileDialog.opts)
-        
+
     def getScene(self):
         if isinstance(self.item, GraphicsScene):
             return self.item
         else:
             return self.item.scene()
-        
+
     def getSourceRect(self):
         if isinstance(self.item, GraphicsScene):
             w = self.item.getViewWidget()
             return w.viewportTransform().inverted()[0].mapRect(w.rect())
         else:
             return self.item.sceneBoundingRect()
-        
-    def getTargetRect(self):        
+
+    def getTargetRect(self):
         if isinstance(self.item, GraphicsScene):
             return self.item.getViewWidget().rect()
         else:
             return self.item.mapRectToDevice(self.item.boundingRect())
-        
+
     def setExportMode(self, export, opts=None):
         """
-        Call setExportMode(export, opts) on all items that will 
+        Call setExportMode(export, opts) on all items that will
         be painted during the export. This informs the item
-        that it is about to be painted for export, allowing it to 
+        that it is about to be painted for export, allowing it to
         alter its appearance temporarily
-        
-        
+
+
         *export*  - bool; must be True before exporting and False afterward
         *opts*    - dict; common parameters are 'antialias' and 'background'
         """
@@ -111,7 +111,7 @@ class Exporter(object):
         for item in self.getPaintItems():
             if hasattr(item, 'setExportMode'):
                 item.setExportMode(export, opts)
-    
+
     def getPaintItems(self, root=None):
         """Return a list of all items that should be painted in the correct order."""
         if root is None:
@@ -132,7 +132,7 @@ class Exporter(object):
                 preItems.extend(tree)
             else:
                 postItems.extend(tree)
-                
+
         return preItems + rootItem + postItems
 
     def render(self, painter, targetRect, sourceRect, item=None):

--- a/pyqtgraph/exporters/HDF5Exporter.py
+++ b/pyqtgraph/exporters/HDF5Exporter.py
@@ -3,16 +3,16 @@ from .Exporter import Exporter
 from ..parametertree import Parameter
 from .. import PlotItem
 
-import numpy 
+import numpy
 try:
     import h5py
     HAVE_HDF5 = True
 except ImportError:
     HAVE_HDF5 = False
-    
+
 __all__ = ['HDF5Exporter']
 
-    
+
 class HDF5Exporter(Exporter):
     Name = "HDF5 Export: plot (x,y)"
     windows = []
@@ -24,32 +24,32 @@ class HDF5Exporter(Exporter):
             {'name': 'Name', 'type': 'str', 'value': 'Export',},
             {'name': 'columnMode', 'type': 'list', 'values': ['(x,y) per plot', '(x,y,y,y) for all plots']},
         ])
-        
+
     def parameters(self):
         return self.params
-    
+
     def export(self, fileName=None):
         if not HAVE_HDF5:
             raise RuntimeError("This exporter requires the h5py package, "
                                "but it was not importable.")
-        
+
         if not isinstance(self.item, PlotItem):
             raise Exception("Must have a PlotItem selected for HDF5 export.")
-        
+
         if fileName is None:
             self.fileSaveDialog(filter=["*.h5", "*.hdf", "*.hd5"])
             return
         dsname = self.params['Name']
         fd = h5py.File(fileName, 'a') # forces append to file... 'w' doesn't seem to "delete/overwrite"
         data = []
-        
+
         appendAllX = self.params['columnMode'] == '(x,y) per plot'
         for i,c in enumerate(self.item.curves):
             d = c.getData()
             if appendAllX or i == 0:
                 data.append(d[0])
             data.append(d[1])
-                
+
         fdata = numpy.array(data).astype('double')
         dset = fd.create_dataset(dsname, data=fdata)
         fd.close()

--- a/pyqtgraph/exporters/ImageExporter.py
+++ b/pyqtgraph/exporters/ImageExporter.py
@@ -9,7 +9,7 @@ __all__ = ['ImageExporter']
 class ImageExporter(Exporter):
     Name = "Image File (PNG, TIF, JPG, ...)"
     allowCopy = True
-    
+
     def __init__(self, item):
         Exporter.__init__(self, item)
         tr = self.getTargetRect()
@@ -21,7 +21,7 @@ class ImageExporter(Exporter):
         bg = bgbrush.color()
         if bgbrush.style() == QtCore.Qt.NoBrush:
             bg.setAlpha(0)
-            
+
         self.params = Parameter(name='params', type='group', children=[
             {'name': 'width', 'type': 'int', 'value': tr.width(), 'limits': (0, None)},
             {'name': 'height', 'type': 'int', 'value': tr.height(), 'limits': (0, None)},
@@ -30,20 +30,20 @@ class ImageExporter(Exporter):
         ])
         self.params.param('width').sigValueChanged.connect(self.widthChanged)
         self.params.param('height').sigValueChanged.connect(self.heightChanged)
-        
+
     def widthChanged(self):
         sr = self.getSourceRect()
         ar = float(sr.height()) / sr.width()
         self.params.param('height').setValue(self.params['width'] * ar, blockSignal=self.heightChanged)
-        
+
     def heightChanged(self):
         sr = self.getSourceRect()
         ar = float(sr.width()) / sr.height()
         self.params.param('width').setValue(self.params['height'] * ar, blockSignal=self.widthChanged)
-        
+
     def parameters(self):
         return self.params
-    
+
     def export(self, fileName=None, toBytes=False, copy=False):
         if fileName is None and not toBytes and not copy:
             if USE_PYSIDE:
@@ -57,11 +57,11 @@ class ImageExporter(Exporter):
                     filter.insert(0, p)
             self.fileSaveDialog(filter=filter)
             return
-            
+
         targetRect = QtCore.QRect(0, 0, self.params['width'], self.params['height'])
         sourceRect = self.getSourceRect()
-        
-        
+
+
         #self.png = QtGui.QImage(targetRect.size(), QtGui.QImage.Format_ARGB32)
         #self.png.fill(pyqtgraph.mkColor(self.params['background']))
         w, h = self.params['width'], self.params['height']
@@ -74,13 +74,13 @@ class ImageExporter(Exporter):
         bg[:,:,2] = color.red()
         bg[:,:,3] = color.alpha()
         self.png = fn.makeQImage(bg, alpha=True)
-        
+
         ## set resolution of image:
         origTargetRect = self.getTargetRect()
         resolutionScale = targetRect.width() / origTargetRect.width()
         #self.png.setDotsPerMeterX(self.png.dotsPerMeterX() * resolutionScale)
         #self.png.setDotsPerMeterY(self.png.dotsPerMeterY() * resolutionScale)
-        
+
         painter = QtGui.QPainter(self.png)
         #dtr = painter.deviceTransform()
         try:
@@ -90,13 +90,12 @@ class ImageExporter(Exporter):
         finally:
             self.setExportMode(False)
         painter.end()
-        
+
         if copy:
             QtGui.QApplication.clipboard().setImage(self.png)
         elif toBytes:
             return self.png
         else:
             self.png.save(fileName)
-        
-ImageExporter.register()        
-        
+
+ImageExporter.register()

--- a/pyqtgraph/exporters/Matplotlib.py
+++ b/pyqtgraph/exporters/Matplotlib.py
@@ -27,13 +27,13 @@ The advantage is that there is less to do to get an exported file cleaned and re
 publication. Fonts are not vectorized (outlined), and window colors are white.
 
 """
-    
+
 class MatplotlibExporter(Exporter):
     Name = "Matplotlib Window"
     windows = []
     def __init__(self, item):
         Exporter.__init__(self, item)
-        
+
     def parameters(self):
         return None
 
@@ -53,17 +53,17 @@ class MatplotlibExporter(Exporter):
                     raise ValueError('Unknown spine location: %s' % loc)
                 # turn off ticks when there is no spine
                 ax.xaxis.set_ticks_position('bottom')
-    
+
     def export(self, fileName=None):
-        
+
         if isinstance(self.item, PlotItem):
             mpw = MatplotlibWindow()
             MatplotlibExporter.windows.append(mpw)
 
             stdFont = 'Arial'
-            
+
             fig = mpw.getFigure()
-            
+
             # get labels from the graphic item
             xlabel = self.item.axes['bottom']['item'].label.toPlainText()
             ylabel = self.item.axes['left']['item'].label.toPlainText()
@@ -90,13 +90,13 @@ class MatplotlibExporter(Exporter):
                 markeredgecolor = tuple([c/255. for c in fn.colorTuple(symbolPen.color())])
                 markerfacecolor = tuple([c/255. for c in fn.colorTuple(symbolBrush.color())])
                 markersize = opts['symbolSize']
-                
+
                 if opts['fillLevel'] is not None and opts['fillBrush'] is not None:
                     fillBrush = fn.mkBrush(opts['fillBrush'])
                     fillcolor = tuple([c/255. for c in fn.colorTuple(fillBrush.color())])
                     ax.fill_between(x=x, y1=y, y2=opts['fillLevel'], facecolor=fillcolor)
-                
-                pl = ax.plot(x, y, marker=symbol, color=color, linewidth=pen.width(), 
+
+                pl = ax.plot(x, y, marker=symbol, color=color, linewidth=pen.width(),
                         linestyle=linestyle, markeredgecolor=markeredgecolor, markerfacecolor=markerfacecolor,
                         markersize=markersize)
                 xr, yr = self.item.viewRange()
@@ -107,9 +107,9 @@ class MatplotlibExporter(Exporter):
             mpw.draw()
         else:
             raise Exception("Matplotlib export currently only works with plot items")
-                
-MatplotlibExporter.register()        
-        
+
+MatplotlibExporter.register()
+
 
 class MatplotlibWindow(QtGui.QMainWindow):
     def __init__(self):
@@ -118,11 +118,9 @@ class MatplotlibWindow(QtGui.QMainWindow):
         self.mpl = MatplotlibWidget.MatplotlibWidget()
         self.setCentralWidget(self.mpl)
         self.show()
-        
+
     def __getattr__(self, attr):
         return getattr(self.mpl, attr)
-        
+
     def closeEvent(self, ev):
         MatplotlibExporter.windows.remove(self)
-
-

--- a/pyqtgraph/exporters/PrintExporter.py
+++ b/pyqtgraph/exporters/PrintExporter.py
@@ -3,7 +3,7 @@ from ..parametertree import Parameter
 from ..Qt import QtGui, QtCore, QtSvg
 import re
 
-__all__ = ['PrintExporter']  
+__all__ = ['PrintExporter']
 #__all__ = []   ## Printer is disabled for now--does not work very well.
 
 class PrintExporter(Exporter):
@@ -22,24 +22,24 @@ class PrintExporter(Exporter):
         sr = self.getSourceRect()
         ar = sr.height() / sr.width()
         self.params.param('height').setValue(self.params['width'] * ar, blockSignal=self.heightChanged)
-        
+
     def heightChanged(self):
         sr = self.getSourceRect()
         ar = sr.width() / sr.height()
         self.params.param('width').setValue(self.params['height'] * ar, blockSignal=self.widthChanged)
-        
+
     def parameters(self):
         return self.params
-    
+
     def export(self, fileName=None):
         printer = QtGui.QPrinter(QtGui.QPrinter.HighResolution)
         dialog = QtGui.QPrintDialog(printer)
         dialog.setWindowTitle("Print Document")
         if dialog.exec_() != QtGui.QDialog.Accepted:
             return
-            
+
         #dpi = QtGui.QDesktopWidget().physicalDpiX()
-        
+
         #self.svg.setSize(QtCore.QSize(100,100))
         #self.svg.setResolution(600)
         #res = printer.resolution()
@@ -53,7 +53,7 @@ class PrintExporter(Exporter):
         w = self.params['width'] * res * 100. / 2.54
         x = center.x() - w/2.
         y = center.y() - h/2.
-        
+
         targetRect = QtCore.QRect(x, y, w, h)
         sourceRect = self.getSourceRect()
         painter = QtGui.QPainter(printer)
@@ -65,4 +65,4 @@ class PrintExporter(Exporter):
         painter.end()
 
 
-#PrintExporter.register()        
+#PrintExporter.register()

--- a/pyqtgraph/exporters/__init__.py
+++ b/pyqtgraph/exporters/__init__.py
@@ -8,4 +8,3 @@ from .HDF5Exporter import *
 
 def listExporters():
     return Exporter.Exporters[:]
-

--- a/pyqtgraph/exporters/tests/test_csv.py
+++ b/pyqtgraph/exporters/tests/test_csv.py
@@ -17,19 +17,19 @@ def approxeq(a, b):
 def test_CSVExporter():
     tempfilename = tempfile.NamedTemporaryFile(suffix='.csv').name
     print("using %s as a temporary file" % tempfilename)
-    
+
     plt = pg.plot()
     y1 = [1,3,2,3,1,6,9,8,4,2]
     plt.plot(y=y1, name='myPlot')
-    
+
     y2 = [3,4,6,1,2,4,2,3,5,3,5,1,3]
     x2 = pg.np.linspace(0, 1.0, len(y2))
     plt.plot(x=x2, y=y2)
-    
+
     y3 = [1,5,2,3,4,6,1,2,4,2,3,5,3]
     x3 = pg.np.linspace(0, 1.0, len(y3)+1)
     plt.plot(x=x3, y=y3, stepMode=True)
-    
+
     ex = pg.exporters.CSVExporter(plt.plotItem)
     ex.export(fileName=tempfilename)
 
@@ -37,16 +37,16 @@ def test_CSVExporter():
     lines = [line for line in r]
     header = lines.pop(0)
     assert header == ['myPlot_x', 'myPlot_y', 'x0001', 'y0001', 'x0002', 'y0002']
-    
+
     i = 0
     for vals in lines:
         vals = list(map(str.strip, vals))
-        assert (i >= len(y1) and vals[0] == '') or approxeq(float(vals[0]), i) 
-        assert (i >= len(y1) and vals[1] == '') or approxeq(float(vals[1]), y1[i]) 
-        
+        assert (i >= len(y1) and vals[0] == '') or approxeq(float(vals[0]), i)
+        assert (i >= len(y1) and vals[1] == '') or approxeq(float(vals[1]), y1[i])
+
         assert (i >= len(x2) and vals[2] == '') or approxeq(float(vals[2]), x2[i])
         assert (i >= len(y2) and vals[3] == '') or approxeq(float(vals[3]), y2[i])
-        
+
         assert (i >= len(x3) and vals[4] == '') or approxeq(float(vals[4]), x3[i])
         assert (i >= len(y3) and vals[5] == '') or approxeq(float(vals[5]), y3[i])
         i += 1

--- a/pyqtgraph/exporters/tests/test_svg.py
+++ b/pyqtgraph/exporters/tests/test_svg.py
@@ -15,7 +15,7 @@ def test_plotscene():
     print("using %s as a temporary file" % tempfilename)
     pg.setConfigOption('foreground', (0,0,0))
     w = pg.GraphicsWindow()
-    w.show()        
+    w.show()
     p1 = w.addPlot()
     p2 = w.addPlot()
     p1.plot([1,3,2,3,1,6,9,8,4,2,3,5,3], pen={'color':'k'})
@@ -23,7 +23,7 @@ def test_plotscene():
     p2.plot([1,5,2,3,4,6,1,2,4,2,3,5,3], pen={'color':'k', 'cosmetic':False, 'width': 0.3})
     app.processEvents()
     app.processEvents()
-    
+
     ex = pg.exporters.SVGExporter(w.scene())
     ex.export(fileName=tempfilename)
     # clean up after the test is done
@@ -39,20 +39,20 @@ def test_simple():
     #rect.translate(50, 50)
     #rect.rotate(30)
     #rect.scale(0.5, 0.5)
-    
+
     #rect1 = pg.QtGui.QGraphicsRectItem(0, 0, 100, 100)
     #rect1.setParentItem(rect)
     #rect1.setFlag(rect1.ItemIgnoresTransformations)
     #rect1.setPos(20, 20)
     #rect1.scale(2,2)
-    
+
     #el1 = pg.QtGui.QGraphicsEllipseItem(0, 0, 100, 100)
     #el1.setParentItem(rect1)
     ##grp = pg.ItemGroup()
     #grp.setParentItem(rect)
     #grp.translate(200,0)
     ##grp.rotate(30)
-    
+
     #rect2 = pg.QtGui.QGraphicsRectItem(0, 0, 100, 25)
     #rect2.setFlag(rect2.ItemClipsChildrenToShape)
     #rect2.setParentItem(grp)

--- a/pyqtgraph/flowchart/FlowchartGraphicsView.py
+++ b/pyqtgraph/flowchart/FlowchartGraphicsView.py
@@ -6,10 +6,10 @@ from ..graphicsItems.ViewBox import ViewBox
 
 #class FlowchartGraphicsView(QtGui.QGraphicsView):
 class FlowchartGraphicsView(GraphicsView):
-    
+
     sigHoverOver = QtCore.Signal(object)
     sigClicked = QtCore.Signal(object)
-    
+
     def __init__(self, widget, *args):
         #QtGui.QGraphicsView.__init__(self, *args)
         GraphicsView.__init__(self, *args, useOpenGL=False)
@@ -24,11 +24,11 @@ class FlowchartGraphicsView(GraphicsView):
         self.setRenderHint(QtGui.QPainter.Antialiasing, True)
         #self.setDragMode(QtGui.QGraphicsView.RubberBandDrag)
         #self.setRubberBandSelectionMode(QtCore.Qt.ContainsItemBoundingRect)
-    
+
     def viewBox(self):
         return self._vb
-    
-    
+
+
     #def mousePressEvent(self, ev):
         #self.moved = False
         #self.lastPos = ev.pos()
@@ -50,27 +50,27 @@ class FlowchartGraphicsView(GraphicsView):
             #self.sigHoverOver.emit(self.items(ev.pos()))
             #callSuper = True
         #self.lastPos = ev.pos()
-        
+
         #if callSuper:
             #QtGui.QGraphicsView.mouseMoveEvent(self, ev)
-            
+
     #def mouseReleaseEvent(self, ev):
         #if not self.moved:
             ##self.emit(QtCore.SIGNAL('clicked'), ev)
             #self.sigClicked.emit(ev)
         #return QtGui.QGraphicsView.mouseReleaseEvent(self, ev)
-        
+
 class FlowchartViewBox(ViewBox):
-    
+
     def __init__(self, widget, *args, **kwargs):
         ViewBox.__init__(self, *args, **kwargs)
         self.widget = widget
         #self.menu = None
         #self._subMenus = None ## need a place to store the menus otherwise they dissappear (even though they've been added to other menus) ((yes, it doesn't make sense))
-        
-        
-        
-        
+
+
+
+
     def getMenu(self, ev):
         ## called by ViewBox to create a new context menu
         self._fc_menu = QtGui.QMenu()
@@ -78,31 +78,31 @@ class FlowchartViewBox(ViewBox):
         for menu in self._subMenus:
             self._fc_menu.addMenu(menu)
         return self._fc_menu
-    
+
     def getContextMenus(self, ev):
         ## called by scene to add menus on to someone else's context menu
         menu = self.widget.buildMenu(ev.scenePos())
         menu.setTitle("Add node")
         return [menu, ViewBox.getMenu(self, ev)]
 
-    
-    
-        
-        
-        
-        
-        
+
+
+
+
+
+
+
 
 
 ##class FlowchartGraphicsScene(QtGui.QGraphicsScene):
 #class FlowchartGraphicsScene(GraphicsScene):
-    
+
     #sigContextMenuEvent = QtCore.Signal(object)
-    
+
     #def __init__(self, *args):
         ##QtGui.QGraphicsScene.__init__(self, *args)
         #GraphicsScene.__init__(self, *args)
-        
+
     #def mouseClickEvent(self, ev):
         ##QtGui.QGraphicsScene.contextMenuEvent(self, ev)
         #if not ev.button() in [QtCore.Qt.RightButton]:

--- a/pyqtgraph/flowchart/Node.py
+++ b/pyqtgraph/flowchart/Node.py
@@ -14,9 +14,9 @@ def strDict(d):
 
 class Node(QtCore.QObject):
     """
-    Node represents the basic processing unit of a flowchart. 
+    Node represents the basic processing unit of a flowchart.
     A Node subclass implements at least:
-    
+
     1) A list of input / ouptut terminals and their properties
     2) a process() function which takes the names of input terminals as keyword arguments and returns a dict with the names of output terminals as keys.
 
@@ -25,7 +25,7 @@ class Node(QtCore.QObject):
     This allows Nodes within the flowchart to connect to the input/output nodes of the flowchart itself.
 
     Optionally, a node class can implement the ctrlWidget() method, which must return a QWidget (usually containing other widgets) that will be displayed in the flowchart control panel. Some nodes implement fairly complex control widgets, but most nodes follow a simple form-like pattern: a list of parameter names and a single value (represented as spin box, check box, etc..) for each parameter. To make this easier, the CtrlNode subclass allows you to instead define a simple data structure that CtrlNode will use to automatically generate the control widget.     """
-    
+
     sigOutputChanged = QtCore.Signal(object)   # self
     sigClosed = QtCore.Signal(object)
     sigRenamed = QtCore.Signal(object, object)
@@ -33,21 +33,21 @@ class Node(QtCore.QObject):
     sigTerminalAdded = QtCore.Signal(object, object)  # self, term
     sigTerminalRemoved = QtCore.Signal(object, object)  # self, term
 
-    
+
     def __init__(self, name, terminals=None, allowAddInput=False, allowAddOutput=False, allowRemove=True):
         """
         ==============  ============================================================
         **Arguments:**
-        name            The name of this specific node instance. It can be any 
+        name            The name of this specific node instance. It can be any
                         string, but must be unique within a flowchart. Usually,
                         we simply let the flowchart decide on a name when calling
                         Flowchart.addNode(...)
         terminals       Dict-of-dicts specifying the terminals present on this Node.
                         Terminal specifications look like::
-                        
+
                             'inputTerminalName': {'io': 'in'}
-                            'outputTerminalName': {'io': 'out'} 
-                            
+                            'outputTerminalName': {'io': 'out'}
+
                         There are a number of optional parameters for terminals:
                         multi, pos, renamable, removable, multiable, bypass. See
                         the Terminal class for more information.
@@ -57,8 +57,8 @@ class Node(QtCore.QObject):
                         context menu.
         allowRemove     bool; whether the user is allowed to remove this node by the
                         context menu.
-        ==============  ============================================================  
-        
+        ==============  ============================================================
+
         """
         QtCore.QObject.__init__(self)
         self._name = name
@@ -71,14 +71,14 @@ class Node(QtCore.QObject):
         self._allowAddInput = allowAddInput   ## flags to allow the user to add/remove terminals
         self._allowAddOutput = allowAddOutput
         self._allowRemove = allowRemove
-        
+
         self.exception = None
         if terminals is None:
             return
         for name, opts in terminals.items():
             self.addTerminal(name, **opts)
 
-        
+
     def nextTerminalName(self, name):
         """Return an unused terminal name"""
         name2 = name
@@ -87,33 +87,33 @@ class Node(QtCore.QObject):
             name2 = "%s.%d" % (name, i)
             i += 1
         return name2
-        
+
     def addInput(self, name="Input", **args):
         """Add a new input terminal to this Node with the given name. Extra
         keyword arguments are passed to Terminal.__init__.
-        
+
         This is a convenience function that just calls addTerminal(io='in', ...)"""
         #print "Node.addInput called."
         return self.addTerminal(name, io='in', **args)
-        
+
     def addOutput(self, name="Output", **args):
         """Add a new output terminal to this Node with the given name. Extra
         keyword arguments are passed to Terminal.__init__.
-        
+
         This is a convenience function that just calls addTerminal(io='out', ...)"""
         return self.addTerminal(name, io='out', **args)
-        
+
     def removeTerminal(self, term):
-        """Remove the specified terminal from this Node. May specify either the 
+        """Remove the specified terminal from this Node. May specify either the
         terminal's name or the terminal itself.
-        
+
         Causes sigTerminalRemoved to be emitted."""
         if isinstance(term, Terminal):
             name = term.name()
         else:
             name = term
             term = self.terminals[name]
-        
+
         #print "remove", name
         #term.disconnectAll()
         term.close()
@@ -124,11 +124,11 @@ class Node(QtCore.QObject):
             del self._outputs[name]
         self.graphicsItem().updateTerminals()
         self.sigTerminalRemoved.emit(self, term)
-        
-        
+
+
     def terminalRenamed(self, term, oldName):
-        """Called after a terminal has been renamed        
-        
+        """Called after a terminal has been renamed
+
         Causes sigTerminalRenamed to be emitted."""
         newName = term.name()
         for d in [self.terminals, self._inputs, self._outputs]:
@@ -136,14 +136,14 @@ class Node(QtCore.QObject):
                 continue
             d[newName] = d[oldName]
             del d[oldName]
-            
+
         self.graphicsItem().updateTerminals()
         self.sigTerminalRenamed.emit(term, oldName)
-        
+
     def addTerminal(self, name, **opts):
         """Add a new terminal to this Node with the given name. Extra
         keyword arguments are passed to Terminal.__init__.
-                
+
         Causes sigTerminalAdded to be emitted."""
         name = self.nextTerminalName(name)
         term = Terminal(self, name, **opts)
@@ -156,37 +156,37 @@ class Node(QtCore.QObject):
         self.sigTerminalAdded.emit(self, term)
         return term
 
-        
+
     def inputs(self):
         """Return dict of all input terminals.
         Warning: do not modify."""
         return self._inputs
-        
+
     def outputs(self):
         """Return dict of all output terminals.
         Warning: do not modify."""
         return self._outputs
-        
+
     def process(self, **kargs):
-        """Process data through this node. This method is called any time the flowchart 
+        """Process data through this node. This method is called any time the flowchart
         wants the node to process data. It will be called with one keyword argument
         corresponding to each input terminal, and must return a dict mapping the name
         of each output terminal to its new value.
-        
+
         This method is also called with a 'display' keyword argument, which indicates
         whether the node should update its display (if it implements any) while processing
         this data. This is primarily used to disable expensive display operations
         during batch processing.
         """
         return {}
-    
+
     def graphicsItem(self):
         """Return the GraphicsItem for this node. Subclasses may re-implement
         this method to customize their appearance in the flowchart."""
         if self._graphicsItem is None:
             self._graphicsItem = NodeGraphicsItem(self)
         return self._graphicsItem
-    
+
     ## this is just bad planning. Causes too many bugs.
     def __getattr__(self, attr):
         """Return the terminal with the given name"""
@@ -197,7 +197,7 @@ class Node(QtCore.QObject):
             traceback.print_stack()
             print("Warning: use of node.terminalName is deprecated; use node['terminalName'] instead.")
             return self.terminals[attr]
-            
+
     def __getitem__(self, item):
         #return getattr(self, item)
         """Return the terminal with the given name"""
@@ -205,7 +205,7 @@ class Node(QtCore.QObject):
             raise KeyError(item)
         else:
             return self.terminals[item]
-            
+
     def name(self):
         """Return the name of this node."""
         return self._name
@@ -224,32 +224,32 @@ class Node(QtCore.QObject):
             nodes |= set([i.node() for i in t.inputTerminals()])
         return nodes
         #return set([t.inputTerminals().node() for t in self.listInputs().itervalues()])
-        
+
     def __repr__(self):
         return "<Node %s @%x>" % (self.name(), id(self))
-        
+
     def ctrlWidget(self):
-        """Return this Node's control widget. 
-        
-        By default, Nodes have no control widget. Subclasses may reimplement this 
+        """Return this Node's control widget.
+
+        By default, Nodes have no control widget. Subclasses may reimplement this
         method to provide a custom widget. This method is called by Flowcharts
         when they are constructing their Node list."""
         return None
 
     def bypass(self, byp):
         """Set whether this node should be bypassed.
-        
+
         When bypassed, a Node's process() method is never called. In some cases,
-        data is automatically copied directly from specific input nodes to 
-        output nodes instead (see the bypass argument to Terminal.__init__). 
-        This is usually called when the user disables a node from the flowchart 
+        data is automatically copied directly from specific input nodes to
+        output nodes instead (see the bypass argument to Terminal.__init__).
+        This is usually called when the user disables a node from the flowchart
         control panel.
         """
         self._bypass = byp
         if self.bypassButton is not None:
             self.bypassButton.setChecked(byp)
         self.update()
-        
+
     def isBypassed(self):
         """Return True if this Node is currently bypassed."""
         return self._bypass
@@ -266,29 +266,29 @@ class Node(QtCore.QObject):
             term.setValue(v, process=False)
         if changed and '_updatesHandled_' not in args:
             self.update()
-        
+
     def inputValues(self):
         """Return a dict of all input values currently assigned to this node."""
         vals = {}
         for n, t in self.inputs().items():
             vals[n] = t.value()
         return vals
-            
+
     def outputValues(self):
         """Return a dict of all output values currently generated by this node."""
         vals = {}
         for n, t in self.outputs().items():
             vals[n] = t.value()
         return vals
-            
+
     def connected(self, localTerm, remoteTerm):
         """Called whenever one of this node's terminals is connected elsewhere."""
         pass
-    
+
     def disconnected(self, localTerm, remoteTerm):
         """Called whenever one of this node's terminals is disconnected from another."""
-        pass 
-    
+        pass
+
     def update(self, signal=True):
         """Collect all input values, attempt to process new output values, and propagate downstream.
         Subclasses should call update() whenever thir internal state has changed
@@ -316,7 +316,7 @@ class Node(QtCore.QObject):
             for n,t in self.outputs().items():
                 t.setValue(None)
             self.setException(sys.exc_info())
-            
+
             if signal:
                 #self.emit(QtCore.SIGNAL('outputChanged'), self)  ## triggers flowchart to propagate new data
                 self.sigOutputChanged.emit(self)  ## triggers flowchart to propagate new data
@@ -353,10 +353,10 @@ class Node(QtCore.QObject):
     def setException(self, exc):
         self.exception = exc
         self.recolor()
-        
+
     def clearException(self):
         self.setException(None)
-        
+
     def recolor(self):
         if self.exception is None:
             self.graphicsItem().setPen(QtGui.QPen(QtGui.QColor(0, 0, 0)))
@@ -367,8 +367,8 @@ class Node(QtCore.QObject):
         """Return a dictionary representing the current state of this node
         (excluding input / output values). This is used for saving/reloading
         flowcharts. The default implementation returns this Node's position,
-        bypass state, and information about each of its terminals. 
-        
+        bypass state, and information about each of its terminals.
+
         Subclasses may want to extend this method, adding extra keys to the returned
         dict."""
         pos = self.graphicsItem().pos()
@@ -379,7 +379,7 @@ class Node(QtCore.QObject):
         if termsEditable:
             state['terminals'] = self.saveTerminals()
         return state
-        
+
     def restoreState(self, state):
         """Restore the state of this node from a structure previously generated
         by saveState(). """
@@ -394,7 +394,7 @@ class Node(QtCore.QObject):
         for n, t in self.terminals.items():
             terms[n] = (t.saveState())
         return terms
-        
+
     def restoreTerminals(self, state):
         for name in list(self.terminals.keys()):
             if name not in state:
@@ -409,15 +409,15 @@ class Node(QtCore.QObject):
                 self.addTerminal(name, **opts)
             except:
                 printExc("Error restoring terminal %s (%s):" % (str(name), str(opts)))
-                
-        
+
+
     def clearTerminals(self):
         for t in self.terminals.values():
             t.close()
         self.terminals = OrderedDict()
         self._inputs = OrderedDict()
         self._outputs = OrderedDict()
-        
+
     def close(self):
         """Cleans up after the node--removes terminals, graphicsItem, widget"""
         self.disconnectAll()
@@ -431,11 +431,11 @@ class Node(QtCore.QObject):
             w.setParent(None)
         #self.emit(QtCore.SIGNAL('closed'), self)
         self.sigClosed.emit(self)
-            
+
     def disconnectAll(self):
         for t in self.terminals.values():
             t.disconnectAll()
-    
+
 
 #class NodeGraphicsItem(QtGui.QGraphicsItem):
 class NodeGraphicsItem(GraphicsObject):
@@ -443,19 +443,19 @@ class NodeGraphicsItem(GraphicsObject):
         #QtGui.QGraphicsItem.__init__(self)
         GraphicsObject.__init__(self)
         #QObjectWorkaround.__init__(self)
-        
+
         #self.shadow = QtGui.QGraphicsDropShadowEffect()
         #self.shadow.setOffset(5,5)
         #self.shadow.setBlurRadius(10)
         #self.setGraphicsEffect(self.shadow)
-        
+
         self.pen = fn.mkPen(0,0,0)
         self.selectPen = fn.mkPen(200,200,200,width=2)
         self.brush = fn.mkBrush(200, 200, 200, 150)
         self.hoverBrush = fn.mkBrush(200, 200, 200, 200)
         self.selectBrush = fn.mkBrush(200, 200, 255, 200)
         self.hovered = False
-        
+
         self.node = node
         flags = self.ItemIsMovable | self.ItemIsSelectable | self.ItemIsFocusable |self.ItemSendsGeometryChanges
         #flags =  self.ItemIsFocusable |self.ItemSendsGeometryChanges
@@ -471,32 +471,32 @@ class NodeGraphicsItem(GraphicsObject):
 
         self.nameItem.focusOutEvent = self.labelFocusOut
         self.nameItem.keyPressEvent = self.labelKeyPress
-        
+
         self.menu = None
         self.buildMenu()
-        
+
         #self.node.sigTerminalRenamed.connect(self.updateActionMenu)
-        
+
     #def setZValue(self, z):
         #for t, item in self.terminals.itervalues():
             #item.setZValue(z+1)
         #GraphicsObject.setZValue(self, z)
-        
+
     def labelFocusOut(self, ev):
         QtGui.QGraphicsTextItem.focusOutEvent(self.nameItem, ev)
         self.labelChanged()
-        
+
     def labelKeyPress(self, ev):
         if ev.key() == QtCore.Qt.Key_Enter or ev.key() == QtCore.Qt.Key_Return:
             self.labelChanged()
         else:
             QtGui.QGraphicsTextItem.keyPressEvent(self.nameItem, ev)
-        
+
     def labelChanged(self):
         newName = str(self.nameItem.toPlainText())
         if newName != self.node.name():
             self.node.rename(newName)
-            
+
         ### re-center the label
         bounds = self.boundingRect()
         self.nameItem.setPos(bounds.width()/2. - self.nameItem.boundingRect().width()/2., 0)
@@ -504,12 +504,12 @@ class NodeGraphicsItem(GraphicsObject):
     def setPen(self, *args, **kwargs):
         self.pen = fn.mkPen(*args, **kwargs)
         self.update()
-        
+
     def setBrush(self, brush):
         self.brush = brush
         self.update()
-        
-        
+
+
     def updateTerminals(self):
         bounds = self.bounds
         self.terminals = {}
@@ -524,7 +524,7 @@ class NodeGraphicsItem(GraphicsObject):
             item.setAnchor(0, y)
             self.terminals[i] = (t, item)
             y += dy
-        
+
         out = self.node.outputs()
         dy = bounds.height() / (len(out)+1)
         y = dy
@@ -536,15 +536,15 @@ class NodeGraphicsItem(GraphicsObject):
             item.setAnchor(bounds.width(), y)
             self.terminals[i] = (t, item)
             y += dy
-        
+
         #self.buildMenu()
-        
-        
+
+
     def boundingRect(self):
         return self.bounds.adjusted(-5, -5, 5, 5)
-        
+
     def paint(self, p, *args):
-        
+
         p.setPen(self.pen)
         if self.isSelected():
             p.setPen(self.selectPen)
@@ -555,10 +555,10 @@ class NodeGraphicsItem(GraphicsObject):
                 p.setBrush(self.hoverBrush)
             else:
                 p.setBrush(self.brush)
-                
+
         p.drawRect(self.bounds)
 
-        
+
     def mousePressEvent(self, ev):
         ev.ignore()
 
@@ -577,20 +577,20 @@ class NodeGraphicsItem(GraphicsObject):
                 #self.scene().selectionChanged.emit() ## for some reason this doesn't seem to be happening automatically
                 self.update()
             #return ret
-        
+
         elif int(ev.button()) == int(QtCore.Qt.RightButton):
             #print "    ev.button: right"
             ev.accept()
             #pos = ev.screenPos()
             self.raiseContextMenu(ev)
             #self.menu.popup(QtCore.QPoint(pos.x(), pos.y()))
-            
+
     def mouseDragEvent(self, ev):
         #print "Node.mouseDrag"
         if ev.button() == QtCore.Qt.LeftButton:
             ev.accept()
             self.setPos(self.pos()+self.mapToParent(ev.pos())-self.mapToParent(ev.lastPos()))
-        
+
     def hoverEvent(self, ev):
         if not ev.isExit() and ev.acceptClicks(QtCore.Qt.LeftButton):
             ev.acceptDrags(QtCore.Qt.LeftButton)
@@ -598,7 +598,7 @@ class NodeGraphicsItem(GraphicsObject):
         else:
             self.hovered = False
         self.update()
-            
+
     def keyPressEvent(self, ev):
         if ev.key() == QtCore.Qt.Key_Delete or ev.key() == QtCore.Qt.Key_Backspace:
             ev.accept()
@@ -613,16 +613,16 @@ class NodeGraphicsItem(GraphicsObject):
             for k, t in self.terminals.items():
                 t[1].nodeMoved()
         return GraphicsObject.itemChange(self, change, val)
-            
+
 
     def getMenu(self):
         return self.menu
-    
+
     def raiseContextMenu(self, ev):
         menu = self.scene().addParentContextMenus(self, self.getMenu(), ev)
         pos = ev.screenPos()
         menu.popup(QtCore.QPoint(pos.x(), pos.y()))
-        
+
     def buildMenu(self):
         self.menu = QtGui.QMenu()
         self.menu.setTitle("Node")
@@ -635,10 +635,9 @@ class NodeGraphicsItem(GraphicsObject):
         a = self.menu.addAction("Remove node", self.node.close)
         if not self.node._allowRemove:
             a.setEnabled(False)
-        
+
     def addInputFromMenu(self):  ## called when add input is clicked in context menu
         self.node.addInput(renamable=True, removable=True, multiable=True)
-        
+
     def addOutputFromMenu(self):  ## called when add output is clicked in context menu
         self.node.addOutput(renamable=True, removable=True, multiable=False)
-        

--- a/pyqtgraph/flowchart/NodeLibrary.py
+++ b/pyqtgraph/flowchart/NodeLibrary.py
@@ -13,35 +13,35 @@ def isNodeClass(cls):
 
 class NodeLibrary:
     """
-    A library of flowchart Node types. Custom libraries may be built to provide 
+    A library of flowchart Node types. Custom libraries may be built to provide
     each flowchart with a specific set of allowed Node types.
     """
 
     def __init__(self):
         self.nodeList = OrderedDict()
         self.nodeTree = OrderedDict()
-        
+
     def addNodeType(self, nodeClass, paths, override=False):
         """
         Register a new node type. If the type's name is already in use,
         an exception will be raised (unless override=True).
-        
+
         ============== =========================================================
         **Arguments:**
-        
+
         nodeClass      a subclass of Node (must have typ.nodeName)
-        paths          list of tuples specifying the location(s) this 
+        paths          list of tuples specifying the location(s) this
                        type will appear in the library tree.
         override       if True, overwrite any class having the same name
         ============== =========================================================
         """
         if not isNodeClass(nodeClass):
             raise Exception("Object %s is not a Node subclass" % str(nodeClass))
-        
+
         name = nodeClass.nodeName
         if not override and name in self.nodeList:
             raise Exception("Node type name '%s' is already registered." % name)
-        
+
         self.nodeList[name] = nodeClass
         for path in paths:
             root = self.nodeTree

--- a/pyqtgraph/flowchart/Terminal.py
+++ b/pyqtgraph/flowchart/Terminal.py
@@ -10,8 +10,8 @@ from .eq import *
 class Terminal(object):
     def __init__(self, node, name, io, optional=False, multi=False, pos=None, renamable=False, removable=False, multiable=False, bypass=None):
         """
-        Construct a new terminal. 
-        
+        Construct a new terminal.
+
         ==============  =================================================================================
         **Arguments:**
         node            the node to which this terminal belongs
@@ -42,20 +42,20 @@ class Terminal(object):
         self._connections = {}
         self._graphicsItem = TerminalGraphicsItem(self, parent=self._node().graphicsItem())
         self._bypass = bypass
-        
+
         if multi:
             self._value = {}  ## dictionary of terminal:value pairs.
         else:
-            self._value = None  
-        
+            self._value = None
+
         self.valueOk = None
         self.recolor()
-        
+
     def value(self, term=None):
         """Return the value this terminal provides for the connected terminal"""
         if term is None:
             return self._value
-            
+
         if self.isMultiValue():
             return self._value.get(term, None)
         else:
@@ -76,25 +76,25 @@ class Terminal(object):
                 self._value = {}
             if val is not None:
                 self._value.update(val)
-            
-        self.setValueAcceptable(None)  ## by default, input values are 'unchecked' until Node.update(). 
+
+        self.setValueAcceptable(None)  ## by default, input values are 'unchecked' until Node.update().
         if self.isInput() and process:
             self.node().update()
-            
+
         ## Let the flowchart handle this.
         #if self.isOutput():
             #for c in self.connections():
                 #if c.isInput():
                     #c.inputChanged(self)
         self.recolor()
-        
+
     def setOpts(self, **opts):
         self._renamable = opts.get('renamable', self._renamable)
         self._removable = opts.get('removable', self._removable)
         self._multiable = opts.get('multiable', self._multiable)
         if 'multi' in opts:
             self.setMultiValue(opts['multi'])
-        
+
 
     def connected(self, term):
         """Called whenever this terminal has been connected to another. (note--this function is called on both terminals)"""
@@ -103,7 +103,7 @@ class Terminal(object):
         if self.isOutput() and self.isMultiValue():
             self.node().update()
         self.node().connected(self, term)
-        
+
     def disconnected(self, term):
         """Called whenever this terminal has been disconnected from another. (note--this function is called on both terminals)"""
         if self.isMultiValue() and term in self._value:
@@ -123,39 +123,39 @@ class Terminal(object):
             self.setValue({term: term.value(self)}, process=process)
         else:
             self.setValue(term.value(self), process=process)
-            
+
     def valueIsAcceptable(self):
         """Returns True->acceptable  None->unknown  False->Unacceptable"""
         return self.valueOk
-        
+
     def setValueAcceptable(self, v=True):
         self.valueOk = v
         self.recolor()
-        
+
     def connections(self):
         return self._connections
-        
+
     def node(self):
         return self._node()
-        
+
     def isInput(self):
         return self._io == 'in'
-    
+
     def isMultiValue(self):
         return self._multi
-    
+
     def setMultiValue(self, multi):
         """Set whether this is a multi-value terminal."""
         self._multi = multi
         if not multi and len(self.inputTerminals()) > 1:
             self.disconnectAll()
-            
+
         for term in self.inputTerminals():
             self.inputChanged(term)
 
     def isOutput(self):
         return self._io == 'out'
-        
+
     def isRenamable(self):
         return self._renamable
 
@@ -167,23 +167,23 @@ class Terminal(object):
 
     def name(self):
         return self._name
-        
+
     def graphicsItem(self):
         return self._graphicsItem
-        
+
     def isConnected(self):
         return len(self.connections()) > 0
-        
+
     def connectedTo(self, term):
         return term in self.connections()
-        
+
     def hasInput(self):
         #conn = self.extendedConnections()
         for t in self.connections():
             if t.isOutput():
                 return True
-        return False        
-        
+        return False
+
     def inputTerminals(self):
         """Return the terminal(s) that give input to this one."""
         #terms = self.extendedConnections()
@@ -191,14 +191,14 @@ class Terminal(object):
             #if t.isOutput():
                 #return t
         return [t for t in self.connections() if t.isOutput()]
-                
-        
+
+
     def dependentNodes(self):
         """Return the list of nodes which receive input from this terminal."""
         #conn = self.extendedConnections()
         #del conn[self]
         return set([t.node() for t in self.connections() if t.isInput()])
-        
+
     def connectTo(self, term, connectionItem=None):
         try:
             if self.connectedTo(term):
@@ -212,7 +212,7 @@ class Terminal(object):
                     raise Exception("Cannot connect %s <-> %s: Terminal %s is already connected to %s (and does not allow multiple connections)" % (self, term, t, list(t.connections().keys())))
             #if self.hasInput() and term.hasInput():
                 #raise Exception('Target terminal already has input')
-            
+
             #if term in self.node().terminals.values():
                 #if self.isOutput() or term.isOutput():
                     #raise Exception('Can not connect an output back to the same node.')
@@ -220,7 +220,7 @@ class Terminal(object):
             if connectionItem is not None:
                 connectionItem.close()
             raise
-            
+
         if connectionItem is None:
             connectionItem = ConnectionItem(self.graphicsItem(), term.graphicsItem())
             #self.graphicsItem().scene().addItem(connectionItem)
@@ -228,18 +228,18 @@ class Terminal(object):
             #connectionItem.setParentItem(self.graphicsItem().parent().parent())
         self._connections[term] = connectionItem
         term._connections[self] = connectionItem
-        
+
         self.recolor()
-        
+
         #if self.isOutput() and term.isInput():
             #term.inputChanged(self)
         #if term.isInput() and term.isOutput():
             #self.inputChanged(term)
         self.connected(term)
         term.connected(self)
-        
+
         return connectionItem
-        
+
     def disconnectFrom(self, term):
         if not self.connectedTo(term):
             return
@@ -251,26 +251,26 @@ class Terminal(object):
         del term._connections[self]
         self.recolor()
         term.recolor()
-        
+
         self.disconnected(term)
         term.disconnected(self)
         #if self.isOutput() and term.isInput():
             #term.inputChanged(self)
         #if term.isInput() and term.isOutput():
             #self.inputChanged(term)
-            
-        
+
+
     def disconnectAll(self):
         for t in list(self._connections.keys()):
             self.disconnectFrom(t)
-        
+
     def recolor(self, color=None, recurse=True):
         if color is None:
             if not self.isConnected():       ## disconnected terminals are black
                 color = QtGui.QColor(0,0,0)
-            elif self.isInput() and not self.hasInput():   ## input terminal with no connected output terminals 
+            elif self.isInput() and not self.hasInput():   ## input terminal with no connected output terminals
                 color = QtGui.QColor(200,200,0)
-            elif self._value is None or eq(self._value, {}):         ## terminal is connected but has no data (possibly due to processing error) 
+            elif self._value is None or eq(self._value, {}):         ## terminal is connected but has no data (possibly due to processing error)
                 color = QtGui.QColor(255,255,255)
             elif self.valueIsAcceptable() is None:   ## terminal has data, but it is unknown if the data is ok
                 color = QtGui.QColor(200, 200, 0)
@@ -279,23 +279,23 @@ class Terminal(object):
             else:                                    ## terminal has bad input
                 color = QtGui.QColor(200, 0, 0)
         self.graphicsItem().setBrush(QtGui.QBrush(color))
-        
+
         if recurse:
             for t in self.connections():
                 t.recolor(color, recurse=False)
 
-        
+
     def rename(self, name):
         oldName = self._name
         self._name = name
         self.node().terminalRenamed(self, oldName)
         self.graphicsItem().termRenamed(name)
-        
+
     def __repr__(self):
         return "<Terminal %s.%s>" % (str(self.node().name()), str(self.name()))
-        
+
     #def extendedConnections(self, terms=None):
-        #"""Return list of terminals (including this one) that are directly or indirectly wired to this."""        
+        #"""Return list of terminals (including this one) that are directly or indirectly wired to this."""
         #if terms is None:
             #terms = {}
         #terms[self] = None
@@ -304,7 +304,7 @@ class Terminal(object):
                 #continue
             #terms.update(t.extendedConnections(terms))
         #return terms
-        
+
     def __hash__(self):
         return id(self)
 
@@ -313,14 +313,14 @@ class Terminal(object):
         item = self.graphicsItem()
         if item.scene() is not None:
             item.scene().removeItem(item)
-        
+
     def saveState(self):
         return {'io': self._io, 'multi': self._multi, 'optional': self._optional, 'renamable': self._renamable, 'removable': self._removable, 'multiable': self._multiable}
 
 
 #class TerminalGraphicsItem(QtGui.QGraphicsItem):
 class TerminalGraphicsItem(GraphicsObject):
-    
+
     def __init__(self, term, parent=None):
         self.term = term
         #QtGui.QGraphicsItem.__init__(self, parent)
@@ -338,18 +338,18 @@ class TerminalGraphicsItem(GraphicsObject):
             self.label.keyPressEvent = self.labelKeyPress
         self.setZValue(1)
         self.menu = None
-            
+
 
     def labelFocusOut(self, ev):
         QtGui.QGraphicsTextItem.focusOutEvent(self.label, ev)
         self.labelChanged()
-        
+
     def labelKeyPress(self, ev):
         if ev.key() == QtCore.Qt.Key_Enter or ev.key() == QtCore.Qt.Key_Return:
             self.labelChanged()
         else:
             QtGui.QGraphicsTextItem.keyPressEvent(self.label, ev)
-        
+
     def labelChanged(self):
         newName = str(self.label.toPlainText())
         if newName != self.term.name():
@@ -369,17 +369,17 @@ class TerminalGraphicsItem(GraphicsObject):
         br = self.box.mapRectToParent(self.box.boundingRect())
         lr = self.label.mapRectToParent(self.label.boundingRect())
         return br | lr
-        
+
     def paint(self, p, *args):
         pass
-        
+
     def setAnchor(self, x, y):
         pos = QtCore.QPointF(x, y)
         self.anchorPos = pos
         br = self.box.mapRectToParent(self.box.boundingRect())
         lr = self.label.mapRectToParent(self.label.boundingRect())
-        
-        
+
+
         if self.term.isInput():
             self.box.setPos(pos.x(), pos.y()-br.height()/2.)
             self.label.setPos(pos.x() + br.width(), pos.y() - lr.height()/2.)
@@ -387,11 +387,11 @@ class TerminalGraphicsItem(GraphicsObject):
             self.box.setPos(pos.x()-br.width(), pos.y()-br.height()/2.)
             self.label.setPos(pos.x()-br.width()-lr.width(), pos.y()-lr.height()/2.)
         self.updateConnections()
-        
+
     def updateConnections(self):
         for t, c in self.term.connections().items():
             c.updateLine()
-            
+
     def mousePressEvent(self, ev):
         #ev.accept()
         ev.ignore() ## necessary to allow click/drag events to process correctly
@@ -403,14 +403,14 @@ class TerminalGraphicsItem(GraphicsObject):
         elif ev.button() == QtCore.Qt.RightButton:
             ev.accept()
             self.raiseContextMenu(ev)
-            
+
     def raiseContextMenu(self, ev):
         ## only raise menu if this terminal is removable
         menu = self.getMenu()
         menu = self.scene().addParentContextMenus(self, menu, ev)
         pos = ev.screenPos()
         menu.popup(QtCore.QPoint(pos.x(), pos.y()))
-        
+
     def getMenu(self):
         if self.menu is None:
             self.menu = QtGui.QMenu()
@@ -425,7 +425,7 @@ class TerminalGraphicsItem(GraphicsObject):
             multiAct.setCheckable(True)
             multiAct.setChecked(self.term.isMultiValue())
             multiAct.setEnabled(self.term.isMultiable())
-            
+
             multiAct.triggered.connect(self.toggleMulti)
             self.menu.addAction(multiAct)
             self.menu.multiAct = multiAct
@@ -436,15 +436,15 @@ class TerminalGraphicsItem(GraphicsObject):
     def toggleMulti(self):
         multi = self.menu.multiAct.isChecked()
         self.term.setMultiValue(multi)
-    
+
     def removeSelf(self):
         self.term.node().removeTerminal(self.term)
-        
+
     def mouseDragEvent(self, ev):
         if ev.button() != QtCore.Qt.LeftButton:
             ev.ignore()
             return
-        
+
         ev.accept()
         if ev.isStart():
             if self.newConnection is None:
@@ -469,7 +469,7 @@ class TerminalGraphicsItem(GraphicsObject):
                             self.newConnection = None
                             raise
                         break
-                
+
                 if not gotTarget:
                     #print "remove unused connection"
                     #self.scene().removeItem(self.newConnection)
@@ -478,7 +478,7 @@ class TerminalGraphicsItem(GraphicsObject):
         else:
             if self.newConnection is not None:
                 self.newConnection.setTarget(self.mapToView(ev.pos()))
-        
+
     def hoverEvent(self, ev):
         if not ev.isExit() and ev.acceptDrags(QtCore.Qt.LeftButton):
             ev.acceptClicks(QtCore.Qt.LeftButton) ## we don't use the click, but we also don't want anyone else to use it.
@@ -487,13 +487,13 @@ class TerminalGraphicsItem(GraphicsObject):
         else:
             self.box.setBrush(self.brush)
         self.update()
-        
+
     #def hoverEnterEvent(self, ev):
         #self.hover = True
-        
+
     #def hoverLeaveEvent(self, ev):
         #self.hover = False
-        
+
     def connectPoint(self):
         ## return the connect position of this terminal in view coords
         return self.mapToView(self.mapFromItem(self.box, self.box.boundingRect().center()))
@@ -505,12 +505,12 @@ class TerminalGraphicsItem(GraphicsObject):
 
 #class ConnectionItem(QtGui.QGraphicsItem):
 class ConnectionItem(GraphicsObject):
-    
+
     def __init__(self, source, target=None):
         #QtGui.QGraphicsItem.__init__(self)
         GraphicsObject.__init__(self)
         self.setFlags(
-            self.ItemIsSelectable | 
+            self.ItemIsSelectable |
             self.ItemIsFocusable
         )
         self.source = source
@@ -532,23 +532,23 @@ class ConnectionItem(GraphicsObject):
         self.source.getViewBox().addItem(self)
         self.updateLine()
         self.setZValue(0)
-        
+
     def close(self):
         if self.scene() is not None:
             #self.scene().removeItem(self.line)
             self.scene().removeItem(self)
-        
+
     def setTarget(self, target):
         self.target = target
         self.updateLine()
-    
+
     def setStyle(self, **kwds):
         self.style.update(kwds)
         if 'shape' in kwds:
             self.updateLine()
         else:
             self.update()
-    
+
     def updateLine(self):
         start = Point(self.source.connectPoint())
         if isinstance(self.target, TerminalGraphicsItem):
@@ -558,11 +558,11 @@ class ConnectionItem(GraphicsObject):
         else:
             return
         self.prepareGeometryChange()
-        
+
         self.path = self.generatePath(start, stop)
         self.shapePath = None
         self.update()
-        
+
     def generatePath(self, start, stop):
         path = QtGui.QPainterPath()
         path.moveTo(start)
@@ -581,10 +581,10 @@ class ConnectionItem(GraphicsObject):
             ev.accept()
         else:
             ev.ignore()
-    
+
     def mousePressEvent(self, ev):
         ev.ignore()
-        
+
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.LeftButton:
             ev.accept()
@@ -592,15 +592,15 @@ class ConnectionItem(GraphicsObject):
             self.setSelected(True)
             if not sel and self.isSelected():
                 self.update()
-                
+
     def hoverEvent(self, ev):
         if (not ev.isExit()) and ev.acceptClicks(QtCore.Qt.LeftButton):
             self.hovered = True
         else:
             self.hovered = False
         self.update()
-            
-            
+
+
     def boundingRect(self):
         return self.shape().boundingRect()
         ##return self.line.boundingRect()
@@ -609,7 +609,7 @@ class ConnectionItem(GraphicsObject):
     def viewRangeChanged(self):
         self.shapePath = None
         self.prepareGeometryChange()
-        
+
     def shape(self):
         if self.shapePath is None:
             if self.path is None:
@@ -619,7 +619,7 @@ class ConnectionItem(GraphicsObject):
             stroker.setWidth(px*8)
             self.shapePath = stroker.createStroke(self.path)
         return self.shapePath
-        
+
     def paint(self, p, *args):
         if self.isSelected():
             p.setPen(fn.mkPen(self.style['selectedColor'], width=self.style['selectedWidth']))
@@ -628,7 +628,7 @@ class ConnectionItem(GraphicsObject):
                 p.setPen(fn.mkPen(self.style['hoverColor'], width=self.style['hoverWidth']))
             else:
                 p.setPen(fn.mkPen(self.style['color'], width=self.style['width']))
-                
+
         #p.drawLine(0, 0, 0, self.length)
-        
+
         p.drawPath(self.path)

--- a/pyqtgraph/flowchart/eq.py
+++ b/pyqtgraph/flowchart/eq.py
@@ -6,12 +6,12 @@ def eq(a, b):
     """The great missing equivalence function: Guaranteed evaluation to a single bool value."""
     if a is b:
         return True
-        
+
     try:
         e = a==b
     except ValueError:
         return False
-    except AttributeError: 
+    except AttributeError:
         return False
     except:
         print("a:", str(type(a)), str(a))

--- a/pyqtgraph/flowchart/library/Data.py
+++ b/pyqtgraph/flowchart/library/Data.py
@@ -19,11 +19,11 @@ class ColumnSelectNode(Node):
         self.columnList = QtGui.QListWidget()
         self.axis = 0
         self.columnList.itemChanged.connect(self.itemChanged)
-        
+
     def process(self, In, display=True):
         if display:
             self.updateList(In)
-                
+
         out = {}
         if hasattr(In, 'implements') and In.implements('MetaArray'):
             for c in self.columns:
@@ -34,9 +34,9 @@ class ColumnSelectNode(Node):
         else:
             self.In.setValueAcceptable(False)
             raise Exception("Input must be MetaArray or ndarray with named fields")
-            
+
         return out
-        
+
     def ctrlWidget(self):
         return self.columnList
 
@@ -50,14 +50,14 @@ class ColumnSelectNode(Node):
                     break
         else:
             cols = list(data.dtype.fields.keys())
-                
+
         rem = set()
         for c in self.columns:
             if c not in cols:
                 self.removeTerminal(c)
                 rem.add(c)
         self.columns -= rem
-                
+
         self.columnList.blockSignals(True)
         self.columnList.clear()
         for c in cols:
@@ -69,7 +69,7 @@ class ColumnSelectNode(Node):
                 item.setCheckState(QtCore.Qt.Unchecked)
             self.columnList.addItem(item)
         self.columnList.blockSignals(False)
-        
+
 
     def itemChanged(self, item):
         col = str(item.text())
@@ -82,12 +82,12 @@ class ColumnSelectNode(Node):
                 self.columns.remove(col)
                 self.removeTerminal(col)
         self.update()
-        
+
     def saveState(self):
         state = Node.saveState(self)
         state['columns'] = list(self.columns)
         return state
-    
+
     def restoreState(self, state):
         Node.restoreState(self, state)
         self.columns = set(state.get('columns', []))
@@ -105,7 +105,7 @@ class RegionSelectNode(CtrlNode):
         ('display', 'check', {'value': True}),
         ('movable', 'check', {'value': True}),
     ]
-    
+
     def __init__(self, name):
         self.items = {}
         CtrlNode.__init__(self, name, terminals={
@@ -116,21 +116,21 @@ class RegionSelectNode(CtrlNode):
         })
         self.ctrls['display'].toggled.connect(self.displayToggled)
         self.ctrls['movable'].toggled.connect(self.movableToggled)
-        
+
     def displayToggled(self, b):
         for item in self.items.values():
             item.setVisible(b)
-            
+
     def movableToggled(self, b):
         for item in self.items.values():
             item.setMovable(b)
-            
-        
+
+
     def process(self, data=None, display=True):
         #print "process.."
         s = self.stateGroup.state()
         region = [s['start'], s['stop']]
-        
+
         if display:
             conn = self['widget'].connections()
             for c in conn:
@@ -151,7 +151,7 @@ class RegionSelectNode(CtrlNode):
                     item.setMovable(s['movable'])
                     #print "  new rgn:", c, region
                     #self.items[c].setYRange([0., 0.2], relative=True)
-        
+
         if self['selected'].isConnected():
             if data is None:
                 sliced = None
@@ -162,31 +162,31 @@ class RegionSelectNode(CtrlNode):
             sliced = data[mask]
         else:
             sliced = None
-            
+
         return {'selected': sliced, 'widget': self.items, 'region': region}
-        
-        
+
+
     def rgnChanged(self, item):
         region = item.getRegion()
         self.stateGroup.setState({'start': region[0], 'stop': region[1]})
         self.update()
-        
-        
+
+
 class EvalNode(Node):
     """Return the output of a string evaluated/executed by the python interpreter.
-    The string may be either an expression or a python script, and inputs are accessed as the name of the terminal. 
+    The string may be either an expression or a python script, and inputs are accessed as the name of the terminal.
     For expressions, a single value may be evaluated for a single output, or a dict for multiple outputs.
     For a script, the text will be executed as the body of a function."""
     nodeName = 'PythonEval'
-    
+
     def __init__(self, name):
-        Node.__init__(self, name, 
+        Node.__init__(self, name,
             terminals = {
                 'input': {'io': 'in', 'renamable': True, 'multiable': True},
                 'output': {'io': 'out', 'renamable': True, 'multiable': True},
             },
             allowAddInput=True, allowAddOutput=True)
-        
+
         self.ui = QtGui.QWidget()
         self.layout = QtGui.QGridLayout()
         #self.addInBtn = QtGui.QPushButton('+Input')
@@ -198,35 +198,35 @@ class EvalNode(Node):
         #self.layout.addWidget(self.addOutBtn, 0, 1)
         self.layout.addWidget(self.text, 1, 0, 1, 2)
         self.ui.setLayout(self.layout)
-        
+
         #QtCore.QObject.connect(self.addInBtn, QtCore.SIGNAL('clicked()'), self.addInput)
         #self.addInBtn.clicked.connect(self.addInput)
         #QtCore.QObject.connect(self.addOutBtn, QtCore.SIGNAL('clicked()'), self.addOutput)
         #self.addOutBtn.clicked.connect(self.addOutput)
         self.text.focusOutEvent = self.focusOutEvent
         self.lastText = None
-        
+
     def ctrlWidget(self):
         return self.ui
-        
+
     #def addInput(self):
         #Node.addInput(self, 'input', renamable=True)
-        
+
     #def addOutput(self):
         #Node.addOutput(self, 'output', renamable=True)
-        
+
     def focusOutEvent(self, ev):
         text = str(self.text.toPlainText())
         if text != self.lastText:
             self.lastText = text
             self.update()
         return QtGui.QTextEdit.focusOutEvent(self.text, ev)
-        
+
     def process(self, display=True, **args):
         l = locals()
         l.update(args)
         ## try eval first, then exec
-        try:  
+        try:
             text = str(self.text.toPlainText()).replace('\n', ' ')
             output = eval(text, globals(), l)
         except SyntaxError:
@@ -238,39 +238,39 @@ class EvalNode(Node):
             print("Error processing node: %s" % self.name())
             raise
         return output
-        
+
     def saveState(self):
         state = Node.saveState(self)
         state['text'] = str(self.text.toPlainText())
         #state['terminals'] = self.saveTerminals()
         return state
-        
+
     def restoreState(self, state):
         Node.restoreState(self, state)
         self.text.clear()
         self.text.insertPlainText(state['text'])
         self.restoreTerminals(state['terminals'])
         self.update()
-        
+
 class ColumnJoinNode(Node):
     """Concatenates record arrays and/or adds new columns"""
     nodeName = 'ColumnJoin'
-    
+
     def __init__(self, name):
         Node.__init__(self, name, terminals = {
             'output': {'io': 'out'},
         })
-        
+
         #self.items = []
-        
+
         self.ui = QtGui.QWidget()
         self.layout = QtGui.QGridLayout()
         self.ui.setLayout(self.layout)
-        
+
         self.tree = TreeWidget()
         self.addInBtn = QtGui.QPushButton('+ Input')
         self.remInBtn = QtGui.QPushButton('- Input')
-        
+
         self.layout.addWidget(self.tree, 0, 0, 1, 2)
         self.layout.addWidget(self.addInBtn, 1, 0)
         self.layout.addWidget(self.remInBtn, 1, 1)
@@ -278,10 +278,10 @@ class ColumnJoinNode(Node):
         self.addInBtn.clicked.connect(self.addInput)
         self.remInBtn.clicked.connect(self.remInput)
         self.tree.sigItemMoved.connect(self.update)
-        
+
     def ctrlWidget(self):
         return self.ui
-        
+
     def addInput(self):
         #print "ColumnJoinNode.addInput called."
         term = Node.addInput(self, 'input', renamable=True, removable=True, multiable=True)
@@ -321,7 +321,7 @@ class ColumnJoinNode(Node):
         state = Node.saveState(self)
         state['order'] = self.order()
         return state
-        
+
     def restoreState(self, state):
         Node.restoreState(self, state)
         inputs = self.inputs()
@@ -337,7 +337,7 @@ class ColumnJoinNode(Node):
         for name in inputs:
             if name not in order:
                 order.append(name)
-        
+
         self.tree.clear()
         for name in order:
             term = self[name]
@@ -352,5 +352,3 @@ class ColumnJoinNode(Node):
         item = term.joinItem
         item.setText(0, term.name())
         self.update()
-        
-        

--- a/pyqtgraph/flowchart/library/Filters.py
+++ b/pyqtgraph/flowchart/library/Filters.py
@@ -17,7 +17,7 @@ class Downsample(CtrlNode):
     uiTemplate = [
         ('n', 'intSpin', {'min': 1, 'max': 1000000})
     ]
-    
+
     def processData(self, data):
         return functions.downsample(data, self.ctrls['n'].value(), axis=0)
 
@@ -28,7 +28,7 @@ class Subsample(CtrlNode):
     uiTemplate = [
         ('n', 'intSpin', {'min': 1, 'max': 1000000})
     ]
-    
+
     def processData(self, data):
         return data[::self.ctrls['n'].value()]
 
@@ -42,7 +42,7 @@ class Bessel(CtrlNode):
         ('order', 'intSpin', {'value': 4, 'min': 1, 'max': 16}),
         ('bidir', 'check', {'checked': True})
     ]
-    
+
     def processData(self, data):
         s = self.stateGroup.state()
         if s['band'] == 'lowpass':
@@ -63,7 +63,7 @@ class Butterworth(CtrlNode):
         ('gStop', 'spin', {'value': 20.0, 'step': 1, 'dec': True, 'range': [0.0, None], 'suffix': 'dB', 'siPrefix': True}),
         ('bidir', 'check', {'checked': True})
     ]
-    
+
     def processData(self, data):
         s = self.stateGroup.state()
         if s['band'] == 'lowpass':
@@ -73,7 +73,7 @@ class Butterworth(CtrlNode):
         ret = functions.butterworthFilter(data, bidir=s['bidir'], btype=mode, wPass=s['wPass'], wStop=s['wStop'], gPass=s['gPass'], gStop=s['gStop'])
         return ret
 
-        
+
 class ButterworthNotch(CtrlNode):
     """Butterworth notch filter"""
     nodeName = 'ButterworthNotchFilter'
@@ -88,14 +88,14 @@ class ButterworthNotch(CtrlNode):
         ('high_gStop', 'spin', {'value': 20.0, 'step': 1, 'dec': True, 'range': [0.0, None], 'suffix': 'dB', 'siPrefix': True}),
         ('bidir', 'check', {'checked': True})
     ]
-    
+
     def processData(self, data):
         s = self.stateGroup.state()
-        
+
         low = functions.butterworthFilter(data, bidir=s['bidir'], btype='low', wPass=s['low_wPass'], wStop=s['low_wStop'], gPass=s['low_gPass'], gStop=s['low_gStop'])
         high = functions.butterworthFilter(data, bidir=s['bidir'], btype='high', wPass=s['high_wPass'], wStop=s['high_wStop'], gPass=s['high_gPass'], gStop=s['high_gStop'])
         return low + high
-    
+
 
 class Mean(CtrlNode):
     """Filters data by taking the mean of a sliding window"""
@@ -103,7 +103,7 @@ class Mean(CtrlNode):
     uiTemplate = [
         ('n', 'intSpin', {'min': 1, 'max': 1000000})
     ]
-    
+
     @metaArrayWrapper
     def processData(self, data):
         n = self.ctrls['n'].value()
@@ -116,7 +116,7 @@ class Median(CtrlNode):
     uiTemplate = [
         ('n', 'intSpin', {'min': 1, 'max': 1000000})
     ]
-    
+
     @metaArrayWrapper
     def processData(self, data):
         try:
@@ -131,7 +131,7 @@ class Mode(CtrlNode):
     uiTemplate = [
         ('window', 'intSpin', {'value': 500, 'min': 1, 'max': 1000000}),
     ]
-    
+
     @metaArrayWrapper
     def processData(self, data):
         return functions.modeFilter(data, self.ctrls['window'].value())
@@ -144,7 +144,7 @@ class Denoise(CtrlNode):
         ('radius', 'intSpin', {'value': 2, 'min': 0, 'max': 1000000}),
         ('threshold', 'doubleSpin', {'value': 4.0, 'min': 0, 'max': 1000})
     ]
-    
+
     def processData(self, data):
         #print "DENOISE"
         s = self.stateGroup.state()
@@ -157,7 +157,7 @@ class Gaussian(CtrlNode):
     uiTemplate = [
         ('sigma', 'doubleSpin', {'min': 0, 'max': 1000000})
     ]
-    
+
     @metaArrayWrapper
     def processData(self, data):
         try:
@@ -170,7 +170,7 @@ class Gaussian(CtrlNode):
 class Derivative(CtrlNode):
     """Returns the pointwise derivative of the input"""
     nodeName = 'DerivativeFilter'
-    
+
     def processData(self, data):
         if hasattr(data, 'implements') and data.implements('MetaArray'):
             info = data.infoCopy()
@@ -184,7 +184,7 @@ class Derivative(CtrlNode):
 class Integral(CtrlNode):
     """Returns the pointwise integral of the input"""
     nodeName = 'IntegralFilter'
-    
+
     @metaArrayWrapper
     def processData(self, data):
         data[1:] += data[:-1]
@@ -194,7 +194,7 @@ class Integral(CtrlNode):
 class Detrend(CtrlNode):
     """Removes linear trend from the data"""
     nodeName = 'DetrendFilter'
-    
+
     @metaArrayWrapper
     def processData(self, data):
         try:
@@ -206,39 +206,39 @@ class Detrend(CtrlNode):
 class RemoveBaseline(PlottingCtrlNode):
     """Remove an arbitrary, graphically defined baseline from the data."""
     nodeName = 'RemoveBaseline'
-    
+
     def __init__(self, name):
         ## define inputs and outputs (one output needs to be a plot)
         PlottingCtrlNode.__init__(self, name)
         self.line = PolyLineROI([[0,0],[1,0]])
         self.line.sigRegionChanged.connect(self.changed)
-        
+
         ## create a PolyLineROI, add it to a plot -- actually, I think we want to do this after the node is connected to a plot (look at EventDetection.ThresholdEvents node for ideas), and possible after there is data. We will need to update the end positions of the line each time the input data changes
         #self.line = None ## will become a PolyLineROI
-        
+
     def connectToPlot(self, node):
         """Define what happens when the node is connected to a plot"""
 
         if node.plot is None:
             return
         node.getPlot().addItem(self.line)
-       
+
     def disconnectFromPlot(self, plot):
         """Define what happens when the node is disconnected from a plot"""
-        plot.removeItem(self.line)    
-    
+        plot.removeItem(self.line)
+
     def processData(self, data):
         ## get array of baseline (from PolyLineROI)
         h0 = self.line.getHandles()[0]
         h1 = self.line.getHandles()[-1]
-        
+
         timeVals = data.xvals(0)
         h0.setPos(timeVals[0], h0.pos()[1])
-        h1.setPos(timeVals[-1], h1.pos()[1])      
-        
+        h1.setPos(timeVals[-1], h1.pos()[1])
+
         pts = self.line.listPoints() ## lists line handles in same coordinates as data
         pts, indices = self.adjustXPositions(pts, timeVals) ## maxe sure x positions match x positions of data points
-        
+
         ## construct an array that represents the baseline
         arr = np.zeros(len(data), dtype=float)
         n = 1
@@ -250,13 +250,13 @@ class RemoveBaseline(PlottingCtrlNode):
             y2 = pts[i+1].y()
             m = (y2-y1)/(x2-x1)
             b = y1
-            
+
             times = timeVals[(timeVals > x1)*(timeVals <= x2)]
             arr[n:n+len(times)] = (m*(times-times[0]))+b
             n += len(times)
-                
+
         return data - arr ## subract baseline from data
-        
+
     def adjustXPositions(self, pts, data):
         """Return a list of Point() where the x position is set to the nearest x value in *data* for each point in *pts*."""
         points = []
@@ -265,7 +265,7 @@ class RemoveBaseline(PlottingCtrlNode):
             x = np.argwhere(abs(data - p.x()) == abs(data - p.x()).min())
             points.append(Point(data[x], p.y()))
             timeIndices.append(x)
-            
+
         return points, timeIndices
 
 
@@ -276,7 +276,7 @@ class AdaptiveDetrend(CtrlNode):
     uiTemplate = [
         ('threshold', 'doubleSpin', {'value': 3.0, 'min': 0, 'max': 1000000})
     ]
-    
+
     def processData(self, data):
         return functions.adaptiveDetrend(data, threshold=self.ctrls['threshold'].value())
 
@@ -288,7 +288,7 @@ class HistogramDetrend(CtrlNode):
         ('numBins', 'intSpin', {'value': 50, 'min': 3, 'max': 1000000}),
         ('offsetOnly', 'check', {'checked': False}),
     ]
-    
+
     def processData(self, data):
         s = self.stateGroup.state()
         #ws = self.ctrls['windowSize'].value()
@@ -297,7 +297,7 @@ class HistogramDetrend(CtrlNode):
         return functions.histogramDetrend(data, window=s['windowSize'], bins=s['numBins'], offsetOnly=s['offsetOnly'])
 
 
-    
+
 class RemovePeriodic(CtrlNode):
     nodeName = 'RemovePeriodic'
     uiTemplate = [
@@ -311,19 +311,19 @@ class RemovePeriodic(CtrlNode):
     def processData(self, data):
         times = data.xvals('Time')
         dt = times[1]-times[0]
-        
+
         data1 = data.asarray()
         ft = np.fft.fft(data1)
-        
+
         ## determine frequencies in fft data
         df = 1.0 / (len(data1) * dt)
         freqs = np.linspace(0.0, (len(ft)-1) * df, len(ft))
-        
+
         ## flatten spikes at f0 and harmonics
         f0 = self.ctrls['f0'].value()
         for i in xrange(1, self.ctrls['harmonics'].value()+2):
             f = f0 * i # target frequency
-            
+
             ## determine index range to check for this frequency
             ind1 = int(np.floor(f / df))
             ind2 = int(np.ceil(f / df)) + (self.ctrls['samples'].value()-1)
@@ -336,11 +336,8 @@ class RemovePeriodic(CtrlNode):
                 im = mag * np.sin(phase)
                 ft[j] = re + im*1j
                 ft[len(ft)-j] = re - im*1j
-                
+
         data2 = np.fft.ifft(ft).real
-        
+
         ma = metaarray.MetaArray(data2, info=data.infoCopy())
         return ma
-        
-        
-        

--- a/pyqtgraph/flowchart/library/Operators.py
+++ b/pyqtgraph/flowchart/library/Operators.py
@@ -9,7 +9,7 @@ class UniOpNode(Node):
             'In': {'io': 'in'},
             'Out': {'io': 'out', 'bypass': 'In'}
         })
-        
+
     def process(self, **args):
         return {'Out': getattr(args['In'], self.fn)()}
 
@@ -22,7 +22,7 @@ class BinOpNode(Node):
             'B': {'io': 'in'},
             'Out': {'io': 'out', 'bypass': 'A'}
         })
-        
+
     def process(self, **args):
         if isinstance(self.fn, tuple):
             for name in self.fn:
@@ -70,5 +70,3 @@ class DivideNode(BinOpNode):
     def __init__(self, name):
         # try truediv first, followed by div
         BinOpNode.__init__(self, name, ('__truediv__', '__div__'))
-        
-

--- a/pyqtgraph/flowchart/library/__init__.py
+++ b/pyqtgraph/flowchart/library/__init__.py
@@ -22,7 +22,3 @@ for mod in [Data, Display, Filters, Operators]:
     nodes = [getattr(mod, name) for name in dir(mod) if isNodeClass(getattr(mod, name))]
     for node in nodes:
         LIBRARY.addNodeType(node, [(mod.__name__.split('.')[-1],)])
-    
-
-
-

--- a/pyqtgraph/flowchart/library/common.py
+++ b/pyqtgraph/flowchart/library/common.py
@@ -43,7 +43,7 @@ def generateUi(opts):
             if 'max' in o:
                 w.setMaximum(o['max'])
             if 'min' in o:
-                w.setMinimum(o['min'])                
+                w.setMinimum(o['min'])
             if 'value' in o:
                 w.setValue(o['value'])
         elif t == 'spin':
@@ -71,7 +71,7 @@ def generateUi(opts):
             w.hide()
             label = l.labelForField(w)
             label.hide()
-            
+
         ctrls[k] = w
         w.rowNum = row
         row += 1
@@ -81,9 +81,9 @@ def generateUi(opts):
 
 class CtrlNode(Node):
     """Abstract class for nodes with auto-generated control UI"""
-    
+
     sigStateChanged = QtCore.Signal(object)
-    
+
     def __init__(self, name, ui=None, terminals=None):
         if ui is None:
             if hasattr(self, 'uiTemplate'):
@@ -93,13 +93,13 @@ class CtrlNode(Node):
         if terminals is None:
             terminals = {'In': {'io': 'in'}, 'Out': {'io': 'out', 'bypass': 'In'}}
         Node.__init__(self, name=name, terminals=terminals)
-        
+
         self.ui, self.stateGroup, self.ctrls = generateUi(ui)
         self.stateGroup.sigChanged.connect(self.changed)
-       
+
     def ctrlWidget(self):
         return self.ui
-       
+
     def changed(self):
         self.update()
         self.sigStateChanged.emit(self)
@@ -107,23 +107,23 @@ class CtrlNode(Node):
     def process(self, In, display=True):
         out = self.processData(In)
         return {'Out': out}
-    
+
     def saveState(self):
         state = Node.saveState(self)
         state['ctrl'] = self.stateGroup.state()
         return state
-    
+
     def restoreState(self, state):
         Node.restoreState(self, state)
         if self.stateGroup is not None:
             self.stateGroup.setState(state.get('ctrl', {}))
-            
+
     def hideRow(self, name):
         w = self.ctrls[name]
         l = self.ui.layout().labelForField(w)
         w.hide()
         l.hide()
-        
+
     def showRow(self, name):
         w = self.ctrls[name]
         l = self.ui.layout().labelForField(w)
@@ -133,31 +133,31 @@ class CtrlNode(Node):
 
 class PlottingCtrlNode(CtrlNode):
     """Abstract class for CtrlNodes that can connect to plots."""
-    
+
     def __init__(self, name, ui=None, terminals=None):
         #print "PlottingCtrlNode.__init__ called."
         CtrlNode.__init__(self, name, ui=ui, terminals=terminals)
         self.plotTerminal = self.addOutput('plot', optional=True)
-        
+
     def connected(self, term, remote):
         CtrlNode.connected(self, term, remote)
         if term is not self.plotTerminal:
             return
         node = remote.node()
         node.sigPlotChanged.connect(self.connectToPlot)
-        self.connectToPlot(node)    
-        
+        self.connectToPlot(node)
+
     def disconnected(self, term, remote):
         CtrlNode.disconnected(self, term, remote)
         if term is not self.plotTerminal:
             return
         remote.node().sigPlotChanged.disconnect(self.connectToPlot)
-        self.disconnectFromPlot(remote.node().getPlot())   
-       
+        self.disconnectFromPlot(remote.node().getPlot())
+
     def connectToPlot(self, node):
         """Define what happens when the node is connected to a plot"""
         raise Exception("Must be re-implemented in subclass")
-    
+
     def disconnectFromPlot(self, plot):
         """Define what happens when the node is disconnected from a plot"""
         raise Exception("Must be re-implemented in subclass")
@@ -181,4 +181,3 @@ def metaArrayWrapper(fn):
         else:
             return fn(self, data, *args, **kargs)
     return newFn
-

--- a/pyqtgraph/flowchart/library/functions.py
+++ b/pyqtgraph/flowchart/library/functions.py
@@ -13,15 +13,15 @@ def downsample(data, n, axis=0, xvals='subsample'):
     if (hasattr(data, 'implements') and data.implements('MetaArray')):
         ma = data
         data = data.view(np.ndarray)
-        
-    
+
+
     if hasattr(axis, '__len__'):
         if not hasattr(n, '__len__'):
             n = [n]*len(axis)
         for i in range(len(axis)):
             data = downsample(data, n[i], axis[i])
         return data
-    
+
     nPts = int(data.shape[axis] / n)
     s = list(data.shape)
     s[axis] = nPts
@@ -32,7 +32,7 @@ def downsample(data, n, axis=0, xvals='subsample'):
     #print d1.shape, s
     d1.shape = tuple(s)
     d2 = d1.mean(axis+1)
-    
+
     if ma is None:
         return d2
     else:
@@ -52,41 +52,41 @@ def applyFilter(data, b, a, padding=100, bidir=True):
         import scipy.signal
     except ImportError:
         raise Exception("applyFilter() requires the package scipy.signal.")
-    
+
     d1 = data.view(np.ndarray)
-    
+
     if padding > 0:
         d1 = np.hstack([d1[:padding], d1, d1[-padding:]])
-    
+
     if bidir:
         d1 = scipy.signal.lfilter(b, a, scipy.signal.lfilter(b, a, d1)[::-1])[::-1]
     else:
         d1 = scipy.signal.lfilter(b, a, d1)
-    
+
     if padding > 0:
         d1 = d1[padding:-padding]
-        
+
     if (hasattr(data, 'implements') and data.implements('MetaArray')):
         return MetaArray(d1, info=data.infoCopy())
     else:
         return d1
-    
+
 def besselFilter(data, cutoff, order=1, dt=None, btype='low', bidir=True):
     """return data passed through bessel filter"""
     try:
         import scipy.signal
     except ImportError:
         raise Exception("besselFilter() requires the package scipy.signal.")
-    
+
     if dt is None:
         try:
             tvals = data.xvals('Time')
             dt = (tvals[-1]-tvals[0]) / (len(tvals)-1)
         except:
             dt = 1.0
-    
-    b,a = scipy.signal.bessel(order, cutoff * dt, btype=btype) 
-    
+
+    b,a = scipy.signal.bessel(order, cutoff * dt, btype=btype)
+
     return applyFilter(data, b, a, bidir=bidir)
     #base = data.mean()
     #d1 = scipy.signal.lfilter(b, a, data.view(ndarray)-base) + base
@@ -100,20 +100,20 @@ def butterworthFilter(data, wPass, wStop=None, gPass=2.0, gStop=20.0, order=1, d
         import scipy.signal
     except ImportError:
         raise Exception("butterworthFilter() requires the package scipy.signal.")
-    
+
     if dt is None:
         try:
             tvals = data.xvals('Time')
             dt = (tvals[-1]-tvals[0]) / (len(tvals)-1)
         except:
             dt = 1.0
-    
+
     if wStop is None:
         wStop = wPass * 2.0
     ord, Wn = scipy.signal.buttord(wPass*dt*2., wStop*dt*2., gPass, gStop)
     #print "butterworth ord %f   Wn %f   c %f   sc %f" % (ord, Wn, cutoff, stopCutoff)
-    b,a = scipy.signal.butter(ord, Wn, btype=btype) 
-    
+    b,a = scipy.signal.butter(ord, Wn, btype=btype)
+
     return applyFilter(data, b, a, bidir=bidir)
 
 
@@ -136,7 +136,7 @@ def mode(data, bins=None):
     ind = np.argmax(y)
     mode = 0.5 * (x[ind] + x[ind+1])
     return mode
-    
+
 def modeFilter(data, window=500, step=None, bins=None):
     """Filter based on histogram-based mode function"""
     d1 = data.view(np.ndarray)
@@ -150,14 +150,14 @@ def modeFilter(data, window=500, step=None, bins=None):
             break
         vals.append(mode(d1[i:i+window], bins))
         i += step
-            
+
     chunks = [np.linspace(vals[0], vals[0], l2)]
     for i in range(len(vals)-1):
         chunks.append(np.linspace(vals[i], vals[i+1], step))
     remain = len(data) - step*(len(vals)-1) - l2
     chunks.append(np.linspace(vals[-1], vals[-1], remain))
     d2 = np.hstack(chunks)
-    
+
     if (hasattr(data, 'implements') and data.implements('MetaArray')):
         return MetaArray(d2, info=data.infoCopy())
     return d2
@@ -165,8 +165,8 @@ def modeFilter(data, window=500, step=None, bins=None):
 def denoise(data, radius=2, threshold=4):
     """Very simple noise removal function. Compares a point to surrounding points,
     replaces with nearby values if the difference is too large."""
-    
-    
+
+
     r2 = radius * 2
     d1 = data.view(np.ndarray)
     d2 = d1[radius:] - d1[:-radius] #a derivative
@@ -184,7 +184,7 @@ def denoise(data, radius=2, threshold=4):
     d6[radius:-radius] = d5
     d6[:radius] = d1[:radius]
     d6[-radius:] = d1[-radius:]
-    
+
     if (hasattr(data, 'implements') and data.implements('MetaArray')):
         return MetaArray(d6, info=data.infoCopy())
     return d6
@@ -195,33 +195,33 @@ def adaptiveDetrend(data, x=None, threshold=3.0):
         import scipy.signal
     except ImportError:
         raise Exception("adaptiveDetrend() requires the package scipy.signal.")
-    
+
     if x is None:
         x = data.xvals(0)
-    
+
     d = data.view(np.ndarray)
-    
+
     d2 = scipy.signal.detrend(d)
-    
+
     stdev = d2.std()
     mask = abs(d2) < stdev*threshold
     #d3 = where(mask, 0, d2)
     #d4 = d2 - lowPass(d3, cutoffs[1], dt=dt)
-    
+
     lr = scipy.stats.linregress(x[mask], d[mask])
     base = lr[1] + lr[0]*x
     d4 = d - base
-    
+
     if (hasattr(data, 'implements') and data.implements('MetaArray')):
         return MetaArray(d4, info=data.infoCopy())
     return d4
-    
+
 
 def histogramDetrend(data, window=500, bins=50, threshold=3.0, offsetOnly=False):
     """Linear detrend. Works by finding the most common value at the beginning and end of a trace, excluding outliers.
     If offsetOnly is True, then only the offset from the beginning of the trace is subtracted.
     """
-    
+
     d1 = data.view(np.ndarray)
     d2 = [d1[:window], d1[-window:]]
     v = [0, 0]
@@ -233,22 +233,22 @@ def histogramDetrend(data, window=500, bins=50, threshold=3.0, offsetOnly=False)
         y, x = np.histogram(d4, bins=bins)
         ind = np.argmax(y)
         v[i] = 0.5 * (x[ind] + x[ind+1])
-        
+
     if offsetOnly:
         d3 = data.view(np.ndarray) - v[0]
     else:
         base = np.linspace(v[0], v[1], len(data))
         d3 = data.view(np.ndarray) - base
-    
+
     if (hasattr(data, 'implements') and data.implements('MetaArray')):
         return MetaArray(d3, info=data.infoCopy())
     return d3
-    
+
 def concatenateColumns(data):
-    """Returns a single record array with columns taken from the elements in data. 
+    """Returns a single record array with columns taken from the elements in data.
     data should be a list of elements, which can be either record arrays or tuples (name, type, data)
     """
-    
+
     ## first determine dtype
     dtype = []
     names = set()
@@ -270,12 +270,12 @@ def concatenateColumns(data):
         if name in names:
             raise Exception('Name "%s" repeated' % name)
         names.add(name)
-            
-            
-    
+
+
+
     ## create empty array
     out = np.empty(maxLen, dtype)
-    
+
     ## fill columns
     for element in data:
         if isinstance(element, np.ndarray):
@@ -291,16 +291,16 @@ def concatenateColumns(data):
         else:
             name, type, d = element
             out[name] = d
-            
+
     return out
-    
+
 def suggestDType(x):
     """Return a suitable dtype for x"""
     if isinstance(x, list) or isinstance(x, tuple):
         if len(x) == 0:
             raise Exception('can not determine dtype for empty list')
         x = x[0]
-        
+
     if hasattr(x, 'dtype'):
         return x.dtype
     elif isinstance(x, float):
@@ -322,17 +322,17 @@ def removePeriodic(data, f0=60.0, dt=None, harmonics=10, samples=4):
         data1 = data
         if dt is None:
             raise Exception('Must specify dt for this data')
-    
+
     ft = np.fft.fft(data1)
-    
+
     ## determine frequencies in fft data
     df = 1.0 / (len(data1) * dt)
     freqs = np.linspace(0.0, (len(ft)-1) * df, len(ft))
-    
+
     ## flatten spikes at f0 and harmonics
     for i in xrange(1, harmonics + 2):
         f = f0 * i # target frequency
-        
+
         ## determine index range to check for this frequency
         ind1 = int(np.floor(f / df))
         ind2 = int(np.ceil(f / df)) + (samples-1)
@@ -345,13 +345,10 @@ def removePeriodic(data, f0=60.0, dt=None, harmonics=10, samples=4):
             im = mag * np.sin(phase)
             ft[j] = re + im*1j
             ft[len(ft)-j] = re - im*1j
-            
+
     data2 = np.fft.ifft(ft).real
-    
+
     if (hasattr(data, 'implements') and data.implements('MetaArray')):
         return metaarray.MetaArray(data2, info=data.infoCopy())
     else:
         return data2
-    
-    
-    

--- a/pyqtgraph/frozenSupport.py
+++ b/pyqtgraph/frozenSupport.py
@@ -5,11 +5,11 @@ def listdir(path):
     """Replacement for os.listdir that works in frozen environments."""
     if not hasattr(sys, 'frozen'):
         return os.listdir(path)
-    
+
     (zipPath, archivePath) = splitZip(path)
     if archivePath is None:
         return os.listdir(path)
-    
+
     with zipfile.ZipFile(zipPath, "r") as zipobj:
         contents = zipobj.namelist()
     results = set()
@@ -24,7 +24,7 @@ def isdir(path):
     """Replacement for os.path.isdir that works in frozen environments."""
     if not hasattr(sys, 'frozen'):
         return os.path.isdir(path)
-    
+
     (zipPath, archivePath) = splitZip(path)
     if archivePath is None:
         return os.path.isdir(path)
@@ -35,8 +35,8 @@ def isdir(path):
         if c.startswith(archivePath):
             return True
     return False
-    
-    
+
+
 def splitZip(path):
     """Splits a path containing a zip file into (zipfile, subpath).
     If there is no zip file, returns (path, None)"""
@@ -48,5 +48,3 @@ def splitZip(path):
             return (zipPath, archivePath)
     else:
         return (path, None)
-    
-    

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -20,7 +20,7 @@ Colors = {
     'd': QtGui.QColor(150,150,150,255),
     'l': QtGui.QColor(200,200,200,255),
     's': QtGui.QColor(100,100,150,255),
-}  
+}
 
 SI_PREFIXES = asUnicode('yzafpnµm kMGTPEZY')
 SI_PREFIXES_ASCII = 'yzafpnum kMGTPEZY'
@@ -39,16 +39,16 @@ from . import debug
 def siScale(x, minVal=1e-25, allowUnicode=True):
     """
     Return the recommended scale factor and SI prefix string for x.
-    
+
     Example::
-    
+
         siScale(0.0001)   # returns (1e6, 'μ')
         # This indicates that the number 0.0001 is best represented as 0.0001 * 1e6 = 100 μUnits
     """
-    
+
     if isinstance(x, decimal.Decimal):
         x = float(x)
-        
+
     try:
         if np.isnan(x) or np.isinf(x):
             return(1, '')
@@ -60,7 +60,7 @@ def siScale(x, minVal=1e-25, allowUnicode=True):
         x = 0
     else:
         m = int(np.clip(np.floor(np.log(abs(x))/np.log(1000)), -9.0, 9.0))
-    
+
     if m == 0:
         pref = ''
     elif m < -8 or m > 8:
@@ -71,27 +71,27 @@ def siScale(x, minVal=1e-25, allowUnicode=True):
         else:
             pref = SI_PREFIXES_ASCII[m+8]
     p = .001**m
-    
-    return (p, pref)    
+
+    return (p, pref)
 
 def siFormat(x, precision=3, suffix='', space=True, error=None, minVal=1e-25, allowUnicode=True):
     """
     Return the number x formatted in engineering notation with SI prefix.
-    
+
     Example::
         siFormat(0.0001, suffix='V')  # returns "100 μV"
     """
-    
+
     if space is True:
         space = ' '
     if space is False:
         space = ''
-        
-    
+
+
     (p, pref) = siScale(x, minVal, allowUnicode)
     if not (len(pref) > 0 and pref[0] == 'e'):
         pref = space + pref
-    
+
     if error is None:
         fmt = "%." + str(precision) + "g%s%s"
         return fmt % (x*p, pref, suffix)
@@ -102,16 +102,16 @@ def siFormat(x, precision=3, suffix='', space=True, error=None, minVal=1e-25, al
             plusminus = " +/- "
         fmt = "%." + str(precision) + "g%s%s%s%s"
         return fmt % (x*p, pref, suffix, plusminus, siFormat(error, precision=precision, suffix=suffix, space=space, minVal=minVal))
-    
+
 def siEval(s):
     """
     Convert a value written in SI notation to its equivalent prefixless value
-    
+
     Example::
-    
+
         siEval("100 μV")  # returns 0.0001
     """
-    
+
     s = asUnicode(s)
     m = re.match(r'(-?((\d+(\.\d*)?)|(\.\d+))([eE]-?\d+)?)\s*([u' + SI_PREFIXES + r']?).*$', s)
     if m is None:
@@ -127,35 +127,35 @@ def siEval(s):
     else:
         n = SI_PREFIXES.index(p) - 8
     return v * 1000**n
-    
+
 
 class Color(QtGui.QColor):
     def __init__(self, *args):
         QtGui.QColor.__init__(self, mkColor(*args))
-        
+
     def glColor(self):
         """Return (r,g,b,a) normalized for use in opengl"""
         return (self.red()/255., self.green()/255., self.blue()/255., self.alpha()/255.)
-        
+
     def __getitem__(self, ind):
         return (self.red, self.green, self.blue, self.alpha)[ind]()
-        
-    
+
+
 def mkColor(*args):
     """
     Convenience function for constructing QColor from a variety of argument types. Accepted arguments are:
-    
+
     ================ ================================================
-     'c'             one of: r, g, b, c, m, y, k, w                      
+     'c'             one of: r, g, b, c, m, y, k, w
      R, G, B, [A]    integers 0-255
      (R, G, B, [A])  tuple of integers 0-255
      float           greyscale, 0.0-1.0
      int             see :func:`intColor() <pyqtgraph.intColor>`
      (int, hues)     see :func:`intColor() <pyqtgraph.intColor>`
      "RGB"           hexadecimal strings; may begin with '#'
-     "RGBA"          
-     "RRGGBB"       
-     "RRGGBBAA"     
+     "RGBA"
+     "RRGGBB"
+     "RRGGBBAA"
      QColor          QColor instance; makes a copy.
     ================ ================================================
     """
@@ -216,7 +216,7 @@ def mkColor(*args):
         (r, g, b, a) = args
     else:
         raise Exception(err)
-    
+
     args = [r,g,b,a]
     args = [0 if np.isnan(a) or np.isinf(a) else a for a in args]
     args = list(map(int, args))
@@ -245,25 +245,25 @@ def mkBrush(*args, **kwds):
 
 def mkPen(*args, **kargs):
     """
-    Convenience function for constructing QPen. 
-    
+    Convenience function for constructing QPen.
+
     Examples::
-    
+
         mkPen(color)
         mkPen(color, width=2)
         mkPen(cosmetic=False, width=4.5, color='r')
         mkPen({'color': "FF0", width: 2})
         mkPen(None)   # (no pen)
-    
+
     In these examples, *color* may be replaced with any arguments accepted by :func:`mkColor() <pyqtgraph.mkColor>`    """
-    
+
     color = kargs.get('color', None)
     width = kargs.get('width', 1)
     style = kargs.get('style', None)
     dash = kargs.get('dash', None)
     cosmetic = kargs.get('cosmetic', True)
     hsv = kargs.get('hsv', None)
-    
+
     if len(args) == 1:
         arg = args[0]
         if isinstance(arg, dict):
@@ -276,14 +276,14 @@ def mkPen(*args, **kargs):
             color = arg
     if len(args) > 1:
         color = args
-        
+
     if color is None:
         color = mkColor('l')
     if hsv is not None:
         color = hsvColor(*hsv)
     else:
         color = mkColor(color)
-        
+
     pen = QtGui.QPen(QtGui.QBrush(color), width)
     pen.setCosmetic(cosmetic)
     if style is not None:
@@ -298,7 +298,7 @@ def hsvColor(hue, sat=1.0, val=1.0, alpha=1.0):
     c.setHsvF(hue, sat, val, alpha)
     return c
 
-    
+
 def colorTuple(c):
     """Return a tuple (R,G,B,A) from a QColor"""
     return (c.red(), c.green(), c.blue(), c.alpha())
@@ -310,10 +310,10 @@ def colorStr(c):
 def intColor(index, hues=9, values=1, maxValue=255, minValue=150, maxHue=360, minHue=0, sat=255, alpha=255, **kargs):
     """
     Creates a QColor from a single index. Useful for stepping through a predefined list of colors.
-    
+
     The argument *index* determines which color from the set will be returned. All other arguments determine what the set of predefined colors will be
-     
-    Colors are chosen by cycling across hues while varying the value (brightness). 
+
+    Colors are chosen by cycling across hues while varying the value (brightness).
     By default, this selects from a list of 9 hues."""
     hues = int(hues)
     values = int(values)
@@ -325,7 +325,7 @@ def intColor(index, hues=9, values=1, maxValue=255, minValue=150, maxHue=360, mi
     else:
         v = maxValue
     h = minHue + (indh * (maxHue-minHue)) / hues
-    
+
     c = QtGui.QColor()
     c.setHsv(h, sat, v)
     c.setAlpha(alpha)
@@ -339,7 +339,7 @@ def glColor(*args, **kargs):
     c = mkColor(*args, **kargs)
     return (c.red()/255., c.green()/255., c.blue()/255., c.alpha()/255.)
 
-    
+
 
 def makeArrowPath(headLen=20, tipAngle=20, tailLen=20, tailWidth=3, baseAngle=0):
     """
@@ -365,25 +365,25 @@ def makeArrowPath(headLen=20, tipAngle=20, tailLen=20, tailWidth=3, baseAngle=0)
     path.lineTo(headLen, headWidth)
     path.lineTo(0,0)
     return path
-    
-    
-    
+
+
+
 def affineSlice(data, shape, origin, vectors, axes, order=1, returnCoords=False, **kargs):
     """
     Take a slice of any orientation through an array. This is useful for extracting sections of multi-dimensional arrays such as MRI images for viewing as 1D or 2D data.
-    
+
     The slicing axes are aribtrary; they do not need to be orthogonal to the original data or even to each other. It is possible to use this function to extract arbitrary linear, rectangular, or parallelepiped shapes from within larger datasets. The original data is interpolated onto a new array of coordinates using scipy.ndimage.map_coordinates if it is available (see the scipy documentation for more information about this). If scipy is not available, then a slower implementation of map_coordinates is used.
-    
+
     For a graphical interface to this function, see :func:`ROI.getArrayRegion <pyqtgraph.ROI.getArrayRegion>`
-    
+
     ==============  ====================================================================================================
     **Arguments:**
     *data*          (ndarray) the original dataset
     *shape*         the shape of the slice to take (Note the return value may have more dimensions than len(shape))
     *origin*        the location in the original dataset that will become the origin of the sliced data.
-    *vectors*       list of unit vectors which point in the direction of the slice axes. Each vector must have the same 
-                    length as *axes*. If the vectors are not unit length, the result will be scaled relative to the 
-                    original data. If the vectors are not orthogonal, the result will be sheared relative to the 
+    *vectors*       list of unit vectors which point in the direction of the slice axes. Each vector must have the same
+                    length as *axes*. If the vectors are not unit length, the result will be scaled relative to the
+                    original data. If the vectors are not orthogonal, the result will be sheared relative to the
                     original data.
     *axes*          The axes in the original dataset which correspond to the slice *vectors*
     *order*         The order of spline interpolation. Default is 1 (linear). See scipy.ndimage.map_coordinates
@@ -393,23 +393,23 @@ def affineSlice(data, shape, origin, vectors, axes, order=1, returnCoords=False,
     *All extra keyword arguments are passed to scipy.ndimage.map_coordinates.*
     --------------------------------------------------------------------------------------------------------------------
     ==============  ====================================================================================================
-    
-    Note the following must be true: 
-        
-        | len(shape) == len(vectors) 
+
+    Note the following must be true:
+
+        | len(shape) == len(vectors)
         | len(origin) == len(axes) == len(vectors[i])
-        
+
     Example: start with a 4D fMRI data set, take a diagonal-planar slice out of the last 3 axes
-        
+
         * data = array with dims (time, x, y, z) = (100, 40, 40, 40)
-        * The plane to pull out is perpendicular to the vector (x,y,z) = (1,1,1) 
+        * The plane to pull out is perpendicular to the vector (x,y,z) = (1,1,1)
         * The origin of the slice will be at (x,y,z) = (40, 0, 0)
         * We will slice a 20x20 plane from each timepoint, giving a final shape (100, 20, 20)
-        
+
     The call for this example would look like::
-        
+
         affineSlice(data, shape=(20,20), origin=(40,0,0), vectors=((-1, 1, 0), (-1, 0, 1)), axes=(1,2,3))
-    
+
     """
     try:
         import scipy.ndimage
@@ -426,7 +426,7 @@ def affineSlice(data, shape, origin, vectors, axes, order=1, returnCoords=False,
     for v in vectors:
         if len(v) != len(axes):
             raise Exception("each vector must be same length as axes.")
-        
+
     shape = list(map(np.ceil, shape))
 
     ## transpose data so slice axes come first
@@ -437,15 +437,15 @@ def affineSlice(data, shape, origin, vectors, axes, order=1, returnCoords=False,
     data = data.transpose(tr1)
     #print "tr1:", tr1
     ## dims are now [(slice axes), (other axes)]
-    
+
     ## make sure vectors are arrays
     if not isinstance(vectors, np.ndarray):
         vectors = np.array(vectors)
     if not isinstance(origin, np.ndarray):
         origin = np.array(origin)
     origin.shape = (len(axes),) + (1,)*len(shape)
-    
-    ## Build array of sample locations. 
+
+    ## Build array of sample locations.
     grid = np.mgrid[tuple([slice(0,x) for x in shape])]  ## mesh grid of indexes
     x = (grid[np.newaxis,...] * vectors.transpose()[(Ellipsis,) + (np.newaxis,)*len(shape)]).sum(axis=1)  ## magic
     x += origin
@@ -459,10 +459,10 @@ def affineSlice(data, shape, origin, vectors, axes, order=1, returnCoords=False,
             output[ind] = scipy.ndimage.map_coordinates(data[ind], x, order=order, **kargs)
     else:
         # map_coordinates expects the indexes as the first axis, whereas
-        # interpolateArray expects indexes at the last axis. 
+        # interpolateArray expects indexes at the last axis.
         tr = tuple(range(1,x.ndim)) + (0,)
         output = interpolateArray(data, x.transpose(tr))
-    
+
     tr = list(range(output.ndim))
     trb = []
     for i in range(min(axes)):
@@ -481,51 +481,51 @@ def affineSlice(data, shape, origin, vectors, axes, order=1, returnCoords=False,
 def interpolateArray(data, x, default=0.0):
     """
     N-dimensional interpolation similar to scipy.ndimage.map_coordinates.
-    
+
     This function returns linearly-interpolated values sampled from a regular
-    grid of data. 
-    
+    grid of data.
+
     *data* is an array of any shape containing the values to be interpolated.
     *x* is an array with (shape[-1] <= data.ndim) containing the locations
-        within *data* to interpolate. 
-    
+        within *data* to interpolate.
+
     Returns array of shape (x.shape[:-1] + data.shape[x.shape[-1]:])
-    
+
     For example, assume we have the following 2D image data::
-    
+
         >>> data = np.array([[1,   2,   4  ],
                              [10,  20,  40 ],
                              [100, 200, 400]])
-        
+
     To compute a single interpolated point from this data::
-        
+
         >>> x = np.array([(0.5, 0.5)])
         >>> interpolateArray(data, x)
         array([ 8.25])
-        
-    To compute a 1D list of interpolated locations:: 
-        
+
+    To compute a 1D list of interpolated locations::
+
         >>> x = np.array([(0.5, 0.5),
                           (1.0, 1.0),
                           (1.0, 2.0),
                           (1.5, 0.0)])
         >>> interpolateArray(data, x)
         array([  8.25,  20.  ,  40.  ,  55.  ])
-        
+
     To compute a 2D array of interpolated locations::
-    
+
         >>> x = np.array([[(0.5, 0.5), (1.0, 2.0)],
                           [(1.0, 1.0), (1.5, 0.0)]])
         >>> interpolateArray(data, x)
         array([[  8.25,  40.  ],
                [ 20.  ,  55.  ]])
-               
-    ..and so on. The *x* argument may have any shape as long as 
-    ```x.shape[-1] <= data.ndim```. In the case that 
-    ```x.shape[-1] < data.ndim```, then the remaining axes are simply 
+
+    ..and so on. The *x* argument may have any shape as long as
+    ```x.shape[-1] <= data.ndim```. In the case that
+    ```x.shape[-1] < data.ndim```, then the remaining axes are simply
     broadcasted as usual. For example, we can interpolate one location
     from an entire row of the data::
-    
+
         >>> x = np.array([[0.5]])
         >>> interpolateArray(data, x)
         array([[  5.5,  11. ,  22. ]])
@@ -533,13 +533,13 @@ def interpolateArray(data, x, default=0.0):
     This is useful for interpolating from arrays of colors, vertexes, etc.
     """
     prof = debug.Profiler()
-    
+
     nd = data.ndim
     md = x.shape[-1]
     if md > nd:
         raise TypeError("x.shape[-1] must be less than or equal to data.ndim")
 
-    # First we generate arrays of indexes that are needed to 
+    # First we generate arrays of indexes that are needed to
     # extract the data surrounding each point
     fields = np.mgrid[(slice(0,2),) * md]
     xmin = np.floor(x).astype(int)
@@ -548,11 +548,11 @@ def interpolateArray(data, x, default=0.0):
     fieldInds = []
     totalMask = np.ones(x.shape[:-1], dtype=bool) # keep track of out-of-bound indexes
     for ax in range(md):
-        mask = (xmin[...,ax] >= 0) & (x[...,ax] <= data.shape[ax]-1) 
+        mask = (xmin[...,ax] >= 0) & (x[...,ax] <= data.shape[ax]-1)
         # keep track of points that need to be set to default
         totalMask &= mask
-        
-        # ..and keep track of indexes that are out of bounds 
+
+        # ..and keep track of indexes that are out of bounds
         # (note that when x[...,ax] == data.shape[ax], then xmax[...,ax] will be out
         #  of bounds, but the interpolation will work anyway)
         mask &= (xmax[...,ax] < data.shape[ax])
@@ -565,7 +565,7 @@ def interpolateArray(data, x, default=0.0):
     # Get data values surrounding each requested point
     fieldData = data[tuple(fieldInds)]
     prof()
-    
+
     ## Interpolate
     s = np.empty((md,) + fieldData.shape, dtype=float)
     dx = x - xmin
@@ -595,22 +595,22 @@ def interpolateArray(data, x, default=0.0):
 def subArray(data, offset, shape, stride):
     """
     Unpack a sub-array from *data* using the specified offset, shape, and stride.
-    
+
     Note that *stride* is specified in array elements, not bytes.
     For example, we have a 2x3 array packed in a 1D array as follows::
-    
+
         data = [_, _, 00, 01, 02, _, 10, 11, 12, _]
-        
+
     Then we can unpack the sub-array with this call::
-    
+
         subArray(data, offset=2, shape=(2, 3), stride=(4, 1))
-        
+
     ..which returns::
-    
+
         [[00, 01, 02],
          [10, 11, 12]]
-         
-    This function operates only on the first axis of *data*. So changing 
+
+    This function operates only on the first axis of *data*. So changing
     the input in the example above to have shape (10, 7) would cause the
     output to have shape (2, 3, 7).
     """
@@ -625,14 +625,14 @@ def subArray(data, offset, shape, stride):
         newShape = shape[:i+1]
         if i < len(shape)-1:
             newShape += (stride[i],)
-        newShape += extraShape 
+        newShape += extraShape
         #print i, mask, newShape
         #print "start:\n", data.shape, data
         data = data[mask]
         #print "mask:\n", data.shape, data
         data = data.reshape(newShape)
         #print "reshape:\n", data.shape, data
-    
+
     return data
 
 
@@ -640,20 +640,20 @@ def transformToArray(tr):
     """
     Given a QTransform, return a 3x3 numpy array.
     Given a QMatrix4x4, return a 4x4 numpy array.
-    
+
     Example: map an array of x,y coordinates through a transform::
-    
+
         ## coordinates to map are (1,5), (2,6), (3,7), and (4,8)
         coords = np.array([[1,2,3,4], [5,6,7,8], [1,1,1,1]])  # the extra '1' coordinate is needed for translation to work
-        
+
         ## Make an example transform
         tr = QtGui.QTransform()
         tr.translate(3,4)
         tr.scale(2, 0.1)
-        
+
         ## convert to array
         m = pg.transformToArray()[:2]  # ignore the perspective portion of the transformation
-        
+
         ## map coordinates through transform
         mapped = np.dot(m, coords)
     """
@@ -674,24 +674,24 @@ def transformCoordinates(tr, coords, transpose=False):
     Map a set of 2D or 3D coordinates through a QTransform or QMatrix4x4.
     The shape of coords must be (2,...) or (3,...)
     The mapping will _ignore_ any perspective transformations.
-    
+
     For coordinate arrays with ndim=2, this is basically equivalent to matrix multiplication.
-    Most arrays, however, prefer to put the coordinate axis at the end (eg. shape=(...,3)). To 
+    Most arrays, however, prefer to put the coordinate axis at the end (eg. shape=(...,3)). To
     allow this, use transpose=True.
-    
+
     """
-    
+
     if transpose:
         ## move last axis to beginning. This transposition will be reversed before returning the mapped coordinates.
         coords = coords.transpose((coords.ndim-1,) + tuple(range(0,coords.ndim-1)))
-    
+
     nd = coords.shape[0]
     if isinstance(tr, np.ndarray):
         m = tr
     else:
         m = transformToArray(tr)
         m = m[:m.shape[0]-1]  # remove perspective
-    
+
     ## If coords are 3D and tr is 2D, assume no change for Z axis
     if m.shape == (2,3) and nd == 3:
         m2 = np.zeros((3,4))
@@ -699,38 +699,38 @@ def transformCoordinates(tr, coords, transpose=False):
         m2[:2, 3] = m[:2,2]
         m2[2,2] = 1
         m = m2
-    
+
     ## if coords are 2D and tr is 3D, ignore Z axis
     if m.shape == (3,4) and nd == 2:
         m2 = np.empty((2,3))
         m2[:,:2] = m[:2,:2]
         m2[:,2] = m[:2,3]
         m = m2
-    
+
     ## reshape tr and coords to prepare for multiplication
     m = m.reshape(m.shape + (1,)*(coords.ndim-1))
     coords = coords[np.newaxis, ...]
-    
-    # separate scale/rotate and translation    
-    translate = m[:,-1]  
+
+    # separate scale/rotate and translation
+    translate = m[:,-1]
     m = m[:, :-1]
-    
+
     ## map coordinates and return
     mapped = (m*coords).sum(axis=1)  ## apply scale/rotate
     mapped += translate
-    
+
     if transpose:
         ## move first axis to end.
         mapped = mapped.transpose(tuple(range(1,mapped.ndim)) + (0,))
     return mapped
-    
-    
 
-    
+
+
+
 def solve3DTransform(points1, points2):
     """
     Find a 3D transformation matrix that maps points1 onto points2.
-    Points must be specified as either lists of 4 Vectors or 
+    Points must be specified as either lists of 4 Vectors or
     (4, 3) arrays.
     """
     import numpy.linalg
@@ -743,22 +743,22 @@ def solve3DTransform(points1, points2):
         else:
             A = np.array([[inp[i].x(), inp[i].y(), inp[i].z(), 1] for i in range(4)])
         pts.append(A)
-    
+
     ## solve 3 sets of linear equations to determine transformation matrix elements
     matrix = np.zeros((4,4))
     for i in range(3):
         ## solve Ax = B; x is one row of the desired transformation matrix
-        matrix[i] = numpy.linalg.solve(pts[0], pts[1][:,i])  
-    
+        matrix[i] = numpy.linalg.solve(pts[0], pts[1][:,i])
+
     return matrix
-    
+
 def solveBilinearTransform(points1, points2):
     """
     Find a bilinear transformation matrix (2x4) that maps points1 onto points2.
     Points must be specified as a list of 4 Vector, Point, QPointF, etc.
-    
+
     To use this matrix to map a point [x,y]::
-    
+
         mapped = np.dot(matrix, [x*y, x, y, 1])
     """
     import numpy.linalg
@@ -766,26 +766,26 @@ def solveBilinearTransform(points1, points2):
     ## B is 4 rows (points) x 2 columns (x, y)
     A = np.array([[points1[i].x()*points1[i].y(), points1[i].x(), points1[i].y(), 1] for i in range(4)])
     B = np.array([[points2[i].x(), points2[i].y()] for i in range(4)])
-    
+
     ## solve 2 sets of linear equations to determine transformation matrix elements
     matrix = np.zeros((2,4))
     for i in range(2):
         matrix[i] = numpy.linalg.solve(A, B[:,i])  ## solve Ax = B; x is one row of the desired transformation matrix
-    
+
     return matrix
-    
+
 def rescaleData(data, scale, offset, dtype=None):
     """Return data rescaled and optionally cast to a new dtype::
-    
+
         data => (data-offset) * scale
-        
+
     Uses scipy.weave (if available) to improve performance.
     """
     if dtype is None:
         dtype = data.dtype
     else:
         dtype = np.dtype(dtype)
-    
+
     try:
         if not getConfigOption('useWeave'):
             raise Exception('Weave is disabled; falling back to slower version.')
@@ -793,7 +793,7 @@ def rescaleData(data, scale, offset, dtype=None):
             import scipy.weave
         except ImportError:
             raise Exception('scipy.weave is not importable; falling back to slower version.')
-        
+
         ## require native dtype when using weave
         if not data.dtype.isnative:
             data = data.astype(data.dtype.newbyteorder('='))
@@ -801,11 +801,11 @@ def rescaleData(data, scale, offset, dtype=None):
             weaveDtype = dtype.newbyteorder('=')
         else:
             weaveDtype = dtype
-        
+
         newData = np.empty((data.size,), dtype=weaveDtype)
         flat = np.ascontiguousarray(data).reshape(data.size)
         size = data.size
-        
+
         code = """
         double sc = (double)scale;
         double off = (double)offset;
@@ -822,82 +822,82 @@ def rescaleData(data, scale, offset, dtype=None):
             if getConfigOption('weaveDebug'):
                 debug.printExc("Error; disabling weave.")
             setConfigOptions(useWeave=False)
-        
+
         #p = np.poly1d([scale, -offset*scale])
         #data = p(data).astype(dtype)
         d2 = data-offset
         d2 *= scale
         data = d2.astype(dtype)
     return data
-    
+
 def applyLookupTable(data, lut):
     """
     Uses values in *data* as indexes to select values from *lut*.
     The returned data has shape data.shape + lut.shape[1:]
-    
+
     Note: color gradient lookup tables can be generated using GradientWidget.
     """
     if data.dtype.kind not in ('i', 'u'):
         data = data.astype(int)
-    
-    return np.take(lut, data, axis=0, mode='clip')  
-    
+
+    return np.take(lut, data, axis=0, mode='clip')
+
 
 def makeRGBA(*args, **kwds):
     """Equivalent to makeARGB(..., useRGBA=True)"""
     kwds['useRGBA'] = True
     return makeARGB(*args, **kwds)
 
-def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False): 
-    """ 
+def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False):
+    """
     Convert an array of values into an ARGB array suitable for building QImages, OpenGL textures, etc.
-    
+
     Returns the ARGB array (values 0-255) and a boolean indicating whether there is alpha channel data.
     This is a two stage process:
-    
+
         1) Rescale the data based on the values in the *levels* argument (min, max).
         2) Determine the final output by passing the rescaled values through a lookup table.
-   
+
     Both stages are optional.
-    
+
     ============== ==================================================================================
     **Arguments:**
-    data           numpy array of int/float types. If 
+    data           numpy array of int/float types. If
     levels         List [min, max]; optionally rescale data before converting through the
                    lookup table. The data is rescaled such that min->0 and max->*scale*::
-                   
+
                       rescaled = (clip(data, min, max) - min) * (*scale* / (max - min))
-                   
+
                    It is also possible to use a 2D (N,2) array of values for levels. In this case,
-                   it is assumed that each pair of min,max values in the levels array should be 
-                   applied to a different subset of the input data (for example, the input data may 
-                   already have RGB values and the levels are used to independently scale each 
+                   it is assumed that each pair of min,max values in the levels array should be
+                   applied to a different subset of the input data (for example, the input data may
+                   already have RGB values and the levels are used to independently scale each
                    channel). The use of this feature requires that levels.shape[0] == data.shape[-1].
-    scale          The maximum value to which data will be rescaled before being passed through the 
+    scale          The maximum value to which data will be rescaled before being passed through the
                    lookup table (or returned if there is no lookup table). By default this will
                    be set to the length of the lookup table, or 256 is no lookup table is provided.
                    For OpenGL color specifications (as in GLColor4f) use scale=1.0
     lut            Optional lookup table (array with dtype=ubyte).
                    Values in data will be converted to color by indexing directly from lut.
                    The output data shape will be input.shape + lut.shape[1:].
-                   
+
                    Note: the output of makeARGB will have the same dtype as the lookup table, so
                    for conversion to QImage, the dtype must be ubyte.
-                   
+
                    Lookup tables can be built using GradientWidget.
-    useRGBA        If True, the data is returned in RGBA order (useful for building OpenGL textures). 
-                   The default is False, which returns in ARGB order for use with QImage 
-                   (Note that 'ARGB' is a term used by the Qt documentation; the _actual_ order 
+    useRGBA        If True, the data is returned in RGBA order (useful for building OpenGL textures).
+                   The default is False, which returns in ARGB order for use with QImage
+                   (Note that 'ARGB' is a term used by the Qt documentation; the _actual_ order
                    is BGRA).
     ============== ==================================================================================
     """
     profile = debug.Profiler()
-    
+
     if lut is not None and not isinstance(lut, np.ndarray):
         lut = np.array(lut)
     if levels is not None and not isinstance(levels, np.ndarray):
         levels = np.array(levels)
-    
+
     if levels is not None:
         if levels.ndim == 1:
             if len(levels) != 2:
@@ -921,7 +921,7 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False):
 
     ## Apply levels if given
     if levels is not None:
-        
+
         if isinstance(levels, np.ndarray) and levels.ndim == 2:
             ## we are going to rescale each channel independently
             if levels.shape[0] != data.shape[-1]:
@@ -962,7 +962,7 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False):
         order = [0,1,2,3] ## array comes out RGBA
     else:
         order = [2,1,0,3] ## for some reason, the colors line up as BGR in the final image.
-        
+
     if data.ndim == 2:
         # This is tempting:
         #   imgData[..., :3] = data[..., np.newaxis]
@@ -974,16 +974,16 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False):
             imgData[..., i] = data[..., 0]
     else:
         for i in range(0, data.shape[2]):
-            imgData[..., i] = data[..., order[i]] 
-        
+            imgData[..., i] = data[..., order[i]]
+
     profile()
-        
+
     if data.ndim == 2 or data.shape[2] == 3:
         alpha = False
         imgData[..., 3] = 255
     else:
         alpha = True
-        
+
     profile()
     return imgData, alpha
 
@@ -995,11 +995,11 @@ def makeQImage(imgData, alpha=None, copy=True, transpose=True):
     be reflected in the image. The image will be given a 'data' attribute
     pointing to the array which shares its data to prevent python
     freeing that memory while the image is in use.
-    
+
     ============== ===================================================================
     **Arguments:**
-    imgData        Array of data to convert. Must have shape (width, height, 3 or 4) 
-                   and dtype=ubyte. The order of values in the 3rd axis must be 
+    imgData        Array of data to convert. Must have shape (width, height, 3 or 4)
+                   and dtype=ubyte. The order of values in the 3rd axis must be
                    (b, g, r, a).
     alpha          If True, the QImage returned will have format ARGB32. If False,
                    the format will be RGB32. By default, _alpha_ is True if
@@ -1008,19 +1008,19 @@ def makeQImage(imgData, alpha=None, copy=True, transpose=True):
                    If False, the new QImage points directly to the data in the array.
                    Note that the array must be contiguous for this to work
                    (see numpy.ascontiguousarray).
-    transpose      If True (the default), the array x/y axes are transposed before 
-                   creating the image. Note that Qt expects the axes to be in 
-                   (height, width) order whereas pyqtgraph usually prefers the 
+    transpose      If True (the default), the array x/y axes are transposed before
+                   creating the image. Note that Qt expects the axes to be in
+                   (height, width) order whereas pyqtgraph usually prefers the
                    opposite.
-    ============== ===================================================================    
+    ============== ===================================================================
     """
     ## create QImage from buffer
     profile = debug.Profiler()
-    
+
     ## If we didn't explicitly specify alpha, check the array shape.
     if alpha is None:
         alpha = (imgData.shape[2] == 4)
-        
+
     copied = False
     if imgData.shape[2] == 3:  ## need to make alpha channel (even if alpha==False; QImage requires 32 bpp)
         if copy is True:
@@ -1031,12 +1031,12 @@ def makeQImage(imgData, alpha=None, copy=True, transpose=True):
             copied = True
         else:
             raise Exception('Array has only 3 channels; cannot make QImage without copying.')
-    
+
     if alpha:
         imgFormat = QtGui.QImage.Format_ARGB32
     else:
         imgFormat = QtGui.QImage.Format_RGB32
-        
+
     if transpose:
         imgData = imgData.transpose((1, 0, 2))  ## QImage expects the row/column order to be opposite
 
@@ -1048,10 +1048,10 @@ def makeQImage(imgData, alpha=None, copy=True, transpose=True):
             raise Exception('Array is not contiguous; cannot make QImage without copying.'+extra)
         imgData = np.ascontiguousarray(imgData)
         copied = True
-        
+
     if copy is True and copied is False:
         imgData = imgData.copy()
-        
+
     if USE_PYSIDE:
         ch = ctypes.c_char.from_buffer(imgData, 0)
         img = QtGui.QImage(ch, imgData.shape[1], imgData.shape[0], imgFormat)
@@ -1062,7 +1062,7 @@ def makeQImage(imgData, alpha=None, copy=True, transpose=True):
         #addr = ctypes.c_char.from_buffer(imgData, 0)
         #try:
             #img = QtGui.QImage(addr, imgData.shape[1], imgData.shape[0], imgFormat)
-        #except TypeError:  
+        #except TypeError:
             #addr = ctypes.addressof(addr)
             #img = QtGui.QImage(addr, imgData.shape[1], imgData.shape[0], imgFormat)
         try:
@@ -1074,14 +1074,14 @@ def makeQImage(imgData, alpha=None, copy=True, transpose=True):
             else:
                 # mutable, but leaks memory
                 img = QtGui.QImage(memoryview(imgData), imgData.shape[1], imgData.shape[0], imgFormat)
-                
+
     img.data = imgData
     return img
     #try:
         #buf = imgData.data
     #except AttributeError:  ## happens when image data is non-contiguous
         #buf = imgData.data
-        
+
     #profiler()
     #qimage = QtGui.QImage(buf, imgData.shape[1], imgData.shape[0], imgFormat)
     #profiler()
@@ -1091,7 +1091,7 @@ def makeQImage(imgData, alpha=None, copy=True, transpose=True):
 def imageToArray(img, copy=False, transpose=True):
     """
     Convert a QImage into numpy array. The image must have format RGB32, ARGB32, or ARGB32_Premultiplied.
-    By default, the image is not copied; changes made to the array will appear in the QImage as well (beware: if 
+    By default, the image is not copied; changes made to the array will appear in the QImage as well (beware: if
     the QImage is collected before the array, there may be trouble).
     The array will have shape (width, height, (b,g,r,a)).
     """
@@ -1106,34 +1106,34 @@ def imageToArray(img, copy=False, transpose=True):
             # Required for Python 2.6, PyQt 4.10
             # If this works on all platforms, then there is no need to use np.asarray..
             arr = np.frombuffer(ptr, np.ubyte, img.byteCount())
-    
+
     if fmt == img.Format_RGB32:
         arr = arr.reshape(img.height(), img.width(), 3)
     elif fmt == img.Format_ARGB32 or fmt == img.Format_ARGB32_Premultiplied:
         arr = arr.reshape(img.height(), img.width(), 4)
-    
+
     if copy:
         arr = arr.copy()
-        
+
     if transpose:
         return arr.transpose((1,0,2))
     else:
         return arr
-    
+
 def colorToAlpha(data, color):
     """
-    Given an RGBA image in *data*, convert *color* to be transparent. 
-    *data* must be an array (w, h, 3 or 4) of ubyte values and *color* must be 
+    Given an RGBA image in *data*, convert *color* to be transparent.
+    *data* must be an array (w, h, 3 or 4) of ubyte values and *color* must be
     an array (3) of ubyte values.
     This is particularly useful for use with images that have a black or white background.
-    
+
     Algorithm is taken from Gimp's color-to-alpha function in plug-ins/common/colortoalpha.c
     Credit:
         /*
         * Color To Alpha plug-in v1.0 by Seth Burgess, sjburges@gimp.org 1999/05/14
         *  with algorithm by clahey
         */
-    
+
     """
     data = data.astype(float)
     if data.shape[-1] == 3:  ## add alpha channel if needed
@@ -1141,11 +1141,11 @@ def colorToAlpha(data, color):
         d2[...,:3] = data
         d2[...,3] = 255
         data = d2
-    
+
     color = color.astype(float)
     alpha = np.zeros(data.shape[:2]+(3,), dtype=float)
     output = data.copy()
-    
+
     for i in [0,1,2]:
         d = data[...,i]
         c = color[i]
@@ -1153,35 +1153,35 @@ def colorToAlpha(data, color):
         alpha[...,i][mask] = (d[mask] - c) / (255. - c)
         imask = d < c
         alpha[...,i][imask] = (c - d[imask]) / c
-    
+
     output[...,3] = alpha.max(axis=2) * 255.
-    
+
     mask = output[...,3] >= 1.0  ## avoid zero division while processing alpha channel
     correction = 255. / output[...,3][mask]  ## increase value to compensate for decreased alpha
     for i in [0,1,2]:
         output[...,i][mask] = ((output[...,i][mask]-color[i]) * correction) + color[i]
         output[...,3][mask] *= data[...,3][mask] / 255.  ## combine computed and previous alpha values
-    
+
     #raise Exception()
     return np.clip(output, 0, 255).astype(np.ubyte)
 
 def gaussianFilter(data, sigma):
     """
     Drop-in replacement for scipy.ndimage.gaussian_filter.
-    
+
     (note: results are only approximately equal to the output of
      gaussian_filter)
     """
     if np.isscalar(sigma):
         sigma = (sigma,) * data.ndim
-        
+
     baseline = data.mean()
     filtered = data - baseline
     for ax in range(data.ndim):
         s = sigma[ax]
         if s == 0:
             continue
-        
+
         # generate 1D gaussian kernel
         ksize = int(s * 6)
         x = np.arange(-ksize, ksize)
@@ -1189,21 +1189,21 @@ def gaussianFilter(data, sigma):
         kshape = [1,] * data.ndim
         kshape[ax] = len(kernel)
         kernel = kernel.reshape(kshape)
-        
+
         # convolve as product of FFTs
         shape = data.shape[ax] + ksize
         scale = 1.0 / (abs(s) * (2*np.pi)**0.5)
-        filtered = scale * np.fft.irfft(np.fft.rfft(filtered, shape, axis=ax) * 
-                                        np.fft.rfft(kernel, shape, axis=ax), 
+        filtered = scale * np.fft.irfft(np.fft.rfft(filtered, shape, axis=ax) *
+                                        np.fft.rfft(kernel, shape, axis=ax),
                                         axis=ax)
-        
+
         # clip off extra data
         sl = [slice(None)] * data.ndim
         sl[ax] = slice(filtered.shape[ax]-data.shape[ax],None,None)
         filtered = filtered[sl]
     return filtered + baseline
-    
-    
+
+
 def downsample(data, n, axis=0, xvals='subsample'):
     """Downsample by averaging points together across axis.
     If multiple axes are specified, runs once per axis.
@@ -1214,15 +1214,15 @@ def downsample(data, n, axis=0, xvals='subsample'):
     if (hasattr(data, 'implements') and data.implements('MetaArray')):
         ma = data
         data = data.view(np.ndarray)
-        
-    
+
+
     if hasattr(axis, '__len__'):
         if not hasattr(n, '__len__'):
             n = [n]*len(axis)
         for i in range(len(axis)):
             data = downsample(data, n[i], axis[i])
         return data
-    
+
     if n <= 1:
         return data
     nPts = int(data.shape[axis] / n)
@@ -1235,7 +1235,7 @@ def downsample(data, n, axis=0, xvals='subsample'):
     #print d1.shape, s
     d1.shape = tuple(s)
     d2 = d1.mean(axis+1)
-    
+
     if ma is None:
         return d2
     else:
@@ -1349,28 +1349,28 @@ def arrayToQPath(x, y, connect='all'):
     #"""
     #Generate isosurface from volumetric data using marching tetrahedra algorithm.
     #See Paul Bourke, "Polygonising a Scalar Field Using Tetrahedrons"  (http://local.wasp.uwa.edu.au/~pbourke/geometry/polygonise/)
-    
+
     #*data*   3D numpy array of scalar values
     #*level*  The level at which to generate an isosurface
     #"""
-    
+
     #facets = []
-    
+
     ### mark everything below the isosurface level
     #mask = data < level
-    
-    #### make eight sub-fields 
+
+    #### make eight sub-fields
     #fields = np.empty((2,2,2), dtype=object)
     #slices = [slice(0,-1), slice(1,None)]
     #for i in [0,1]:
         #for j in [0,1]:
             #for k in [0,1]:
                 #fields[i,j,k] = mask[slices[i], slices[j], slices[k]]
-    
-    
-    
+
+
+
     ### split each cell into 6 tetrahedra
-    ### these all have the same 'orienation'; points 1,2,3 circle 
+    ### these all have the same 'orienation'; points 1,2,3 circle
     ### clockwise around point 0
     #tetrahedra = [
         #[(0,1,0), (1,1,1), (0,1,1), (1,0,1)],
@@ -1380,15 +1380,15 @@ def arrayToQPath(x, y, connect='all'):
         #[(0,1,0), (1,0,0), (1,1,0), (1,0,1)],
         #[(0,1,0), (1,1,0), (1,1,1), (1,0,1)]
     #]
-    
+
     ### each tetrahedron will be assigned an index
     ### which determines how to generate its facets.
-    ### this structure is: 
+    ### this structure is:
     ###    facets[index][facet1, facet2, ...]
-    ### where each facet is triangular and its points are each 
+    ### where each facet is triangular and its points are each
     ### interpolated between two points on the tetrahedron
     ###    facet = [(p1a, p1b), (p2a, p2b), (p3a, p3b)]
-    ### facet points always circle clockwise if you are looking 
+    ### facet points always circle clockwise if you are looking
     ### at them from below the isosurface.
     #indexFacets = [
         #[],  ## all above
@@ -1408,15 +1408,15 @@ def arrayToQPath(x, y, connect='all'):
         #[[(0,1), (0,3), (0,2)]], # 1,2,3 below
         #[]  ## all below
     #]
-    
+
     #for tet in tetrahedra:
-        
+
         ### get the 4 fields for this tetrahedron
         #tetFields = [fields[c] for c in tet]
-        
+
         ### generate an index for each grid cell
         #index = tetFields[0] + tetFields[1]*2 + tetFields[2]*4 + tetFields[3]*8
-        
+
         ### add facets
         #for i in xrange(index.shape[0]):                 # data x-axis
             #for j in xrange(index.shape[1]):             # data y-axis
@@ -1430,32 +1430,32 @@ def arrayToQPath(x, y, connect='all'):
                         #facets.append(pts)
 
     #return facets
-    
+
 
 def isocurve(data, level, connected=False, extendToEdge=False, path=False):
     """
     Generate isocurve from 2D data using marching squares algorithm.
-    
+
     ============== =========================================================
     **Arguments:**
     data           2D numpy array of scalar values
     level          The level at which to generate an isosurface
     connected      If False, return a single long list of point pairs
-                   If True, return multiple long lists of connected point 
-                   locations. (This is slower but better for drawing 
+                   If True, return multiple long lists of connected point
+                   locations. (This is slower but better for drawing
                    continuous lines)
-    extendToEdge   If True, extend the curves to reach the exact edges of 
-                   the data. 
-    path           if True, return a QPainterPath rather than a list of 
+    extendToEdge   If True, extend the curves to reach the exact edges of
+                   the data.
+    path           if True, return a QPainterPath rather than a list of
                    vertex coordinates. This forces connected=True.
     ============== =========================================================
-    
+
     This function is SLOW; plenty of room for optimization here.
-    """    
-    
+    """
+
     if path is True:
         connected = True
-    
+
     if extendToEdge:
         d2 = np.empty((data.shape[0]+2, data.shape[1]+2), dtype=data.dtype)
         d2[1:-1, 1:-1] = data
@@ -1468,7 +1468,7 @@ def isocurve(data, level, connected=False, extendToEdge=False, path=False):
         d2[-1,0] = d2[-1,1]
         d2[-1,-1] = d2[-1,-2]
         data = d2
-    
+
     sideTable = [
         [],
         [0,1],
@@ -1487,20 +1487,20 @@ def isocurve(data, level, connected=False, extendToEdge=False, path=False):
         [0,1],
         []
         ]
-    
+
     edgeKey=[
         [(0,1), (0,0)],
         [(0,0), (1,0)],
         [(1,0), (1,1)],
         [(1,1), (0,1)]
         ]
-    
-    
+
+
     lines = []
-    
+
     ## mark everything below the isosurface level
     mask = data < level
-    
+
     ### make four sub-fields and compute indexes for grid cells
     index = np.zeros([x-1 for x in data.shape], dtype=np.ubyte)
     fields = np.empty((2,2), dtype=object)
@@ -1514,10 +1514,10 @@ def isocurve(data, level, connected=False, extendToEdge=False, path=False):
             index += fields[i,j] * 2**vertIndex
             #print index
     #print index
-    
+
     ## add lines
     for i in range(index.shape[0]):                 # data x-axis
-        for j in range(index.shape[1]):             # data y-axis     
+        for j in range(index.shape[1]):             # data y-axis
             sides = sideTable[index[i,j]]
             for l in range(0, len(sides), 2):     ## faces for this grid cell
                 edges = sides[l:l+2]
@@ -1530,26 +1530,26 @@ def isocurve(data, level, connected=False, extendToEdge=False, path=False):
                     f = (level-v1) / (v2-v1)
                     fi = 1.0 - f
                     p = (    ## interpolate between corners
-                        p1[0]*fi + p2[0]*f + i + 0.5, 
+                        p1[0]*fi + p2[0]*f + i + 0.5,
                         p1[1]*fi + p2[1]*f + j + 0.5
                         )
                     if extendToEdge:
                         ## check bounds
                         p = (
                             min(data.shape[0]-2, max(0, p[0]-1)),
-                            min(data.shape[1]-2, max(0, p[1]-1)),                        
+                            min(data.shape[1]-2, max(0, p[1]-1)),
                         )
                     if connected:
                         gridKey = i + (1 if edges[m]==2 else 0), j + (1 if edges[m]==3 else 0), edges[m]%2
                         pts.append((p, gridKey))  ## give the actual position and a key identifying the grid location (for connecting segments)
                     else:
                         pts.append(p)
-                
+
                 lines.append(pts)
 
     if not connected:
         return lines
-                
+
     ## turn disjoint list of segments into continuous lines
 
     #lines = [[2,5], [5,4], [3,4], [1,3], [6,7], [7,8], [8,6], [11,12], [12,15], [11,13], [13,14]]
@@ -1576,9 +1576,9 @@ def isocurve(data, level, connected=False, extendToEdge=False, path=False):
             while True:
                 if x == chain[-1][1]:
                     break ## nothing left to do on this chain
-                    
+
                 x = chain[-1][1]
-                if x == k:  
+                if x == k:
                     break ## chain has looped; we're done and can ignore the opposite chain
                 y = chain[-2][1]
                 connects = points[x]
@@ -1591,9 +1591,9 @@ def isocurve(data, level, connected=False, extendToEdge=False, path=False):
             if chain[0][1] == chain[-1][1]:  # looped chain; no need to continue the other direction
                 chains.pop()
                 break
-                
 
-    ## extract point locations 
+
+    ## extract point locations
     lines = []
     for chain in points.values():
         if len(chain) == 2:
@@ -1601,25 +1601,25 @@ def isocurve(data, level, connected=False, extendToEdge=False, path=False):
         else:
             chain = chain[0]
         lines.append([p[0] for p in chain])
-    
+
     if not path:
         return lines ## a list of pairs of points
-    
+
     path = QtGui.QPainterPath()
     for line in lines:
         path.moveTo(*line[0])
         for p in line[1:]:
             path.lineTo(*p)
-    
+
     return path
-    
-    
+
+
 def traceImage(image, values, smooth=0.5):
     """
     Convert an image to a set of QPainterPath curves.
     One curve will be generated for each item in *values*; each curve outlines the area
     of the image that is closer to its value than to any others.
-    
+
     If image is RGB or RGBA, then the shape of values should be (nvals, 3/4)
     The parameter *smooth* is expressed in pixels.
     """
@@ -1627,7 +1627,7 @@ def traceImage(image, values, smooth=0.5):
         import scipy.ndimage as ndi
     except ImportError:
         raise Exception("traceImage() requires the package scipy.ndimage, but it is not importable.")
-    
+
     if values.ndim == 2:
         values = values.T
     values = values[np.newaxis, np.newaxis, ...].astype(float)
@@ -1635,11 +1635,11 @@ def traceImage(image, values, smooth=0.5):
     diff = np.abs(image-values)
     if values.ndim == 4:
         diff = diff.sum(axis=2)
-        
+
     labels = np.argmin(diff, axis=2)
-    
+
     paths = []
-    for i in range(diff.shape[-1]):    
+    for i in range(diff.shape[-1]):
         d = (labels==i).astype(float)
         d = gaussianFilter(d, (smooth, smooth))
         lines = isocurve(d, 0.5, connected=True, extendToEdge=True)
@@ -1648,31 +1648,31 @@ def traceImage(image, values, smooth=0.5):
             path.moveTo(*line[0])
             for p in line[1:]:
                 path.lineTo(*p)
-        
+
         paths.append(path)
     return paths
-    
-    
-    
+
+
+
 IsosurfaceDataCache = None
 def isosurface(data, level):
     """
     Generate isosurface from volumetric data using marching cubes algorithm.
-    See Paul Bourke, "Polygonising a Scalar Field"  
+    See Paul Bourke, "Polygonising a Scalar Field"
     (http://paulbourke.net/geometry/polygonise/)
-    
+
     *data*   3D numpy array of scalar values
     *level*  The level at which to generate an isosurface
-    
-    Returns an array of vertex coordinates (Nv, 3) and an array of 
-    per-face vertex indexes (Nf, 3)    
+
+    Returns an array of vertex coordinates (Nv, 3) and an array of
+    per-face vertex indexes (Nf, 3)
     """
     ## For improvement, see:
-    ## 
+    ##
     ## Efficient implementation of Marching Cubes' cases with topological guarantees.
     ## Thomas Lewiner, Helio Lopes, Antonio Wilson Vieira and Geovan Tavares.
     ## Journal of Graphics Tools 8(2): pp. 1-15 (december 2003)
-    
+
     ## Precompute lookup tables on the first run
     global IsosurfaceDataCache
     if IsosurfaceDataCache is None:
@@ -1712,9 +1712,9 @@ def isosurface(data, level):
             0xe90, 0xf99, 0xc93, 0xd9a, 0xa96, 0xb9f, 0x895, 0x99c,
             0x69c, 0x795, 0x49f, 0x596, 0x29a, 0x393, 0x99 , 0x190,
             0xf00, 0xe09, 0xd03, 0xc0a, 0xb06, 0xa0f, 0x905, 0x80c,
-            0x70c, 0x605, 0x50f, 0x406, 0x30a, 0x203, 0x109, 0x0   
+            0x70c, 0x605, 0x50f, 0x406, 0x30a, 0x203, 0x109, 0x0
             ], dtype=np.uint16)
-        
+
         ## Table of triangles to use for filling each grid cell.
         ## Each set of three integers tells us which three edges to
         ## draw a triangle between.
@@ -1976,9 +1976,9 @@ def isosurface(data, level):
             [0, 9, 1],
             [0, 3, 8],
             []
-        ]    
+        ]
         edgeShifts = np.array([  ## maps edge ID (0-11) to (x,y,z) cell offset and edge ID (0-2)
-            [0, 0, 0, 0],   
+            [0, 0, 0, 0],
             [1, 0, 0, 1],
             [0, 1, 0, 0],
             [0, 0, 0, 1],
@@ -2001,23 +2001,23 @@ def isosurface(data, level):
             faceTableI[faceTableInds[:,0]] = np.array([triTable[j] for j in faceTableInds])
             faceTableI = faceTableI.reshape((len(triTable), i, 3))
             faceShiftTables.append(edgeShifts[faceTableI])
-            
+
         ## Let's try something different:
         #faceTable = np.empty((256, 5, 3, 4), dtype=np.ubyte)   # (grid cell index, faces, vertexes, edge lookup)
         #for i,f in enumerate(triTable):
             #f = np.array(f + [12] * (15-len(f))).reshape(5,3)
             #faceTable[i] = edgeShifts[f]
-        
-        
+
+
         IsosurfaceDataCache = (faceShiftTables, edgeShifts, edgeTable, nTableFaces)
     else:
         faceShiftTables, edgeShifts, edgeTable, nTableFaces = IsosurfaceDataCache
 
 
-    
+
     ## mark everything below the isosurface level
     mask = data < level
-    
+
     ### make eight sub-fields and compute indexes for grid cells
     index = np.zeros([x-1 for x in data.shape], dtype=np.ubyte)
     fields = np.empty((2,2,2), dtype=object)
@@ -2028,23 +2028,23 @@ def isosurface(data, level):
                 fields[i,j,k] = mask[slices[i], slices[j], slices[k]]
                 vertIndex = i - 2*j*i + 3*j + 4*k  ## this is just to match Bourk's vertex numbering scheme
                 index += fields[i,j,k] * 2**vertIndex
-    
+
     ### Generate table of edges that have been cut
     cutEdges = np.zeros([x+1 for x in index.shape]+[3], dtype=np.uint32)
     edges = edgeTable[index]
-    for i, shift in enumerate(edgeShifts[:12]):        
+    for i, shift in enumerate(edgeShifts[:12]):
         slices = [slice(shift[j],cutEdges.shape[j]+(shift[j]-1)) for j in range(3)]
         cutEdges[slices[0], slices[1], slices[2], shift[3]] += edges & 2**i
-    
+
     ## for each cut edge, interpolate to see where exactly the edge is cut and generate vertex positions
     m = cutEdges > 0
     vertexInds = np.argwhere(m)   ## argwhere is slow!
     vertexes = vertexInds[:,:3].astype(np.float32)
     dataFlat = data.reshape(data.shape[0]*data.shape[1]*data.shape[2])
-    
+
     ## re-use the cutEdges array as a lookup table for vertex IDs
     cutEdges[vertexInds[:,0], vertexInds[:,1], vertexInds[:,2], vertexInds[:,3]] = np.arange(vertexInds.shape[0])
-    
+
     for i in [0,1,2]:
         vim = vertexInds[:,3] == i
         vi = vertexInds[vim, :3]
@@ -2052,9 +2052,9 @@ def isosurface(data, level):
         v1 = dataFlat[viFlat]
         v2 = dataFlat[viFlat + data.strides[i]//data.itemsize]
         vertexes[vim,i] += (level-v1) / (v2-v1)
-    
-    ### compute the set of vertex indexes for each face. 
-    
+
+    ### compute the set of vertex indexes for each face.
+
     ## This works, but runs a bit slower.
     #cells = np.argwhere((index != 0) & (index != 255))  ## all cells with at least one face
     #cellInds = index[cells[:,0], cells[:,1], cells[:,2]]
@@ -2063,9 +2063,9 @@ def isosurface(data, level):
     #verts[...,:3] += cells[:,np.newaxis,np.newaxis,:]  ## we now have indexes into cutEdges
     #verts = verts[mask]
     #faces = cutEdges[verts[...,0], verts[...,1], verts[...,2], verts[...,3]]  ## and these are the vertex indexes we want.
-    
-    
-    ## To allow this to be vectorized efficiently, we count the number of faces in each 
+
+
+    ## To allow this to be vectorized efficiently, we count the number of faces in each
     ## grid cell and handle each group of cells with the same number together.
     ## determine how many faces to assign to each grid cell
     nFaces = nTableFaces[index]
@@ -2074,7 +2074,7 @@ def isosurface(data, level):
     ptr = 0
     #import debug
     #p = debug.Profiler()
-    
+
     ## this helps speed up an indexing operation later on
     cs = np.array(cutEdges.strides)//cutEdges.itemsize
     cutEdges = cutEdges.flatten()
@@ -2092,14 +2092,14 @@ def isosurface(data, level):
             continue
         cellInds = index[cells[:,0], cells[:,1], cells[:,2]]   ## index values of cells to process for this round
         #profiler()
-        
+
         ### expensive:
         verts = faceShiftTables[i][cellInds]
         #profiler()
         verts[...,:3] += cells[:,np.newaxis,np.newaxis,:]  ## we now have indexes into cutEdges
         verts = verts.reshape((verts.shape[0]*i,)+verts.shape[2:])
         #profiler()
-        
+
         ### expensive:
         verts = (verts * cs[np.newaxis, np.newaxis, :]).sum(axis=2)
         vertInds = cutEdges[verts]
@@ -2109,15 +2109,15 @@ def isosurface(data, level):
         faces[ptr:ptr+nv] = vertInds #.reshape((nv, 3))
         #profiler()
         ptr += nv
-        
+
     return vertexes, faces
 
 
-    
+
 def invertQTransform(tr):
     """Return a QTransform that is the inverse of *tr*.
     Rasises an exception if tr is not invertible.
-    
+
     Note that this function is preferred over QTransform.inverted() due to
     bugs in that method. (specifically, Qt has floating-point precision issues
     when determining whether a matrix is invertible)
@@ -2132,25 +2132,25 @@ def invertQTransform(tr):
         if inv[1] is False:
             raise Exception("Transform is not invertible.")
         return inv[0]
-    
-    
+
+
 def pseudoScatter(data, spacing=None, shuffle=True, bidir=False):
     """
     Used for examining the distribution of values in a set. Produces scattering as in beeswarm or column scatter plots.
-    
+
     Given a list of x-values, construct a set of y-values such that an x,y scatter-plot
     will not have overlapping points (it will look similar to a histogram).
     """
     inds = np.arange(len(data))
     if shuffle:
         np.random.shuffle(inds)
-        
+
     data = data[inds]
-    
+
     if spacing is None:
         spacing = 2.*np.std(data)/len(data)**0.5
     s2 = spacing**2
-    
+
     yvals = np.empty(len(data))
     if len(data) == 0:
         return yvals
@@ -2160,10 +2160,10 @@ def pseudoScatter(data, spacing=None, shuffle=True, bidir=False):
         x0 = data[:i]   # all x values already placed
         y0 = yvals[:i]  # all y values already placed
         y = 0
-        
+
         dx = (x0-x)**2  # x-distance to each previous point
         xmask = dx < s2  # exclude anything too far away
-        
+
         if xmask.sum() > 0:
             if bidir:
                 dirs = [-1, 1]
@@ -2173,24 +2173,24 @@ def pseudoScatter(data, spacing=None, shuffle=True, bidir=False):
             for direction in dirs:
                 y = 0
                 dx2 = dx[xmask]
-                dy = (s2 - dx2)**0.5   
+                dy = (s2 - dx2)**0.5
                 limits = np.empty((2,len(dy)))  # ranges of y-values to exclude
                 limits[0] = y0[xmask] - dy
-                limits[1] = y0[xmask] + dy    
+                limits[1] = y0[xmask] + dy
                 while True:
                     # ignore anything below this y-value
                     if direction > 0:
                         mask = limits[1] >= y
                     else:
                         mask = limits[0] <= y
-                        
+
                     limits2 = limits[:,mask]
-                    
+
                     # are we inside an excluded region?
                     mask = (limits2[0] < y) & (limits2[1] > y)
                     if mask.sum() == 0:
                         break
-                        
+
                     if direction > 0:
                         y = limits2[:,mask].max()
                     else:
@@ -2201,7 +2201,7 @@ def pseudoScatter(data, spacing=None, shuffle=True, bidir=False):
             else:
                 y = yopts[0]
         yvals[i] = y
-    
+
     return yvals[np.argsort(inds)]  ## un-shuffle values before returning
 
 
@@ -2209,18 +2209,18 @@ def pseudoScatter(data, spacing=None, shuffle=True, bidir=False):
 def toposort(deps, nodes=None, seen=None, stack=None, depth=0):
     """Topological sort. Arguments are:
       deps    dictionary describing dependencies where a:[b,c] means "a depends on b and c"
-      nodes   optional, specifies list of starting nodes (these should be the nodes 
+      nodes   optional, specifies list of starting nodes (these should be the nodes
               which are not depended on by any other nodes). Other candidate starting
               nodes will be ignored.
-              
+
     Example::
 
         # Sort the following graph:
-        # 
+        #
         #   B ──┬─────> C <── D
-        #       │       │       
+        #       │       │
         #   E <─┴─> A <─┘
-        #     
+        #
         deps = {'a': ['b', 'c'], 'c': ['b', 'd'], 'e': ['b']}
         toposort(deps)
          => ['b', 'd', 'c', 'a', 'e']
@@ -2231,7 +2231,7 @@ def toposort(deps, nodes=None, seen=None, stack=None, depth=0):
         for k in v:
             if k not in deps:
                 deps[k] = []
-    
+
     if nodes is None:
         ## run through deps to find nodes that are not depended upon
         rem = set()

--- a/pyqtgraph/graphicsItems/ArrowItem.py
+++ b/pyqtgraph/graphicsItems/ArrowItem.py
@@ -7,13 +7,13 @@ class ArrowItem(QtGui.QGraphicsPathItem):
     """
     For displaying scale-invariant arrows.
     For arrows pointing to a location on a curve, see CurveArrow
-    
+
     """
-    
-    
+
+
     def __init__(self, **opts):
         """
-        Arrows can be initialized with any keyword arguments accepted by 
+        Arrows can be initialized with any keyword arguments accepted by
         the setStyle() method.
         """
         self.opts = {}
@@ -36,17 +36,17 @@ class ArrowItem(QtGui.QGraphicsPathItem):
             'brush': (50,50,200),
         }
         defaultOpts.update(opts)
-        
+
         self.setStyle(**defaultOpts)
-        
+
         self.rotate(self.opts['angle'])
         self.moveBy(*self.opts['pos'])
-    
+
     def setStyle(self, **opts):
         """
         Changes the appearance of the arrow.
         All arguments are optional:
-        
+
         ======================  =================================================
         **Keyword Arguments:**
         angle                   Orientation of the arrow in degrees. Default is
@@ -70,23 +70,23 @@ class ArrowItem(QtGui.QGraphicsPathItem):
         ======================  =================================================
         """
         self.opts.update(opts)
-        
+
         opt = dict([(k,self.opts[k]) for k in ['headLen', 'tipAngle', 'baseAngle', 'tailLen', 'tailWidth']])
         self.path = fn.makeArrowPath(**opt)
         self.setPath(self.path)
-        
+
         self.setPen(fn.mkPen(self.opts['pen']))
         self.setBrush(fn.mkBrush(self.opts['brush']))
-        
+
         if self.opts['pxMode']:
             self.setFlags(self.flags() | self.ItemIgnoresTransformations)
         else:
             self.setFlags(self.flags() & ~self.ItemIgnoresTransformations)
-        
+
     def paint(self, p, *args):
         p.setRenderHint(QtGui.QPainter.Antialiasing)
         QtGui.QGraphicsPathItem.paint(self, p, *args)
-        
+
         #p.setPen(fn.mkPen('r'))
         #p.setBrush(fn.mkBrush(None))
         #p.drawRect(self.boundingRect())
@@ -95,9 +95,9 @@ class ArrowItem(QtGui.QGraphicsPathItem):
         #if not self.opts['pxMode']:
             #return QtGui.QGraphicsPathItem.shape(self)
         return self.path
-    
+
     ## dataBounds and pixelPadding methods are provided to ensure ViewBox can
-    ## properly auto-range 
+    ## properly auto-range
     def dataBounds(self, ax, frac, orthoRange=None):
         pw = 0
         pen = self.pen()
@@ -111,7 +111,7 @@ class ArrowItem(QtGui.QGraphicsPathItem):
                 return [br.left()-pw, br.right()+pw]
             else:
                 return [br.top()-pw, br.bottom()+pw]
-        
+
     def pixelPadding(self):
         pad = 0
         if self.opts['pxMode']:
@@ -121,6 +121,3 @@ class ArrowItem(QtGui.QGraphicsPathItem):
         if pen.isCosmetic():
             pad += max(1, pen.width()) * 0.7072
         return pad
-        
-        
-    

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -14,9 +14,9 @@ class AxisItem(GraphicsWidget):
     GraphicsItem showing a single plot axis with ticks, values, and label.
     Can be configured to fit on any side of a plot, and can automatically synchronize its displayed scale with ViewBox items.
     Ticks can be extended to draw a grid.
-    If maxTickLength is negative, ticks point into the plot. 
+    If maxTickLength is negative, ticks point into the plot.
     """
-    
+
     def __init__(self, orientation, pen=None, linkView=None, parent=None, maxTickLength=-5, showValues=True):
         """
         ==============  ===============================================================
@@ -26,11 +26,11 @@ class AxisItem(GraphicsWidget):
                         into the plot, positive values draw outward.
         linkView        (ViewBox) causes the range of values displayed in the axis
                         to be linked to the visible range of a ViewBox.
-        showValues      (bool) Whether to display values adjacent to ticks 
+        showValues      (bool) Whether to display values adjacent to ticks
         pen             (QPen) Pen used when drawing ticks.
         ==============  ===============================================================
         """
-        
+
         GraphicsWidget.__init__(self, parent)
         self.label = QtGui.QGraphicsTextItem(self)
         self.picture = None
@@ -39,15 +39,15 @@ class AxisItem(GraphicsWidget):
             raise Exception("Orientation argument must be one of 'left', 'right', 'top', or 'bottom'.")
         if orientation in ['left', 'right']:
             self.label.rotate(-90)
-            
+
         self.style = {
-            'tickTextOffset': [5, 2],  ## (horizontal, vertical) spacing between text and axis 
+            'tickTextOffset': [5, 2],  ## (horizontal, vertical) spacing between text and axis
             'tickTextWidth': 30,  ## space reserved for tick text
-            'tickTextHeight': 18, 
+            'tickTextHeight': 18,
             'autoExpandTextSpace': True,  ## automatically expand text space if needed
             'tickFont': None,
-            'stopAxisAtTick': (False, False),  ## whether axis is drawn to edge of box or to last tick 
-            'textFillLimits': [  ## how much of the axis to fill up with tick text, maximally. 
+            'stopAxisAtTick': (False, False),  ## whether axis is drawn to edge of box or to last tick
+            'textFillLimits': [  ## how much of the axis to fill up with tick text, maximally.
                 (0, 0.8),    ## never fill more than 80% of the axis
                 (2, 0.6),    ## If we already have 2 ticks with text, fill no more than 60% of the axis
                 (4, 0.4),    ## If we already have 4 ticks with text, fill no more than 40% of the axis
@@ -58,93 +58,93 @@ class AxisItem(GraphicsWidget):
             'maxTickLevel': 2,
             'maxTextLevel': 2,
         }
-        
-        self.textWidth = 30  ## Keeps track of maximum width / height of tick text 
+
+        self.textWidth = 30  ## Keeps track of maximum width / height of tick text
         self.textHeight = 18
-        
+
         # If the user specifies a width / height, remember that setting
         # indefinitely.
         self.fixedWidth = None
         self.fixedHeight = None
-        
+
         self.labelText = ''
         self.labelUnits = ''
         self.labelUnitPrefix=''
         self.labelStyle = {}
         self.logMode = False
         self.tickFont = None
-        
+
         self._tickLevels = None  ## used to override the automatic ticking system with explicit ticks
         self._tickSpacing = None  # used to override default tickSpacing method
         self.scale = 1.0
         self.autoSIPrefix = True
         self.autoSIPrefixScale = 1.0
-        
+
         self.setRange(0, 1)
-        
+
         if pen is None:
             self.setPen()
         else:
             self.setPen(pen)
-        
+
         self._linkedView = None
         if linkView is not None:
             self.linkToView(linkView)
-        
+
         self.showLabel(False)
-        
+
         self.grid = False
         #self.setCacheMode(self.DeviceCoordinateCache)
 
     def setStyle(self, **kwds):
         """
         Set various style options.
-        
+
         =================== =======================================================
         Keyword Arguments:
-        tickLength          (int) The maximum length of ticks in pixels. 
-                            Positive values point toward the text; negative 
+        tickLength          (int) The maximum length of ticks in pixels.
+                            Positive values point toward the text; negative
                             values point away.
         tickTextOffset      (int) reserved spacing between text and axis in px
         tickTextWidth       (int) Horizontal space reserved for tick text in px
         tickTextHeight      (int) Vertical space reserved for tick text in px
         autoExpandTextSpace (bool) Automatically expand text space if the tick
                             strings become too long.
-        tickFont            (QFont or None) Determines the font used for tick 
+        tickFont            (QFont or None) Determines the font used for tick
                             values. Use None for the default font.
-        stopAxisAtTick      (tuple: (bool min, bool max)) If True, the axis 
-                            line is drawn only as far as the last tick. 
-                            Otherwise, the line is drawn to the edge of the 
+        stopAxisAtTick      (tuple: (bool min, bool max)) If True, the axis
+                            line is drawn only as far as the last tick.
+                            Otherwise, the line is drawn to the edge of the
                             AxisItem boundary.
         textFillLimits      (list of (tick #, % fill) tuples). This structure
-                            determines how the AxisItem decides how many ticks 
+                            determines how the AxisItem decides how many ticks
                             should have text appear next to them. Each tuple in
                             the list specifies what fraction of the axis length
                             may be occupied by text, given the number of ticks
                             that already have text displayed. For example::
-                            
+
                                 [(0, 0.8), # Never fill more than 80% of the axis
-                                 (2, 0.6), # If we already have 2 ticks with text, 
+                                 (2, 0.6), # If we already have 2 ticks with text,
                                            # fill no more than 60% of the axis
-                                 (4, 0.4), # If we already have 4 ticks with text, 
+                                 (4, 0.4), # If we already have 4 ticks with text,
                                            # fill no more than 40% of the axis
-                                 (6, 0.2)] # If we already have 6 ticks with text, 
+                                 (6, 0.2)] # If we already have 6 ticks with text,
                                            # fill no more than 20% of the axis
-                                
+
         showValues          (bool) indicates whether text is displayed adjacent
                             to ticks.
         =================== =======================================================
-        
+
         Added in version 0.9.9
         """
         for kwd,value in kwds.items():
             if kwd not in self.style:
                 raise NameError("%s is not a valid style argument." % kwd)
-            
+
             if kwd in ('tickLength', 'tickTextOffset', 'tickTextWidth', 'tickTextHeight'):
                 if not isinstance(value, int):
                     raise ValueError("Argument '%s' must be int" % kwd)
-            
+
             if kwd == 'tickTextOffset':
                 if self.orientation in ('left', 'right'):
                     self.style['tickTextOffset'][0] = value
@@ -158,19 +158,19 @@ class AxisItem(GraphicsWidget):
                 self.style[kwd] = value
             else:
                 self.style[kwd] = value
-        
+
         self.picture = None
         self._adjustSize()
         self.update()
-        
+
     def close(self):
         self.scene().removeItem(self.label)
         self.label = None
         self.scene().removeItem(self)
-        
+
     def setGrid(self, grid):
         """Set the alpha value (0-255) for the grid, or False to disable.
-        
+
         When grid lines are enabled, the axis tick lines are extended to cover
         the extent of the linked ViewBox, if any.
         """
@@ -178,28 +178,28 @@ class AxisItem(GraphicsWidget):
         self.picture = None
         self.prepareGeometryChange()
         self.update()
-        
+
     def setLogMode(self, log):
         """
         If *log* is True, then ticks are displayed on a logarithmic scale and values
-        are adjusted accordingly. (This is usually accessed by changing the log mode 
+        are adjusted accordingly. (This is usually accessed by changing the log mode
         of a :func:`PlotItem <pyqtgraph.PlotItem.setLogMode>`)
         """
         self.logMode = log
         self.picture = None
         self.update()
-        
+
     def setTickFont(self, font):
         self.tickFont = font
         self.picture = None
         self.prepareGeometryChange()
         ## Need to re-allocate space depending on font size?
-        
+
         self.update()
-        
+
     def resizeEvent(self, ev=None):
         #s = self.size()
-        
+
         ## Set the position of the label
         nudge = 5
         br = self.label.boundingRect()
@@ -218,7 +218,7 @@ class AxisItem(GraphicsWidget):
             p.setY(int(self.size().height()-br.height()+nudge))
         self.label.setPos(p)
         self.picture = None
-        
+
     def showLabel(self, show=True):
         """Show/hide the label text for this axis."""
         #self.drawLabel = show
@@ -229,10 +229,10 @@ class AxisItem(GraphicsWidget):
             self._updateHeight()
         if self.autoSIPrefix:
             self.updateAutoSIPrefix()
-        
+
     def setLabel(self, text=None, units=None, unitPrefix=None, **args):
         """Set the text displayed adjacent to the axis.
-        
+
         ==============  =============================================================
         **Arguments:**
         text            The text (excluding units) to display on the label for this
@@ -244,17 +244,17 @@ class AxisItem(GraphicsWidget):
         **args          All extra keyword arguments become CSS style options for
                         the <span> tag which will surround the axis label and units.
         ==============  =============================================================
-        
+
         The final text generated for the label will look like::
-        
+
             <span style="...options...">{text} (prefix{units})</span>
-            
-        Each extra keyword argument will become a CSS option in the above template. 
+
+        Each extra keyword argument will become a CSS option in the above template.
         For example, you can set the font size and color of the label::
-        
+
             labelStyle = {'color': '#FFF', 'font-size': '14pt'}
             axis.setLabel('label text', units='V', **labelStyle)
-        
+
         """
         if text is not None:
             self.labelText = text
@@ -270,7 +270,7 @@ class AxisItem(GraphicsWidget):
         self._adjustSize()
         self.picture = None
         self.update()
-            
+
     def labelString(self):
         if self.labelUnits == '':
             if not self.autoSIPrefix or self.autoSIPrefixScale == 1.0:
@@ -280,13 +280,13 @@ class AxisItem(GraphicsWidget):
         else:
             #print repr(self.labelUnitPrefix), repr(self.labelUnits)
             units = asUnicode('(%s%s)') % (asUnicode(self.labelUnitPrefix), asUnicode(self.labelUnits))
-            
+
         s = asUnicode('%s %s') % (asUnicode(self.labelText), asUnicode(units))
-        
+
         style = ';'.join(['%s: %s' % (k, self.labelStyle[k]) for k in self.labelStyle])
-        
+
         return asUnicode("<span style='%s'>%s</span>") % (style, asUnicode(s))
-    
+
     def _updateMaxTextSize(self, x):
         ## Informs that the maximum tick size orthogonal to the axis has
         ## changed; we use this to decide whether the item needs to be resized
@@ -305,22 +305,22 @@ class AxisItem(GraphicsWidget):
                 if self.style['autoExpandTextSpace'] is True:
                     self._updateHeight()
                     #return True  ## size has changed
-        
+
     def _adjustSize(self):
         if self.orientation in ['left', 'right']:
             self._updateWidth()
         else:
             self._updateHeight()
-    
+
     def setHeight(self, h=None):
         """Set the height of this axis reserved for ticks and tick labels.
         The height of the axis label is automatically added.
-        
+
         If *height* is None, then the value will be determined automatically
         based on the size of the tick text."""
         self.fixedHeight = h
         self._updateHeight()
-        
+
     def _updateHeight(self):
         if not self.isVisible():
             h = 0
@@ -338,20 +338,20 @@ class AxisItem(GraphicsWidget):
                     h += self.label.boundingRect().height() * 0.8
             else:
                 h = self.fixedHeight
-        
+
         self.setMaximumHeight(h)
         self.setMinimumHeight(h)
         self.picture = None
-        
+
     def setWidth(self, w=None):
         """Set the width of this axis reserved for ticks and tick labels.
         The width of the axis label is automatically added.
-        
+
         If *width* is None, then the value will be determined automatically
         based on the size of the tick text."""
         self.fixedWidth = w
         self._updateWidth()
-        
+
     def _updateWidth(self):
         if not self.isVisible():
             w = 0
@@ -369,20 +369,20 @@ class AxisItem(GraphicsWidget):
                     w += self.label.boundingRect().height() * 0.8  ## bounding rect is usually an overestimate
             else:
                 w = self.fixedWidth
-        
+
         self.setMaximumWidth(w)
         self.setMinimumWidth(w)
         self.picture = None
-        
+
     def pen(self):
         if self._pen is None:
             return fn.mkPen(getConfigOption('foreground'))
         return fn.mkPen(self._pen)
-        
+
     def setPen(self, *args, **kwargs):
         """
         Set the pen used for drawing text, axes, ticks, and grid lines.
-        If no arguments are given, the default foreground color will be used 
+        If no arguments are given, the default foreground color will be used
         (see :func:`setConfigOption <pyqtgraph.setConfigOption>`).
         """
         self.picture = None
@@ -393,44 +393,44 @@ class AxisItem(GraphicsWidget):
         self.labelStyle['color'] = '#' + fn.colorStr(self._pen.color())[:6]
         self.setLabel()
         self.update()
-        
+
     def setScale(self, scale=None):
         """
-        Set the value scaling for this axis. 
-        
+        Set the value scaling for this axis.
+
         Setting this value causes the axis to draw ticks and tick labels as if
-        the view coordinate system were scaled. By default, the axis scaling is 
+        the view coordinate system were scaled. By default, the axis scaling is
         1.0.
         """
         # Deprecated usage, kept for backward compatibility
-        if scale is None:  
+        if scale is None:
             scale = 1.0
             self.enableAutoSIPrefix(True)
-            
+
         if scale != self.scale:
             self.scale = scale
             self.setLabel()
             self.picture = None
             self.update()
-        
+
     def enableAutoSIPrefix(self, enable=True):
         """
-        Enable (or disable) automatic SI prefix scaling on this axis. 
-        
-        When enabled, this feature automatically determines the best SI prefix 
+        Enable (or disable) automatic SI prefix scaling on this axis.
+
+        When enabled, this feature automatically determines the best SI prefix
         to prepend to the label units, while ensuring that axis values are scaled
-        accordingly. 
-        
-        For example, if the axis spans values from -0.1 to 0.1 and has units set 
+        accordingly.
+
+        For example, if the axis spans values from -0.1 to 0.1 and has units set
         to 'V' then the axis would display values -100 to 100
         and the units would appear as 'mV'
-        
+
         This feature is enabled by default, and is only available when a suffix
         (unit string) is provided to display on the label.
         """
         self.autoSIPrefix = enable
         self.updateAutoSIPrefix()
-        
+
     def updateAutoSIPrefix(self):
         if self.label.isVisible():
             (scale, prefix) = fn.siScale(max(abs(self.range[0]*self.scale), abs(self.range[1]*self.scale)))
@@ -440,12 +440,12 @@ class AxisItem(GraphicsWidget):
             self.setLabel(unitPrefix=prefix)
         else:
             scale = 1.0
-        
+
         self.autoSIPrefixScale = scale
         self.picture = None
         self.update()
-        
-        
+
+
     def setRange(self, mn, mx):
         """Set the range of values displayed by the axis.
         Usually this is handled automatically by linking the axis to a ViewBox with :func:`linkToView <pyqtgraph.AxisItem.linkToView>`"""
@@ -456,14 +456,14 @@ class AxisItem(GraphicsWidget):
             self.updateAutoSIPrefix()
         self.picture = None
         self.update()
-        
+
     def linkedView(self):
         """Return the ViewBox this axis is linked to"""
         if self._linkedView is None:
             return None
         else:
             return self._linkedView()
-        
+
     def linkToView(self, view):
         """Link this axis to a ViewBox, causing its displayed range to match the visible range of the view."""
         oldView = self.linkedView()
@@ -476,11 +476,11 @@ class AxisItem(GraphicsWidget):
             if oldView is not None:
                 oldView.sigXRangeChanged.disconnect(self.linkedViewChanged)
             view.sigXRangeChanged.connect(self.linkedViewChanged)
-        
+
         if oldView is not None:
             oldView.sigResized.disconnect(self.linkedViewChanged)
         view.sigResized.connect(self.linkedViewChanged)
-        
+
     def linkedViewChanged(self, view, newRange=None):
         if self.orientation in ['right', 'left']:
             if newRange is None:
@@ -496,7 +496,7 @@ class AxisItem(GraphicsWidget):
                 self.setRange(*newRange[::-1])
             else:
                 self.setRange(*newRange)
-        
+
     def boundingRect(self):
         linkedView = self.linkedView()
         if linkedView is None or self.grid is False:
@@ -515,7 +515,7 @@ class AxisItem(GraphicsWidget):
             return rect
         else:
             return self.mapRectFromParent(self.geometry()) | linkedView.mapRectToItem(self, linkedView.boundingRect())
-        
+
     def paint(self, p, opt, widget):
         profiler = debug.Profiler()
         if self.picture is None:
@@ -544,26 +544,26 @@ class AxisItem(GraphicsWidget):
                 [ (minorTickValue1, minorTickString1), (minorTickValue2, minorTickString2), ... ],
                 ...
             ]
-        
+
         If *ticks* is None, then the default tick system will be used instead.
         """
         self._tickLevels = ticks
         self.picture = None
         self.update()
-    
+
     def setTickSpacing(self, major=None, minor=None, levels=None):
         """
-        Explicitly determine the spacing of major and minor ticks. This 
+        Explicitly determine the spacing of major and minor ticks. This
         overrides the default behavior of the tickSpacing method, and disables
-        the effect of setTicks(). Arguments may be either *major* and *minor*, 
-        or *levels* which is a list of (spacing, offset) tuples for each 
+        the effect of setTicks(). Arguments may be either *major* and *minor*,
+        or *levels* which is a list of (spacing, offset) tuples for each
         tick level desired.
-        
+
         If no arguments are given, then the default behavior of tickSpacing
         is enabled.
-        
+
         Examples::
-        
+
             # two levels, all offsets = 0
             axis.setTickSpacing(5, 1)
             # three levels, all offsets = 0
@@ -571,7 +571,7 @@ class AxisItem(GraphicsWidget):
             # reset to default
             axis.setTickSpacing()
         """
-        
+
         if levels is None:
             if major is None:
                 levels = None
@@ -580,16 +580,16 @@ class AxisItem(GraphicsWidget):
         self._tickSpacing = levels
         self.picture = None
         self.update()
-        
+
 
     def tickSpacing(self, minVal, maxVal, size):
         """Return values describing the desired spacing and offset of ticks.
-        
-        This method is called whenever the axis needs to be redrawn and is a 
+
+        This method is called whenever the axis needs to be redrawn and is a
         good method to override in subclasses that require control over tick locations.
-        
+
         The return value must be a list of tuples, one for each set of ticks::
-        
+
             [
                 (major tick spacing, offset),
                 (minor tick spacing, offset),
@@ -600,32 +600,32 @@ class AxisItem(GraphicsWidget):
         # First check for override tick spacing
         if self._tickSpacing is not None:
             return self._tickSpacing
-        
+
         dif = abs(maxVal - minVal)
         if dif == 0:
             return []
-        
+
         ## decide optimal minor tick spacing in pixels (this is just aesthetics)
         optimalTickCount = max(2., np.log(size))
-        
-        ## optimal minor tick spacing 
+
+        ## optimal minor tick spacing
         optimalSpacing = dif / optimalTickCount
-        
+
         ## the largest power-of-10 spacing which is smaller than optimal
         p10unit = 10 ** np.floor(np.log10(optimalSpacing))
-        
+
         ## Determine major/minor tick spacings which flank the optimal spacing.
         intervals = np.array([1., 2., 10., 20., 100.]) * p10unit
         minorIndex = 0
         while intervals[minorIndex+1] <= optimalSpacing:
             minorIndex += 1
-            
+
         levels = [
             (intervals[minorIndex+2], 0),
             (intervals[minorIndex+1], 0),
             #(intervals[minorIndex], 0)    ## Pretty, but eats up CPU
         ]
-        
+
         if self.style['maxTickLevel'] >= 2:
             ## decide whether to include the last level of ticks
             minSpacing = min(size / 20., 30.)
@@ -633,16 +633,16 @@ class AxisItem(GraphicsWidget):
             if dif / intervals[minorIndex] <= maxTickCount:
                 levels.append((intervals[minorIndex], 0))
             return levels
-        
-        
-        
+
+
+
         ##### This does not work -- switching between 2/5 confuses the automatic text-level-selection
         ### Determine major/minor tick spacings which flank the optimal spacing.
         #intervals = np.array([1., 2., 5., 10., 20., 50., 100.]) * p10unit
         #minorIndex = 0
         #while intervals[minorIndex+1] <= optimalSpacing:
             #minorIndex += 1
-            
+
         ### make sure we never see 5 and 2 at the same time
         #intIndexes = [
             #[0,1,3],
@@ -651,42 +651,42 @@ class AxisItem(GraphicsWidget):
             #[3,4,6],
             #[3,5,6],
         #][minorIndex]
-        
+
         #return [
             #(intervals[intIndexes[2]], 0),
             #(intervals[intIndexes[1]], 0),
             #(intervals[intIndexes[0]], 0)
         #]
-        
+
     def tickValues(self, minVal, maxVal, size):
         """
         Return the values and spacing of ticks to draw::
-        
-            [  
-                (spacing, [major ticks]), 
-                (spacing, [minor ticks]), 
-                ... 
+
+            [
+                (spacing, [major ticks]),
+                (spacing, [minor ticks]),
+                ...
             ]
-        
+
         By default, this method calls tickSpacing to determine the correct tick locations.
         This is a good method to override in subclasses.
         """
         minVal, maxVal = sorted((minVal, maxVal))
-        
 
-        minVal *= self.scale  
+
+        minVal *= self.scale
         maxVal *= self.scale
         #size *= self.scale
-            
+
         ticks = []
         tickLevels = self.tickSpacing(minVal, maxVal, size)
         allValues = np.array([])
         for i in range(len(tickLevels)):
             spacing, offset = tickLevels[i]
-            
+
             ## determine starting tick
             start = (np.ceil((minVal-offset) / spacing) * spacing) + offset
-            
+
             ## determine number of ticks
             num = int((maxVal-start) / spacing) + 1
             values = (np.arange(num) * spacing + start) / self.scale
@@ -696,11 +696,11 @@ class AxisItem(GraphicsWidget):
             values = list(filter(lambda x: all(np.abs(allValues-x) > spacing*0.01), values) )
             allValues = np.concatenate([allValues, values])
             ticks.append((spacing/self.scale, values))
-            
+
         if self.logMode:
             return self.logTickValues(minVal, maxVal, size, ticks)
-        
-        
+
+
         #nticks = []
         #for t in ticks:
             #nvals = []
@@ -708,24 +708,24 @@ class AxisItem(GraphicsWidget):
                 #nvals.append(v/self.scale)
             #nticks.append((t[0]/self.scale,nvals))
         #ticks = nticks
-            
+
         return ticks
-    
+
     def logTickValues(self, minVal, maxVal, size, stdTicks):
-        
+
         ## start with the tick spacing given by tickValues().
         ## Any level whose spacing is < 1 needs to be converted to log scale
-        
+
         ticks = []
         for (spacing, t) in stdTicks:
             if spacing >= 1.0:
                 ticks.append((spacing, t))
-        
+
         if len(ticks) < 3:
             v1 = int(np.floor(minVal))
             v2 = int(np.ceil(maxVal))
             #major = list(range(v1+1, v2))
-            
+
             minor = []
             for v in range(v1, v2):
                 minor.extend(v + np.log10(np.arange(1, 10)))
@@ -734,21 +734,21 @@ class AxisItem(GraphicsWidget):
         return ticks
 
     def tickStrings(self, values, scale, spacing):
-        """Return the strings that should be placed next to ticks. This method is called 
+        """Return the strings that should be placed next to ticks. This method is called
         when redrawing the axis and is a good method to override in subclasses.
-        The method is called with a list of tick values, a scaling factor (see below), and the 
-        spacing between ticks (this is required since, in some instances, there may be only 
+        The method is called with a list of tick values, a scaling factor (see below), and the
+        spacing between ticks (this is required since, in some instances, there may be only
         one tick and thus no other way to determine the tick spacing)
-        
+
         The scale argument is used when the axis label is displaying units which may have an SI scaling prefix.
         When determining the text to display, use value*scale to correctly account for this prefix.
         For example, if the axis label's units are set to 'V', then a tick value of 0.001 might
-        be accompanied by a scale value of 1000. This indicates that the label is displaying 'mV', and 
+        be accompanied by a scale value of 1000. This indicates that the label is displaying 'mV', and
         thus the tick should display 0.001 * 1000 = 1.
         """
         if self.logMode:
             return self.logTickStrings(values, scale, spacing)
-        
+
         places = max(0, np.ceil(-np.log10(spacing*scale)))
         strings = []
         for v in values:
@@ -759,27 +759,27 @@ class AxisItem(GraphicsWidget):
                 vstr = ("%%0.%df" % places) % vs
             strings.append(vstr)
         return strings
-        
+
     def logTickStrings(self, values, scale, spacing):
         return ["%0.1g"%x for x in 10 ** np.array(values).astype(float)]
-        
+
     def generateDrawSpecs(self, p):
         """
         Calls tickValues() and tickStrings() to determine where and how ticks should
-        be drawn, then generates from this a set of drawing commands to be 
+        be drawn, then generates from this a set of drawing commands to be
         interpreted by drawPicture().
         """
         profiler = debug.Profiler()
 
         #bounds = self.boundingRect()
         bounds = self.mapRectFromParent(self.geometry())
-        
+
         linkedView = self.linkedView()
         if linkedView is None or self.grid is False:
             tickBounds = bounds
         else:
             tickBounds = linkedView.mapRectToItem(self, linkedView.boundingRect())
-        
+
         if self.orientation == 'left':
             span = (bounds.topRight(), bounds.bottomRight())
             tickStart = tickBounds.right()
@@ -805,7 +805,7 @@ class AxisItem(GraphicsWidget):
             tickDir = 1
             axis = 1
         #print tickStart, tickStop, span
-        
+
         ## determine size of this item in pixels
         points = list(map(self.mapToDevice, span))
         if None in points:
@@ -830,7 +830,7 @@ class AxisItem(GraphicsWidget):
                 for val, strn in level:
                     values.append(val)
                     strings.append(strn)
-        
+
         ## determine mapping between tick values and local coordinates
         dif = self.range[1] - self.range[0]
         if dif == 0:
@@ -843,29 +843,29 @@ class AxisItem(GraphicsWidget):
             else:
                 xScale = bounds.width() / dif
                 offset = self.range[0] * xScale
-            
+
         xRange = [x * xScale - offset for x in self.range]
         xMin = min(xRange)
         xMax = max(xRange)
-        
+
         profiler('init')
-            
+
         tickPositions = [] # remembers positions of previously drawn ticks
-        
+
         ## compute coordinates to draw ticks
         ## draw three different intervals, long ticks first
         tickSpecs = []
         for i in range(len(tickLevels)):
             tickPositions.append([])
             ticks = tickLevels[i][1]
-        
+
             ## length of tick
             tickLength = self.style['tickLength'] / ((i*0.5)+1.0)
-                
+
             lineAlpha = 255 / (i+1)
             if self.grid is not False:
                 lineAlpha *= self.grid/255. * np.clip((0.05  * lengthInPixels / (len(ticks)+1)), 0., 1.)
-            
+
             for v in ticks:
                 ## determine actual position to draw this tick
                 x = (v * xScale) - offset
@@ -873,7 +873,7 @@ class AxisItem(GraphicsWidget):
                     tickPositions[i].append(None)
                     continue
                 tickPositions[i].append(x)
-                
+
                 p1 = [x, x]
                 p2 = [x, x]
                 p1[axis] = tickStart
@@ -887,7 +887,7 @@ class AxisItem(GraphicsWidget):
                 tickSpecs.append((tickPen, Point(p1), Point(p2)))
         profiler('compute ticks')
 
-        
+
         if self.style['stopAxisAtTick'][0] is True:
             stop = max(span[0].y(), min(map(min, tickPositions)))
             if axis == 0:
@@ -902,7 +902,7 @@ class AxisItem(GraphicsWidget):
                 span[1].setX(stop)
         axisSpec = (self.pen(), span[0], span[1])
 
-        
+
         textOffset = self.style['tickTextOffset'][axis]  ## spacing between axis and text
         #if self.style['autoExpandTextSpace'] is True:
             #textWidth = self.textWidth
@@ -910,15 +910,15 @@ class AxisItem(GraphicsWidget):
         #else:
             #textWidth = self.style['tickTextWidth'] ## space allocated for horizontal text
             #textHeight = self.style['tickTextHeight'] ## space allocated for horizontal text
-            
+
         textSize2 = 0
         textRects = []
         textSpecs = []  ## list of draw
-        
+
         # If values are hidden, return early
         if not self.style['showValues']:
             return (axisSpec, tickSpecs, textSpecs)
-            
+
         for i in range(min(len(tickLevels), self.style['maxTextLevel']+1)):
             ## Get the list of strings to display for this level
             if tickStrings is None:
@@ -926,10 +926,10 @@ class AxisItem(GraphicsWidget):
                 strings = self.tickStrings(values, self.autoSIPrefixScale * self.scale, spacing)
             else:
                 strings = tickStrings[i]
-                
+
             if len(strings) == 0:
                 continue
-            
+
             ## ignore strings belonging to ticks that were previously ignored
             for j in range(len(strings)):
                 if tickPositions[i][j] is None:
@@ -945,10 +945,10 @@ class AxisItem(GraphicsWidget):
                     ## boundingRect is usually just a bit too large
                     ## (but this probably depends on per-font metrics?)
                     br.setHeight(br.height() * 0.8)
-                    
+
                     rects.append(br)
                     textRects.append(rects[-1])
-            
+
             if len(textRects) > 0:
                 ## measure all text, make sure there's enough room
                 if axis == 0:
@@ -973,7 +973,7 @@ class AxisItem(GraphicsWidget):
                         break
                 if finished:
                     break
-            
+
             #spacing, values = tickLevels[best]
             #strings = self.tickStrings(values, self.scale, spacing)
             # Determine exactly where tick text should be drawn
@@ -1006,24 +1006,24 @@ class AxisItem(GraphicsWidget):
                 #p.drawText(rect, textFlags, vstr)
                 textSpecs.append((rect, textFlags, vstr))
         profiler('compute text')
-            
+
         ## update max text size if needed.
         self._updateMaxTextSize(textSize2)
-        
+
         return (axisSpec, tickSpecs, textSpecs)
-    
+
     def drawPicture(self, p, axisSpec, tickSpecs, textSpecs):
         profiler = debug.Profiler()
 
         p.setRenderHint(p.Antialiasing, False)
         p.setRenderHint(p.TextAntialiasing, True)
-        
+
         ## draw long line along axis
         pen, p1, p2 = axisSpec
         p.setPen(pen)
         p.drawLine(p1, p2)
         p.translate(0.5,0)  ## resolves some damn pixel ambiguity
-        
+
         ## draw ticks
         for pen, p1, p2 in tickSpecs:
             p.setPen(pen)
@@ -1045,7 +1045,7 @@ class AxisItem(GraphicsWidget):
             self._updateWidth()
         else:
             self._updateHeight()
-        
+
     def hide(self):
         GraphicsWidget.hide(self)
         if self.orientation in ['left', 'right']:
@@ -1054,23 +1054,23 @@ class AxisItem(GraphicsWidget):
             self._updateHeight()
 
     def wheelEvent(self, ev):
-        if self.linkedView() is None: 
+        if self.linkedView() is None:
             return
         if self.orientation in ['left', 'right']:
             self.linkedView().wheelEvent(ev, axis=1)
         else:
             self.linkedView().wheelEvent(ev, axis=0)
         ev.accept()
-        
+
     def mouseDragEvent(self, event):
-        if self.linkedView() is None: 
+        if self.linkedView() is None:
             return
         if self.orientation in ['left', 'right']:
             return self.linkedView().mouseDragEvent(event, axis=1)
         else:
             return self.linkedView().mouseDragEvent(event, axis=0)
-        
+
     def mouseClickEvent(self, event):
-        if self.linkedView() is None: 
+        if self.linkedView() is None:
             return
         return self.linkedView().mouseClickEvent(event)

--- a/pyqtgraph/graphicsItems/BarGraphItem.py
+++ b/pyqtgraph/graphicsItems/BarGraphItem.py
@@ -12,25 +12,25 @@ class BarGraphItem(GraphicsObject):
         """
         Valid keyword options are:
         x, x0, x1, y, y0, y1, width, height, pen, brush
-        
+
         x specifies the x-position of the center of the bar.
         x0, x1 specify left and right edges of the bar, respectively.
         width specifies distance from x0 to x1.
         You may specify any combination:
-            
+
             x, width
             x0, width
             x1, width
             x0, x1
-            
-        Likewise y, y0, y1, and height. 
+
+        Likewise y, y0, y1, and height.
         If only height is specified, then y0 will be set to 0
-        
+
         Example uses:
-        
+
             BarGraphItem(x=range(5), height=[1,5,2,4,3], width=0.5)
-            
-        
+
+
         """
         GraphicsObject.__init__(self)
         self.opts = dict(
@@ -50,41 +50,41 @@ class BarGraphItem(GraphicsObject):
         self._shape = None
         self.picture = None
         self.setOpts(**opts)
-        
+
     def setOpts(self, **opts):
         self.opts.update(opts)
         self.picture = None
         self._shape = None
         self.update()
         self.informViewBoundsChanged()
-        
+
     def drawPicture(self):
         self.picture = QtGui.QPicture()
         self._shape = QtGui.QPainterPath()
         p = QtGui.QPainter(self.picture)
-        
+
         pen = self.opts['pen']
         pens = self.opts['pens']
-        
+
         if pen is None and pens is None:
             pen = getConfigOption('foreground')
-        
+
         brush = self.opts['brush']
         brushes = self.opts['brushes']
         if brush is None and brushes is None:
             brush = (128, 128, 128)
-        
+
         def asarray(x):
             if x is None or np.isscalar(x) or isinstance(x, np.ndarray):
                 return x
             return np.array(x)
 
-        
+
         x = asarray(self.opts.get('x'))
         x0 = asarray(self.opts.get('x0'))
         x1 = asarray(self.opts.get('x1'))
         width = asarray(self.opts.get('width'))
-        
+
         if x0 is None:
             if width is None:
                 raise Exception('must specify either x0 or width')
@@ -98,7 +98,7 @@ class BarGraphItem(GraphicsObject):
             if x1 is None:
                 raise Exception('must specify either x1 or width')
             width = x1 - x0
-            
+
         y = asarray(self.opts.get('y'))
         y0 = asarray(self.opts.get('y0'))
         y1 = asarray(self.opts.get('y1'))
@@ -117,7 +117,7 @@ class BarGraphItem(GraphicsObject):
             if y1 is None:
                 raise Exception('must specify either y1 or height')
             height = y1 - y0
-        
+
         p.setPen(fn.mkPen(pen))
         p.setBrush(fn.mkBrush(brush))
         for i in range(len(x0)):
@@ -125,7 +125,7 @@ class BarGraphItem(GraphicsObject):
                 p.setPen(fn.mkPen(pens[i]))
             if brushes is not None:
                 p.setBrush(fn.mkBrush(brushes[i]))
-                
+
             if np.isscalar(x0):
                 x = x0
             else:
@@ -142,26 +142,26 @@ class BarGraphItem(GraphicsObject):
                 h = height
             else:
                 h = height[i]
-                
-                
+
+
             rect = QtCore.QRectF(x, y, w, h)
             p.drawRect(rect)
             self._shape.addRect(rect)
-            
+
         p.end()
         self.prepareGeometryChange()
-        
-        
+
+
     def paint(self, p, *args):
         if self.picture is None:
             self.drawPicture()
         self.picture.play(p)
-            
+
     def boundingRect(self):
         if self.picture is None:
             self.drawPicture()
         return QtCore.QRectF(self.picture.boundingRect())
-    
+
     def shape(self):
         if self.picture is None:
             self.drawPicture()

--- a/pyqtgraph/graphicsItems/ButtonItem.py
+++ b/pyqtgraph/graphicsItems/ButtonItem.py
@@ -4,9 +4,9 @@ from .GraphicsObject import GraphicsObject
 __all__ = ['ButtonItem']
 class ButtonItem(GraphicsObject):
     """Button graphicsItem displaying an image."""
-    
+
     clicked = QtCore.Signal(object)
-    
+
     def __init__(self, imageFile=None, width=None, parentItem=None, pixmap=None):
         self.enabled = True
         GraphicsObject.__init__(self)
@@ -14,25 +14,25 @@ class ButtonItem(GraphicsObject):
             self.setImageFile(imageFile)
         elif pixmap is not None:
             self.setPixmap(pixmap)
-            
+
         if width is not None:
             s = float(width) / self.pixmap.width()
             self.scale(s, s)
         if parentItem is not None:
             self.setParentItem(parentItem)
         self.setOpacity(0.7)
-        
-    def setImageFile(self, imageFile):        
+
+    def setImageFile(self, imageFile):
         self.setPixmap(QtGui.QPixmap(imageFile))
-        
+
     def setPixmap(self, pixmap):
         self.pixmap = pixmap
         self.update()
-        
+
     def mouseClickEvent(self, ev):
         if self.enabled:
             self.clicked.emit(self)
-        
+
     def mouseHoverEvent(self, ev):
         if not self.enabled:
             return
@@ -44,15 +44,14 @@ class ButtonItem(GraphicsObject):
     def disable(self):
         self.enabled = False
         self.setOpacity(0.4)
-        
+
     def enable(self):
         self.enabled = True
         self.setOpacity(0.7)
-        
+
     def paint(self, p, *args):
         p.setRenderHint(p.Antialiasing)
         p.drawPixmap(0, 0, self.pixmap)
-        
+
     def boundingRect(self):
         return QtCore.QRectF(self.pixmap.rect())
-        

--- a/pyqtgraph/graphicsItems/CurvePoint.py
+++ b/pyqtgraph/graphicsItems/CurvePoint.py
@@ -10,16 +10,16 @@ class CurvePoint(GraphicsObject):
     """A GraphicsItem that sets its location to a point on a PlotCurveItem.
     Also rotates to be tangent to the curve.
     The position along the curve is a Qt property, and thus can be easily animated.
-    
+
     Note: This class does not display anything; see CurveArrow for an applied example
     """
-    
+
     def __init__(self, curve, index=0, pos=None, rotate=True):
         """Position can be set either as an index referring to the sample number or
         the position 0.0 - 1.0
         If *rotate* is True, then the item rotates to match the tangent of the curve.
         """
-        
+
         GraphicsObject.__init__(self)
         #QObjectWorkaround.__init__(self)
         self._rotate = rotate
@@ -27,25 +27,25 @@ class CurvePoint(GraphicsObject):
         self.setParentItem(curve)
         self.setProperty('position', 0.0)
         self.setProperty('index', 0)
-        
+
         if hasattr(self, 'ItemHasNoContents'):
             self.setFlags(self.flags() | self.ItemHasNoContents)
-        
+
         if pos is not None:
             self.setPos(pos)
         else:
             self.setIndex(index)
-            
+
     def setPos(self, pos):
         self.setProperty('position', float(pos))## cannot use numpy types here, MUST be python float.
-        
+
     def setIndex(self, index):
         self.setProperty('index', int(index))  ## cannot use numpy types here, MUST be python int.
-        
+
     def event(self, ev):
         if not isinstance(ev, QtCore.QDynamicPropertyChangeEvent) or self.curve() is None:
             return False
-            
+
         if ev.propertyName() == 'index':
             index = self.property('index')
             if 'QVariant' in repr(index):
@@ -54,7 +54,7 @@ class CurvePoint(GraphicsObject):
             index = None
         else:
             return False
-            
+
         (x, y) = self.curve().getData()
         if index is None:
             #print ev.propertyName(), self.property('position').toDouble()[0], self.property('position').typeName()
@@ -62,7 +62,7 @@ class CurvePoint(GraphicsObject):
             if 'QVariant' in repr(pos):   ## need to support 2 APIs  :(
                 pos = pos.toDouble()[0]
             index = (len(x)-1) * np.clip(pos, 0.0, 1.0)
-            
+
         if index != int(index):  ## interpolate floating-point values
             i1 = int(index)
             i2 = np.clip(i1+1, 0, len(x)-1)
@@ -74,7 +74,7 @@ class CurvePoint(GraphicsObject):
             i1 = np.clip(index-1, 0, len(x)-1)
             i2 = np.clip(index+1, 0, len(x)-1)
             newPos = (x[index], y[index])
-            
+
         p1 = self.parentItem().mapToScene(QtCore.QPointF(x[i1], y[i1]))
         p2 = self.parentItem().mapToScene(QtCore.QPointF(x[i2], y[i2]))
         ang = np.arctan2(p2.y()-p1.y(), p2.x()-p1.x()) ## returns radians
@@ -83,13 +83,13 @@ class CurvePoint(GraphicsObject):
             self.rotate(180+ ang * 180 / np.pi) ## takes degrees
         QtGui.QGraphicsItem.setPos(self, *newPos)
         return True
-        
+
     def boundingRect(self):
         return QtCore.QRectF()
-        
+
     def paint(self, *args):
         pass
-    
+
     def makeAnimation(self, prop='position', start=0.0, end=1.0, duration=10000, loop=1):
         anim = QtCore.QPropertyAnimation(self, prop)
         anim.setDuration(duration)
@@ -102,7 +102,7 @@ class CurvePoint(GraphicsObject):
 class CurveArrow(CurvePoint):
     """Provides an arrow that points to any specific sample on a PlotCurveItem.
     Provides properties that can be animated."""
-    
+
     def __init__(self, curve, index=0, pos=None, **opts):
         CurvePoint.__init__(self, curve, index=index, pos=pos)
         if opts.get('pxMode', True):
@@ -111,7 +111,6 @@ class CurveArrow(CurvePoint):
         opts['angle'] = 0
         self.arrow = ArrowItem.ArrowItem(**opts)
         self.arrow.setParentItem(self)
-        
+
     def setStyle(self, **opts):
         return self.arrow.setStyle(**opts)
-        

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -28,10 +28,10 @@ class ErrorBarItem(GraphicsObject):
     def setData(self, **opts):
         """
         Update the data in the item. All arguments are optional.
-        
+
         Valid keyword options are:
         x, y, height, width, top, bottom, left, right, beam, pen
-        
+
         * x and y must be numpy arrays specifying the coordinates of data points.
         * height, width, top, bottom, left, right, and beam may be numpy arrays,
           single values, or None to disable. All values should be positive.
@@ -41,7 +41,7 @@ class ErrorBarItem(GraphicsObject):
         * If width is specified, it overrides left and right.
         * beam specifies the width of the beam at the end of each bar.
         * pen may be any single argument accepted by pg.mkPen().
-        
+
         This method was added in version 0.9.9. For prior versions, use setOpts.
         """
         self.opts.update(opts)
@@ -49,21 +49,21 @@ class ErrorBarItem(GraphicsObject):
         self.update()
         self.prepareGeometryChange()
         self.informViewBoundsChanged()
-        
+
     def setOpts(self, **opts):
         # for backward compatibility
         self.setData(**opts)
-        
+
     def drawPath(self):
         p = QtGui.QPainterPath()
-        
+
         x, y = self.opts['x'], self.opts['y']
         if x is None or y is None:
             return
-        
+
         beam = self.opts['beam']
-        
-        
+
+
         height, top, bottom = self.opts['height'], self.opts['top'], self.opts['bottom']
         if height is not None or top is not None or bottom is not None:
             ## draw vertical error bars
@@ -79,11 +79,11 @@ class ErrorBarItem(GraphicsObject):
                     y2 = y
                 else:
                     y2 = y + top
-            
+
             for i in range(len(x)):
                 p.moveTo(x[i], y1[i])
                 p.lineTo(x[i], y2[i])
-                
+
             if beam is not None and beam > 0:
                 x1 = x - beam/2.
                 x2 = x + beam/2.
@@ -95,7 +95,7 @@ class ErrorBarItem(GraphicsObject):
                     for i in range(len(x)):
                         p.moveTo(x1[i], y1[i])
                         p.lineTo(x2[i], y1[i])
-        
+
         width, right, left = self.opts['width'], self.opts['right'], self.opts['left']
         if width is not None or right is not None or left is not None:
             ## draw vertical error bars
@@ -111,11 +111,11 @@ class ErrorBarItem(GraphicsObject):
                     x2 = x
                 else:
                     x2 = x + right
-            
+
             for i in range(len(x)):
                 p.moveTo(x1[i], y[i])
                 p.lineTo(x2[i], y[i])
-                
+
             if beam is not None and beam > 0:
                 y1 = y - beam/2.
                 y2 = y + beam/2.
@@ -127,11 +127,11 @@ class ErrorBarItem(GraphicsObject):
                     for i in range(len(x)):
                         p.moveTo(x1[i], y1[i])
                         p.lineTo(x1[i], y2[i])
-                    
+
         self.path = p
         self.prepareGeometryChange()
-        
-        
+
+
     def paint(self, p, *args):
         if self.path is None:
             self.drawPath()
@@ -140,10 +140,8 @@ class ErrorBarItem(GraphicsObject):
             pen = getConfigOption('foreground')
         p.setPen(fn.mkPen(pen))
         p.drawPath(self.path)
-            
+
     def boundingRect(self):
         if self.path is None:
             self.drawPath()
         return self.path.boundingRect()
-    
-        

--- a/pyqtgraph/graphicsItems/FillBetweenItem.py
+++ b/pyqtgraph/graphicsItems/FillBetweenItem.py
@@ -19,18 +19,18 @@ class FillBetweenItem(QtGui.QGraphicsPathItem):
             self.setBrush(brush)
         self.setPen(pen)
         self.updatePath()
-        
+
     def setBrush(self, *args, **kwds):
         QtGui.QGraphicsPathItem.setBrush(self, fn.mkBrush(*args, **kwds))
-        
+
     def setPen(self, *args, **kwds):
         QtGui.QGraphicsPathItem.setPen(self, fn.mkPen(*args, **kwds))
 
     def setCurves(self, curve1, curve2):
         """Set the curves to fill between.
-        
+
         Arguments must be instances of PlotDataItem or PlotCurveItem.
-        
+
         Added in version 0.9.9
         """
         if self.curves is not None:

--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -30,9 +30,9 @@ Gradients = OrderedDict([
 class TickSliderItem(GraphicsWidget):
     ## public class
     """**Bases:** :class:`GraphicsWidget <pyqtgraph.GraphicsWidget>`
-    
+
     A rectangular item with tick marks along its length that can (optionally) be moved by the user."""
-        
+
     def __init__(self, orientation='bottom', allowAdd=True, **kargs):
         """
         ==============  =================================================================================
@@ -56,32 +56,32 @@ class TickSliderItem(GraphicsWidget):
             self.tickPen = fn.mkPen(kargs['tickPen'])
         else:
             self.tickPen = fn.mkPen('w')
-            
+
         self.orientations = {
-            'left': (90, 1, 1), 
-            'right': (90, 1, 1), 
-            'top': (0, 1, -1), 
+            'left': (90, 1, 1),
+            'right': (90, 1, 1),
+            'top': (0, 1, -1),
             'bottom': (0, 1, 1)
         }
-        
+
         self.setOrientation(orientation)
         #self.setFrameStyle(QtGui.QFrame.NoFrame | QtGui.QFrame.Plain)
         #self.setBackgroundRole(QtGui.QPalette.NoRole)
         #self.setMouseTracking(True)
-        
+
     #def boundingRect(self):
         #return self.mapRectFromParent(self.geometry()).normalized()
-        
+
     #def shape(self):  ## No idea why this is necessary, but rotated items do not receive clicks otherwise.
         #p = QtGui.QPainterPath()
         #p.addRect(self.boundingRect())
         #return p
-        
+
     def paint(self, p, opt, widget):
         #p.setPen(fn.mkPen('g', width=3))
         #p.drawRect(self.boundingRect())
         return
-        
+
     def keyPressEvent(self, ev):
         ev.ignore()
 
@@ -90,19 +90,19 @@ class TickSliderItem(GraphicsWidget):
             mx = self.maxDim
         else:
             self.maxDim = mx
-            
+
         if self.orientation in ['bottom', 'top']:
             self.setFixedHeight(mx)
             self.setMaximumWidth(16777215)
         else:
             self.setFixedWidth(mx)
             self.setMaximumHeight(16777215)
-            
-    
+
+
     def setOrientation(self, orientation):
         ## public
         """Set the orientation of the TickSliderItem.
-        
+
         ==============  ===================================================================
         **Arguments:**
         orientation     Options are: 'left', 'right', 'top', 'bottom'
@@ -132,14 +132,14 @@ class TickSliderItem(GraphicsWidget):
             self.setTransform(transform)
         elif ort != 'bottom':
             raise Exception("%s is not a valid orientation. Options are 'left', 'right', 'top', and 'bottom'" %str(ort))
-        
+
         self.translate(self.tickSize/2., 0)
-    
+
     def addTick(self, x, color=None, movable=True):
         ## public
         """
         Add a tick to the item.
-        
+
         ==============  ==================================================================
         **Arguments:**
         x               Position where tick should be added.
@@ -147,15 +147,15 @@ class TickSliderItem(GraphicsWidget):
                         white.
         movable         Specifies whether the tick is movable with the mouse.
         ==============  ==================================================================
-        """        
-        
+        """
+
         if color is None:
             color = QtGui.QColor(255,255,255)
         tick = Tick(self, [x*self.length, 0], color, movable, self.tickSize, pen=self.tickPen)
         self.ticks[tick] = x
         tick.setParentItem(self)
         return tick
-    
+
     def removeTick(self, tick):
         ## public
         """
@@ -165,7 +165,7 @@ class TickSliderItem(GraphicsWidget):
         tick.setParentItem(None)
         if self.scene() is not None:
             self.scene().removeItem(tick)
-    
+
     def tickMoved(self, tick, pos):
         #print "tick changed"
         ## Correct position of tick if it has left bounds.
@@ -173,20 +173,20 @@ class TickSliderItem(GraphicsWidget):
         pos.setX(newX)
         tick.setPos(pos)
         self.ticks[tick] = float(newX) / self.length
-    
+
     def tickMoveFinished(self, tick):
         pass
-    
+
     def tickClicked(self, tick, ev):
         if ev.button() == QtCore.Qt.RightButton:
             self.removeTick(tick)
-    
+
     def widgetLength(self):
         if self.orientation in ['bottom', 'top']:
             return self.width()
         else:
             return self.height()
-    
+
     def resizeEvent(self, ev):
         wlen = max(40, self.widgetLength())
         self.setLength(wlen-self.tickSize-2)
@@ -196,13 +196,13 @@ class TickSliderItem(GraphicsWidget):
         #bounds.setRight(max(self.length + self.tickSize, bounds.right()))
         #self.setSceneRect(bounds)
         #self.fitInView(bounds, QtCore.Qt.KeepAspectRatio)
-        
+
     def setLength(self, newLen):
         #private
         for t, x in list(self.ticks.items()):
             t.setPos(x * newLen + 1, t.pos().y())
         self.length = float(newLen)
-        
+
     #def mousePressEvent(self, ev):
         #QtGui.QGraphicsView.mousePressEvent(self, ev)
         #self.ignoreRelease = False
@@ -212,14 +212,14 @@ class TickSliderItem(GraphicsWidget):
                 #break
         ##if len(self.items(ev.pos())) > 0:  ## Let items handle their own clicks
             ##self.ignoreRelease = True
-        
+
     #def mouseReleaseEvent(self, ev):
         #QtGui.QGraphicsView.mouseReleaseEvent(self, ev)
         #if self.ignoreRelease:
             #return
-            
+
         #pos = self.mapToScene(ev.pos())
-            
+
         #if ev.button() == QtCore.Qt.LeftButton and self.allowAdd:
             #if pos.x() < 0 or pos.x() > self.length:
                 #return
@@ -229,7 +229,7 @@ class TickSliderItem(GraphicsWidget):
             #self.addTick(pos.x()/self.length)
         #elif ev.button() == QtCore.Qt.RightButton:
             #self.showMenu(ev)
-            
+
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.LeftButton and self.allowAdd:
             pos = ev.pos()
@@ -262,13 +262,13 @@ class TickSliderItem(GraphicsWidget):
         #else:
             #self.currentPen = self.pen
         #self.update()
-        
+
     def showMenu(self, ev):
         pass
 
     def setTickColor(self, tick, color):
         """Set the color of the specified tick.
-        
+
         ==============  ==================================================================
         **Arguments:**
         tick            Can be either an integer corresponding to the index of the tick
@@ -287,7 +287,7 @@ class TickSliderItem(GraphicsWidget):
         ## public
         """
         Set the position (along the slider) of the tick.
-        
+
         ==============   ==================================================================
         **Arguments:**
         tick             Can be either an integer corresponding to the index of the tick
@@ -305,11 +305,11 @@ class TickSliderItem(GraphicsWidget):
         tick.setPos(pos)
         self.ticks[tick] = val
         self.updateGradient()
-        
+
     def tickValue(self, tick):
         ## public
         """Return the value (from 0.0 to 1.0) of the specified tick.
-        
+
         ==============  ==================================================================
         **Arguments:**
         tick            Can be either an integer corresponding to the index of the tick
@@ -319,11 +319,11 @@ class TickSliderItem(GraphicsWidget):
         """
         tick = self.getTick(tick)
         return self.ticks[tick]
-        
+
     def getTick(self, tick):
         ## public
         """Return the Tick object at the specified index.
-        
+
         ==============  ==================================================================
         **Arguments:**
         tick            An integer corresponding to the index of the desired tick. If the
@@ -348,29 +348,29 @@ class TickSliderItem(GraphicsWidget):
 class GradientEditorItem(TickSliderItem):
     """
     **Bases:** :class:`TickSliderItem <pyqtgraph.TickSliderItem>`
-    
-    An item that can be used to define a color gradient. Implements common pre-defined gradients that are 
+
+    An item that can be used to define a color gradient. Implements common pre-defined gradients that are
     customizable by the user. :class: `GradientWidget <pyqtgraph.GradientWidget>` provides a widget
-    with a GradientEditorItem that can be added to a GUI. 
-    
+    with a GradientEditorItem that can be added to a GUI.
+
     ================================ ===========================================================
     **Signals:**
-    sigGradientChanged(self)         Signal is emitted anytime the gradient changes. The signal 
-                                     is emitted in real time while ticks are being dragged or 
+    sigGradientChanged(self)         Signal is emitted anytime the gradient changes. The signal
+                                     is emitted in real time while ticks are being dragged or
                                      colors are being changed.
     sigGradientChangeFinished(self)  Signal is emitted when the gradient is finished changing.
-    ================================ ===========================================================    
- 
+    ================================ ===========================================================
+
     """
-    
+
     sigGradientChanged = QtCore.Signal(object)
     sigGradientChangeFinished = QtCore.Signal(object)
-    
+
     def __init__(self, *args, **kargs):
         """
-        Create a new GradientEditorItem. 
+        Create a new GradientEditorItem.
         All arguments are passed to :func:`TickSliderItem.__init__ <pyqtgraph.TickSliderItem.__init__>`
-        
+
         ===============  =================================================================================
         **Arguments:**
         orientation      Set the orientation of the gradient. Options are: 'left', 'right'
@@ -387,31 +387,31 @@ class GradientEditorItem(TickSliderItem):
         self.backgroundRect = QtGui.QGraphicsRectItem(QtCore.QRectF(0, -self.rectSize, 100, self.rectSize))
         self.backgroundRect.setBrush(QtGui.QBrush(QtCore.Qt.DiagCrossPattern))
         self.colorMode = 'rgb'
-        
+
         TickSliderItem.__init__(self, *args, **kargs)
-        
+
         self.colorDialog = QtGui.QColorDialog()
         self.colorDialog.setOption(QtGui.QColorDialog.ShowAlphaChannel, True)
         self.colorDialog.setOption(QtGui.QColorDialog.DontUseNativeDialog, True)
-        
+
         self.colorDialog.currentColorChanged.connect(self.currentColorChanged)
         self.colorDialog.rejected.connect(self.currentColorRejected)
         self.colorDialog.accepted.connect(self.currentColorAccepted)
-        
+
         self.backgroundRect.setParentItem(self)
         self.gradRect.setParentItem(self)
-        
+
         self.setMaxDim(self.rectSize + self.tickSize)
-        
+
         self.rgbAction = QtGui.QAction('RGB', self)
         self.rgbAction.setCheckable(True)
         self.rgbAction.triggered.connect(lambda: self.setColorMode('rgb'))
         self.hsvAction = QtGui.QAction('HSV', self)
         self.hsvAction.setCheckable(True)
         self.hsvAction.triggered.connect(lambda: self.setColorMode('hsv'))
-            
+
         self.menu = QtGui.QMenu()
-        
+
         ## build context menu of gradients
         l = self.length
         self.length = 100
@@ -436,20 +436,20 @@ class GradientEditorItem(TickSliderItem):
         self.menu.addSeparator()
         self.menu.addAction(self.rgbAction)
         self.menu.addAction(self.hsvAction)
-        
-        
+
+
         for t in list(self.ticks.keys()):
             self.removeTick(t)
         self.addTick(0, QtGui.QColor(0,0,0), True)
         self.addTick(1, QtGui.QColor(255,0,0), True)
         self.setColorMode('rgb')
         self.updateGradient()
-    
+
     def setOrientation(self, orientation):
         ## public
         """
-        Set the orientation of the GradientEditorItem. 
-        
+        Set the orientation of the GradientEditorItem.
+
         ==============  ===================================================================
         **Arguments:**
         orientation     Options are: 'left', 'right', 'top', 'bottom'
@@ -460,35 +460,35 @@ class GradientEditorItem(TickSliderItem):
         """
         TickSliderItem.setOrientation(self, orientation)
         self.translate(0, self.rectSize)
-    
+
     def showMenu(self, ev):
         #private
         self.menu.popup(ev.screenPos().toQPoint())
-    
+
     def contextMenuClicked(self, b=None):
         #private
         #global Gradients
         act = self.sender()
         self.loadPreset(act.name)
-        
+
     def loadPreset(self, name):
         """
-        Load a predefined gradient. 
-    
+        Load a predefined gradient.
+
         """ ## TODO: provide image with names of defined gradients
         #global Gradients
         self.restoreState(Gradients[name])
-    
+
     def setColorMode(self, cm):
         """
         Set the color mode for the gradient. Options are: 'hsv', 'rgb'
-        
+
         """
-        
+
         ## public
         if cm not in ['rgb', 'hsv']:
             raise Exception("Unknown color mode %s. Options are 'rgb' and 'hsv'." % str(cm))
-        
+
         try:
             self.rgbAction.blockSignals(True)
             self.hsvAction.blockSignals(True)
@@ -499,7 +499,7 @@ class GradientEditorItem(TickSliderItem):
             self.hsvAction.blockSignals(False)
         self.colorMode = cm
         self.updateGradient()
-        
+
     def colorMap(self):
         """Return a ColorMap object representing the current state of the editor."""
         if self.colorMode == 'hsv':
@@ -511,41 +511,41 @@ class GradientEditorItem(TickSliderItem):
             c = t.color
             color.append([c.red(), c.green(), c.blue(), c.alpha()])
         return ColorMap(np.array(pos), np.array(color, dtype=np.ubyte))
-        
+
     def updateGradient(self):
         #private
         self.gradient = self.getGradient()
         self.gradRect.setBrush(QtGui.QBrush(self.gradient))
         self.sigGradientChanged.emit(self)
-        
+
     def setLength(self, newLen):
         #private (but maybe public)
         TickSliderItem.setLength(self, newLen)
         self.backgroundRect.setRect(1, -self.rectSize, newLen, self.rectSize)
         self.gradRect.setRect(1, -self.rectSize, newLen, self.rectSize)
         self.updateGradient()
-        
+
     def currentColorChanged(self, color):
         #private
         if color.isValid() and self.currentTick is not None:
             self.setTickColor(self.currentTick, color)
             self.updateGradient()
-            
+
     def currentColorRejected(self):
         #private
         self.setTickColor(self.currentTick, self.currentTickColor)
         self.updateGradient()
-        
+
     def currentColorAccepted(self):
         self.sigGradientChangeFinished.emit(self)
-        
+
     def tickClicked(self, tick, ev):
         #private
         if ev.button() == QtCore.Qt.LeftButton:
             self.raiseColorDialog(tick)
         elif ev.button() == QtCore.Qt.RightButton:
             self.raiseTickContextMenu(tick, ev)
-            
+
     def raiseColorDialog(self, tick):
         if not tick.colorChangeAllowed:
             return
@@ -553,11 +553,11 @@ class GradientEditorItem(TickSliderItem):
         self.currentTickColor = tick.color
         self.colorDialog.setCurrentColor(tick.color)
         self.colorDialog.open()
-        
+
     def raiseTickContextMenu(self, tick, ev):
         self.tickMenu = TickMenu(tick, self)
         self.tickMenu.popup(ev.screenPos().toQPoint())
-    
+
     def tickMoved(self, tick, pos):
         #private
         TickSliderItem.tickMoved(self, tick, pos)
@@ -565,7 +565,7 @@ class GradientEditorItem(TickSliderItem):
 
     def tickMoveFinished(self, tick):
         self.sigGradientChangeFinished.emit(self)
-    
+
 
     def getGradient(self):
         """Return a QLinearGradient object."""
@@ -587,11 +587,11 @@ class GradientEditorItem(TickSliderItem):
                 stops.append((x2, self.getColor(x2)))
             g.setStops(stops)
         return g
-        
+
     def getColor(self, x, toQColor=True):
         """
         Return a color for a given value.
-        
+
         ==============  ==================================================================
         **Arguments:**
         x               Value (position on gradient) of requested color.
@@ -611,14 +611,14 @@ class GradientEditorItem(TickSliderItem):
                 return QtGui.QColor(c)  # always copy colors before handing them out
             else:
                 return (c.red(), c.green(), c.blue(), c.alpha())
-            
+
         x2 = ticks[0][1]
         for i in range(1,len(ticks)):
             x1 = x2
             x2 = ticks[i][1]
             if x1 <= x and x2 >= x:
                 break
-                
+
         dx = (x2-x1)
         if dx == 0:
             f = 0.
@@ -647,11 +647,11 @@ class GradientEditorItem(TickSliderItem):
                 return c
             else:
                 return (c.red(), c.green(), c.blue(), c.alpha())
-                    
+
     def getLookupTable(self, nPts, alpha=None):
         """
-        Return an RGB(A) lookup table (ndarray). 
-        
+        Return an RGB(A) lookup table (ndarray).
+
         ==============  ============================================================================
         **Arguments:**
         nPts            The number of points in the returned lookup table.
@@ -665,24 +665,24 @@ class GradientEditorItem(TickSliderItem):
             table = np.empty((nPts,4), dtype=np.ubyte)
         else:
             table = np.empty((nPts,3), dtype=np.ubyte)
-            
+
         for i in range(nPts):
             x = float(i)/(nPts-1)
             color = self.getColor(x, toQColor=False)
             table[i] = color[:table.shape[1]]
-            
+
         return table
-    
+
     def usesAlpha(self):
         """Return True if any ticks have an alpha < 255"""
-        
+
         ticks = self.listTicks()
         for t in ticks:
             if t[0].color.alpha() < 255:
                 return True
-            
+
         return False
-            
+
     def isLookupTrivial(self):
         """Return True if the gradient has exactly two stops in it: black at 0.0 and white at 1.0"""
         ticks = self.listTicks()
@@ -701,11 +701,11 @@ class GradientEditorItem(TickSliderItem):
         #private
         TickSliderItem.mouseReleaseEvent(self, ev)
         self.updateGradient()
-        
+
     def addTick(self, x, color=None, movable=True, finish=True):
         """
         Add a tick to the gradient. Return the tick.
-        
+
         ==============  ==================================================================
         **Arguments:**
         x               Position where tick should be added.
@@ -714,14 +714,14 @@ class GradientEditorItem(TickSliderItem):
         movable         Specifies whether the tick is movable with the mouse.
         ==============  ==================================================================
         """
-        
-        
+
+
         if color is None:
             color = self.getColor(x)
         t = TickSliderItem.addTick(self, x, color=color, movable=movable)
         t.colorChangeAllowed = True
         t.removeAllowed = True
-        
+
         if finish:
             self.sigGradientChangeFinished.emit(self)
         return t
@@ -732,12 +732,12 @@ class GradientEditorItem(TickSliderItem):
         if finish:
             self.updateGradient()
             self.sigGradientChangeFinished.emit(self)
-        
-        
+
+
     def saveState(self):
         """
         Return a dictionary with parameters for rebuilding the gradient. Keys will include:
-        
+
            - 'mode': hsv or rgb
            - 'ticks': a list of tuples (pos, (r,g,b,a))
         """
@@ -748,18 +748,18 @@ class GradientEditorItem(TickSliderItem):
             ticks.append((self.ticks[t], (c.red(), c.green(), c.blue(), c.alpha())))
         state = {'mode': self.colorMode, 'ticks': ticks}
         return state
-        
+
     def restoreState(self, state):
         """
         Restore the gradient specified in state.
-        
+
         ==============  ====================================================================
         **Arguments:**
         state           A dictionary with same structure as those returned by
                         :func:`saveState <pyqtgraph.GradientEditorItem.saveState>`
-                      
+
                         Keys must include:
-                      
+
                             - 'mode': hsv or rgb
                             - 'ticks': a list of tuples (pos, (r,g,b,a))
         ==============  ====================================================================
@@ -773,7 +773,7 @@ class GradientEditorItem(TickSliderItem):
             self.addTick(t[0], c, finish=False)
         self.updateGradient()
         self.sigGradientChangeFinished.emit(self)
-        
+
     def setColorMap(self, cm):
         self.setColorMode('rgb')
         for t in list(self.ticks.keys()):
@@ -797,7 +797,7 @@ class Tick(QtGui.QGraphicsWidget):  ## NOTE: Making this a subclass of GraphicsO
 
     sigMoving = QtCore.Signal(object)
     sigMoved = QtCore.Signal(object)
-    
+
     def __init__(self, view, pos, color, movable=True, scale=10, pen='w'):
         self.movable = movable
         self.moving = False
@@ -811,7 +811,7 @@ class Tick(QtGui.QGraphicsWidget):  ## NOTE: Making this a subclass of GraphicsO
         self.pg.lineTo(QtCore.QPointF(-scale/3**0.5, scale))
         self.pg.lineTo(QtCore.QPointF(scale/3**0.5, scale))
         self.pg.closeSubpath()
-        
+
         QtGui.QGraphicsWidget.__init__(self)
         self.setPos(pos[0], pos[1])
         if self.movable:
@@ -821,14 +821,14 @@ class Tick(QtGui.QGraphicsWidget):  ## NOTE: Making this a subclass of GraphicsO
 
     def boundingRect(self):
         return self.pg.boundingRect()
-    
+
     def shape(self):
         return self.pg
 
     def paint(self, p, *args):
         p.setRenderHints(QtGui.QPainter.Antialiasing)
         p.fillPath(self.pg, fn.mkBrush(self.color))
-        
+
         p.setPen(self.currentPen)
         p.drawPath(self.pg)
 
@@ -840,13 +840,13 @@ class Tick(QtGui.QGraphicsWidget):  ## NOTE: Making this a subclass of GraphicsO
                 self.cursorOffset = self.pos() - self.mapToParent(ev.buttonDownPos())
                 self.startPosition = self.pos()
             ev.accept()
-            
+
             if not self.moving:
                 return
-                
+
             newPos = self.cursorOffset + self.mapToParent(ev.pos())
             newPos.setY(self.pos().y())
-            
+
             self.setPos(newPos)
             self.view().tickMoved(self, newPos)
             self.sigMoving.emit(self)
@@ -875,46 +875,46 @@ class Tick(QtGui.QGraphicsWidget):  ## NOTE: Making this a subclass of GraphicsO
         else:
             self.currentPen = self.pen
         self.update()
-        
+
 
 class TickMenu(QtGui.QMenu):
-    
+
     def __init__(self, tick, sliderItem):
         QtGui.QMenu.__init__(self)
-        
+
         self.tick = weakref.ref(tick)
         self.sliderItem = weakref.ref(sliderItem)
-        
+
         self.removeAct = self.addAction("Remove Tick", lambda: self.sliderItem().removeTick(tick))
         if (not self.tick().removeAllowed) or len(self.sliderItem().ticks) < 3:
             self.removeAct.setEnabled(False)
-            
+
         positionMenu = self.addMenu("Set Position")
         w = QtGui.QWidget()
         l = QtGui.QGridLayout()
         w.setLayout(l)
-        
+
         value = sliderItem.tickValue(tick)
         self.fracPosSpin = SpinBox()
         self.fracPosSpin.setOpts(value=value, bounds=(0.0, 1.0), step=0.01, decimals=2)
         #self.dataPosSpin = SpinBox(value=dataVal)
         #self.dataPosSpin.setOpts(decimals=3, siPrefix=True)
-                
+
         l.addWidget(QtGui.QLabel("Position:"), 0,0)
         l.addWidget(self.fracPosSpin, 0, 1)
         #l.addWidget(QtGui.QLabel("Position (data units):"), 1, 0)
         #l.addWidget(self.dataPosSpin, 1,1)
-        
+
         #if self.sliderItem().dataParent is None:
         #    self.dataPosSpin.setEnabled(False)
-        
+
         a = QtGui.QWidgetAction(self)
         a.setDefaultWidget(w)
-        positionMenu.addAction(a)        
-        
+        positionMenu.addAction(a)
+
         self.fracPosSpin.sigValueChanging.connect(self.fractionalValueChanged)
         #self.dataPosSpin.valueChanged.connect(self.dataValueChanged)
-        
+
         colorAct = self.addAction("Set Color", lambda: self.sliderItem().raiseColorDialog(self.tick()))
         if not self.tick().colorChangeAllowed:
             colorAct.setEnabled(False)
@@ -925,10 +925,9 @@ class TickMenu(QtGui.QMenu):
         #    self.dataPosSpin.blockSignals(True)
         #    self.dataPosSpin.setValue(self.sliderItem().tickDataValue(self.tick()))
         #    self.dataPosSpin.blockSignals(False)
-            
+
     #def dataValueChanged(self, val):
     #    self.sliderItem().setTickValue(self.tick(), val, dataUnits=True)
     #    self.fracPosSpin.blockSignals(True)
     #    self.fracPosSpin.setValue(self.sliderItem().tickValue(self.tick()))
     #    self.fracPosSpin.blockSignals(False)
-

--- a/pyqtgraph/graphicsItems/GradientLegend.py
+++ b/pyqtgraph/graphicsItems/GradientLegend.py
@@ -6,10 +6,10 @@ __all__ = ['GradientLegend']
 
 class GradientLegend(UIGraphicsItem):
     """
-    Draws a color gradient rectangle along with text labels denoting the value at specific 
+    Draws a color gradient rectangle along with text labels denoting the value at specific
     points along the gradient.
     """
-    
+
     def __init__(self, size, offset):
         self.size = size
         self.offset = offset
@@ -21,11 +21,11 @@ class GradientLegend(UIGraphicsItem):
         self.gradient = QtGui.QLinearGradient()
         self.gradient.setColorAt(0, QtGui.QColor(0,0,0))
         self.gradient.setColorAt(1, QtGui.QColor(255,0,0))
-        
+
     def setGradient(self, g):
         self.gradient = g
         self.update()
-        
+
     def setIntColorScale(self, minVal, maxVal, *args, **kargs):
         colors = [fn.intColor(i, maxVal-minVal, *args, **kargs) for i in range(minVal, maxVal)]
         g = QtGui.QLinearGradient()
@@ -37,19 +37,19 @@ class GradientLegend(UIGraphicsItem):
             self.setLabels({str(minVal/10.): 0, str(maxVal): 1})
         else:
             self.setLabels({kargs['labels'][0]:0, kargs['labels'][1]:1})
-        
+
     def setLabels(self, l):
         """Defines labels to appear next to the color scale. Accepts a dict of {text: value} pairs"""
         self.labels = l
         self.update()
-        
+
     def paint(self, p, opt, widget):
         UIGraphicsItem.paint(self, p, opt, widget)
         rect = self.boundingRect()   ## Boundaries of visible area in scene coords.
         unit = self.pixelSize()       ## Size of one view pixel in scene coords.
-        if unit[0] is None:  
+        if unit[0] is None:
             return
-        
+
         ## determine max width of all labels
         labelWidth = 0
         labelHeight = 0
@@ -57,12 +57,12 @@ class GradientLegend(UIGraphicsItem):
             b = p.boundingRect(QtCore.QRectF(0, 0, 0, 0), QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter, str(k))
             labelWidth = max(labelWidth, b.width())
             labelHeight = max(labelHeight, b.height())
-            
+
         labelWidth *= unit[0]
         labelHeight *= unit[1]
-        
+
         textPadding = 2  # in px
-        
+
         if self.offset[0] < 0:
             x3 = rect.right() + unit[0] * self.offset[0]
             x2 = x3 - labelWidth - unit[0]*textPadding*2
@@ -78,31 +78,31 @@ class GradientLegend(UIGraphicsItem):
             y1 = rect.bottom() - unit[1] * self.offset[1]
             y2 = y1 - unit[1] * self.size[1]
         self.b = [x1,x2,x3,y1,y2,labelWidth]
-            
+
         ## Draw background
         p.setPen(self.pen)
         p.setBrush(QtGui.QBrush(QtGui.QColor(255,255,255,100)))
         rect = QtCore.QRectF(
-            QtCore.QPointF(x1 - unit[0]*textPadding, y1 + labelHeight/2 + unit[1]*textPadding), 
+            QtCore.QPointF(x1 - unit[0]*textPadding, y1 + labelHeight/2 + unit[1]*textPadding),
             QtCore.QPointF(x3, y2 - labelHeight/2 - unit[1]*textPadding)
         )
         p.drawRect(rect)
-        
-        
+
+
         ## Have to scale painter so that text and gradients are correct size. Bleh.
         p.scale(unit[0], unit[1])
-        
+
         ## Draw color bar
         self.gradient.setStart(0, y1/unit[1])
         self.gradient.setFinalStop(0, y2/unit[1])
         p.setBrush(self.gradient)
         rect = QtCore.QRectF(
-            QtCore.QPointF(x1/unit[0], y1/unit[1]), 
+            QtCore.QPointF(x1/unit[0], y1/unit[1]),
             QtCore.QPointF(x2/unit[0], y2/unit[1])
         )
         p.drawRect(rect)
-        
-        
+
+
         ## draw labels
         p.setPen(QtGui.QPen(QtGui.QColor(0,0,0)))
         tx = x2 + unit[0]*textPadding
@@ -110,5 +110,3 @@ class GradientLegend(UIGraphicsItem):
         for k in self.labels:
             y = y1 + self.labels[k] * (y2-y1)
             p.drawText(QtCore.QRectF(tx/unit[0], y/unit[1] - lh/2.0, 1000, lh), QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter, str(k))
-        
-        

--- a/pyqtgraph/graphicsItems/GraphItem.py
+++ b/pyqtgraph/graphicsItems/GraphItem.py
@@ -10,7 +10,7 @@ __all__ = ['GraphItem']
 
 class GraphItem(GraphicsObject):
     """A GraphItem displays graph information as
-    a set of nodes connected by lines (as in 'graph theory', not 'graphics'). 
+    a set of nodes connected by lines (as in 'graph theory', not 'graphics').
     Useful for drawing networks, trees, etc.
     """
 
@@ -23,11 +23,11 @@ class GraphItem(GraphicsObject):
         self.picture = None
         self.pen = 'default'
         self.setData(**kwds)
-        
+
     def setData(self, **kwds):
         """
-        Change the data displayed by the graph. 
-        
+        Change the data displayed by the graph.
+
         ==============  =======================================================================
         **Arguments:**
         pos             (N,2) array of the positions of each node in the graph.
@@ -35,7 +35,7 @@ class GraphItem(GraphicsObject):
                         of two nodes that are connected.
         pen             The pen to use when drawing lines between connected
                         nodes. May be one of:
-                     
+
                         * QPen
                         * a single argument to pass to pg.mkPen
                         * a record array of length M
@@ -44,7 +44,7 @@ class GraphItem(GraphicsObject):
                           cost.
                         * None (to disable connection drawing)
                         * 'default' to use the default foreground color.
-                     
+
         symbolPen       The pen(s) used for drawing nodes.
         symbolBrush     The brush(es) used for drawing nodes.
         ``**opts``      All other keyword arguments are given to
@@ -64,10 +64,10 @@ class GraphItem(GraphicsObject):
         if 'pen' in kwds:
             self.setPen(kwds.pop('pen'))
             self._update()
-            
-        if 'symbolPen' in kwds:    
+
+        if 'symbolPen' in kwds:
             kwds['pen'] = kwds.pop('symbolPen')
-        if 'symbolBrush' in kwds:    
+        if 'symbolBrush' in kwds:
             kwds['brush'] = kwds.pop('symbolBrush')
         self.scatter.setData(**kwds)
         self.informViewBoundsChanged()
@@ -80,11 +80,11 @@ class GraphItem(GraphicsObject):
     def setPen(self, *args, **kwargs):
         """
         Set the pen used to draw graph lines.
-        May be: 
-        
+        May be:
+
         * None to disable line drawing
         * Record array with fields (red, green, blue, alpha, width)
-        * Any set of arguments and keyword arguments accepted by 
+        * Any set of arguments and keyword arguments accepted by
           :func:`mkPen <pyqtgraph.mkPen>`.
         * 'default' to use the default foreground color.
         """
@@ -99,7 +99,7 @@ class GraphItem(GraphicsObject):
         self.picture = QtGui.QPicture()
         if self.pen is None or self.pos is None or self.adjacency is None:
             return
-        
+
         p = QtGui.QPainter(self.picture)
         try:
             pts = self.pos[self.adjacency]
@@ -111,7 +111,7 @@ class GraphItem(GraphicsObject):
                     if np.any(pen != lastPen):
                         lastPen = pen
                         if pen.dtype.fields is None:
-                            p.setPen(fn.mkPen(color=(pen[0], pen[1], pen[2], pen[3]), width=1))                            
+                            p.setPen(fn.mkPen(color=(pen[0], pen[1], pen[2], pen[3]), width=1))
                         else:
                             p.setPen(fn.mkPen(color=(pen['red'], pen['green'], pen['blue'], pen['alpha']), width=pen['width']))
                     p.drawLine(QtCore.QPointF(*pts[i][0]), QtCore.QPointF(*pts[i][1]))
@@ -131,17 +131,12 @@ class GraphItem(GraphicsObject):
         if getConfigOption('antialias') is True:
             p.setRenderHint(p.Antialiasing)
         self.picture.play(p)
-        
+
     def boundingRect(self):
         return self.scatter.boundingRect()
-        
+
     def dataBounds(self, *args, **kwds):
         return self.scatter.dataBounds(*args, **kwds)
-    
+
     def pixelPadding(self):
         return self.scatter.pixelPadding()
-        
-        
-        
-        
-

--- a/pyqtgraph/graphicsItems/GraphicsLayout.py
+++ b/pyqtgraph/graphicsItems/GraphicsLayout.py
@@ -26,7 +26,7 @@ class GraphicsLayout(GraphicsWidget):
         self.currentRow = 0
         self.currentCol = 0
         self.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding))
-    
+
     #def resizeEvent(self, ev):
         #ret = GraphicsWidget.resizeEvent(self, ev)
         #print self.pos(), self.mapToDevice(self.rect().topLeft())
@@ -35,29 +35,29 @@ class GraphicsLayout(GraphicsWidget):
     def setBorder(self, *args, **kwds):
         """
         Set the pen used to draw border between cells.
-        
-        See :func:`mkPen <pyqtgraph.mkPen>` for arguments.        
+
+        See :func:`mkPen <pyqtgraph.mkPen>` for arguments.
         """
         self.border = fn.mkPen(*args, **kwds)
         self.update()
-    
+
     def nextRow(self):
         """Advance to next row for automatic item placement"""
         self.currentRow += 1
         self.currentCol = -1
         self.nextColumn()
-        
+
     def nextColumn(self):
         """Advance to next available column
         (generally only for internal use--called by addItem)"""
         self.currentCol += 1
         while self.getItem(self.currentRow, self.currentCol) is not None:
             self.currentCol += 1
-        
+
     def nextCol(self, *args, **kargs):
         """Alias of nextColumn"""
         return self.nextColumn(*args, **kargs)
-        
+
     def addPlot(self, row=None, col=None, rowspan=1, colspan=1, **kargs):
         """
         Create a PlotItem and place it in the next available cell (or in the cell specified)
@@ -67,7 +67,7 @@ class GraphicsLayout(GraphicsWidget):
         plot = PlotItem(**kargs)
         self.addItem(plot, row, col, rowspan, colspan)
         return plot
-        
+
     def addViewBox(self, row=None, col=None, rowspan=1, colspan=1, **kargs):
         """
         Create a ViewBox and place it in the next available cell (or in the cell specified)
@@ -77,19 +77,19 @@ class GraphicsLayout(GraphicsWidget):
         vb = ViewBox(**kargs)
         self.addItem(vb, row, col, rowspan, colspan)
         return vb
-        
+
     def addLabel(self, text=' ', row=None, col=None, rowspan=1, colspan=1, **kargs):
         """
         Create a LabelItem with *text* and place it in the next available cell (or in the cell specified)
         All extra keyword arguments are passed to :func:`LabelItem.__init__ <pyqtgraph.LabelItem.__init__>`
         Returns the created item.
-        
+
         To create a vertical label, use *angle* = -90.
         """
         text = LabelItem(text, **kargs)
         self.addItem(text, row, col, rowspan, colspan)
         return text
-        
+
     def addLayout(self, row=None, col=None, rowspan=1, colspan=1, **kargs):
         """
         Create an empty GraphicsLayout and place it in the next available cell (or in the cell specified)
@@ -99,7 +99,7 @@ class GraphicsLayout(GraphicsWidget):
         layout = GraphicsLayout(**kargs)
         self.addItem(layout, row, col, rowspan, colspan)
         return layout
-        
+
     def addItem(self, item, row=None, col=None, rowspan=1, colspan=1):
         """
         Add an item to the layout and place it in the next available cell (or in the cell specified).
@@ -109,7 +109,7 @@ class GraphicsLayout(GraphicsWidget):
             row = self.currentRow
         if col is None:
             col = self.currentCol
-            
+
         self.items[item] = []
         for i in range(rowspan):
             for j in range(colspan):
@@ -119,7 +119,7 @@ class GraphicsLayout(GraphicsWidget):
                     self.rows[row2] = {}
                 self.rows[row2][col2] = item
                 self.items[item].append((row2, col2))
-        
+
         self.layout.addItem(item, row, col, rowspan, colspan)
         self.nextColumn()
 
@@ -129,7 +129,7 @@ class GraphicsLayout(GraphicsWidget):
 
     def boundingRect(self):
         return self.rect()
-        
+
     def paint(self, p, *args):
         if self.border is None:
             return
@@ -137,24 +137,24 @@ class GraphicsLayout(GraphicsWidget):
         for i in self.items:
             r = i.mapRectToParent(i.boundingRect())
             p.drawRect(r)
-    
+
     def itemIndex(self, item):
         for i in range(self.layout.count()):
             if self.layout.itemAt(i).graphicsItem() is item:
                 return i
         raise Exception("Could not determine index of item " + str(item))
-    
+
     def removeItem(self, item):
         """Remove *item* from the layout."""
         ind = self.itemIndex(item)
         self.layout.removeAt(ind)
         self.scene().removeItem(item)
-        
+
         for r,c in self.items[item]:
             del self.rows[r][c]
         del self.items[item]
         self.update()
-    
+
     def clear(self):
         items = []
         for i in list(self.items.keys()):
@@ -168,4 +168,3 @@ class GraphicsLayout(GraphicsWidget):
 
     def setSpacing(self, *args):
         self.layout.setSpacing(*args)
-    

--- a/pyqtgraph/graphicsItems/GraphicsObject.py
+++ b/pyqtgraph/graphicsItems/GraphicsObject.py
@@ -16,7 +16,7 @@ class GraphicsObject(GraphicsItem, QtGui.QGraphicsObject):
         QtGui.QGraphicsObject.__init__(self, *args)
         self.setFlag(self.ItemSendsGeometryChanges)
         GraphicsItem.__init__(self)
-        
+
     def itemChange(self, change, value):
         ret = QtGui.QGraphicsObject.itemChange(self, change, value)
         if change in [self.ItemParentHasChanged, self.ItemSceneHasChanged]:
@@ -30,7 +30,7 @@ class GraphicsObject(GraphicsItem, QtGui.QGraphicsObject):
         else:
             if inform_view_on_change and change in [self.ItemPositionHasChanged, self.ItemTransformHasChanged]:
                 self.informViewBoundsChanged()
-            
+
         ## workaround for pyqt bug:
         ## http://www.riverbankcomputing.com/pipermail/pyqt/2012-August/031818.html
         if not USE_PYSIDE and change == self.ItemParentChange and isinstance(ret, QtGui.QGraphicsItem):

--- a/pyqtgraph/graphicsItems/GraphicsWidget.py
+++ b/pyqtgraph/graphicsItems/GraphicsWidget.py
@@ -1,22 +1,22 @@
-from ..Qt import QtGui, QtCore  
+from ..Qt import QtGui, QtCore
 from ..GraphicsScene import GraphicsScene
 from .GraphicsItem import GraphicsItem
 
 __all__ = ['GraphicsWidget']
 
 class GraphicsWidget(GraphicsItem, QtGui.QGraphicsWidget):
-    
+
     _qtBaseClass = QtGui.QGraphicsWidget
     def __init__(self, *args, **kargs):
         """
         **Bases:** :class:`GraphicsItem <pyqtgraph.GraphicsItem>`, :class:`QtGui.QGraphicsWidget`
-        
-        Extends QGraphicsWidget with several helpful methods and workarounds for PyQt bugs. 
+
+        Extends QGraphicsWidget with several helpful methods and workarounds for PyQt bugs.
         Most of the extra functionality is inherited from :class:`GraphicsItem <pyqtgraph.GraphicsItem>`.
         """
         QtGui.QGraphicsWidget.__init__(self, *args, **kargs)
         GraphicsItem.__init__(self)
-        
+
         ## done by GraphicsItem init
         #GraphicsScene.registerObject(self)  ## workaround for pyqt bug in graphicsscene.items()
 
@@ -38,10 +38,10 @@ class GraphicsWidget(GraphicsItem, QtGui.QGraphicsWidget):
     def setFixedWidth(self, h):
         self.setMaximumWidth(h)
         self.setMinimumWidth(h)
-        
+
     def height(self):
         return self.geometry().height()
-    
+
     def width(self):
         return self.geometry().width()
 
@@ -49,11 +49,9 @@ class GraphicsWidget(GraphicsItem, QtGui.QGraphicsWidget):
         br = self.mapRectFromParent(self.geometry()).normalized()
         #print "bounds:", br
         return br
-        
+
     def shape(self):  ## No idea why this is necessary, but rotated items do not receive clicks otherwise.
         p = QtGui.QPainterPath()
         p.addRect(self.boundingRect())
         #print "shape:", p.boundingRect()
         return p
-
-

--- a/pyqtgraph/graphicsItems/GraphicsWidgetAnchor.py
+++ b/pyqtgraph/graphicsItems/GraphicsWidgetAnchor.py
@@ -5,8 +5,8 @@ from ..Point import Point
 class GraphicsWidgetAnchor(object):
     """
     Class used to allow GraphicsWidgets to anchor to a specific position on their
-    parent. The item will be automatically repositioned if the parent is resized. 
-    This is used, for example, to anchor a LegendItem to a corner of its parent 
+    parent. The item will be automatically repositioned if the parent is resized.
+    This is used, for example, to anchor a LegendItem to a corner of its parent
     PlotItem.
 
     """
@@ -24,43 +24,43 @@ class GraphicsWidgetAnchor(object):
         Anchors the item at its local itemPos to the item's parent at parentPos.
         Both positions are expressed in values relative to the size of the item or parent;
         a value of 0 indicates left or top edge, while 1 indicates right or bottom edge.
-        
-        Optionally, offset may be specified to introduce an absolute offset. 
-        
+
+        Optionally, offset may be specified to introduce an absolute offset.
+
         Example: anchor a box such that its upper-right corner is fixed 10px left
         and 10px down from its parent's upper-right corner::
-        
+
             box.anchor(itemPos=(1,0), parentPos=(1,0), offset=(-10,10))
         """
         parent = self.parentItem()
         if parent is None:
             raise Exception("Cannot anchor; parent is not set.")
-        
+
         if self.__parent is not parent:
             if self.__parent is not None:
                 self.__parent.geometryChanged.disconnect(self.__geometryChanged)
-                
+
             self.__parent = parent
             parent.geometryChanged.connect(self.__geometryChanged)
-        
+
         self.__itemAnchor = itemPos
         self.__parentAnchor = parentPos
         self.__offset = offset
         self.__geometryChanged()
-    
+
 
     def autoAnchor(self, pos, relative=True):
         """
-        Set the position of this item relative to its parent by automatically 
+        Set the position of this item relative to its parent by automatically
         choosing appropriate anchor settings.
-        
-        If relative is True, one corner of the item will be anchored to 
+
+        If relative is True, one corner of the item will be anchored to
         the appropriate location on the parent with no offset. The anchored
         corner will be whichever is closest to the parent's boundary.
-        
+
         If relative is False, one corner of the item will be anchored to the same
         corner of the parent, with an absolute offset to achieve the correct
-        position. 
+        position.
         """
         pos = Point(pos)
         br = self.mapRectToParent(self.boundingRect()).translated(pos - self.pos())
@@ -85,20 +85,20 @@ class GraphicsWidgetAnchor(object):
             anchorPos[1] = 1
             parentPos[1] = pbr.bottom()
             itemPos[1] = br.bottom()
-        
+
         if relative:
             relPos = [(itemPos[0]-pbr.left()) / pbr.width(), (itemPos[1]-pbr.top()) / pbr.height()]
             self.anchor(anchorPos, relPos)
         else:
             offset = itemPos - parentPos
             self.anchor(anchorPos, anchorPos, offset)
-    
+
     def __geometryChanged(self):
         if self.__parent is None:
             return
         if self.__itemAnchor is None:
             return
-            
+
         o = self.mapToParent(Point(0,0))
         a = self.boundingRect().bottomRight() * Point(self.__itemAnchor)
         a = self.mapToParent(a)
@@ -106,5 +106,3 @@ class GraphicsWidgetAnchor(object):
         off = Point(self.__offset)
         pos = p + (o-a) + off
         self.setPos(pos)
-        
-        

--- a/pyqtgraph/graphicsItems/GridItem.py
+++ b/pyqtgraph/graphicsItems/GridItem.py
@@ -8,26 +8,26 @@ __all__ = ['GridItem']
 class GridItem(UIGraphicsItem):
     """
     **Bases:** :class:`UIGraphicsItem <pyqtgraph.UIGraphicsItem>`
-    
+
     Displays a rectangular grid of lines indicating major divisions within a coordinate system.
     Automatically determines what divisions to use.
     """
-    
+
     def __init__(self):
         UIGraphicsItem.__init__(self)
         #QtGui.QGraphicsItem.__init__(self, *args)
         #self.setFlag(QtGui.QGraphicsItem.ItemClipsToShape)
         #self.setCacheMode(QtGui.QGraphicsItem.DeviceCoordinateCache)
-        
+
         self.picture = None
-        
-        
+
+
     def viewRangeChanged(self):
         UIGraphicsItem.viewRangeChanged(self)
         self.picture = None
         #UIGraphicsItem.viewRangeChanged(self)
         #self.update()
-        
+
     def paint(self, p, opt, widget):
         #p.setPen(QtGui.QPen(QtGui.QColor(100, 100, 100)))
         #p.drawRect(self.boundingRect())
@@ -41,13 +41,13 @@ class GridItem(UIGraphicsItem):
         #p.drawLine(0, -100, 0, 100)
         #p.drawLine(-100, 0, 100, 0)
         #print "drawing Grid."
-        
-        
+
+
     def generatePicture(self):
         self.picture = QtGui.QPicture()
         p = QtGui.QPainter()
         p.begin(self.picture)
-        
+
         dt = fn.invertQTransform(self.viewTransform())
         vr = self.getViewWidget().rect()
         unit = self.pixelWidth(), self.pixelHeight()
@@ -55,9 +55,9 @@ class GridItem(UIGraphicsItem):
         lvr = self.boundingRect()
         ul = np.array([lvr.left(), lvr.top()])
         br = np.array([lvr.right(), lvr.bottom()])
-        
+
         texts = []
-        
+
         if ul[1] > br[1]:
             x = ul[1]
             ul[1] = br[1]
@@ -78,8 +78,8 @@ class GridItem(UIGraphicsItem):
             for ax in range(0,2):  ## Draw grid for both axes
                 ppl = dim[ax] / nl[ax]
                 c = np.clip(3.*(ppl-3), 0., 30.)
-                linePen = QtGui.QPen(QtGui.QColor(255, 255, 255, c)) 
-                textPen = QtGui.QPen(QtGui.QColor(255, 255, 255, c*2)) 
+                linePen = QtGui.QPen(QtGui.QColor(255, 255, 255, c))
+                textPen = QtGui.QPen(QtGui.QColor(255, 255, 255, c*2))
                 #linePen.setCosmetic(True)
                 #linePen.setWidth(1)
                 bx = (ax+1) % 2

--- a/pyqtgraph/graphicsItems/HistogramLUTItem.py
+++ b/pyqtgraph/graphicsItems/HistogramLUTItem.py
@@ -27,15 +27,15 @@ class HistogramLUTItem(GraphicsWidget):
     This is a graphicsWidget which provides controls for adjusting the display of an image.
     Includes:
 
-    - Image histogram 
+    - Image histogram
     - Movable region over histogram to select black/white levels
     - Gradient editor to define color lookup table for single-channel images
     """
-    
+
     sigLookupTableChanged = QtCore.Signal(object)
     sigLevelsChanged = QtCore.Signal(object)
     sigLevelChangeFinished = QtCore.Signal(object)
-    
+
     def __init__(self, image=None, fillHistogram=True):
         """
         If *image* (ImageItem) is provided, then the control will be automatically linked to the image and changes to the control will be immediately reflected in the image's appearance.
@@ -44,7 +44,7 @@ class HistogramLUTItem(GraphicsWidget):
         GraphicsWidget.__init__(self)
         self.lut = None
         self.imageItem = lambda: None  # fake a dead weakref
-        
+
         self.layout = QtGui.QGraphicsGridLayout()
         self.setLayout(self.layout)
         self.layout.setContentsMargins(1,1,1,1)
@@ -66,10 +66,10 @@ class HistogramLUTItem(GraphicsWidget):
         self.range = None
         self.gradient.setFlag(self.gradient.ItemStacksBehindParent)
         self.vb.setFlag(self.gradient.ItemStacksBehindParent)
-        
+
         #self.grid = GridItem()
         #self.vb.addItem(self.grid)
-        
+
         self.gradient.sigGradientChanged.connect(self.gradientChanged)
         self.region.sigRegionChanged.connect(self.regionChanging)
         self.region.sigRegionChangeFinished.connect(self.regionChanged)
@@ -77,24 +77,24 @@ class HistogramLUTItem(GraphicsWidget):
         self.plot = PlotDataItem()
         self.plot.rotate(90)
         self.fillHistogram(fillHistogram)
-            
+
         self.vb.addItem(self.plot)
         self.autoHistogramRange()
-        
+
         if image is not None:
             self.setImageItem(image)
         #self.setSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Expanding)
-        
+
     def fillHistogram(self, fill=True, level=0.0, color=(100, 100, 200)):
         if fill:
             self.plot.setFillLevel(level)
             self.plot.setFillBrush(color)
         else:
             self.plot.setFillLevel(None)
-        
+
     #def sizeHint(self, *args):
         #return QtCore.QSizeF(115, 200)
-        
+
     def paint(self, p, *args):
         pen = self.region.lines[0].pen
         rgn = self.getLevels()
@@ -108,13 +108,13 @@ class HistogramLUTItem(GraphicsWidget):
             p.drawLine(gradRect.topLeft(), gradRect.topRight())
             p.drawLine(gradRect.bottomLeft(), gradRect.bottomRight())
         #p.drawRect(self.boundingRect())
-        
-        
+
+
     def setHistogramRange(self, mn, mx, padding=0.1):
         """Set the Y range on the histogram plot. This disables auto-scaling."""
         self.vb.enableAutoRange(self.vb.YAxis, False)
         self.vb.setYRange(mn, mx, padding)
-        
+
         #d = mx-mn
         #mn -= d*padding
         #mx += d*padding
@@ -122,20 +122,20 @@ class HistogramLUTItem(GraphicsWidget):
         #self.updateRange()
         #self.vb.setMouseEnabled(False, True)
         #self.region.setBounds([mn,mx])
-        
+
     def autoHistogramRange(self):
         """Enable auto-scaling on the histogram plot."""
         self.vb.enableAutoRange(self.vb.XYAxes)
         #self.range = None
         #self.updateRange()
         #self.vb.setMouseEnabled(False, False)
-            
+
     #def updateRange(self):
         #self.vb.autoRange()
         #if self.range is not None:
             #self.vb.setYRange(*self.range)
         #vr = self.vb.viewRect()
-        
+
         #self.region.setBounds([vr.top(), vr.bottom()])
 
     def setImageItem(self, img):
@@ -149,24 +149,24 @@ class HistogramLUTItem(GraphicsWidget):
         self.regionChanged()
         self.imageChanged(autoLevel=True)
         #self.vb.autoRange()
-        
+
     def viewRangeChanged(self):
         self.update()
-    
+
     def gradientChanged(self):
         if self.imageItem() is not None:
             if self.gradient.isLookupTrivial():
                 self.imageItem().setLookupTable(None) #lambda x: x.astype(np.uint8))
             else:
                 self.imageItem().setLookupTable(self.getLookupTable)  ## send function pointer, not the result
-            
+
         self.lut = None
         #if self.imageItem is not None:
             #self.imageItem.setLookupTable(self.gradient.getLookupTable(512))
         self.sigLookupTableChanged.emit(self)
 
     def getLookupTable(self, img=None, n=None, alpha=None):
-        """Return a lookup table from the color gradient defined by this 
+        """Return a lookup table from the color gradient defined by this
         HistogramLUTItem.
         """
         if n is None:
@@ -203,12 +203,12 @@ class HistogramLUTItem(GraphicsWidget):
             mx = h[0][-1]
             self.region.setRegion([mn, mx])
             profiler('set region')
-            
+
     def getLevels(self):
         """Return the min and max levels.
         """
         return self.region.getRegion()
-        
+
     def setLevels(self, mn, mx):
         """Set the min and max levels.
         """

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -14,24 +14,24 @@ __all__ = ['ImageItem']
 class ImageItem(GraphicsObject):
     """
     **Bases:** :class:`GraphicsObject <pyqtgraph.GraphicsObject>`
-    
+
     GraphicsObject displaying an image. Optimized for rapid update (ie video display).
     This item displays either a 2D numpy array (height, width) or
-    a 3D array (height, width, RGBa). This array is optionally scaled (see 
+    a 3D array (height, width, RGBa). This array is optionally scaled (see
     :func:`setLevels <pyqtgraph.ImageItem.setLevels>`) and/or colored
     with a lookup table (see :func:`setLookupTable <pyqtgraph.ImageItem.setLookupTable>`)
     before being displayed.
-    
-    ImageItem is frequently used in conjunction with 
-    :class:`HistogramLUTItem <pyqtgraph.HistogramLUTItem>` or 
+
+    ImageItem is frequently used in conjunction with
+    :class:`HistogramLUTItem <pyqtgraph.HistogramLUTItem>` or
     :class:`HistogramLUTWidget <pyqtgraph.HistogramLUTWidget>` to provide a GUI
     for controlling the levels and lookup table used to display the image.
     """
-    
-    
+
+
     sigImageChanged = QtCore.Signal()
     sigRemoveRequested = QtCore.Signal(object)  # self; emitted when 'remove' is selected from context menu
-    
+
     def __init__(self, image=None, **kargs):
         """
         See :func:`setImage <pyqtgraph.ImageItem.setImage>` for all allowed initialization arguments.
@@ -40,17 +40,17 @@ class ImageItem(GraphicsObject):
         self.menu = None
         self.image = None   ## original image data
         self.qimage = None  ## rendered image for display
-        
+
         self.paintMode = None
-        
+
         self.levels = None  ## [min, max] or [[redMin, redMax], ...]
         self.lut = None
         self.autoDownsample = False
-        
+
         self.drawKernel = None
         self.border = None
         self.removable = False
-        
+
         if image is not None:
             self.setImage(image, **kargs)
         else:
@@ -59,15 +59,15 @@ class ImageItem(GraphicsObject):
     def setCompositionMode(self, mode):
         """Change the composition mode of the item (see QPainter::CompositionMode
         in the Qt documentation). This is useful when overlaying multiple ImageItems.
-        
+
         ============================================  ============================================================
         **Most common arguments:**
         QtGui.QPainter.CompositionMode_SourceOver     Default; image replaces the background if it
                                                       is opaque. Otherwise, it uses the alpha channel to blend
                                                       the image with the background.
-        QtGui.QPainter.CompositionMode_Overlay        The image color is mixed with the background color to 
+        QtGui.QPainter.CompositionMode_Overlay        The image color is mixed with the background color to
                                                       reflect the lightness or darkness of the background.
-        QtGui.QPainter.CompositionMode_Plus           Both the alpha and color of the image and background pixels 
+        QtGui.QPainter.CompositionMode_Plus           Both the alpha and color of the image and background pixels
                                                       are added together.
         QtGui.QPainter.CompositionMode_Multiply       The output is the image color multiplied by the background.
         ============================================  ============================================================
@@ -79,16 +79,16 @@ class ImageItem(GraphicsObject):
     #def setAlpha(self, alpha):
         #self.setOpacity(alpha)
         #self.updateImage()
-        
+
     def setBorder(self, b):
         self.border = fn.mkPen(b)
         self.update()
-        
+
     def width(self):
         if self.image is None:
             return None
         return self.image.shape[0]
-        
+
     def height(self):
         if self.image is None:
             return None
@@ -102,7 +102,7 @@ class ImageItem(GraphicsObject):
     #def setClipLevel(self, level=None):
         #self.clipLevel = level
         #self.updateImage()
-        
+
     #def paint(self, p, opt, widget):
         #pass
         #if self.pixmap is not None:
@@ -112,28 +112,28 @@ class ImageItem(GraphicsObject):
     def setLevels(self, levels, update=True):
         """
         Set image scaling levels. Can be one of:
-        
+
         * [blackLevel, whiteLevel]
         * [[minRed, maxRed], [minGreen, maxGreen], [minBlue, maxBlue]]
-            
+
         Only the first format is compatible with lookup tables. See :func:`makeARGB <pyqtgraph.makeARGB>`
         for more details on how levels are applied.
         """
         self.levels = levels
         if update:
             self.updateImage()
-        
+
     def getLevels(self):
         return self.levels
         #return self.whiteLevel, self.blackLevel
 
     def setLookupTable(self, lut, update=True):
         """
-        Set the lookup table (numpy array) to use for this image. (see 
+        Set the lookup table (numpy array) to use for this image. (see
         :func:`makeARGB <pyqtgraph.makeARGB>` for more information on how this is used).
-        Optionally, lut can be a callable that accepts the current image as an 
+        Optionally, lut can be a callable that accepts the current image as an
         argument and returns the lookup table to use.
-        
+
         Ordinarily, this table is supplied by a :class:`HistogramLUTItem <pyqtgraph.HistogramLUTItem>`
         or :class:`GradientEditorItem <pyqtgraph.GradientEditorItem>`.
         """
@@ -144,7 +144,7 @@ class ImageItem(GraphicsObject):
     def setAutoDownsample(self, ads):
         """
         Set the automatic downsampling mode for this ImageItem.
-        
+
         Added in version 0.9.9
         """
         self.autoDownsample = ads
@@ -152,7 +152,7 @@ class ImageItem(GraphicsObject):
         self.update()
 
     def setOpts(self, update=True, **kargs):
-        
+
         if 'lut' in kargs:
             self.setLookupTable(kargs['lut'], update=update)
         if 'levels' in kargs:
@@ -189,27 +189,27 @@ class ImageItem(GraphicsObject):
         """
         Update the image displayed by this item. For more information on how the image
         is processed before displaying, see :func:`makeARGB <pyqtgraph.makeARGB>`
-        
+
         =================  =========================================================================
         **Arguments:**
-        image              (numpy array) Specifies the image data. May be 2D (width, height) or 
+        image              (numpy array) Specifies the image data. May be 2D (width, height) or
                            3D (width, height, RGBa). The array dtype must be integer or floating
                            point of any bit depth. For 3D arrays, the third dimension must
                            be of length 3 (RGB) or 4 (RGBA).
-        autoLevels         (bool) If True, this forces the image to automatically select 
+        autoLevels         (bool) If True, this forces the image to automatically select
                            levels based on the maximum and minimum values in the data.
                            By default, this argument is true unless the levels argument is
                            given.
         lut                (numpy array) The color lookup table to use when displaying the image.
                            See :func:`setLookupTable <pyqtgraph.ImageItem.setLookupTable>`.
         levels             (min, max) The minimum and maximum values to use when rescaling the image
-                           data. By default, this will be set to the minimum and maximum values 
+                           data. By default, this will be set to the minimum and maximum values
                            in the image. If the image array has dtype uint8, no rescaling is necessary.
         opacity            (float 0.0-1.0)
         compositionMode    see :func:`setCompositionMode <pyqtgraph.ImageItem.setCompositionMode>`
         border             Sets the pen used when drawing the image border. Default is None.
         autoDownsample     (bool) If True, the image is automatically downsampled to match the
-                           screen resolution. This improves performance for large images and 
+                           screen resolution. This improves performance for large images and
                            reduces aliasing.
         =================  =========================================================================
         """
@@ -264,7 +264,7 @@ class ImageItem(GraphicsObject):
 
     def updateImage(self, *args, **kargs):
         ## used for re-rendering qimage from self.image.
-        
+
         ## can we make any assumptions here that speed things up?
         ## dtype, range, size are all the same?
         defaults = {
@@ -275,7 +275,7 @@ class ImageItem(GraphicsObject):
 
     def render(self):
         # Convert data to QImage for display.
-        
+
         profile = debug.Profiler()
         if self.image is None or self.image.size == 0:
             return
@@ -297,7 +297,7 @@ class ImageItem(GraphicsObject):
             image = fn.downsample(image, yds, axis=1)
         else:
             image = self.image
-        
+
         argb, alpha = fn.makeARGB(image.transpose((1, 0, 2)[:image.ndim]), lut=lut, levels=self.levels)
         self.qimage = fn.makeQImage(argb, alpha, transpose=False)
 
@@ -329,19 +329,19 @@ class ImageItem(GraphicsObject):
     def getHistogram(self, bins='auto', step='auto', targetImageSize=200, targetHistogramSize=500, **kwds):
         """Returns x and y arrays containing the histogram values for the current image.
         For an explanation of the return format, see numpy.histogram().
-        
+
         The *step* argument causes pixels to be skipped when computing the histogram to save time.
         If *step* is 'auto', then a step is chosen such that the analyzed data has
         dimensions roughly *targetImageSize* for each axis.
-        
-        The *bins* argument and any extra keyword arguments are passed to 
+
+        The *bins* argument and any extra keyword arguments are passed to
         np.histogram(). If *bins* is 'auto', then a bin number is automatically
         chosen based on the image characteristics:
-        
-        * Integer images will have approximately *targetHistogramSize* bins, 
+
+        * Integer images will have approximately *targetHistogramSize* bins,
           with each bin having an integer width.
         * All other types will have *targetHistogramSize* bins.
-        
+
         This method is also used when automatically computing levels.
         """
         if self.image is None:
@@ -352,7 +352,7 @@ class ImageItem(GraphicsObject):
         if np.isscalar(step):
             step = (step, step)
         stepData = self.image[::step[0], ::step[1]]
-        
+
         if bins == 'auto':
             if stepData.dtype.kind in "ui":
                 mn = stepData.min()
@@ -366,7 +366,7 @@ class ImageItem(GraphicsObject):
 
         kwds['bins'] = bins
         hist = np.histogram(stepData, **kwds)
-        
+
         return hist[1][:-1], hist[0]
 
     def setPxMode(self, b):
@@ -377,7 +377,7 @@ class ImageItem(GraphicsObject):
         (see GraphicsItem::ItemIgnoresTransformations in the Qt documentation)
         """
         self.setFlag(self.ItemIgnoresTransformations, b)
-    
+
     def setScaledMode(self):
         self.setPxMode(False)
 
@@ -387,14 +387,14 @@ class ImageItem(GraphicsObject):
             if self.qimage is None:
                 return None
         return QtGui.QPixmap.fromImage(self.qimage)
-    
+
     def pixelSize(self):
         """return scene-size of a single pixel in the image"""
         br = self.sceneBoundingRect()
         if self.image is None:
             return 1,1
         return br.width()/self.width(), br.height()/self.height()
-    
+
     def viewTransformChanged(self):
         if self.autoDownsample:
             self.qimage = None
@@ -406,12 +406,12 @@ class ImageItem(GraphicsObject):
             #ev.accept()
         #else:
             #ev.ignore()
-        
+
     #def mouseMoveEvent(self, ev):
         ##print "mouse move", ev.pos()
         #if self.drawKernel is not None:
             #self.drawAt(ev.pos(), ev)
-    
+
     #def mouseReleaseEvent(self, ev):
         #pass
 
@@ -450,8 +450,8 @@ class ImageItem(GraphicsObject):
             self.menu.addAction(remAct)
             self.menu.remAct = remAct
         return self.menu
-        
-        
+
+
     def hoverEvent(self, ev):
         if not ev.isExit() and self.drawKernel is not None and ev.acceptDrags(QtCore.Qt.LeftButton):
             ev.acceptClicks(QtCore.Qt.LeftButton) ## we don't use the click, but we also don't want anyone else to use it.
@@ -464,12 +464,12 @@ class ImageItem(GraphicsObject):
         #self.update()
 
 
-        
+
     def tabletEvent(self, ev):
         print(ev.device())
         print(ev.pointerType())
         print(ev.pressure())
-    
+
     def drawAt(self, pos, ev=None):
         pos = [int(pos.x()), int(pos.y())]
         dk = self.drawKernel
@@ -478,7 +478,7 @@ class ImageItem(GraphicsObject):
         sy = [0,dk.shape[1]]
         tx = [pos[0] - kc[0], pos[0] - kc[0]+ dk.shape[0]]
         ty = [pos[1] - kc[1], pos[1] - kc[1]+ dk.shape[1]]
-        
+
         for i in [0,1]:
             dx1 = -min(0, tx[i])
             dx2 = min(0, self.image.shape[0]-tx[i])
@@ -494,7 +494,7 @@ class ImageItem(GraphicsObject):
         ss = (slice(sx[0],sx[1]), slice(sy[0],sy[1]))
         mask = self.drawMask
         src = dk
-        
+
         if isinstance(self.drawMode, collections.Callable):
             self.drawMode(dk, self.image, mask, ss, ts, ev)
         else:
@@ -510,7 +510,7 @@ class ImageItem(GraphicsObject):
             else:
                 raise Exception("Unknown draw mode '%s'" % self.drawMode)
             self.updateImage()
-        
+
     def setDrawKernel(self, kernel=None, mask=None, center=(0,0), mode='set'):
         self.drawKernel = kernel
         self.drawKernelCenter = center

--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -10,10 +10,10 @@ __all__ = ['InfiniteLine']
 class InfiniteLine(GraphicsObject):
     """
     **Bases:** :class:`GraphicsObject <pyqtgraph.GraphicsObject>`
-    
+
     Displays a line of infinite length.
     This line may be dragged to indicate a position in data coordinates.
-    
+
     =============================== ===================================================
     **Signals:**
     sigDragged(self)
@@ -21,11 +21,11 @@ class InfiniteLine(GraphicsObject):
     sigPositionChanged(self)
     =============================== ===================================================
     """
-    
+
     sigDragged = QtCore.Signal(object)
     sigPositionChangeFinished = QtCore.Signal(object)
     sigPositionChanged = QtCore.Signal(object)
-    
+
     def __init__(self, pos=None, angle=90, pen=None, movable=False, bounds=None):
         """
         =============== ==================================================================
@@ -41,9 +41,9 @@ class InfiniteLine(GraphicsObject):
                         line is vertical or horizontal.
         =============== ==================================================================
         """
-        
+
         GraphicsObject.__init__(self)
-        
+
         if bounds is None:              ## allowed value boundaries for orthogonal lines
             self.maxRange = [None, None]
         else:
@@ -59,57 +59,57 @@ class InfiniteLine(GraphicsObject):
 
         if pen is None:
             pen = (200, 200, 100)
-        
+
         self.setPen(pen)
         self.setHoverPen(color=(255,0,0), width=self.pen.width())
         self.currentPen = self.pen
-      
+
     def setMovable(self, m):
         """Set whether the line is movable by the user."""
         self.movable = m
         self.setAcceptHoverEvents(m)
-      
+
     def setBounds(self, bounds):
         """Set the (minimum, maximum) allowable values when dragging."""
         self.maxRange = bounds
         self.setValue(self.value())
-        
+
     def setPen(self, *args, **kwargs):
-        """Set the pen for drawing the line. Allowable arguments are any that are valid 
+        """Set the pen for drawing the line. Allowable arguments are any that are valid
         for :func:`mkPen <pyqtgraph.mkPen>`."""
         self.pen = fn.mkPen(*args, **kwargs)
         if not self.mouseHovering:
             self.currentPen = self.pen
             self.update()
-        
+
     def setHoverPen(self, *args, **kwargs):
-        """Set the pen for drawing the line while the mouse hovers over it. 
-        Allowable arguments are any that are valid 
+        """Set the pen for drawing the line while the mouse hovers over it.
+        Allowable arguments are any that are valid
         for :func:`mkPen <pyqtgraph.mkPen>`.
-        
+
         If the line is not movable, then hovering is also disabled.
-        
+
         Added in version 0.9.9."""
         self.hoverPen = fn.mkPen(*args, **kwargs)
         if self.mouseHovering:
             self.currentPen = self.hoverPen
             self.update()
-        
+
     def setAngle(self, angle):
         """
         Takes angle argument in degrees.
         0 is horizontal; 90 is vertical.
-        
-        Note that the use of value() and setValue() changes if the line is 
+
+        Note that the use of value() and setValue() changes if the line is
         not vertical or horizontal.
         """
         self.angle = ((angle+45) % 180) - 45   ##  -45 <= angle < 135
         self.resetTransform()
         self.rotate(self.angle)
         self.update()
-        
+
     def setPos(self, pos):
-        
+
         if type(pos) in [list, tuple]:
             newPos = pos
         elif isinstance(pos, QtCore.QPointF):
@@ -121,10 +121,10 @@ class InfiniteLine(GraphicsObject):
                 newPos = [0, pos]
             else:
                 raise Exception("Must specify 2D coordinate for non-orthogonal lines.")
-            
+
         ## check bounds (only works for orthogonal lines)
         if self.angle == 90:
-            if self.maxRange[0] is not None:    
+            if self.maxRange[0] is not None:
                 newPos[0] = max(newPos[0], self.maxRange[0])
             if self.maxRange[1] is not None:
                 newPos[0] = min(newPos[0], self.maxRange[1])
@@ -133,7 +133,7 @@ class InfiniteLine(GraphicsObject):
                 newPos[1] = max(newPos[1], self.maxRange[0])
             if self.maxRange[1] is not None:
                 newPos[1] = min(newPos[1], self.maxRange[1])
-            
+
         if self.p != newPos:
             self.p = newPos
             GraphicsObject.setPos(self, Point(self.p))
@@ -142,15 +142,15 @@ class InfiniteLine(GraphicsObject):
 
     def getXPos(self):
         return self.p[0]
-        
+
     def getYPos(self):
         return self.p[1]
-        
+
     def getPos(self):
         return self.p
 
     def value(self):
-        """Return the value of the line. Will be a single number for horizontal and 
+        """Return the value of the line. Will be a single number for horizontal and
         vertical lines, and a list of [x,y] values for diagonal lines."""
         if self.angle%180 == 0:
             return self.getYPos()
@@ -158,10 +158,10 @@ class InfiniteLine(GraphicsObject):
             return self.getXPos()
         else:
             return self.getPos()
-                
+
     def setValue(self, v):
-        """Set the position of the line. If line is horizontal or vertical, v can be 
-        a single value. Otherwise, a 2D coordinate must be specified (list, tuple and 
+        """Set the position of the line. If line is horizontal or vertical, v can be
+        a single value. Otherwise, a 2D coordinate must be specified (list, tuple and
         QPointF are all acceptable)."""
         self.setPos(v)
 
@@ -174,12 +174,12 @@ class InfiniteLine(GraphicsObject):
         #else:
             #print "ignore", change
         #return GraphicsObject.itemChange(self, change, val)
-                
+
     def boundingRect(self):
         #br = UIGraphicsItem.boundingRect(self)
         br = self.viewRect()
         ## add a 4-pixel radius around the line for mouse interaction.
-        
+
         px = self.pixelLength(direction=Point(1,0), ortho=True)  ## get pixel length orthogonal to the line
         if px is None:
             px = 0
@@ -187,12 +187,12 @@ class InfiniteLine(GraphicsObject):
         br.setBottom(-w)
         br.setTop(w)
         return br.normalized()
-    
+
     def paint(self, p, *args):
         br = self.boundingRect()
         p.setPen(self.currentPen)
         p.drawLine(Point(br.right(), 0), Point(br.left(), 0))
-        
+
     def dataBounds(self, axis, frac=1.0, orthoRange=None):
         if axis == 0:
             return None   ## x axis should never be auto-scaled
@@ -206,16 +206,16 @@ class InfiniteLine(GraphicsObject):
                 self.cursorOffset = self.pos() - self.mapToParent(ev.buttonDownPos())
                 self.startPosition = self.pos()
             ev.accept()
-            
+
             if not self.moving:
                 return
-                
+
             self.setPos(self.cursorOffset + self.mapToParent(ev.pos()))
             self.sigDragged.emit(self)
             if ev.isFinish():
                 self.moving = False
                 self.sigPositionChangeFinished.emit(self)
-            
+
     def mouseClickEvent(self, ev):
         if self.moving and ev.button() == QtCore.Qt.RightButton:
             ev.accept()

--- a/pyqtgraph/graphicsItems/IsocurveItem.py
+++ b/pyqtgraph/graphicsItems/IsocurveItem.py
@@ -8,16 +8,16 @@ from ..Qt import QtGui, QtCore
 class IsocurveItem(GraphicsObject):
     """
     **Bases:** :class:`GraphicsObject <pyqtgraph.GraphicsObject>`
-    
-    Item displaying an isocurve of a 2D array.To align this item correctly with an 
+
+    Item displaying an isocurve of a 2D array.To align this item correctly with an
     ImageItem,call isocurve.setParentItem(image)
     """
-    
+
 
     def __init__(self, data=None, level=0, pen='w'):
         """
-        Create a new isocurve item. 
-        
+        Create a new isocurve item.
+
         ==============  ===============================================================
         **Arguments:**
         data            A 2-dimensional ndarray. Can be initialized as None, and set
@@ -34,12 +34,12 @@ class IsocurveItem(GraphicsObject):
         self.path = None
         self.setPen(pen)
         self.setData(data, level)
-        
-    
+
+
     def setData(self, data, level=None):
         """
         Set the data/image to draw isocurves for.
-        
+
         ==============  ========================================================================
         **Arguments:**
         data            A 2-dimensional ndarray.
@@ -54,7 +54,7 @@ class IsocurveItem(GraphicsObject):
         self.path = None
         self.prepareGeometryChange()
         self.update()
-        
+
 
     def setLevel(self, level):
         """Set the level at which the isocurve is drawn."""
@@ -62,21 +62,21 @@ class IsocurveItem(GraphicsObject):
         self.path = None
         self.prepareGeometryChange()
         self.update()
-    
+
 
     def setPen(self, *args, **kwargs):
-        """Set the pen used to draw the isocurve. Arguments can be any that are valid 
+        """Set the pen used to draw the isocurve. Arguments can be any that are valid
         for :func:`mkPen <pyqtgraph.mkPen>`"""
         self.pen = fn.mkPen(*args, **kwargs)
         self.update()
 
     def setBrush(self, *args, **kwargs):
-        """Set the brush used to draw the isocurve. Arguments can be any that are valid 
+        """Set the brush used to draw the isocurve. Arguments can be any that are valid
         for :func:`mkBrush <pyqtgraph.mkBrush>`"""
         self.brush = fn.mkBrush(*args, **kwargs)
         self.update()
 
-        
+
     def updateLines(self, data, level):
         ##print "data:", data
         ##print "level", level
@@ -95,7 +95,7 @@ class IsocurveItem(GraphicsObject):
         if self.path is None:
             self.generatePath()
         return self.path.boundingRect()
-    
+
     def generatePath(self):
         if self.data is None:
             self.path = None
@@ -106,7 +106,7 @@ class IsocurveItem(GraphicsObject):
             self.path.moveTo(*line[0])
             for p in line[1:]:
                 self.path.lineTo(*p)
-    
+
     def paint(self, p, *args):
         if self.data is None:
             return
@@ -114,4 +114,3 @@ class IsocurveItem(GraphicsObject):
             self.generatePath()
         p.setPen(self.pen)
         p.drawPath(self.path)
-    

--- a/pyqtgraph/graphicsItems/ItemGroup.py
+++ b/pyqtgraph/graphicsItems/ItemGroup.py
@@ -6,18 +6,17 @@ class ItemGroup(GraphicsObject):
     """
     Replacement for QGraphicsItemGroup
     """
-    
+
     def __init__(self, *args):
         GraphicsObject.__init__(self, *args)
         if hasattr(self, "ItemHasNoContents"):
             self.setFlag(self.ItemHasNoContents)
-    
+
     def boundingRect(self):
         return QtCore.QRectF()
-        
+
     def paint(self, *args):
         pass
-    
+
     def addItem(self, item):
         item.setParentItem(self)
-

--- a/pyqtgraph/graphicsItems/LabelItem.py
+++ b/pyqtgraph/graphicsItems/LabelItem.py
@@ -11,11 +11,11 @@ class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
     """
     GraphicsWidget displaying text.
     Used mainly as axis labels, titles, etc.
-    
+
     Note: To display text inside a scaled view (ViewBox, PlotWidget, etc) use TextItem
     """
-    
-    
+
+
     def __init__(self, text=' ', parent=None, angle=0, **args):
         GraphicsWidget.__init__(self, parent)
         GraphicsWidgetAnchor.__init__(self)
@@ -28,11 +28,11 @@ class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
         self._sizeHint = {}
         self.setText(text)
         self.setAngle(angle)
-            
+
     def setAttr(self, attr, value):
         """Set default text properties. See setText() for accepted parameters."""
         self.opts[attr] = value
-        
+
     def setText(self, text, **args):
         """Set the text and text properties in the label. Accepts optional arguments for auto-generating
         a CSS style string:
@@ -49,9 +49,9 @@ class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
         opts = self.opts
         for k in args:
             opts[k] = args[k]
-        
+
         optlist = []
-        
+
         color = self.opts['color']
         if color is None:
             color = getConfigOption('foreground')
@@ -69,7 +69,7 @@ class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
         self.updateMin()
         self.resizeEvent(None)
         self.updateGeometry()
-        
+
     def resizeEvent(self, ev):
         #c1 = self.boundingRect().center()
         #c2 = self.item.mapToParent(self.item.boundingRect().center()) # + self.item.pos()
@@ -80,7 +80,7 @@ class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
         bounds = self.itemRect()
         left = self.mapFromItem(self.item, QtCore.QPointF(0,0)) - self.mapFromItem(self.item, QtCore.QPointF(1,0))
         rect = self.rect()
-        
+
         if self.opts['justify'] == 'left':
             if left.x() != 0:
                 bounds.moveLeft(rect.left())
@@ -88,7 +88,7 @@ class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
                 bounds.moveTop(rect.top())
             elif left.y() > 0:
                 bounds.moveBottom(rect.bottom())
-                
+
         elif self.opts['justify'] == 'center':
             bounds.moveCenter(rect.center())
             #bounds = self.itemRect()
@@ -102,22 +102,22 @@ class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
                 bounds.moveTop(rect.top())
             #bounds = self.itemRect()
             #self.item.setPos(self.width() - bounds.width(), 0)
-            
+
         self.item.setPos(bounds.topLeft() - self.itemRect().topLeft())
         self.updateMin()
-        
+
     def setAngle(self, angle):
         self.angle = angle
         self.item.resetTransform()
         self.item.rotate(angle)
         self.updateMin()
-        
-        
+
+
     def updateMin(self):
         bounds = self.itemRect()
         self.setMinimumWidth(bounds.width())
         self.setMinimumHeight(bounds.height())
-        
+
         self._sizeHint = {
             QtCore.Qt.MinimumSize: (bounds.width(), bounds.height()),
             QtCore.Qt.PreferredSize: (bounds.width(), bounds.height()),
@@ -125,18 +125,17 @@ class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
             QtCore.Qt.MinimumDescent: (0, 0)  ##?? what is this?
         }
         self.updateGeometry()
-        
+
     def sizeHint(self, hint, constraint):
         if hint not in self._sizeHint:
             return QtCore.QSizeF(0, 0)
         return QtCore.QSizeF(*self._sizeHint[hint])
-        
+
     def itemRect(self):
         return self.item.mapRectToParent(self.item.boundingRect())
-        
+
     #def paint(self, p, *args):
         #p.setPen(fn.mkPen('r'))
         #p.drawRect(self.rect())
         #p.setPen(fn.mkPen('g'))
         #p.drawRect(self.itemRect())
-        

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -32,10 +32,10 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
                         legend must be anchored manually by calling anchor() or
                         positioned by calling setPos().
         ==============  ===============================================================
-        
+
         """
-        
-        
+
+
         GraphicsWidget.__init__(self)
         GraphicsWidgetAnchor.__init__(self)
         self.setFlag(self.ItemIgnoresTransformations)
@@ -46,7 +46,7 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         self.offset = offset
         if size is not None:
             self.setGeometry(QtCore.QRectF(0, 0, self.size[0], self.size[1]))
-        
+
     def setParentItem(self, p):
         ret = GraphicsWidget.setParentItem(self, p)
         if self.offset is not None:
@@ -56,10 +56,10 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
             anchor = (anchorx, anchory)
             self.anchor(itemPos=anchor, parentPos=anchor, offset=offset)
         return ret
-        
+
     def addItem(self, item, name):
         """
-        Add a new entry to the legend. 
+        Add a new entry to the legend.
 
         ==============  ========================================================
         **Arguments:**
@@ -74,16 +74,16 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         if isinstance(item, ItemSample):
             sample = item
         else:
-            sample = ItemSample(item)        
+            sample = ItemSample(item)
         row = self.layout.rowCount()
         self.items.append((sample, label))
         self.layout.addItem(sample, row, 0)
         self.layout.addItem(label, row, 1)
         self.updateSize()
-    
+
     def removeItem(self, name):
         """
-        Removes one item from the legend. 
+        Removes one item from the legend.
 
         ==============  ========================================================
         **Arguments:**
@@ -104,7 +104,7 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
     def updateSize(self):
         if self.size is not None:
             return
-            
+
         height = 0
         width = 0
         #print("-------")
@@ -114,10 +114,10 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
             #print(width, height)
         #print width, height
         self.setGeometry(0, 0, width+25, height)
-    
+
     def boundingRect(self):
         return QtCore.QRectF(0, 0, self.width(), self.height())
-    
+
     def paint(self, p, *args):
         p.setPen(fn.mkPen(255,255,255,100))
         p.setBrush(fn.mkBrush(100,100,100,50))
@@ -125,50 +125,46 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
 
     def hoverEvent(self, ev):
         ev.acceptDrags(QtCore.Qt.LeftButton)
-        
+
     def mouseDragEvent(self, ev):
         if ev.button() == QtCore.Qt.LeftButton:
             dpos = ev.pos() - ev.lastPos()
             self.autoAnchor(self.pos() + dpos)
-        
+
 class ItemSample(GraphicsWidget):
     """ Class responsible for drawing a single item in a LegendItem (sans label).
-    
+
     This may be subclassed to draw custom graphics in a Legend.
     """
     ## Todo: make this more generic; let each item decide how it should be represented.
     def __init__(self, item):
         GraphicsWidget.__init__(self)
         self.item = item
-    
+
     def boundingRect(self):
         return QtCore.QRectF(0, 0, 20, 20)
-        
+
     def paint(self, p, *args):
         #p.setRenderHint(p.Antialiasing)  # only if the data is antialiased.
         opts = self.item.opts
-        
+
         if opts.get('fillLevel',None) is not None and opts.get('fillBrush',None) is not None:
             p.setBrush(fn.mkBrush(opts['fillBrush']))
             p.setPen(fn.mkPen(None))
             p.drawPolygon(QtGui.QPolygonF([QtCore.QPointF(2,18), QtCore.QPointF(18,2), QtCore.QPointF(18,18)]))
-        
+
         if not isinstance(self.item, ScatterPlotItem):
             p.setPen(fn.mkPen(opts['pen']))
             p.drawLine(2, 18, 18, 2)
-        
+
         symbol = opts.get('symbol', None)
         if symbol is not None:
             if isinstance(self.item, PlotDataItem):
                 opts = self.item.scatter.opts
-                
+
             pen = fn.mkPen(opts['pen'])
             brush = fn.mkBrush(opts['brush'])
             size = opts['size']
-            
+
             p.translate(10,10)
             path = drawSymbol(p, symbol, size, pen, brush)
-        
-        
-        
-        

--- a/pyqtgraph/graphicsItems/LinearRegionItem.py
+++ b/pyqtgraph/graphicsItems/LinearRegionItem.py
@@ -9,10 +9,10 @@ __all__ = ['LinearRegionItem']
 class LinearRegionItem(UIGraphicsItem):
     """
     **Bases:** :class:`UIGraphicsItem <pyqtgraph.UIGraphicsItem>`
-    
+
     Used for marking a horizontal or vertical region in plots.
     The region can be dragged and is bounded by lines which can be dragged individually.
-    
+
     ===============================  =============================================================================
     **Signals:**
     sigRegionChangeFinished(self)    Emitted when the user has finished dragging the region (or one of its lines)
@@ -21,15 +21,15 @@ class LinearRegionItem(UIGraphicsItem):
                                      and when the region is changed programatically.
     ===============================  =============================================================================
     """
-    
+
     sigRegionChangeFinished = QtCore.Signal(object)
     sigRegionChanged = QtCore.Signal(object)
     Vertical = 0
     Horizontal = 1
-    
+
     def __init__(self, values=[0,1], orientation=None, brush=None, movable=True, bounds=None):
         """Create a new LinearRegionItem.
-        
+
         ==============  =====================================================================
         **Arguments:**
         values          A list of the positions of the lines in the region. These are not
@@ -44,7 +44,7 @@ class LinearRegionItem(UIGraphicsItem):
         bounds          Optional [min, max] bounding values for the region
         ==============  =====================================================================
         """
-        
+
         UIGraphicsItem.__init__(self)
         if orientation is None:
             orientation = LinearRegionItem.Vertical
@@ -53,30 +53,30 @@ class LinearRegionItem(UIGraphicsItem):
         self.blockLineSignal = False
         self.moving = False
         self.mouseHovering = False
-        
+
         if orientation == LinearRegionItem.Horizontal:
             self.lines = [
-                InfiniteLine(QtCore.QPointF(0, values[0]), 0, movable=movable, bounds=bounds), 
+                InfiniteLine(QtCore.QPointF(0, values[0]), 0, movable=movable, bounds=bounds),
                 InfiniteLine(QtCore.QPointF(0, values[1]), 0, movable=movable, bounds=bounds)]
         elif orientation == LinearRegionItem.Vertical:
             self.lines = [
-                InfiniteLine(QtCore.QPointF(values[1], 0), 90, movable=movable, bounds=bounds), 
+                InfiniteLine(QtCore.QPointF(values[1], 0), 90, movable=movable, bounds=bounds),
                 InfiniteLine(QtCore.QPointF(values[0], 0), 90, movable=movable, bounds=bounds)]
         else:
             raise Exception('Orientation must be one of LinearRegionItem.Vertical or LinearRegionItem.Horizontal')
-        
-        
+
+
         for l in self.lines:
             l.setParentItem(self)
             l.sigPositionChangeFinished.connect(self.lineMoveFinished)
             l.sigPositionChanged.connect(self.lineMoved)
-            
+
         if brush is None:
             brush = QtGui.QBrush(QtGui.QColor(0, 0, 255, 50))
         self.setBrush(brush)
-        
+
         self.setMovable(movable)
-        
+
     def getRegion(self):
         """Return the values at the edges of the region."""
         #if self.orientation[0] == 'h':
@@ -88,7 +88,7 @@ class LinearRegionItem(UIGraphicsItem):
 
     def setRegion(self, rgn):
         """Set the values for the edges of the region.
-        
+
         ==============   ==============================================
         **Arguments:**
         rgn              A list or tuple of the lower and upper values.
@@ -114,14 +114,14 @@ class LinearRegionItem(UIGraphicsItem):
     def setBounds(self, bounds):
         """Optional [min, max] bounding values for the region. To have no bounds on the
         region use [None, None].
-        Does not affect the current position of the region unless it is outside the new bounds. 
-        See :func:`setRegion <pyqtgraph.LinearRegionItem.setRegion>` to set the position 
+        Does not affect the current position of the region unless it is outside the new bounds.
+        See :func:`setRegion <pyqtgraph.LinearRegionItem.setRegion>` to set the position
         of the region."""
         for l in self.lines:
             l.setBounds(bounds)
-        
+
     def setMovable(self, m):
-        """Set lines to be movable by the user, or not. If lines are movable, they will 
+        """Set lines to be movable by the user, or not. If lines are movable, they will
         also accept HoverEvents."""
         for l in self.lines:
             l.setMovable(m)
@@ -138,7 +138,7 @@ class LinearRegionItem(UIGraphicsItem):
             br.setTop(rng[0])
             br.setBottom(rng[1])
         return br.normalized()
-        
+
     def paint(self, p, *args):
         profiler = debug.Profiler()
         UIGraphicsItem.paint(self, p, *args)
@@ -158,12 +158,12 @@ class LinearRegionItem(UIGraphicsItem):
         self.prepareGeometryChange()
         #self.emit(QtCore.SIGNAL('regionChanged'), self)
         self.sigRegionChanged.emit(self)
-            
+
     def lineMoveFinished(self):
         #self.emit(QtCore.SIGNAL('regionChangeFinished'), self)
         self.sigRegionChangeFinished.emit(self)
-        
-            
+
+
     #def updateBounds(self):
         #vb = self.view().viewRect()
         #vals = [self.lines[0].value(), self.lines[1].value()]
@@ -176,7 +176,7 @@ class LinearRegionItem(UIGraphicsItem):
         #if vb != self.bounds:
             #self.bounds = vb
             #self.rect.setRect(vb)
-        
+
     #def mousePressEvent(self, ev):
         #if not self.movable:
             #ev.ignore()
@@ -188,11 +188,11 @@ class LinearRegionItem(UIGraphicsItem):
             ##self.pressDelta = self.mapToParent(ev.pos()) - QtCore.QPointF(*self.p)
         ##else:
             ##ev.ignore()
-            
+
     #def mouseReleaseEvent(self, ev):
         #for l in self.lines:
             #l.mouseReleaseEvent(ev)
-            
+
     #def mouseMoveEvent(self, ev):
         ##print "move", ev.pos()
         #if not self.movable:
@@ -208,16 +208,16 @@ class LinearRegionItem(UIGraphicsItem):
         if not self.movable or int(ev.button() & QtCore.Qt.LeftButton) == 0:
             return
         ev.accept()
-        
+
         if ev.isStart():
             bdp = ev.buttonDownPos()
             self.cursorOffsets = [l.pos() - bdp for l in self.lines]
             self.startPositions = [l.pos() for l in self.lines]
             self.moving = True
-            
+
         if not self.moving:
             return
-            
+
         #delta = ev.pos() - ev.lastPos()
         self.lines[0].blockSignals(True)  # only want to update once
         for i, l in enumerate(self.lines):
@@ -226,13 +226,13 @@ class LinearRegionItem(UIGraphicsItem):
             #l.mouseDragEvent(ev)
         self.lines[0].blockSignals(False)
         self.prepareGeometryChange()
-        
+
         if ev.isFinish():
             self.moving = False
             self.sigRegionChangeFinished.emit(self)
         else:
             self.sigRegionChanged.emit(self)
-            
+
     def mouseClickEvent(self, ev):
         if self.moving and ev.button() == QtCore.Qt.RightButton:
             ev.accept()
@@ -248,7 +248,7 @@ class LinearRegionItem(UIGraphicsItem):
             self.setMouseHover(True)
         else:
             self.setMouseHover(False)
-            
+
     def setMouseHover(self, hover):
         ## Inform the item that the mouse is(not) hovering over it
         if self.mouseHovering == hover:
@@ -276,15 +276,14 @@ class LinearRegionItem(UIGraphicsItem):
         #print "rgn hover leave"
         #ev.ignore()
         #self.updateHoverBrush(False)
-        
+
     #def updateHoverBrush(self, hover=None):
         #if hover is None:
             #scene = self.scene()
             #hover = scene.claimEvent(self, QtCore.Qt.LeftButton, scene.Drag)
-        
+
         #if hover:
             #self.currentBrush = fn.mkBrush(255, 0,0,100)
         #else:
             #self.currentBrush = self.brush
         #self.update()
-

--- a/pyqtgraph/graphicsItems/MultiPlotItem.py
+++ b/pyqtgraph/graphicsItems/MultiPlotItem.py
@@ -18,7 +18,7 @@ class MultiPlotItem(GraphicsLayout.GraphicsLayout):
     def __init__(self, *args, **kwds):
         GraphicsLayout.GraphicsLayout.__init__(self, *args, **kwds)
         self.plots = []
-        
+
 
     def plot(self, data):
         #self.layout.clear()
@@ -57,6 +57,3 @@ class MultiPlotItem(GraphicsLayout.GraphicsLayout):
             p[0].close()
         self.plots = None
         self.clear()
-
-
-

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -4,7 +4,7 @@ try:
     HAVE_OPENGL = True
 except:
     HAVE_OPENGL = False
-    
+
 import numpy as np
 from .GraphicsObject import GraphicsObject
 from .. import functions as fn
@@ -15,48 +15,48 @@ from .. import debug
 
 __all__ = ['PlotCurveItem']
 class PlotCurveItem(GraphicsObject):
-    
-    
+
+
     """
     Class representing a single plot curve. Instances of this class are created
     automatically as part of PlotDataItem; these rarely need to be instantiated
     directly.
-    
+
     Features:
-    
+
     - Fast data update
     - Fill under curve
     - Mouse interaction
-    
+
     ====================  ===============================================
     **Signals:**
     sigPlotChanged(self)  Emitted when the data being plotted has changed
     sigClicked(self)      Emitted when the curve is clicked
     ====================  ===============================================
     """
-    
+
     sigPlotChanged = QtCore.Signal(object)
     sigClicked = QtCore.Signal(object)
-    
+
     def __init__(self, *args, **kargs):
         """
         Forwards all arguments to :func:`setData <pyqtgraph.PlotCurveItem.setData>`.
-        
+
         Some extra arguments are accepted as well:
-        
+
         ==============  =======================================================
         **Arguments:**
         parent          The parent GraphicsObject (optional)
-        clickable       If True, the item will emit sigClicked when it is 
+        clickable       If True, the item will emit sigClicked when it is
                         clicked on. Defaults to False.
         ==============  =======================================================
         """
         GraphicsObject.__init__(self, kargs.get('parent', None))
         self.clear()
-            
+
         ## this is disastrous for performance.
         #self.setCacheMode(QtGui.QGraphicsItem.DeviceCoordinateCache)
-        
+
         self.metaData = {}
         self.opts = {
             'pen': fn.mkPen('w'),
@@ -71,19 +71,19 @@ class PlotCurveItem(GraphicsObject):
         }
         self.setClickable(kargs.get('clickable', False))
         self.setData(*args, **kargs)
-        
+
     def implements(self, interface=None):
         ints = ['plotData']
         if interface is None:
             return ints
         return interface in ints
-    
+
     def name(self):
         return self.opts.get('name', None)
-    
+
     def setClickable(self, s, width=None):
         """Sets whether the item responds to mouse clicks.
-        
+
         The *width* argument specifies the width in pixels orthogonal to the
         curve that will respond to a mouse click.
         """
@@ -91,23 +91,23 @@ class PlotCurveItem(GraphicsObject):
         if width is not None:
             self.opts['mouseWidth'] = width
             self._mouseShape = None
-            self._boundingRect = None        
-        
-        
+            self._boundingRect = None
+
+
     def getData(self):
         return self.xData, self.yData
-        
+
     def dataBounds(self, ax, frac=1.0, orthoRange=None):
         ## Need this to run as fast as possible.
         ## check cache first:
         cache = self._boundsCache[ax]
         if cache is not None and cache[0] == (frac, orthoRange):
             return cache[1]
-        
+
         (x, y) = self.getData()
         if x is None or len(x) == 0:
             return (None, None)
-            
+
         if ax == 0:
             d = x
             d2 = y
@@ -120,7 +120,7 @@ class PlotCurveItem(GraphicsObject):
             mask = (d2 >= orthoRange[0]) * (d2 <= orthoRange[1])
             d = d[mask]
             #d2 = d2[mask]
-            
+
         if len(d) == 0:
             return (None, None)
 
@@ -137,7 +137,7 @@ class PlotCurveItem(GraphicsObject):
         ## adjust for fill level
         if ax == 1 and self.opts['fillLevel'] is not None:
             b = (min(b[0], self.opts['fillLevel']), max(b[1], self.opts['fillLevel']))
-            
+
         ## Add pen width only if it is non-cosmetic.
         pen = self.opts['pen']
         spen = self.opts['shadowPen']
@@ -145,10 +145,10 @@ class PlotCurveItem(GraphicsObject):
             b = (b[0] - pen.widthF()*0.7072, b[1] + pen.widthF()*0.7072)
         if spen is not None and not spen.isCosmetic() and spen.style() != QtCore.Qt.NoPen:
             b = (b[0] - spen.widthF()*0.7072, b[1] + spen.widthF()*0.7072)
-            
+
         self._boundsCache[ax] = [(frac, orthoRange), b]
         return b
-            
+
     def pixelPadding(self):
         pen = self.opts['pen']
         spen = self.opts['shadowPen']
@@ -167,11 +167,11 @@ class PlotCurveItem(GraphicsObject):
             (ymn, ymx) = self.dataBounds(ax=1)
             if xmn is None:
                 return QtCore.QRectF()
-            
+
             px = py = 0.0
             pxPad = self.pixelPadding()
             if pxPad > 0:
-                # determine length of pixel in local x, y directions    
+                # determine length of pixel in local x, y directions
                 px, py = self.pixelVectors()
                 try:
                     px = 0 if px is None else px.length()
@@ -181,68 +181,68 @@ class PlotCurveItem(GraphicsObject):
                     py = 0 if py is None else py.length()
                 except OverflowError:
                     py = 0
-                
+
                 # return bounds expanded by pixel size
                 px *= pxPad
                 py *= pxPad
             #px += self._maxSpotWidth * 0.5
             #py += self._maxSpotWidth * 0.5
             self._boundingRect = QtCore.QRectF(xmn-px, ymn-py, (2*px)+xmx-xmn, (2*py)+ymx-ymn)
-            
+
         return self._boundingRect
-    
+
     def viewTransformChanged(self):
         self.invalidateBounds()
         self.prepareGeometryChange()
-        
+
     #def boundingRect(self):
         #if self._boundingRect is None:
             #(x, y) = self.getData()
             #if x is None or y is None or len(x) == 0 or len(y) == 0:
                 #return QtCore.QRectF()
-                
-                
+
+
             #if self.opts['shadowPen'] is not None:
                 #lineWidth = (max(self.opts['pen'].width(), self.opts['shadowPen'].width()) + 1)
             #else:
                 #lineWidth = (self.opts['pen'].width()+1)
-                
-            
+
+
             #pixels = self.pixelVectors()
             #if pixels == (None, None):
                 #pixels = [Point(0,0), Point(0,0)]
-                
+
             #xmin = x.min()
             #xmax = x.max()
             #ymin = y.min()
             #ymax = y.max()
-            
+
             #if self.opts['fillLevel'] is not None:
                 #ymin = min(ymin, self.opts['fillLevel'])
                 #ymax = max(ymax, self.opts['fillLevel'])
-                
+
             #xmin -= pixels[0].x() * lineWidth
             #xmax += pixels[0].x() * lineWidth
             #ymin -= abs(pixels[1].y()) * lineWidth
             #ymax += abs(pixels[1].y()) * lineWidth
-            
+
             #self._boundingRect = QtCore.QRectF(xmin, ymin, xmax-xmin, ymax-ymin)
         #return self._boundingRect
 
-        
+
     def invalidateBounds(self):
         self._boundingRect = None
         self._boundsCache = [None, None]
-            
+
     def setPen(self, *args, **kargs):
         """Set the pen used to draw the curve."""
         self.opts['pen'] = fn.mkPen(*args, **kargs)
         self.invalidateBounds()
         self.update()
-        
+
     def setShadowPen(self, *args, **kargs):
         """Set the shadow pen used to draw behind tyhe primary pen.
-        This pen must have a larger width than the primary 
+        This pen must have a larger width than the primary
         pen to be visible.
         """
         self.opts['shadowPen'] = fn.mkPen(*args, **kargs)
@@ -254,7 +254,7 @@ class PlotCurveItem(GraphicsObject):
         self.opts['brush'] = fn.mkBrush(*args, **kargs)
         self.invalidateBounds()
         self.update()
-        
+
     def setFillLevel(self, level):
         """Set the level filled to when filling under the curve"""
         self.opts['fillLevel'] = level
@@ -266,11 +266,11 @@ class PlotCurveItem(GraphicsObject):
         """
         ==============  ========================================================
         **Arguments:**
-        x, y            (numpy arrays) Data to show 
+        x, y            (numpy arrays) Data to show
         pen             Pen to use when drawing. Any single argument accepted by
                         :func:`mkPen <pyqtgraph.mkPen>` is allowed.
         shadowPen       Pen for drawing behind the primary pen. Usually this
-                        is used to emphasize the curve by providing a 
+                        is used to emphasize the curve by providing a
                         high-contrast border. Any single argument accepted by
                         :func:`mkPen <pyqtgraph.mkPen>` is allowed.
         fillLevel       (float or None) Fill the area 'under' the curve to
@@ -289,15 +289,15 @@ class PlotCurveItem(GraphicsObject):
                         they are attached to nan or inf values. For any other
                         connectivity, specify an array of boolean values.
         ==============  ========================================================
-        
+
         If non-keyword arguments are used, they will be interpreted as
         setData(y) for a single argument and setData(x, y) for two
         arguments.
-        
-        
+
+
         """
         self.updateData(*args, **kargs)
-        
+
     def updateData(self, *args, **kargs):
         profiler = debug.Profiler()
 
@@ -306,12 +306,12 @@ class PlotCurveItem(GraphicsObject):
         elif len(args) == 2:
             kargs['x'] = args[0]
             kargs['y'] = args[1]
-        
+
         if 'y' not in kargs or kargs['y'] is None:
             kargs['y'] = np.array([])
         if 'x' not in kargs or kargs['x'] is None:
             kargs['x'] = np.arange(len(kargs['y']))
-            
+
         for k in ['x', 'y']:
             data = kargs[k]
             if isinstance(data, list):
@@ -321,9 +321,9 @@ class PlotCurveItem(GraphicsObject):
                 raise Exception("Plot data must be 1D ndarray.")
             if 'complex' in str(data.dtype):
                 raise Exception("Can not plot complex data types.")
-            
+
         profiler("data checks")
-        
+
         #self.setCacheMode(QtGui.QGraphicsItem.NoCache)  ## Disabling and re-enabling the cache works around a bug in Qt 4.6 causing the cached results to display incorrectly
                                                         ##    Test this bug with test_PlotWidget and zoom in on the animated plot
         self.invalidateBounds()
@@ -331,24 +331,24 @@ class PlotCurveItem(GraphicsObject):
         self.informViewBoundsChanged()
         self.yData = kargs['y'].view(np.ndarray)
         self.xData = kargs['x'].view(np.ndarray)
-        
+
         profiler('copy')
-        
+
         if 'stepMode' in kargs:
             self.opts['stepMode'] = kargs['stepMode']
-        
+
         if self.opts['stepMode'] is True:
             if len(self.xData) != len(self.yData)+1:  ## allow difference of 1 for step mode plots
                 raise Exception("len(X) must be len(Y)+1 since stepMode=True (got %s and %s)" % (self.xData.shape, self.yData.shape))
         else:
             if self.xData.shape != self.yData.shape:  ## allow difference of 1 for step mode plots
                 raise Exception("X and Y arrays must be the same shape--got %s and %s." % (self.xData.shape, self.yData.shape))
-        
+
         self.path = None
         self.fillPath = None
         self._mouseShape = None
         #self.xDisp = self.yDisp = None
-        
+
         if 'name' in kargs:
             self.opts['name'] = kargs['name']
         if 'connect' in kargs:
@@ -363,14 +363,14 @@ class PlotCurveItem(GraphicsObject):
             self.setBrush(kargs['brush'])
         if 'antialias' in kargs:
             self.opts['antialias'] = kargs['antialias']
-        
-        
+
+
         profiler('set')
         self.update()
         profiler('update')
         self.sigPlotChanged.emit(self)
         profiler('emit')
-        
+
     def generatePath(self, x, y):
         if self.opts['stepMode']:
             ## each value in the x/y arrays generates 2 points.
@@ -389,9 +389,9 @@ class PlotCurveItem(GraphicsObject):
                 y = y2.reshape(y2.size)[1:-1]
                 y[0] = self.opts['fillLevel']
                 y[-1] = self.opts['fillLevel']
-        
+
         path = fn.arrayToQPath(x, y, connect=self.opts['connect'])
-        
+
         return path
 
 
@@ -404,7 +404,7 @@ class PlotCurveItem(GraphicsObject):
                 self.path = self.generatePath(*self.getData())
             self.fillPath = None
             self._mouseShape = None
-            
+
         return self.path
 
     @debug.warnOnException  ## raising an exception here causes crash
@@ -412,25 +412,25 @@ class PlotCurveItem(GraphicsObject):
         profiler = debug.Profiler()
         if self.xData is None or len(self.xData) == 0:
             return
-        
+
         if HAVE_OPENGL and getConfigOption('enableExperimental') and isinstance(widget, QtOpenGL.QGLWidget):
             self.paintGL(p, opt, widget)
             return
-        
+
         x = None
         y = None
         path = self.getPath()
-        
+
         profiler('generate path')
-        
+
         if self._exportOpts is not False:
             aa = self._exportOpts.get('antialias', True)
         else:
             aa = self.opts['antialias']
-        
+
         p.setRenderHint(p.Antialiasing, aa)
-        
-            
+
+
         if self.opts['brush'] is not None and self.opts['fillLevel'] is not None:
             if self.fillPath is None:
                 if x is None:
@@ -441,14 +441,14 @@ class PlotCurveItem(GraphicsObject):
                 p2.lineTo(x[0], y[0])
                 p2.closeSubpath()
                 self.fillPath = p2
-                
+
             profiler('generate fill path')
             p.fillPath(self.fillPath, self.opts['brush'])
             profiler('draw fill path')
-            
+
         sp = fn.mkPen(self.opts['shadowPen'])
         cp = fn.mkPen(self.opts['pen'])
- 
+
         ## Copy pens and apply alpha adjustment
         #sp = QtGui.QPen(self.opts['shadowPen'])
         #cp = QtGui.QPen(self.opts['pen'])
@@ -459,38 +459,38 @@ class PlotCurveItem(GraphicsObject):
             #c.setAlpha(c.alpha() * self.opts['alphaHint'])
             #pen.setColor(c)
             ##pen.setCosmetic(True)
-            
-            
-            
+
+
+
         if sp is not None and sp.style() != QtCore.Qt.NoPen:
             p.setPen(sp)
             p.drawPath(path)
         p.setPen(cp)
         p.drawPath(path)
         profiler('drawPath')
-        
+
         #print "Render hints:", int(p.renderHints())
         #p.setPen(QtGui.QPen(QtGui.QColor(255,0,0)))
         #p.drawRect(self.boundingRect())
-        
+
     def paintGL(self, p, opt, widget):
         p.beginNativePainting()
         import OpenGL.GL as gl
-        
+
         ## set clipping viewport
         view = self.getViewBox()
         if view is not None:
             rect = view.mapRectToItem(self, view.boundingRect())
             #gl.glViewport(int(rect.x()), int(rect.y()), int(rect.width()), int(rect.height()))
-            
+
             #gl.glTranslate(-rect.x(), -rect.y(), 0)
-            
+
             gl.glEnable(gl.GL_STENCIL_TEST)
             gl.glColorMask(gl.GL_FALSE, gl.GL_FALSE, gl.GL_FALSE, gl.GL_FALSE) # disable drawing to frame buffer
             gl.glDepthMask(gl.GL_FALSE)  # disable drawing to depth buffer
-            gl.glStencilFunc(gl.GL_NEVER, 1, 0xFF)  
-            gl.glStencilOp(gl.GL_REPLACE, gl.GL_KEEP, gl.GL_KEEP)  
-            
+            gl.glStencilFunc(gl.GL_NEVER, 1, 0xFF)
+            gl.glStencilOp(gl.GL_REPLACE, gl.GL_KEEP, gl.GL_KEEP)
+
             ## draw stencil pattern
             gl.glStencilMask(0xFF)
             gl.glClear(gl.GL_STENCIL_BUFFER_BIT)
@@ -502,12 +502,12 @@ class PlotCurveItem(GraphicsObject):
             gl.glVertex2f(rect.x()+rect.width(), rect.y())
             gl.glVertex2f(rect.x(), rect.y()+rect.height())
             gl.glEnd()
-                       
+
             gl.glColorMask(gl.GL_TRUE, gl.GL_TRUE, gl.GL_TRUE, gl.GL_TRUE)
             gl.glDepthMask(gl.GL_TRUE)
             gl.glStencilMask(0x00)
             gl.glStencilFunc(gl.GL_EQUAL, 1, 0xFF)
-            
+
         try:
             x, y = self.getData()
             pos = np.empty((len(x), 2))
@@ -532,7 +532,7 @@ class PlotCurveItem(GraphicsObject):
                 gl.glDisableClientState(gl.GL_VERTEX_ARRAY)
         finally:
             p.endNativePainting()
-        
+
     def clear(self):
         self.xData = None  ## raw values
         self.yData = None
@@ -548,7 +548,7 @@ class PlotCurveItem(GraphicsObject):
     def mouseShape(self):
         """
         Return a QPainterPath representing the clickable shape of the curve
-        
+
         """
         if self._mouseShape is None:
             view = self.getViewBox()
@@ -561,14 +561,14 @@ class PlotCurveItem(GraphicsObject):
             mousePath = stroker.createStroke(path)
             self._mouseShape = self.mapFromItem(view, mousePath)
         return self._mouseShape
-        
+
     def mouseClickEvent(self, ev):
         if not self.clickable or ev.button() != QtCore.Qt.LeftButton:
             return
         if self.mouseShape().contains(ev.pos()):
             ev.accept()
             self.sigClicked.emit(self)
-            
+
 
 
 class ROIPlotItem(PlotCurveItem):
@@ -583,7 +583,7 @@ class ROIPlotItem(PlotCurveItem):
         #roi.connect(roi, QtCore.SIGNAL('regionChanged'), self.roiChangedEvent)
         roi.sigRegionChanged.connect(self.roiChangedEvent)
         #self.roiChangedEvent()
-        
+
     def getRoiData(self):
         d = self.roi.getArrayRegion(self.roiData, self.roiImg, axes=self.axes)
         if d is None:
@@ -591,8 +591,7 @@ class ROIPlotItem(PlotCurveItem):
         while d.ndim > 1:
             d = d.mean(axis=1)
         return d
-        
+
     def roiChangedEvent(self):
         d = self.getRoiData()
         self.updateData(d, self.xVals)
-

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -12,50 +12,50 @@ from .. import getConfigOption
 class PlotDataItem(GraphicsObject):
     """
     **Bases:** :class:`GraphicsObject <pyqtgraph.GraphicsObject>`
-    
-    GraphicsItem for displaying plot curves, scatter plots, or both. 
+
+    GraphicsItem for displaying plot curves, scatter plots, or both.
     While it is possible to use :class:`PlotCurveItem <pyqtgraph.PlotCurveItem>` or
     :class:`ScatterPlotItem <pyqtgraph.ScatterPlotItem>` individually, this class
-    provides a unified interface to both. Instances of :class:`PlotDataItem` are 
+    provides a unified interface to both. Instances of :class:`PlotDataItem` are
     usually created by plot() methods such as :func:`pyqtgraph.plot` and
     :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>`.
-    
+
     ============================== ==============================================
     **Signals:**
-    sigPlotChanged(self)           Emitted when the data in this item is updated.  
+    sigPlotChanged(self)           Emitted when the data in this item is updated.
     sigClicked(self)               Emitted when the item is clicked.
     sigPointsClicked(self, points) Emitted when a plot point is clicked
                                    Sends the list of points under the mouse.
     ============================== ==============================================
     """
-    
+
     sigPlotChanged = QtCore.Signal(object)
     sigClicked = QtCore.Signal(object)
     sigPointsClicked = QtCore.Signal(object, object)
-    
+
     def __init__(self, *args, **kargs):
         """
         There are many different ways to create a PlotDataItem:
-        
+
         **Data initialization arguments:** (x,y data only)
-        
+
             =================================== ======================================
             PlotDataItem(xValues, yValues)      x and y values may be any sequence (including ndarray) of real numbers
             PlotDataItem(yValues)               y values only -- x will be automatically set to range(len(y))
             PlotDataItem(x=xValues, y=yValues)  x and y given by keyword arguments
             PlotDataItem(ndarray(Nx2))          numpy array with shape (N, 2) where x=data[:,0] and y=data[:,1]
             =================================== ======================================
-        
+
         **Data initialization arguments:** (x,y data AND may include spot style)
-        
+
             ===========================   =========================================
             PlotDataItem(recarray)        numpy array with dtype=[('x', float), ('y', float), ...]
-            PlotDataItem(list-of-dicts)   [{'x': x, 'y': y, ...},   ...] 
-            PlotDataItem(dict-of-lists)   {'x': [...], 'y': [...],  ...}           
-            PlotDataItem(MetaArray)       1D array of Y values with X sepecified as axis values 
+            PlotDataItem(list-of-dicts)   [{'x': x, 'y': y, ...},   ...]
+            PlotDataItem(dict-of-lists)   {'x': [...], 'y': [...],  ...}
+            PlotDataItem(MetaArray)       1D array of Y values with X sepecified as axis values
                                           OR 2D array with a column 'y' and extra columns as needed.
             ===========================   =========================================
-        
+
         **Line style keyword arguments:**
 
             ==========   ==============================================================================
@@ -67,49 +67,49 @@ class PlotDataItem(GraphicsObject):
             shadowPen    Pen for secondary line to draw behind the primary line. disabled by default.
                          May be any single argument accepted by :func:`mkPen() <pyqtgraph.mkPen>`
             fillLevel    Fill the area between the curve and fillLevel
-            fillBrush    Fill to use when fillLevel is specified. 
+            fillBrush    Fill to use when fillLevel is specified.
                          May be any single argument accepted by :func:`mkBrush() <pyqtgraph.mkBrush>`
             stepMode     If True, two orthogonal lines are drawn for each sample
                          as steps. This is commonly used when drawing histograms.
                          Note that in this case, `len(x) == len(y) + 1`
                          (added in version 0.9.9)
             ==========   ==============================================================================
-        
+
         **Point style keyword arguments:**  (see :func:`ScatterPlotItem.setData() <pyqtgraph.ScatterPlotItem.setData>` for more information)
-        
+
             ============   =====================================================
-            symbol         Symbol to use for drawing points OR list of symbols, 
+            symbol         Symbol to use for drawing points OR list of symbols,
                            one per point. Default is no symbol.
                            Options are o, s, t, d, +, or any QPainterPath
-            symbolPen      Outline pen for drawing points OR list of pens, one 
-                           per point. May be any single argument accepted by 
+            symbolPen      Outline pen for drawing points OR list of pens, one
+                           per point. May be any single argument accepted by
                            :func:`mkPen() <pyqtgraph.mkPen>`
-            symbolBrush    Brush for filling points OR list of brushes, one per 
-                           point. May be any single argument accepted by 
+            symbolBrush    Brush for filling points OR list of brushes, one per
+                           point. May be any single argument accepted by
                            :func:`mkBrush() <pyqtgraph.mkBrush>`
             symbolSize     Diameter of symbols OR list of diameters.
-            pxMode         (bool) If True, then symbolSize is specified in 
-                           pixels. If False, then symbolSize is 
+            pxMode         (bool) If True, then symbolSize is specified in
+                           pixels. If False, then symbolSize is
                            specified in data coordinates.
             ============   =====================================================
-        
+
         **Optimization keyword arguments:**
-        
+
             ================ =====================================================================
             antialias        (bool) By default, antialiasing is disabled to improve performance.
-                             Note that in some cases (in particluar, when pxMode=True), points 
+                             Note that in some cases (in particluar, when pxMode=True), points
                              will be rendered antialiased even if this is set to False.
             decimate         deprecated.
             downsample       (int) Reduce the number of samples displayed by this value
-            downsampleMethod 'subsample': Downsample by taking the first of N samples. 
+            downsampleMethod 'subsample': Downsample by taking the first of N samples.
                              This method is fastest and least accurate.
                              'mean': Downsample by taking the mean of N samples.
-                             'peak': Downsample by drawing a saw wave that follows the min 
-                             and max of the original data. This method produces the best 
+                             'peak': Downsample by drawing a saw wave that follows the min
+                             and max of the original data. This method produces the best
                              visual representation of the data but is slower.
             autoDownsample   (bool) If True, resample the data before plotting to avoid plotting
                              multiple line segments per pixel. This can improve performance when
-                             viewing very high-density data, but increases the initial overhead 
+                             viewing very high-density data, but increases the initial overhead
                              and memory usage.
             clipToView       (bool) If True, only plot data that is visible within the X range of
                              the containing ViewBox. This can improve performance when plotting
@@ -117,9 +117,9 @@ class PlotDataItem(GraphicsObject):
                              at any time.
             identical        *deprecated*
             ================ =====================================================================
-        
+
         **Meta-info keyword arguments:**
-        
+
             ==========   ================================================
             name         name of dataset. This would appear in a legend
             ==========   ================================================
@@ -137,54 +137,54 @@ class PlotDataItem(GraphicsObject):
         self.scatter = ScatterPlotItem()
         self.curve.setParentItem(self)
         self.scatter.setParentItem(self)
-        
+
         self.curve.sigClicked.connect(self.curveClicked)
         self.scatter.sigClicked.connect(self.scatterClicked)
-        
-        
+
+
         #self.clear()
         self.opts = {
             'connect': 'all',
-            
+
             'fftMode': False,
             'logMode': [False, False],
             'alphaHint': 1.0,
             'alphaMode': False,
-            
+
             'pen': (200,200,200),
             'shadowPen': None,
             'fillLevel': None,
             'fillBrush': None,
-            'stepMode': None, 
-            
+            'stepMode': None,
+
             'symbol': None,
             'symbolSize': 10,
             'symbolPen': (200,200,200),
             'symbolBrush': (50, 50, 150),
             'pxMode': True,
-            
+
             'antialias': getConfigOption('antialias'),
             'pointMode': None,
-            
+
             'downsample': 1,
             'autoDownsample': False,
             'downsampleMethod': 'peak',
             'autoDownsampleFactor': 5.,  # draw ~5 samples per pixel
             'clipToView': False,
-            
+
             'data': None,
         }
         self.setData(*args, **kargs)
-    
+
     def implements(self, interface=None):
         ints = ['plotData']
         if interface is None:
             return ints
         return interface in ints
-    
+
     def name(self):
         return self.opts.get('name', None)
-    
+
     def boundingRect(self):
         return QtCore.QRectF()  ## let child items handle this
 
@@ -195,7 +195,7 @@ class PlotDataItem(GraphicsObject):
         self.opts['alphaMode'] = auto
         self.setOpacity(alpha)
         #self.update()
-        
+
     def setFftMode(self, mode):
         if self.opts['fftMode'] == mode:
             return
@@ -204,7 +204,7 @@ class PlotDataItem(GraphicsObject):
         self.xClean = self.yClean = None
         self.updateItems()
         self.informViewBoundsChanged()
-    
+
     def setLogMode(self, xMode, yMode):
         if self.opts['logMode'] == [xMode, yMode]:
             return
@@ -213,13 +213,13 @@ class PlotDataItem(GraphicsObject):
         self.xClean = self.yClean = None
         self.updateItems()
         self.informViewBoundsChanged()
-    
+
     def setPointMode(self, mode):
         if self.opts['pointMode'] == mode:
             return
         self.opts['pointMode'] = mode
         self.update()
-        
+
     def setPen(self, *args, **kargs):
         """
         | Sets the pen used to draw lines between points.
@@ -232,11 +232,11 @@ class PlotDataItem(GraphicsObject):
             #c.setPen(pen)
         #self.update()
         self.updateItems()
-        
+
     def setShadowPen(self, *args, **kargs):
         """
-        | Sets the shadow pen used to draw lines between points (this is for enhancing contrast or 
-          emphacizing data). 
+        | Sets the shadow pen used to draw lines between points (this is for enhancing contrast or
+          emphacizing data).
         | This line is drawn behind the primary pen (see :func:`setPen() <pyqtgraph.PlotDataItem.setPen>`)
           and should generally be assigned greater width than the primary pen.
         | *pen* can be a QPen or any argument accepted by :func:`pyqtgraph.mkPen() <pyqtgraph.mkPen>`
@@ -247,17 +247,17 @@ class PlotDataItem(GraphicsObject):
             #c.setPen(pen)
         #self.update()
         self.updateItems()
-        
+
     def setFillBrush(self, *args, **kargs):
         brush = fn.mkBrush(*args, **kargs)
         if self.opts['fillBrush'] == brush:
             return
         self.opts['fillBrush'] = brush
         self.updateItems()
-        
+
     def setBrush(self, *args, **kargs):
         return self.setFillBrush(*args, **kargs)
-    
+
     def setFillLevel(self, level):
         if self.opts['fillLevel'] == level:
             return
@@ -270,7 +270,7 @@ class PlotDataItem(GraphicsObject):
         self.opts['symbol'] = symbol
         #self.scatter.setSymbol(symbol)
         self.updateItems()
-        
+
     def setSymbolPen(self, *args, **kargs):
         pen = fn.mkPen(*args, **kargs)
         if self.opts['symbolPen'] == pen:
@@ -278,9 +278,9 @@ class PlotDataItem(GraphicsObject):
         self.opts['symbolPen'] = pen
         #self.scatter.setSymbolPen(pen)
         self.updateItems()
-        
-    
-    
+
+
+
     def setSymbolBrush(self, *args, **kargs):
         brush = fn.mkBrush(*args, **kargs)
         if self.opts['symbolBrush'] == brush:
@@ -288,8 +288,8 @@ class PlotDataItem(GraphicsObject):
         self.opts['symbolBrush'] = brush
         #self.scatter.setSymbolBrush(brush)
         self.updateItems()
-    
-    
+
+
     def setSymbolSize(self, size):
         if self.opts['symbolSize'] == size:
             return
@@ -300,8 +300,8 @@ class PlotDataItem(GraphicsObject):
     def setDownsampling(self, ds=None, auto=None, method=None):
         """
         Set the downsampling mode of this item. Downsampling reduces the number
-        of samples drawn to increase performance. 
-        
+        of samples drawn to increase performance.
+
         ==============  =================================================================
         **Arguments:**
         ds              (int) Reduce visible plot samples by this factor. To disable,
@@ -320,28 +320,28 @@ class PlotDataItem(GraphicsObject):
             if self.opts['downsample'] != ds:
                 changed = True
                 self.opts['downsample'] = ds
-                
+
         if auto is not None and self.opts['autoDownsample'] != auto:
             self.opts['autoDownsample'] = auto
             changed = True
-                
+
         if method is not None:
             if self.opts['downsampleMethod'] != method:
                 changed = True
                 self.opts['downsampleMethod'] = method
-        
+
         if changed:
             self.xDisp = self.yDisp = None
             self.updateItems()
-        
+
     def setClipToView(self, clip):
         if self.opts['clipToView'] == clip:
             return
         self.opts['clipToView'] = clip
         self.xDisp = self.yDisp = None
         self.updateItems()
-        
-        
+
+
     def setData(self, *args, **kargs):
         """
         Clear any data displayed by this item and display new data.
@@ -379,7 +379,7 @@ class PlotDataItem(GraphicsObject):
                 x = data.xvals(0).view(np.ndarray)
             else:
                 raise Exception('Invalid data type %s' % type(data))
-            
+
         elif len(args) == 2:
             seq = ('listOfValues', 'MetaArray', 'empty')
             dtyp = dataType(args[0]), dataType(args[1])
@@ -401,94 +401,94 @@ class PlotDataItem(GraphicsObject):
                     y = np.array(args[1])
             else:
                 y = args[1].view(np.ndarray)
-            
+
         if 'x' in kargs:
             x = kargs['x']
         if 'y' in kargs:
             y = kargs['y']
 
         profiler('interpret data')
-        ## pull in all style arguments. 
+        ## pull in all style arguments.
         ## Use self.opts to fill in anything not present in kargs.
-        
+
         if 'name' in kargs:
             self.opts['name'] = kargs['name']
         if 'connect' in kargs:
             self.opts['connect'] = kargs['connect']
 
         ## if symbol pen/brush are given with no symbol, then assume symbol is 'o'
-        
+
         if 'symbol' not in kargs and ('symbolPen' in kargs or 'symbolBrush' in kargs or 'symbolSize' in kargs):
             kargs['symbol'] = 'o'
-            
+
         if 'brush' in kargs:
             kargs['fillBrush'] = kargs['brush']
-            
+
         for k in list(self.opts.keys()):
             if k in kargs:
                 self.opts[k] = kargs[k]
-                
+
         #curveArgs = {}
         #for k in ['pen', 'shadowPen', 'fillLevel', 'brush']:
             #if k in kargs:
                 #self.opts[k] = kargs[k]
             #curveArgs[k] = self.opts[k]
-            
+
         #scatterArgs = {}
         #for k,v in [('symbolPen','pen'), ('symbolBrush','brush'), ('symbol','symbol')]:
             #if k in kargs:
                 #self.opts[k] = kargs[k]
             #scatterArgs[v] = self.opts[k]
-        
+
 
         if y is None:
             return
         if y is not None and x is None:
             x = np.arange(len(y))
-        
+
         if isinstance(x, list):
             x = np.array(x)
         if isinstance(y, list):
             y = np.array(y)
-        
+
         self.xData = x.view(np.ndarray)  ## one last check to make sure there are no MetaArrays getting by
         self.yData = y.view(np.ndarray)
         self.xClean = self.yClean = None
         self.xDisp = None
         self.yDisp = None
         profiler('set data')
-        
+
         self.updateItems()
         profiler('update items')
-        
+
         self.informViewBoundsChanged()
         #view = self.getViewBox()
         #if view is not None:
             #view.itemBoundsChanged(self)  ## inform view so it can update its range if it wants
-        
+
         self.sigPlotChanged.emit(self)
         profiler('emit')
 
     def updateItems(self):
-        
+
         curveArgs = {}
         for k,v in [('pen','pen'), ('shadowPen','shadowPen'), ('fillLevel','fillLevel'), ('fillBrush', 'brush'), ('antialias', 'antialias'), ('connect', 'connect'), ('stepMode', 'stepMode')]:
             curveArgs[v] = self.opts[k]
-        
+
         scatterArgs = {}
         for k,v in [('symbolPen','pen'), ('symbolBrush','brush'), ('symbol','symbol'), ('symbolSize', 'size'), ('data', 'data'), ('pxMode', 'pxMode'), ('antialias', 'antialias')]:
             if k in self.opts:
                 scatterArgs[v] = self.opts[k]
-        
+
         x,y = self.getData()
         #scatterArgs['mask'] = self.dataMask
-        
+
         if curveArgs['pen'] is not None or (curveArgs['brush'] is not None and curveArgs['fillLevel'] is not None):
             self.curve.setData(x=x, y=y, **curveArgs)
             self.curve.show()
         else:
             self.curve.hide()
-        
+
         if scatterArgs['symbol'] is not None:
             self.scatter.setData(x=x, y=y, **scatterArgs)
             self.scatter.show()
@@ -499,7 +499,7 @@ class PlotDataItem(GraphicsObject):
     def getData(self):
         if self.xData is None:
             return (None, None)
-        
+
         #if self.xClean is None:
             #nanMask = np.isnan(self.xData) | np.isnan(self.yData) | np.isinf(self.xData) | np.isinf(self.yData)
             #if nanMask.any():
@@ -510,12 +510,12 @@ class PlotDataItem(GraphicsObject):
                 #self.dataMask = None
                 #self.xClean = self.xData
                 #self.yClean = self.yData
-            
+
         if self.xDisp is None:
             x = self.xData
             y = self.yData
-            
-            
+
+
             #ds = self.opts['downsample']
             #if isinstance(ds, int) and ds > 1:
                 #x = x[::ds]
@@ -526,7 +526,7 @@ class PlotDataItem(GraphicsObject):
                 # Ignore the first bin for fft data if we have a logx scale
                 if self.opts['logMode'][0]:
                     x=x[1:]
-                    y=y[1:]                
+                    y=y[1:]
             if self.opts['logMode'][0]:
                 x = np.log10(x)
             if self.opts['logMode'][1]:
@@ -539,11 +539,11 @@ class PlotDataItem(GraphicsObject):
                     #y = y[self.dataMask]
                 #else:
                     #self.dataMask = None
-                    
+
             ds = self.opts['downsample']
             if not isinstance(ds, int):
                 ds = 1
-                
+
             if self.opts['autoDownsample']:
                 # this option presumes that x-values have uniform spacing
                 range = self.viewRect()
@@ -555,7 +555,7 @@ class PlotDataItem(GraphicsObject):
                     if width != 0.0:
                         ds = int(max(1, int((x1-x0) / (width*self.opts['autoDownsampleFactor']))))
                     ## downsampling is expensive; delay until after clipping.
-            
+
             if self.opts['clipToView']:
                 view = self.getViewBox()
                 if view is None or not view.autoRangeEnabled()[0]:
@@ -568,7 +568,7 @@ class PlotDataItem(GraphicsObject):
                         x1 = np.clip(int((range.right()-x[0])/dx)+2*ds , 0, len(x)-1)
                         x = x[x0:x1]
                         y = y[x0:x1]
-                    
+
             if ds > 1:
                 if self.opts['downsampleMethod'] == 'subsample':
                     x = x[::ds]
@@ -587,8 +587,8 @@ class PlotDataItem(GraphicsObject):
                     y1[:,0] = y2.max(axis=1)
                     y1[:,1] = y2.min(axis=1)
                     y = y1.reshape(n*2)
-                
-                    
+
+
             self.xDisp = x
             self.yDisp = y
         #print self.yDisp.shape, self.yDisp.min(), self.yDisp.max()
@@ -603,18 +603,18 @@ class PlotDataItem(GraphicsObject):
         =============== =============================================================
         **Arguments:**
         ax              (0 or 1) the axis for which to return this item's data range
-        frac            (float 0.0-1.0) Specifies what fraction of the total data 
+        frac            (float 0.0-1.0) Specifies what fraction of the total data
                         range to return. By default, the entire range is returned.
                         This allows the ViewBox to ignore large spikes in the data
                         when auto-scaling.
         orthoRange      ([min,max] or None) Specifies that only the data within the
-                        given range (orthogonal to *ax*) should me measured when 
+                        given range (orthogonal to *ax*) should me measured when
                         returning the data range. (For example, a ViewBox might ask
                         what is the y-range of all data with x-values between min
                         and max)
         =============== =============================================================
         """
-        
+
         range = [None, None]
         if self.curve.isVisible():
             range = self.curve.dataBounds(ax, frac, orthoRange)
@@ -625,7 +625,7 @@ class PlotDataItem(GraphicsObject):
                 r2[1] if range[1] is None else (range[1] if r2[1] is None else min(r2[1], range[1]))
                 ]
         return range
-    
+
     def pixelPadding(self):
         """
         Return the size in pixels that this item may draw beyond the values returned by dataBounds().
@@ -637,7 +637,7 @@ class PlotDataItem(GraphicsObject):
         elif self.scatter.isVisible():
             pad = max(pad, self.scatter.pixelPadding())
         return pad
-        
+
 
     def clear(self):
         #for i in self.curves+self.scatters:
@@ -653,23 +653,23 @@ class PlotDataItem(GraphicsObject):
         self.yDisp = None
         self.curve.setData([])
         self.scatter.setData([])
-            
+
     def appendData(self, *args, **kargs):
         pass
-    
+
     def curveClicked(self):
         self.sigClicked.emit(self)
-        
+
     def scatterClicked(self, plt, points):
         self.sigClicked.emit(self)
         self.sigPointsClicked.emit(self, points)
-    
+
     def viewRangeChanged(self):
         # view range has changed; re-plot if needed
         if self.opts['clipToView'] or self.opts['autoDownsample']:
             self.xDisp = self.yDisp = None
             self.updateItems()
-            
+
     def _fourierTransform(self, x, y):
         ## Perform fourier transform. If x values are not sampled uniformly,
         ## then use np.interp to resample before taking fft.
@@ -684,7 +684,7 @@ class PlotDataItem(GraphicsObject):
         dt = x[-1] - x[0]
         x = np.linspace(0, 0.5*len(x)/dt, len(y))
         return x, y
-    
+
 def dataType(obj):
     if hasattr(obj, '__len__') and len(obj) == 0:
         return 'empty'
@@ -692,7 +692,7 @@ def dataType(obj):
         return 'dictOfLists'
     elif isSequence(obj):
         first = obj[0]
-        
+
         if (hasattr(obj, 'implements') and obj.implements('MetaArray')):
             return 'MetaArray'
         elif isinstance(obj, np.ndarray):
@@ -709,13 +709,13 @@ def dataType(obj):
             return 'listOfDicts'
         else:
             return 'listOfValues'
-        
-        
+
+
 def isSequence(obj):
     return hasattr(obj, '__iter__') or isinstance(obj, np.ndarray) or (hasattr(obj, 'implements') and obj.implements('MetaArray'))
-    
-            
-            
+
+
+
 #class TableData:
     #"""
     #Class for presenting multiple forms of tabular data through a consistent interface.
@@ -725,7 +725,7 @@ def isSequence(obj):
         #- dict-of-lists
         #- dict (single record)
                #Note: if all the values in this record are lists, it will be interpreted as multiple records
-        
+
     #Data can be accessed and modified by column, by row, or by value
         #data[columnName]
         #data[rowId]
@@ -733,7 +733,7 @@ def isSequence(obj):
         #data[columnName] = [value, value, ...]
         #data[rowId] = {columnName: value, ...}
     #"""
-    
+
     #def __init__(self, data):
         #self.data = data
         #if isinstance(data, np.ndarray):
@@ -754,13 +754,13 @@ def isSequence(obj):
             #self.mode = data.mode
         #else:
             #raise TypeError(type(data))
-        
+
         #for fn in ['__getitem__', '__setitem__']:
             #setattr(self, fn, getattr(self, '_TableData'+fn+self.mode))
-        
+
     #def originalData(self):
         #return self.data
-    
+
     #def toArray(self):
         #if self.mode == 'array':
             #return self.data
@@ -775,13 +775,13 @@ def isSequence(obj):
         #for i in xrange(1, len(self)):
             #arr[i] = tuple(self[i].values())
         #return arr
-            
+
     #def __getitem__array(self, arg):
         #if isinstance(arg, tuple):
             #return self.data[arg[0]][arg[1]]
         #else:
             #return self.data[arg]
-            
+
     #def __getitem__list(self, arg):
         #if isinstance(arg, basestring):
             #return [d.get(arg, None) for d in self.data]
@@ -792,7 +792,7 @@ def isSequence(obj):
             #return self.data[arg[0]][arg[1]]
         #else:
             #raise TypeError(type(arg))
-        
+
     #def __getitem__dict(self, arg):
         #if isinstance(arg, basestring):
             #return self.data[arg]
@@ -823,7 +823,7 @@ def isSequence(obj):
             #self.data[arg[0]][arg[1]] = val
         #else:
             #raise TypeError(type(arg))
-        
+
     #def __setitem__dict(self, arg, val):
         #if isinstance(arg, basestring):
             #if len(val) != len(self.data[arg]):
@@ -844,7 +844,7 @@ def isSequence(obj):
             #return (args[1], args[0])
         #else:
             #return args
-        
+
     #def __iter__(self):
         #for i in xrange(len(self)):
             #yield self[i]
@@ -866,6 +866,6 @@ def isSequence(obj):
             #return list(names)
         #elif self.mode == 'dict':
             #return self.data.keys()
-            
+
     #def keys(self):
         #return self.columnNames()

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -4,7 +4,7 @@ PlotItem.py -  Graphics item implementing a scalable ViewBox with plotting power
 Copyright 2010  Luke Campagnola
 Distributed under MIT/X11 license. See license.txt for more infomation.
 
-This class is one of the workhorses of pyqtgraph. It implements a graphics item with 
+This class is one of the workhorses of pyqtgraph. It implements a graphics item with
 plots, labels, and scales which can be viewed inside a QGraphicsScene. If you want
 a widget that can be added to your GUI, see PlotWidget instead.
 
@@ -54,15 +54,15 @@ except:
 
 
 class PlotItem(GraphicsWidget):
-    
+
     """
     **Bases:** :class:`GraphicsWidget <pyqtgraph.GraphicsWidget>`
-    
-    Plot graphics item that can be added to any graphics scene. Implements axes, titles, and interactive viewbox. 
+
+    Plot graphics item that can be added to any graphics scene. Implements axes, titles, and interactive viewbox.
     PlotItem also provides some basic analysis functionality that may be accessed from the context menu.
     Use :func:`plot() <pyqtgraph.PlotItem.plot>` to create a new PlotDataItem and add it to the view.
     Use :func:`addItem() <pyqtgraph.PlotItem.addItem>` to add any QGraphicsItem to the view.
-    
+
     This class wraps several methods from its internal ViewBox:
     :func:`setXRange <pyqtgraph.ViewBox.setXRange>`,
     :func:`setYRange <pyqtgraph.ViewBox.setYRange>`,
@@ -83,9 +83,9 @@ class PlotItem(GraphicsWidget):
     :func:`invertX <pyqtgraph.ViewBox.invertX>`,
     :func:`register <pyqtgraph.ViewBox.register>`,
     :func:`unregister <pyqtgraph.ViewBox.unregister>`
-    
-    The ViewBox itself can be accessed by calling :func:`getViewBox() <pyqtgraph.PlotItem.getViewBox>` 
-    
+
+    The ViewBox itself can be accessed by calling :func:`getViewBox() <pyqtgraph.PlotItem.getViewBox>`
+
     ==================== =======================================================================
     **Signals:**
     sigYRangeChanged     wrapped from :class:`ViewBox <pyqtgraph.ViewBox>`
@@ -93,27 +93,27 @@ class PlotItem(GraphicsWidget):
     sigRangeChanged      wrapped from :class:`ViewBox <pyqtgraph.ViewBox>`
     ==================== =======================================================================
     """
-    
+
     sigRangeChanged = QtCore.Signal(object, object)    ## Emitted when the ViewBox range has changed
     sigYRangeChanged = QtCore.Signal(object, object)   ## Emitted when the ViewBox Y range has changed
     sigXRangeChanged = QtCore.Signal(object, object)   ## Emitted when the ViewBox X range has changed
-    
-    
+
+
     lastFileDir = None
-    
+
     def __init__(self, parent=None, name=None, labels=None, title=None, viewBox=None, axisItems=None, enableMenu=True, **kargs):
         """
         Create a new PlotItem. All arguments are optional.
         Any extra keyword arguments are passed to PlotItem.plot().
-        
+
         ==============  ==========================================================================================
         **Arguments:**
         *title*         Title to display at the top of the item. Html is allowed.
         *labels*        A dictionary specifying the axis labels to display::
-                   
+
                             {'left': (args), 'bottom': (args), ...}
-                     
-                        The name of each axis and the corresponding arguments are passed to 
+
+                        The name of each axis and the corresponding arguments are passed to
                         :func:`PlotItem.setLabel() <pyqtgraph.PlotItem.setLabel>`
                         Optionally, PlotItem my also be initialized with the keyword arguments left,
                         right, top, or bottom to achieve the same effect.
@@ -124,11 +124,11 @@ class PlotItem(GraphicsWidget):
                         and the values must be instances of AxisItem (or at least compatible with AxisItem).
         ==============  ==========================================================================================
         """
-        
+
         GraphicsWidget.__init__(self, parent)
-        
+
         self.setSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding)
-        
+
         ## Set up control buttons
         path = os.path.dirname(__file__)
         #self.autoImageFile = os.path.join(path, 'auto.png')
@@ -139,32 +139,32 @@ class PlotItem(GraphicsWidget):
         #self.autoBtn.hide()
         self.buttonsHidden = False ## whether the user has requested buttons to be hidden
         self.mouseHovering = False
-        
+
         self.layout = QtGui.QGraphicsGridLayout()
         self.layout.setContentsMargins(1,1,1,1)
         self.setLayout(self.layout)
         self.layout.setHorizontalSpacing(0)
         self.layout.setVerticalSpacing(0)
-        
+
         if viewBox is None:
             viewBox = ViewBox(parent=self)
         self.vb = viewBox
         self.vb.sigStateChanged.connect(self.viewStateChanged)
         self.setMenuEnabled(enableMenu, enableMenu) ## en/disable plotitem and viewbox menus
-        
+
         if name is not None:
             self.vb.register(name)
         self.vb.sigRangeChanged.connect(self.sigRangeChanged)
         self.vb.sigXRangeChanged.connect(self.sigXRangeChanged)
         self.vb.sigYRangeChanged.connect(self.sigYRangeChanged)
-        
+
         self.layout.addItem(self.vb, 2, 1)
         self.alpha = 1.0
         self.autoAlpha = True
         self.spectrumMode = False
-        
+
         self.legend = None
-        
+
         ## Create and place axis items
         if axisItems is None:
             axisItems = {}
@@ -179,18 +179,18 @@ class PlotItem(GraphicsWidget):
             self.layout.addItem(axis, *pos)
             axis.setZValue(-1000)
             axis.setFlag(axis.ItemNegativeZStacksBehindParent)
-        
+
         self.titleLabel = LabelItem('', size='11pt', parent=self)
         self.layout.addItem(self.titleLabel, 0, 1)
         self.setTitle(None)  ## hide
-        
-        
+
+
         for i in range(4):
             self.layout.setRowPreferredHeight(i, 0)
             self.layout.setRowMinimumHeight(i, 0)
             self.layout.setRowSpacing(i, 0)
             self.layout.setRowStretchFactor(i, 1)
-            
+
         for i in range(3):
             self.layout.setColumnPreferredWidth(i, 0)
             self.layout.setColumnMinimumWidth(i, 0)
@@ -198,7 +198,7 @@ class PlotItem(GraphicsWidget):
             self.layout.setColumnStretchFactor(i, 1)
         self.layout.setRowStretchFactor(2, 100)
         self.layout.setColumnStretchFactor(1, 100)
-        
+
 
         self.items = []
         self.curves = []
@@ -206,14 +206,14 @@ class PlotItem(GraphicsWidget):
         self.dataItems = []
         self.paramList = {}
         self.avgCurves = {}
-        
+
         ### Set up context menu
-        
+
         w = QtGui.QWidget()
         self.ctrl = c = Ui_Form()
         c.setupUi(w)
         dv = QtGui.QDoubleValidator(self)
-        
+
         menuItems = [
             ('Transforms', c.transformGroup),
             ('Downsample', c.decimateGroup),
@@ -222,10 +222,10 @@ class PlotItem(GraphicsWidget):
             ('Grid', c.gridGroup),
             ('Points', c.pointsGroup),
         ]
-        
-        
+
+
         self.ctrlMenu = QtGui.QMenu()
-        
+
         self.ctrlMenu.setTitle('Plot Options')
         self.subMenus = []
         for name, grp in menuItems:
@@ -235,13 +235,13 @@ class PlotItem(GraphicsWidget):
             sm.addAction(act)
             self.subMenus.append(sm)
             self.ctrlMenu.addMenu(sm)
-        
+
         self.stateGroup = WidgetGroup()
         for name, w in menuItems:
             self.stateGroup.autoAdd(w)
-        
+
         self.fileDialog = None
-        
+
         c.alphaGroup.toggled.connect(self.updateAlpha)
         c.alphaSlider.valueChanged.connect(self.updateAlpha)
         c.autoAlphaCheck.toggled.connect(self.updateAlpha)
@@ -263,15 +263,15 @@ class PlotItem(GraphicsWidget):
 
         self.ctrl.avgParamList.itemClicked.connect(self.avgParamListClicked)
         self.ctrl.averageGroup.toggled.connect(self.avgToggled)
-        
+
         self.ctrl.maxTracesCheck.toggled.connect(self.updateDecimation)
         self.ctrl.maxTracesSpin.valueChanged.connect(self.updateDecimation)
-        
+
         self.hideAxis('right')
         self.hideAxis('top')
         self.showAxis('left')
         self.showAxis('bottom')
-        
+
         if labels is None:
             labels = {}
         for label in list(self.axes.keys()):
@@ -282,14 +282,14 @@ class PlotItem(GraphicsWidget):
             if isinstance(labels[k], basestring):
                 labels[k] = (labels[k],)
             self.setLabel(k, *labels[k])
-                
+
         if title is not None:
             self.setTitle(title)
-        
+
         if len(kargs) > 0:
             self.plot(**kargs)
-        
-        
+
+
     def implements(self, interface=None):
         return interface in ['ViewBoxWrapper']
 
@@ -297,47 +297,47 @@ class PlotItem(GraphicsWidget):
         """Return the :class:`ViewBox <pyqtgraph.ViewBox>` contained within."""
         return self.vb
 
-    
-    ## Wrap a few methods from viewBox. 
+
+    ## Wrap a few methods from viewBox.
     #Important: don't use a settattr(m, getattr(self.vb, m)) as we'd be leaving the viebox alive
     #because we had a reference to an instance method (creating wrapper methods at runtime instead).
-    
-    for m in ['setXRange', 'setYRange', 'setXLink', 'setYLink', 'setAutoPan',         # NOTE: 
-              'setAutoVisible', 'setRange', 'autoRange', 'viewRect', 'viewRange',     # If you update this list, please 
-              'setMouseEnabled', 'setLimits', 'enableAutoRange', 'disableAutoRange',  # update the class docstring 
+
+    for m in ['setXRange', 'setYRange', 'setXLink', 'setYLink', 'setAutoPan',         # NOTE:
+              'setAutoVisible', 'setRange', 'autoRange', 'viewRect', 'viewRange',     # If you update this list, please
+              'setMouseEnabled', 'setLimits', 'enableAutoRange', 'disableAutoRange',  # update the class docstring
               'setAspectLocked', 'invertY', 'invertX', 'register', 'unregister']:                # as well.
-                
+
         def _create_method(name):
             def method(self, *args, **kwargs):
                 return getattr(self.vb, name)(*args, **kwargs)
             method.__name__ = name
             return method
-        
+
         locals()[m] = _create_method(m)
-        
+
     del _create_method
-    
-    
+
+
     def setLogMode(self, x=None, y=None):
         """
         Set log scaling for x and/or y axes.
         This informs PlotDataItems to transform logarithmically and switches
-        the axes to use log ticking. 
-        
+        the axes to use log ticking.
+
         Note that *no other items* in the scene will be affected by
         this; there is (currently) no generic way to redisplay a GraphicsItem
         with log coordinates.
-        
+
         """
         if x is not None:
             self.ctrl.logXCheck.setChecked(x)
         if y is not None:
             self.ctrl.logYCheck.setChecked(y)
-        
+
     def showGrid(self, x=None, y=None, alpha=None):
         """
         Show or hide the grid for either axis.
-        
+
         ==============  =====================================
         **Arguments:**
         x               (bool) Whether to show the X grid
@@ -347,7 +347,7 @@ class PlotItem(GraphicsWidget):
         """
         if x is None and y is None and alpha is None:
             raise Exception("Must specify at least one of x, y, or alpha.")  ## prevent people getting confused if they just call showGrid()
-        
+
         if x is not None:
             self.ctrl.xGridCheck.setChecked(x)
         if y is not None:
@@ -355,39 +355,39 @@ class PlotItem(GraphicsWidget):
         if alpha is not None:
             v = np.clip(alpha, 0, 1)*self.ctrl.gridAlphaSlider.maximum()
             self.ctrl.gridAlphaSlider.setValue(v)
-        
+
     #def paint(self, *args):
         #prof = debug.Profiler()
         #QtGui.QGraphicsWidget.paint(self, *args)
-        
-    ## bad idea. 
+
+    ## bad idea.
     #def __getattr__(self, attr):  ## wrap ms
         #return getattr(self.vb, attr)
-        
+
     def close(self):
         #print "delete", self
-        ## Most of this crap is needed to avoid PySide trouble. 
+        ## Most of this crap is needed to avoid PySide trouble.
         ## The problem seems to be whenever scene.clear() leads to deletion of widgets (either through proxies or qgraphicswidgets)
         ## the solution is to manually remove all widgets before scene.clear() is called
         if self.ctrlMenu is None: ## already shut down
             return
         self.ctrlMenu.setParent(None)
         self.ctrlMenu = None
-        
+
         self.autoBtn.setParent(None)
         self.autoBtn = None
-        
+
         for k in self.axes:
             i = self.axes[k]['item']
             i.close()
-            
+
         self.axes = None
         self.scene().removeItem(self.vb)
         self.vb = None
-        
+
     def registerPlot(self, name):   ## for backward compatibility
         self.vb.register(name)
-        
+
     def updateGrid(self, *args):
         alpha = self.ctrl.gridAlphaSlider.value()
         x = alpha if self.ctrl.xGridCheck.isChecked() else False
@@ -412,12 +412,12 @@ class PlotItem(GraphicsWidget):
             self.recomputeAverages()
         for k in self.avgCurves:
             self.avgCurves[k][1].setVisible(b)
-        
+
     def avgParamListClicked(self, item):
         name = str(item.text())
         self.paramList[name] = (item.checkState() == QtCore.Qt.Checked)
         self.recomputeAverages()
-        
+
     def recomputeAverages(self):
         if not self.ctrl.averageGroup.isChecked():
             return
@@ -427,15 +427,15 @@ class PlotItem(GraphicsWidget):
         for c in self.curves:
             self.addAvgCurve(c)
         self.replot()
-        
+
     def addAvgCurve(self, curve):
         ## Add a single curve into the pool of curves averaged together
-        
+
         ## If there are plot parameters, then we need to determine which to average together.
         remKeys = []
         addKeys = []
         if self.ctrl.avgParamList.count() > 0:
-        
+
             ### First determine the key of the curve to which this new data should be averaged
             for i in range(self.ctrl.avgParamList.count()):
                 item = self.ctrl.avgParamList.item(i)
@@ -443,10 +443,10 @@ class PlotItem(GraphicsWidget):
                     remKeys.append(str(item.text()))
                 else:
                     addKeys.append(str(item.text()))
-                    
+
             if len(remKeys) < 1:  ## In this case, there would be 1 average plot for each data plot; not useful.
                 return
-                
+
         p = self.itemMeta.get(curve,{}).copy()
         for k in p:
             if type(k) is tuple:
@@ -459,7 +459,7 @@ class PlotItem(GraphicsWidget):
             if ak not in p:
                 p[ak] = None
         key = tuple(p.items())
-        
+
         ### Create a new curve if needed
         if key not in self.avgCurves:
             plot = PlotDataItem()
@@ -471,7 +471,7 @@ class PlotItem(GraphicsWidget):
             self.avgCurves[key] = [0, plot]
         self.avgCurves[key][0] += 1
         (n, plot) = self.avgCurves[key]
-        
+
         ### Average data together
         (x, y) = curve.getData()
         stepMode = curve.opts['stepMode']
@@ -481,17 +481,17 @@ class PlotItem(GraphicsWidget):
             plot.setData(plot.xData, newData, stepMode=stepMode)
         else:
             plot.setData(x, y, stepMode=stepMode)
-        
+
     def autoBtnClicked(self):
         if self.autoBtn.mode == 'auto':
             self.enableAutoRange()
             self.autoBtn.hide()
         else:
             self.disableAutoRange()
-            
+
     def viewStateChanged(self):
         self.updateButtons()
-            
+
     def enableAutoScale(self):
         """
         Enable auto-scaling. The plot will continuously scale to fit the boundaries of its data.
@@ -501,7 +501,7 @@ class PlotItem(GraphicsWidget):
 
     def addItem(self, item, *args, **kargs):
         """
-        Add a graphics item to the view box. 
+        Add a graphics item to the view box.
         If the item has plot data (PlotDataItem, PlotCurveItem, ScatterPlotItem), it may
         be included in analysis performed by the PlotItem.
         """
@@ -515,16 +515,16 @@ class PlotItem(GraphicsWidget):
             name = item.name()
             self.dataItems.append(item)
             #self.plotChanged()
-            
+
             params = kargs.get('params', {})
             self.itemMeta[item] = params
             #item.setMeta(params)
             self.curves.append(item)
             #self.addItem(c)
-            
+
         if hasattr(item, 'setLogMode'):
             item.setLogMode(self.ctrl.logXCheck.isChecked(), self.ctrl.logYCheck.isChecked())
-            
+
         if isinstance(item, PlotDataItem):
             ## configure curve for this plot
             (alpha, auto) = self.alphaState()
@@ -533,40 +533,40 @@ class PlotItem(GraphicsWidget):
             item.setDownsampling(*self.downsampleMode())
             item.setClipToView(self.clipToViewMode())
             item.setPointMode(self.pointMode())
-            
+
             ## Hide older plots if needed
             self.updateDecimation()
-            
+
             ## Add to average if needed
             self.updateParamList()
             if self.ctrl.averageGroup.isChecked() and 'skipAverage' not in kargs:
                 self.addAvgCurve(item)
-                
+
             #c.connect(c, QtCore.SIGNAL('plotChanged'), self.plotChanged)
             #item.sigPlotChanged.connect(self.plotChanged)
             #self.plotChanged()
         #name = kargs.get('name', getattr(item, 'opts', {}).get('name', None))
         if name is not None and hasattr(self, 'legend') and self.legend is not None:
             self.legend.addItem(item, name=name)
-            
+
 
     def addDataItem(self, item, *args):
         print("PlotItem.addDataItem is deprecated. Use addItem instead.")
         self.addItem(item, *args)
-        
+
     def listDataItems(self):
         """Return a list of all data items (PlotDataItem, PlotCurveItem, ScatterPlotItem, etc)
         contained in this PlotItem."""
         return self.dataItems[:]
-        
+
     def addCurve(self, c, params=None):
         print("PlotItem.addCurve is deprecated. Use addItem instead.")
         self.addItem(c, params)
 
     def addLine(self, x=None, y=None, z=None, **kwds):
         """
-        Create an InfiniteLine and add to the plot. 
-        
+        Create an InfiniteLine and add to the plot.
+
         If *x* is specified,
         the line will be vertical. If *y* is specified, the line will be
         horizontal. All extra keyword arguments are passed to
@@ -580,8 +580,8 @@ class PlotItem(GraphicsWidget):
         if z is not None:
             line.setZValue(z)
         return line
-        
-        
+
+
 
     def removeItem(self, item):
         """
@@ -592,7 +592,7 @@ class PlotItem(GraphicsWidget):
         self.items.remove(item)
         if item in self.dataItems:
             self.dataItems.remove(item)
-            
+
         if item.scene() is not None:
             self.vb.removeItem(item)
         if item in self.curves:
@@ -609,36 +609,36 @@ class PlotItem(GraphicsWidget):
         for i in self.items[:]:
             self.removeItem(i)
         self.avgCurves = {}
-    
+
     def clearPlots(self):
         for i in self.curves[:]:
             self.removeItem(i)
         self.avgCurves = {}
-        
-    
+
+
     def plot(self, *args, **kargs):
         """
         Add and return a new plot.
         See :func:`PlotDataItem.__init__ <pyqtgraph.PlotDataItem.__init__>` for data arguments
-        
+
         Extra allowed arguments are:
             clear    - clear all plots before displaying new data
             params   - meta-parameters to associate with this data
         """
-        
-        
+
+
         clear = kargs.get('clear', False)
         params = kargs.get('params', None)
-          
+
         if clear:
             self.clear()
-            
+
         item = PlotDataItem(*args, **kargs)
-            
+
         if params is None:
             params = {}
         self.addItem(item, params=params)
-        
+
         return item
 
     def addLegend(self, size=None, offset=(30, 30)):
@@ -650,22 +650,22 @@ class PlotItem(GraphicsWidget):
         self.legend = LegendItem(size, offset)
         self.legend.setParentItem(self.vb)
         return self.legend
-        
+
     def scatterPlot(self, *args, **kargs):
         if 'pen' in kargs:
             kargs['symbolPen'] = kargs['pen']
         kargs['pen'] = None
-            
+
         if 'brush' in kargs:
             kargs['symbolBrush'] = kargs['brush']
             del kargs['brush']
-            
+
         if 'size' in kargs:
             kargs['symbolSize'] = kargs['size']
             del kargs['size']
 
         return self.plot(*args, **kargs)
-                
+
     def replot(self):
         self.update()
 
@@ -676,7 +676,7 @@ class PlotItem(GraphicsWidget):
             for p in list(self.itemMeta.get(c, {}).keys()):
                 if type(p) is tuple:
                     p = '.'.join(p)
-                    
+
                 ## If the parameter is not in the list, add it.
                 matches = self.ctrl.avgParamList.findItems(p, QtCore.Qt.MatchExactly)
                 if len(matches) == 0:
@@ -688,18 +688,18 @@ class PlotItem(GraphicsWidget):
                     self.ctrl.avgParamList.addItem(i)
                 else:
                     i = matches[0]
-                    
+
                 self.paramList[p] = (i.checkState() == QtCore.Qt.Checked)
 
 
-    ## Qt's SVG-writing capabilities are pretty terrible. 
+    ## Qt's SVG-writing capabilities are pretty terrible.
     def writeSvgCurves(self, fileName=None):
         if fileName is None:
             self.fileDialog = FileDialog()
             if PlotItem.lastFileDir is not None:
                 self.fileDialog.setDirectory(PlotItem.lastFileDir)
             self.fileDialog.setFileMode(QtGui.QFileDialog.AnyFile)
-            self.fileDialog.setAcceptMode(QtGui.QFileDialog.AcceptSave) 
+            self.fileDialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
             self.fileDialog.show()
             self.fileDialog.fileSelected.connect(self.writeSvg)
             return
@@ -709,10 +709,10 @@ class PlotItem(GraphicsWidget):
             raise Exception("Not implemented yet..")
         fileName = str(fileName)
         PlotItem.lastFileDir = os.path.dirname(fileName)
-        
+
         rect = self.vb.viewRect()
-        xRange = rect.left(), rect.right() 
-        
+        xRange = rect.left(), rect.right()
+
         svg = ""
         fh = open(fileName, 'w')
 
@@ -746,23 +746,23 @@ class PlotItem(GraphicsWidget):
                 mask[1:] += m2[:-1]
                 x = x[mask]
                 y = y[mask]
-                
+
                 x *= sx
                 y *= sy
-                
+
                 #fh.write('<g fill="none" stroke="#%s" stroke-opacity="1" stroke-width="1">\n' % color)
                 fh.write('<path fill="none" stroke="#%s" stroke-opacity="%f" stroke-width="1" d="M%f,%f ' % (color, opacity, x[0], y[0]))
                 for i in range(1, len(x)):
                     fh.write('L%f,%f ' % (x[i], y[i]))
-                
+
                 fh.write('"/>')
                 #fh.write("</g>")
         for item in self.dataItems:
             if isinstance(item, ScatterPlotItem):
-                
+
                 pRect = item.boundingRect()
                 vRect = pRect.intersected(rect)
-                
+
                 for point in item.points():
                     pos = point.pos()
                     if not rect.contains(pos):
@@ -772,30 +772,30 @@ class PlotItem(GraphicsWidget):
                     color = color[:6]
                     x = pos.x() * sx
                     y = pos.y() * sy
-                    
+
                     fh.write('<circle cx="%f" cy="%f" r="1" fill="#%s" stroke="none" fill-opacity="%f"/>\n' % (x, y, color, opacity))
-        
+
         fh.write("</svg>\n")
-        
-        
-    
+
+
+
     def writeSvg(self, fileName=None):
         if fileName is None:
             fileName = QtGui.QFileDialog.getSaveFileName()
         fileName = str(fileName)
         PlotItem.lastFileDir = os.path.dirname(fileName)
-        
+
         from ...exporters import SVGExporter
         ex = SVGExporter(self)
         ex.export(fileName)
-        
+
     def writeImage(self, fileName=None):
         if fileName is None:
             self.fileDialog = FileDialog()
             if PlotItem.lastFileDir is not None:
                 self.fileDialog.setDirectory(PlotItem.lastFileDir)
             self.fileDialog.setFileMode(QtGui.QFileDialog.AnyFile)
-            self.fileDialog.setAcceptMode(QtGui.QFileDialog.AcceptSave) 
+            self.fileDialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
             self.fileDialog.show()
             self.fileDialog.fileSelected.connect(self.writeImage)
             return
@@ -811,14 +811,14 @@ class PlotItem(GraphicsWidget):
         self.scene().render(painter, QtCore.QRectF(), self.mapRectToScene(self.boundingRect()))
         painter.end()
         self.png.save(fileName)
-        
+
     def writeCsv(self, fileName=None):
         if fileName is None:
             self.fileDialog = FileDialog()
             if PlotItem.lastFileDir is not None:
                 self.fileDialog.setDirectory(PlotItem.lastFileDir)
             self.fileDialog.setFileMode(QtGui.QFileDialog.AnyFile)
-            self.fileDialog.setAcceptMode(QtGui.QFileDialog.AcceptSave) 
+            self.fileDialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
             self.fileDialog.show()
             self.fileDialog.fileSelected.connect(self.writeCsv)
             return
@@ -826,7 +826,7 @@ class PlotItem(GraphicsWidget):
             #fileName = QtGui.QFileDialog.getSaveFileName()
         fileName = str(fileName)
         PlotItem.lastFileDir = os.path.dirname(fileName)
-        
+
         fd = open(fileName, 'w')
         data = [c.getData() for c in self.curves]
         i = 0
@@ -850,26 +850,26 @@ class PlotItem(GraphicsWidget):
         state['paramList'] = self.paramList.copy()
         state['view'] = self.vb.getState()
         return state
-        
+
     def restoreState(self, state):
         if 'paramList' in state:
             self.paramList = state['paramList'].copy()
-            
+
         self.stateGroup.setState(state)
         self.updateSpectrumMode()
         self.updateDownsampling()
         self.updateAlpha()
         self.updateDecimation()
-        
+
         if 'powerSpectrumGroup' in state:
             state['fftCheck'] = state['powerSpectrumGroup']
         if 'gridGroup' in state:
             state['xGridCheck'] = state['gridGroup']
             state['yGridCheck'] = state['gridGroup']
-            
+
         self.stateGroup.setState(state)
         self.updateParamList()
-        
+
         if 'view' not in state:
             r = [[float(state['xMinText']), float(state['xMaxText'])], [float(state['yMinText']), float(state['yMaxText'])]]
             state['view'] = {
@@ -879,11 +879,11 @@ class PlotItem(GraphicsWidget):
                 'viewRange': r,
             }
         self.vb.setState(state['view'])
-        
+
 
     def widgetGroupInterface(self):
         return (None, PlotItem.saveState, PlotItem.restoreState)
-      
+
     def updateSpectrumMode(self, b=None):
         if b is None:
             b = self.ctrl.fftCheck.isChecked()
@@ -891,7 +891,7 @@ class PlotItem(GraphicsWidget):
             c.setFftMode(b)
         self.enableAutoRange()
         self.recomputeAverages()
-            
+
     def updateLogMode(self):
         x = self.ctrl.logXCheck.isChecked()
         y = self.ctrl.logYCheck.isChecked()
@@ -904,10 +904,10 @@ class PlotItem(GraphicsWidget):
         self.getAxis('right').setLogMode(y)
         self.enableAutoRange()
         self.recomputeAverages()
-        
+
     def setDownsampling(self, ds=None, auto=None, mode=None):
         """Change the default downsampling mode for all PlotDataItems managed by this plot.
-        
+
         =============== =================================================================
         **Arguments:**
         ds              (int) Reduce visible plot samples by this factor, or
@@ -929,12 +929,12 @@ class PlotItem(GraphicsWidget):
             else:
                 self.ctrl.downsampleCheck.setChecked(True)
                 self.ctrl.downsampleSpin.setValue(ds)
-                
+
         if auto is not None:
             if auto and ds is not False:
                 self.ctrl.downsampleCheck.setChecked(True)
             self.ctrl.autoDownsampleCheck.setChecked(auto)
-            
+
         if mode is not None:
             if mode == 'subsample':
                 self.ctrl.subsampleRadio.setChecked(True)
@@ -944,7 +944,7 @@ class PlotItem(GraphicsWidget):
                 self.ctrl.peakRadio.setChecked(True)
             else:
                 raise ValueError("mode argument must be 'subsample', 'mean', or 'peak'.")
-            
+
     def updateDownsampling(self):
         ds, auto, method = self.downsampleMode()
         clip = self.ctrl.clipToViewCheck.isChecked()
@@ -952,41 +952,41 @@ class PlotItem(GraphicsWidget):
             c.setDownsampling(ds, auto, method)
             c.setClipToView(clip)
         self.recomputeAverages()
-        
+
     def downsampleMode(self):
         if self.ctrl.downsampleCheck.isChecked():
             ds = self.ctrl.downsampleSpin.value()
         else:
             ds = 1
-            
+
         auto = self.ctrl.downsampleCheck.isChecked() and self.ctrl.autoDownsampleCheck.isChecked()
-            
+
         if self.ctrl.subsampleRadio.isChecked():
-            method = 'subsample' 
+            method = 'subsample'
         elif self.ctrl.meanRadio.isChecked():
             method = 'mean'
         elif self.ctrl.peakRadio.isChecked():
             method = 'peak'
-        
+
         return ds, auto, method
-        
+
     def setClipToView(self, clip):
         """Set the default clip-to-view mode for all PlotDataItems managed by this plot.
         If *clip* is True, then PlotDataItems will attempt to draw only points within the visible
         range of the ViewBox."""
         self.ctrl.clipToViewCheck.setChecked(clip)
-        
+
     def clipToViewMode(self):
         return self.ctrl.clipToViewCheck.isChecked()
-        
-        
-        
+
+
+
     def updateDecimation(self):
         if self.ctrl.maxTracesCheck.isChecked():
             numCurves = self.ctrl.maxTracesSpin.value()
         else:
             numCurves = -1
-            
+
         curves = self.curves[:]
         split = len(curves) - numCurves
         for i in range(len(curves)):
@@ -998,13 +998,13 @@ class PlotItem(GraphicsWidget):
                     self.removeItem(curves[i])
                 else:
                     curves[i].hide()
-        
-      
+
+
     def updateAlpha(self, *args):
         (alpha, auto) = self.alphaState()
         for c in self.curves:
             c.setAlpha(alpha**2, auto)
-     
+
     def alphaState(self):
         enabled = self.ctrl.alphaGroup.isChecked()
         auto = self.ctrl.autoAlphaCheck.isChecked()
@@ -1025,7 +1025,7 @@ class PlotItem(GraphicsWidget):
         else:
             mode = False
         return mode
-        
+
 
     def resizeEvent(self, ev):
         if self.autoBtn is None:  ## already closed down
@@ -1033,18 +1033,18 @@ class PlotItem(GraphicsWidget):
         btnRect = self.mapRectFromItem(self.autoBtn, self.autoBtn.boundingRect())
         y = self.size().height() - btnRect.height()
         self.autoBtn.setPos(0, y)
-    
-    
+
+
     def getMenu(self):
         return self.ctrlMenu
-    
+
     def getContextMenus(self, event):
         ## called when another item is displaying its context menu; we get to add extras to the end of the menu.
         if self.menuEnabled():
             return self.ctrlMenu
         else:
             return None
-    
+
     def setMenuEnabled(self, enableMenu=True, enableViewBoxMenu='same'):
         """
         Enable or disable the context menu for this PlotItem.
@@ -1055,41 +1055,41 @@ class PlotItem(GraphicsWidget):
         if enableViewBoxMenu is None:
             return
         if enableViewBoxMenu is 'same':
-            enableViewBoxMenu = enableMenu 
+            enableViewBoxMenu = enableMenu
         self.vb.setMenuEnabled(enableViewBoxMenu)
-    
+
     def menuEnabled(self):
         return self._menuEnabled
-    
+
     def hoverEvent(self, ev):
         if ev.enter:
             self.mouseHovering = True
         if ev.exit:
             self.mouseHovering = False
-            
+
         self.updateButtons()
-    
+
 
     def getLabel(self, key):
         pass
-        
+
     def _checkScaleKey(self, key):
         if key not in self.axes:
             raise Exception("Scale '%s' not found. Scales are: %s" % (key, str(list(self.axes.keys()))))
-        
+
     def getScale(self, key):
         return self.getAxis(key)
-        
+
     def getAxis(self, name):
-        """Return the specified AxisItem. 
+        """Return the specified AxisItem.
         *name* should be 'left', 'bottom', 'top', or 'right'."""
         self._checkScaleKey(name)
         return self.axes[name]['item']
-        
+
     def setLabel(self, axis, text=None, units=None, unitPrefix=None, **args):
         """
         Set the label for an axis. Basic HTML formatting is allowed.
-        
+
         ==============  =================================================================
         **Arguments:**
         axis            must be one of 'left', 'bottom', 'right', or 'top'
@@ -1102,7 +1102,7 @@ class PlotItem(GraphicsWidget):
         """
         self.getAxis(axis).setLabel(text=text, units=units, **args)
         self.showAxis(axis)
-        
+
     def setLabels(self, **kwds):
         """
         Convenience function allowing multiple labels and/or title to be set in one call.
@@ -1116,8 +1116,8 @@ class PlotItem(GraphicsWidget):
                 if isinstance(v, basestring):
                     v = (v,)
                 self.setLabel(k, *v)
-        
-        
+
+
     def showLabel(self, axis, show=True):
         """
         Show or hide one of the plot's axis labels (the axis itself will be unaffected).
@@ -1151,27 +1151,27 @@ class PlotItem(GraphicsWidget):
             s.show()
         else:
             s.hide()
-            
+
     def hideAxis(self, axis):
         """Hide one of the PlotItem's axes. ('left', 'bottom', 'right', or 'top')"""
         self.showAxis(axis, False)
-            
+
     def showScale(self, *args, **kargs):
         print("Deprecated. use showAxis() instead")
         return self.showAxis(*args, **kargs)
-            
+
     def hideButtons(self):
         """Causes auto-scale button ('A' in lower-left corner) to be hidden for this PlotItem"""
         #self.ctrlBtn.hide()
         self.buttonsHidden = True
         self.updateButtons()
-        
+
     def showButtons(self):
         """Causes auto-scale button ('A' in lower-left corner) to be visible for this PlotItem"""
         #self.ctrlBtn.hide()
         self.buttonsHidden = False
         self.updateButtons()
-        
+
     def updateButtons(self):
         try:
             if self._exportOpts is False and self.mouseHovering and not self.buttonsHidden and not all(self.vb.autoRangeEnabled()):
@@ -1180,7 +1180,7 @@ class PlotItem(GraphicsWidget):
                 self.autoBtn.hide()
         except RuntimeError:
             pass  # this can happen if the plot has been deleted.
-            
+
     def _plotArray(self, arr, x=None, **kargs):
         if arr.ndim != 1:
             raise Exception("Array must be 1D to plot (shape is %s)" % arr.shape)
@@ -1190,9 +1190,9 @@ class PlotItem(GraphicsWidget):
             raise Exception("X array must be 1D to plot (shape is %s)" % x.shape)
         c = PlotCurveItem(arr, x=x, **kargs)
         return c
-            
-        
-        
+
+
+
     def _plotMetaArray(self, arr, x=None, autoLabel=True, **kargs):
         inf = arr.infoCopy()
         if arr.ndim != 1:
@@ -1207,19 +1207,19 @@ class PlotItem(GraphicsWidget):
                 xv = x
         c = PlotCurveItem(**kargs)
         c.setData(x=xv, y=arr.view(np.ndarray))
-        
+
         if autoLabel:
             name = arr._info[0].get('name', None)
             units = arr._info[0].get('units', None)
             self.setLabel('bottom', text=name, units=units)
-            
+
             name = arr._info[1].get('name', None)
             units = arr._info[1].get('units', None)
             self.setLabel('left', text=name, units=units)
-            
+
         return c
 
-      
+
     def setExportMode(self, export, opts=None):
         GraphicsWidget.setExportMode(self, export, opts)
         self.updateButtons()
@@ -1227,4 +1227,3 @@ class PlotItem(GraphicsWidget):
             #self.autoBtn.hide()
         #else:
             #self.autoBtn.show()
-    

--- a/pyqtgraph/graphicsItems/PlotItem/plotConfigTemplate_pyqt.py
+++ b/pyqtgraph/graphicsItems/PlotItem/plotConfigTemplate_pyqt.py
@@ -179,4 +179,3 @@ class Ui_Form(object):
         self.label.setText(_translate("Form", "Opacity", None))
         self.alphaGroup.setTitle(_translate("Form", "Alpha", None))
         self.autoAlphaCheck.setText(_translate("Form", "Auto", None))
-

--- a/pyqtgraph/graphicsItems/PlotItem/plotConfigTemplate_pyqt5.py
+++ b/pyqtgraph/graphicsItems/PlotItem/plotConfigTemplate_pyqt5.py
@@ -166,4 +166,3 @@ class Ui_Form(object):
         self.label.setText(_translate("Form", "Opacity"))
         self.alphaGroup.setTitle(_translate("Form", "Alpha"))
         self.autoAlphaCheck.setText(_translate("Form", "Auto"))
-

--- a/pyqtgraph/graphicsItems/PlotItem/plotConfigTemplate_pyside.py
+++ b/pyqtgraph/graphicsItems/PlotItem/plotConfigTemplate_pyside.py
@@ -165,4 +165,3 @@ class Ui_Form(object):
         self.label.setText(QtGui.QApplication.translate("Form", "Opacity", None, QtGui.QApplication.UnicodeUTF8))
         self.alphaGroup.setTitle(QtGui.QApplication.translate("Form", "Alpha", None, QtGui.QApplication.UnicodeUTF8))
         self.autoAlphaCheck.setText(QtGui.QApplication.translate("Form", "Auto", None, QtGui.QApplication.UnicodeUTF8))
-

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -5,7 +5,7 @@ Copyright 2010  Luke Campagnola
 Distributed under MIT/X11 license. See license.txt for more infomation.
 
 Implements a series of graphics items which display movable/scalable/rotatable shapes
-for use as region-of-interest markers. ROI class automatically handles extraction 
+for use as region-of-interest markers. ROI class automatically handles extraction
 of array data from ImageItems.
 
 The ROI class is meant to serve as the base for more specific types; see several examples
@@ -23,8 +23,8 @@ from .GraphicsObject import GraphicsObject
 from .UIGraphicsItem import UIGraphicsItem
 
 __all__ = [
-    'ROI', 
-    'TestROI', 'RectROI', 'EllipseROI', 'CircleROI', 'PolygonROI', 
+    'ROI',
+    'TestROI', 'RectROI', 'EllipseROI', 'CircleROI', 'PolygonROI',
     'LineROI', 'MultiLineROI', 'MultiRectROI', 'LineSegmentROI', 'PolyLineROI', 'SpiralROI', 'CrosshairROI',
 ]
 
@@ -35,27 +35,27 @@ def rectStr(r):
 class ROI(GraphicsObject):
     """
     Generic region-of-interest widget.
-    
-    Can be used for implementing many types of selection box with 
+
+    Can be used for implementing many types of selection box with
     rotate/translate/scale handles.
     ROIs can be customized to have a variety of shapes (by subclassing or using
     any of the built-in subclasses) and any combination of draggable handles
     that allow the user to manipulate the ROI.
-    
-    
-    
+
+
+
     ================ ===========================================================
     **Arguments**
-    pos              (length-2 sequence) Indicates the position of the ROI's 
+    pos              (length-2 sequence) Indicates the position of the ROI's
                      origin. For most ROIs, this is the lower-left corner of
                      its bounding rectangle.
-    size             (length-2 sequence) Indicates the width and height of the 
+    size             (length-2 sequence) Indicates the width and height of the
                      ROI.
     angle            (float) The rotation of the ROI in degrees. Default is 0.
-    invertible       (bool) If True, the user may resize the ROI to have 
+    invertible       (bool) If True, the user may resize the ROI to have
                      negative width or height (assuming the ROI has scale
                      handles). Default is False.
-    maxBounds        (QRect, QRectF, or None) Specifies boundaries that the ROI 
+    maxBounds        (QRect, QRectF, or None) Specifies boundaries that the ROI
                      cannot be dragged outside of by the user. Default is None.
     snapSize         (float) The spacing of snap positions used when *scaleSnap*
                      or *translateSnap* are enabled. Default is 1.0.
@@ -65,22 +65,22 @@ class ROI(GraphicsObject):
     translateSnap    (bool) If True, the x and y positions of the ROI are forced
                      to be integer multiples of *snapSize* when being resized
                      by the user. Default is False.
-    rotateSnap       (bool) If True, the ROI angle is forced to a multiple of 
+    rotateSnap       (bool) If True, the ROI angle is forced to a multiple of
                      15 degrees when rotated by the user. Default is False.
     parent           (QGraphicsItem) The graphics item parent of this ROI. It
                      is generally not necessary to specify the parent.
     pen              (QPen or argument to pg.mkPen) The pen to use when drawing
                      the shape of the ROI.
-    movable          (bool) If True, the ROI can be moved by dragging anywhere 
+    movable          (bool) If True, the ROI can be moved by dragging anywhere
                      inside the ROI. Default is True.
     removable        (bool) If True, the ROI will be given a context menu with
                      an option to remove the ROI. The ROI emits
                      sigRemoveRequested when this menu action is selected.
                      Default is False.
     ================ ===========================================================
-    
-    
-    
+
+
+
     ======================= ====================================================
     **Signals**
     sigRegionChangeFinished Emitted when the user stops dragging the ROI (or
@@ -93,23 +93,23 @@ class ROI(GraphicsObject):
     sigHoverEvent           Emitted when the mouse hovers over the ROI.
     sigClicked              Emitted when the user clicks on the ROI.
                             Note that clicking is disabled by default to prevent
-                            stealing clicks from objects behind the ROI. To 
-                            enable clicking, call 
-                            roi.setAcceptedMouseButtons(QtCore.Qt.LeftButton). 
-                            See QtGui.QGraphicsItem documentation for more 
+                            stealing clicks from objects behind the ROI. To
+                            enable clicking, call
+                            roi.setAcceptedMouseButtons(QtCore.Qt.LeftButton).
+                            See QtGui.QGraphicsItem documentation for more
                             details.
-    sigRemoveRequested      Emitted when the user selects 'remove' from the 
+    sigRemoveRequested      Emitted when the user selects 'remove' from the
                             ROI's context menu (if available).
     ======================= ====================================================
     """
-    
+
     sigRegionChangeFinished = QtCore.Signal(object)
     sigRegionChangeStarted = QtCore.Signal(object)
     sigRegionChanged = QtCore.Signal(object)
     sigHoverEvent = QtCore.Signal(object)
     sigClicked = QtCore.Signal(object, object)
     sigRemoveRequested = QtCore.Signal(object)
-    
+
     def __init__(self, pos, size=Point(1, 1), angle=0.0, invertible=False, maxBounds=None, snapSize=1.0, scaleSnap=False, translateSnap=False, rotateSnap=False, parent=None, pen=None, movable=True, removable=False):
         #QObjectWorkaround.__init__(self)
         GraphicsObject.__init__(self, parent)
@@ -121,13 +121,13 @@ class ROI(GraphicsObject):
         self.rotateAllowed = True
         self.removable = removable
         self.menu = None
-        
+
         self.freeHandleMoved = False ## keep track of whether free handles have moved since last change signal was emitted.
         self.mouseHovering = False
         if pen is None:
             pen = (255, 255, 255)
         self.setPen(pen)
-        
+
         self.handlePen = QtGui.QPen(QtGui.QColor(150, 255, 255))
         self.handles = []
         self.state = {'pos': Point(0,0), 'size': Point(1,1), 'angle': 0}  ## angle is in degrees for ease of Qt integration
@@ -137,17 +137,17 @@ class ROI(GraphicsObject):
         self.setSize(size)
         self.setZValue(10)
         self.isMoving = False
-        
+
         self.handleSize = 5
         self.invertible = invertible
         self.maxBounds = maxBounds
-        
+
         self.snapSize = snapSize
         self.translateSnap = translateSnap
         self.rotateSnap = rotateSnap
         self.scaleSnap = scaleSnap
         #self.setFlag(self.ItemIsSelectable, True)
-    
+
     def getState(self):
         return self.stateCopy()
 
@@ -157,19 +157,19 @@ class ROI(GraphicsObject):
         sc['size'] = Point(self.state['size'])
         sc['angle'] = self.state['angle']
         return sc
-        
+
     def saveState(self):
-        """Return the state of the widget in a format suitable for storing to 
+        """Return the state of the widget in a format suitable for storing to
         disk. (Points are converted to tuple)
-        
-        Combined with setState(), this allows ROIs to be easily saved and 
+
+        Combined with setState(), this allows ROIs to be easily saved and
         restored."""
         state = {}
         state['pos'] = tuple(self.state['pos'])
         state['size'] = tuple(self.state['size'])
         state['angle'] = self.state['angle']
         return state
-    
+
     def setState(self, state, update=True):
         """
         Set the state of the ROI from a structure generated by saveState() or
@@ -178,16 +178,16 @@ class ROI(GraphicsObject):
         self.setPos(state['pos'], update=False)
         self.setSize(state['size'], update=False)
         self.setAngle(state['angle'], update=update)
-    
+
     def setZValue(self, z):
         QtGui.QGraphicsItem.setZValue(self, z)
         for h in self.handles:
             h['item'].setZValue(z+1)
-        
+
     def parentBounds(self):
         """
         Return the bounding rectangle of this ROI in the coordinate system
-        of its parent.        
+        of its parent.
         """
         return self.mapToParent(self.boundingRect()).boundingRect()
 
@@ -199,39 +199,39 @@ class ROI(GraphicsObject):
         self.pen = fn.mkPen(*args, **kwargs)
         self.currentPen = self.pen
         self.update()
-        
+
     def size(self):
         """Return the size (w,h) of the ROI."""
         return self.getState()['size']
-        
+
     def pos(self):
-        """Return the position (x,y) of the ROI's origin. 
+        """Return the position (x,y) of the ROI's origin.
         For most ROIs, this will be the lower-left corner."""
         return self.getState()['pos']
-        
+
     def angle(self):
         """Return the angle of the ROI in degrees."""
         return self.getState()['angle']
-        
+
     def setPos(self, pos, update=True, finish=True):
         """Set the position of the ROI (in the parent's coordinate system).
         By default, this will cause both sigRegionChanged and sigRegionChangeFinished to be emitted.
-        
-        If finish is False, then sigRegionChangeFinished will not be emitted. You can then use 
+
+        If finish is False, then sigRegionChangeFinished will not be emitted. You can then use
         stateChangeFinished() to cause the signal to be emitted after a series of state changes.
-        
-        If update is False, the state change will be remembered but not processed and no signals 
+
+        If update is False, the state change will be remembered but not processed and no signals
         will be emitted. You can then use stateChanged() to complete the state change. This allows
         multiple change functions to be called sequentially while minimizing processing overhead
         and repeated signals. Setting update=False also forces finish=False.
         """
-        
+
         pos = Point(pos)
         self.state['pos'] = pos
         QtGui.QGraphicsItem.setPos(self, pos)
         if update:
             self.stateChanged(finish=finish)
-        
+
     def setSize(self, size, update=True, finish=True):
         """Set the size of the ROI. May be specified as a QPoint, Point, or list of two values.
         See setPos() for an explanation of the update and finish arguments.
@@ -241,7 +241,7 @@ class ROI(GraphicsObject):
         self.state['size'] = size
         if update:
             self.stateChanged(finish=finish)
-        
+
     def setAngle(self, angle, update=True, finish=True):
         """Set the angle of rotation (in degrees) for this ROI.
         See setPos() for an explanation of the update and finish arguments.
@@ -253,7 +253,7 @@ class ROI(GraphicsObject):
         self.setTransform(tr)
         if update:
             self.stateChanged(finish=finish)
-        
+
     def scale(self, s, center=[0,0], update=True, finish=True):
         """
         Resize the ROI by scaling relative to *center*.
@@ -264,27 +264,27 @@ class ROI(GraphicsObject):
         newSize = self.state['size'] * s
         c1 = self.mapToParent(Point(center) * newSize)
         newPos = self.state['pos'] + c - c1
-        
+
         self.setSize(newSize, update=False)
         self.setPos(newPos, update=update, finish=finish)
-        
-   
+
+
     def translate(self, *args, **kargs):
         """
         Move the ROI to a new position.
         Accepts either (x, y, snap) or ([x,y], snap) as arguments
         If the ROI is bounded and the move would exceed boundaries, then the ROI
         is moved to the nearest acceptable position instead.
-        
+
         *snap* can be:
-        
+
         =============== ==========================================================================
         None (default)  use self.translateSnap and self.snapSize to determine whether/how to snap
         False           do not snap
         Point(w,h)      snap to rectangular grid with spacing (w,h)
         True            snap using self.snapSize (and ignoring self.translateSnap)
         =============== ==========================================================================
-           
+
         Also accepts *update* and *finish* arguments (see setPos() for a description of these).
         """
 
@@ -292,20 +292,20 @@ class ROI(GraphicsObject):
             pt = args[0]
         else:
             pt = args
-            
+
         newState = self.stateCopy()
         newState['pos'] = newState['pos'] + pt
-        
+
         ## snap position
         #snap = kargs.get('snap', None)
         #if (snap is not False)   and   not (snap is None and self.translateSnap is False):
-        
+
         snap = kargs.get('snap', None)
         if snap is None:
             snap = self.translateSnap
         if snap is not False:
             newState['pos'] = self.getSnapPosition(newState['pos'], snap=snap)
-        
+
         #d = ev.scenePos() - self.mapToScene(self.pressPos)
         if self.maxBounds is not None:
             r = self.stateRect(newState)
@@ -320,7 +320,7 @@ class ROI(GraphicsObject):
             elif self.maxBounds.bottom() < r.bottom():
                 d[1] = self.maxBounds.bottom() - r.bottom()
             newState['pos'] += d
-        
+
         #self.state['pos'] = newState['pos']
         update = kargs.get('update', True)
         finish = kargs.get('finish', True)
@@ -330,82 +330,82 @@ class ROI(GraphicsObject):
 
     def rotate(self, angle, update=True, finish=True):
         """
-        Rotate the ROI by *angle* degrees. 
-        
-        Also accepts *update* and *finish* arguments (see setPos() for a 
+        Rotate the ROI by *angle* degrees.
+
+        Also accepts *update* and *finish* arguments (see setPos() for a
         description of these).
         """
         self.setAngle(self.angle()+angle, update=update, finish=finish)
 
     def handleMoveStarted(self):
         self.preMoveState = self.getState()
-    
+
     def addTranslateHandle(self, pos, axes=None, item=None, name=None, index=None):
         """
-        Add a new translation handle to the ROI. Dragging the handle will move 
-        the entire ROI without changing its angle or shape. 
-        
+        Add a new translation handle to the ROI. Dragging the handle will move
+        the entire ROI without changing its angle or shape.
+
         Note that, by default, ROIs may be moved by dragging anywhere inside the
         ROI. However, for larger ROIs it may be desirable to disable this and
         instead provide one or more translation handles.
-        
+
         =================== ====================================================
         **Arguments**
-        pos                 (length-2 sequence) The position of the handle 
+        pos                 (length-2 sequence) The position of the handle
                             relative to the shape of the ROI. A value of (0,0)
                             indicates the origin, whereas (1, 1) indicates the
                             upper-right corner, regardless of the ROI's size.
         item                The Handle instance to add. If None, a new handle
                             will be created.
-        name                The name of this handle (optional). Handles are 
-                            identified by name when calling 
+        name                The name of this handle (optional). Handles are
+                            identified by name when calling
                             getLocalHandlePositions and getSceneHandlePositions.
         =================== ====================================================
         """
         pos = Point(pos)
         return self.addHandle({'name': name, 'type': 't', 'pos': pos, 'item': item}, index=index)
-    
+
     def addFreeHandle(self, pos=None, axes=None, item=None, name=None, index=None):
         """
         Add a new free handle to the ROI. Dragging free handles has no effect
-        on the position or shape of the ROI. 
-        
+        on the position or shape of the ROI.
+
         =================== ====================================================
         **Arguments**
-        pos                 (length-2 sequence) The position of the handle 
+        pos                 (length-2 sequence) The position of the handle
                             relative to the shape of the ROI. A value of (0,0)
                             indicates the origin, whereas (1, 1) indicates the
                             upper-right corner, regardless of the ROI's size.
         item                The Handle instance to add. If None, a new handle
                             will be created.
-        name                The name of this handle (optional). Handles are 
-                            identified by name when calling 
+        name                The name of this handle (optional). Handles are
+                            identified by name when calling
                             getLocalHandlePositions and getSceneHandlePositions.
         =================== ====================================================
         """
         if pos is not None:
             pos = Point(pos)
         return self.addHandle({'name': name, 'type': 'f', 'pos': pos, 'item': item}, index=index)
-    
+
     def addScaleHandle(self, pos, center, axes=None, item=None, name=None, lockAspect=False, index=None):
         """
         Add a new scale handle to the ROI. Dragging a scale handle allows the
         user to change the height and/or width of the ROI.
-        
+
         =================== ====================================================
         **Arguments**
-        pos                 (length-2 sequence) The position of the handle 
+        pos                 (length-2 sequence) The position of the handle
                             relative to the shape of the ROI. A value of (0,0)
                             indicates the origin, whereas (1, 1) indicates the
                             upper-right corner, regardless of the ROI's size.
-        center              (length-2 sequence) The center point around which 
+        center              (length-2 sequence) The center point around which
                             scaling takes place. If the center point has the
-                            same x or y value as the handle position, then 
+                            same x or y value as the handle position, then
                             scaling will be disabled for that axis.
         item                The Handle instance to add. If None, a new handle
                             will be created.
-        name                The name of this handle (optional). Handles are 
-                            identified by name when calling 
+        name                The name of this handle (optional). Handles are
+                            identified by name when calling
                             getLocalHandlePositions and getSceneHandlePositions.
         =================== ====================================================
         """
@@ -417,50 +417,50 @@ class ROI(GraphicsObject):
         if pos.y() == center.y():
             info['yoff'] = True
         return self.addHandle(info, index=index)
-    
+
     def addRotateHandle(self, pos, center, item=None, name=None, index=None):
         """
-        Add a new rotation handle to the ROI. Dragging a rotation handle allows 
+        Add a new rotation handle to the ROI. Dragging a rotation handle allows
         the user to change the angle of the ROI.
-        
+
         =================== ====================================================
         **Arguments**
-        pos                 (length-2 sequence) The position of the handle 
+        pos                 (length-2 sequence) The position of the handle
                             relative to the shape of the ROI. A value of (0,0)
                             indicates the origin, whereas (1, 1) indicates the
                             upper-right corner, regardless of the ROI's size.
-        center              (length-2 sequence) The center point around which 
+        center              (length-2 sequence) The center point around which
                             rotation takes place.
         item                The Handle instance to add. If None, a new handle
                             will be created.
-        name                The name of this handle (optional). Handles are 
-                            identified by name when calling 
+        name                The name of this handle (optional). Handles are
+                            identified by name when calling
                             getLocalHandlePositions and getSceneHandlePositions.
         =================== ====================================================
         """
         pos = Point(pos)
         center = Point(center)
         return self.addHandle({'name': name, 'type': 'r', 'center': center, 'pos': pos, 'item': item}, index=index)
-    
+
     def addScaleRotateHandle(self, pos, center, item=None, name=None, index=None):
         """
-        Add a new scale+rotation handle to the ROI. When dragging a handle of 
-        this type, the user can simultaneously rotate the ROI around an 
+        Add a new scale+rotation handle to the ROI. When dragging a handle of
+        this type, the user can simultaneously rotate the ROI around an
         arbitrary center point as well as scale the ROI by dragging the handle
         toward or away from the center point.
-        
+
         =================== ====================================================
         **Arguments**
-        pos                 (length-2 sequence) The position of the handle 
+        pos                 (length-2 sequence) The position of the handle
                             relative to the shape of the ROI. A value of (0,0)
                             indicates the origin, whereas (1, 1) indicates the
                             upper-right corner, regardless of the ROI's size.
-        center              (length-2 sequence) The center point around which 
+        center              (length-2 sequence) The center point around which
                             scaling and rotation take place.
         item                The Handle instance to add. If None, a new handle
                             will be created.
-        name                The name of this handle (optional). Handles are 
-                            identified by name when calling 
+        name                The name of this handle (optional). Handles are
+                            identified by name when calling
                             getLocalHandlePositions and getSceneHandlePositions.
         =================== ====================================================
         """
@@ -469,33 +469,33 @@ class ROI(GraphicsObject):
         if pos[0] != center[0] and pos[1] != center[1]:
             raise Exception("Scale/rotate handles must have either the same x or y coordinate as their center point.")
         return self.addHandle({'name': name, 'type': 'sr', 'center': center, 'pos': pos, 'item': item}, index=index)
-    
+
     def addRotateFreeHandle(self, pos, center, axes=None, item=None, name=None, index=None):
         """
-        Add a new rotation+free handle to the ROI. When dragging a handle of 
-        this type, the user can rotate the ROI around an 
-        arbitrary center point, while moving toward or away from the center 
+        Add a new rotation+free handle to the ROI. When dragging a handle of
+        this type, the user can rotate the ROI around an
+        arbitrary center point, while moving toward or away from the center
         point has no effect on the shape of the ROI.
-        
+
         =================== ====================================================
         **Arguments**
-        pos                 (length-2 sequence) The position of the handle 
+        pos                 (length-2 sequence) The position of the handle
                             relative to the shape of the ROI. A value of (0,0)
                             indicates the origin, whereas (1, 1) indicates the
                             upper-right corner, regardless of the ROI's size.
-        center              (length-2 sequence) The center point around which 
+        center              (length-2 sequence) The center point around which
                             rotation takes place.
         item                The Handle instance to add. If None, a new handle
                             will be created.
-        name                The name of this handle (optional). Handles are 
-                            identified by name when calling 
+        name                The name of this handle (optional). Handles are
+                            identified by name when calling
                             getLocalHandlePositions and getSceneHandlePositions.
         =================== ====================================================
         """
         pos = Point(pos)
         center = Point(center)
         return self.addHandle({'name': name, 'type': 'rf', 'center': center, 'pos': pos, 'item': item}, index=index)
-    
+
     def addHandle(self, info, index=None):
         ## If a Handle was not supplied, create it now
         if 'item' not in info or info['item'] is None:
@@ -506,7 +506,7 @@ class ROI(GraphicsObject):
             h = info['item']
             if info['pos'] is None:
                 info['pos'] = h.pos()
-            
+
         ## connect the handle to this ROI
         #iid = len(self.handles)
         h.connectROI(self)
@@ -514,39 +514,39 @@ class ROI(GraphicsObject):
             self.handles.append(info)
         else:
             self.handles.insert(index, info)
-        
+
         h.setZValue(self.zValue()+1)
         self.stateChanged()
         return h
-    
+
     def indexOfHandle(self, handle):
         """
         Return the index of *handle* in the list of this ROI's handles.
         """
         if isinstance(handle, Handle):
-            index = [i for i, info in enumerate(self.handles) if info['item'] is handle]    
+            index = [i for i, info in enumerate(self.handles) if info['item'] is handle]
             if len(index) == 0:
                 raise Exception("Cannot remove handle; it is not attached to this ROI")
             return index[0]
         else:
             return handle
-        
+
     def removeHandle(self, handle):
-        """Remove a handle from this ROI. Argument may be either a Handle 
+        """Remove a handle from this ROI. Argument may be either a Handle
         instance or the integer index of the handle."""
         index = self.indexOfHandle(handle)
-            
+
         handle = self.handles[index]['item']
         self.handles.pop(index)
         handle.disconnectROI(self)
         if len(handle.rois) == 0:
             self.scene().removeItem(handle)
         self.stateChanged()
-    
+
     def replaceHandle(self, oldHandle, newHandle):
-        """Replace one handle in the ROI for another. This is useful when 
+        """Replace one handle in the ROI for another. This is useful when
         connecting multiple ROIs together.
-        
+
         *oldHandle* may be a Handle instance or the index of a handle to be
         replaced."""
         index = self.indexOfHandle(oldHandle)
@@ -555,18 +555,18 @@ class ROI(GraphicsObject):
         info['item'] = newHandle
         info['pos'] = newHandle.pos()
         self.addHandle(info, index=index)
-        
+
     def checkRemoveHandle(self, handle):
         ## This is used when displaying a Handle's context menu to determine
-        ## whether removing is allowed. 
+        ## whether removing is allowed.
         ## Subclasses may wish to override this to disable the menu entry.
         ## Note: by default, handles are not user-removable even if this method returns True.
         return True
-        
-        
+
+
     def getLocalHandlePositions(self, index=None):
         """Returns the position of handles in the ROI's coordinate system.
-        
+
         The format returned is a list of (name, pos) tuples.
         """
         if index == None:
@@ -576,10 +576,10 @@ class ROI(GraphicsObject):
             return positions
         else:
             return (self.handles[index]['name'], self.handles[index]['pos'])
-            
+
     def getSceneHandlePositions(self, index=None):
         """Returns the position of handles in the scene coordinate system.
-        
+
         The format returned is a list of (name, pos) tuples.
         """
         if index == None:
@@ -589,13 +589,13 @@ class ROI(GraphicsObject):
             return positions
         else:
             return (self.handles[index]['name'], self.handles[index]['item'].scenePos())
-        
+
     def getHandles(self):
         """
         Return a list of this ROI's Handles.
         """
         return [h['item'] for h in self.handles]
-    
+
     def mapSceneToParent(self, pt):
         return self.mapToParent(self.mapFromScene(pt))
 
@@ -615,13 +615,13 @@ class ROI(GraphicsObject):
         if not ev.isExit():
             if self.translatable and ev.acceptDrags(QtCore.Qt.LeftButton):
                 hover=True
-                
+
             for btn in [QtCore.Qt.LeftButton, QtCore.Qt.RightButton, QtCore.Qt.MidButton]:
                 if int(self.acceptedMouseButtons() & btn) > 0 and ev.acceptClicks(btn):
                     hover=True
             if self.contextMenuEnabled():
                 ev.acceptClicks(QtCore.Qt.RightButton)
-                
+
         if hover:
             self.setMouseHover(True)
             self.sigHoverEvent.emit(self)
@@ -644,7 +644,7 @@ class ROI(GraphicsObject):
 
     def contextMenuEnabled(self):
         return self.removable
-    
+
     def raiseContextMenu(self, ev):
         if not self.contextMenuEnabled():
             return
@@ -666,13 +666,13 @@ class ROI(GraphicsObject):
     def removeClicked(self):
         ## Send remove event only after we have exited the menu event handler
         QtCore.QTimer.singleShot(0, lambda: self.sigRemoveRequested.emit(self))
-        
+
     def mouseDragEvent(self, ev):
         if ev.isStart():
             #p = ev.pos()
             #if not self.isMoving and not self.shape().contains(p):
                 #ev.ignore()
-                #return        
+                #return
             if ev.button() == QtCore.Qt.LeftButton:
                 self.setSelected(True)
                 if self.translatable:
@@ -695,7 +695,7 @@ class ROI(GraphicsObject):
             snap = True if (ev.modifiers() & QtCore.Qt.ControlModifier) else None
             newPos = self.mapToParent(ev.pos()) + self.cursorOffset
             self.translate(newPos - self.pos(), snap=snap, finish=False)
-        
+
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.RightButton and self.isMoving:
             ev.accept()
@@ -720,15 +720,15 @@ class ROI(GraphicsObject):
         return True
 
     def movePoint(self, handle, pos, modifiers=QtCore.Qt.KeyboardModifier(), finish=True, coords='parent'):
-        ## called by Handles when they are moved. 
+        ## called by Handles when they are moved.
         ## pos is the new position of the handle in scene coords, as requested by the handle.
-        
+
         newState = self.stateCopy()
         index = self.indexOfHandle(handle)
         h = self.handles[index]
         p0 = self.mapToParent(h['pos'] * self.state['size'])
         p1 = Point(pos)
-        
+
         if coords == 'parent':
             pass
         elif coords == 'scene':
@@ -736,7 +736,7 @@ class ROI(GraphicsObject):
         else:
             raise Exception("New point location must be given in either 'parent' or 'scene' coordinates.")
 
-        
+
         ## transform p0 and p1 into parent's coordinates (same as scene coords if there is no parent). I forget why.
         #p0 = self.mapSceneToParent(p0)
         #p1 = self.mapSceneToParent(p1)
@@ -747,37 +747,37 @@ class ROI(GraphicsObject):
             cs = c * self.state['size']
             lp0 = self.mapFromParent(p0) - cs
             lp1 = self.mapFromParent(p1) - cs
-        
+
         if h['type'] == 't':
             snap = True if (modifiers & QtCore.Qt.ControlModifier) else None
             #if self.translateSnap or ():
                 #snap = Point(self.snapSize, self.snapSize)
             self.translate(p1-p0, snap=snap, update=False)
-        
+
         elif h['type'] == 'f':
             newPos = self.mapFromParent(p1)
             h['item'].setPos(newPos)
             h['pos'] = newPos
             self.freeHandleMoved = True
             #self.sigRegionChanged.emit(self)  ## should be taken care of by call to stateChanged()
-            
+
         elif h['type'] == 's':
             ## If a handle and its center have the same x or y value, we can't scale across that axis.
             if h['center'][0] == h['pos'][0]:
                 lp1[0] = 0
             if h['center'][1] == h['pos'][1]:
                 lp1[1] = 0
-            
-            ## snap 
+
+            ## snap
             if self.scaleSnap or (modifiers & QtCore.Qt.ControlModifier):
                 lp1[0] = round(lp1[0] / self.snapSize) * self.snapSize
                 lp1[1] = round(lp1[1] / self.snapSize) * self.snapSize
-                
+
             ## preserve aspect ratio (this can override snapping)
             if h['lockAspect'] or (modifiers & QtCore.Qt.AltModifier):
-                #arv = Point(self.preMoveState['size']) - 
+                #arv = Point(self.preMoveState['size']) -
                 lp1 = lp1.proj(lp0)
-            
+
             ## determine scale factors and new size of ROI
             hs = h['pos'] - c
             if hs[0] == 0:
@@ -785,7 +785,7 @@ class ROI(GraphicsObject):
             if hs[1] == 0:
                 hs[1] = 1
             newSize = lp1 / hs
-            
+
             ## Perform some corrections and limit checks
             if newSize[0] == 0:
                 newSize[0] = newState['size'][0]
@@ -798,12 +798,12 @@ class ROI(GraphicsObject):
                     newSize[1] = newState['size'][1]
             if self.aspectLocked:
                 newSize[0] = newSize[1]
-            
+
             ## Move ROI so the center point occupies the same scene location after the scale
             s0 = c * self.state['size']
             s1 = c * newSize
             cc = self.mapToParent(s0 - s1) - self.mapToParent(Point(0, 0))
-            
+
             ## update state, do more boundary checks
             newState['size'] = newSize
             newState['pos'] = newState['pos'] + cc
@@ -811,14 +811,14 @@ class ROI(GraphicsObject):
                 r = self.stateRect(newState)
                 if not self.maxBounds.contains(r):
                     return
-            
+
             self.setPos(newState['pos'], update=False)
             self.setSize(newState['size'], update=False)
-        
+
         elif h['type'] in ['r', 'rf']:
             if h['type'] == 'rf':
                 self.freeHandleMoved = True
-            
+
             if not self.rotateAllowed:
                 return
             ## If the handle is directly over its center point, we can't compute an angle.
@@ -827,23 +827,23 @@ class ROI(GraphicsObject):
                     return
             except OverflowError:
                 return
-            
+
             ## determine new rotation angle, constrained if necessary
             ang = newState['angle'] - lp0.angle(lp1)
             if ang is None:  ## this should never happen..
                 return
             if self.rotateSnap or (modifiers & QtCore.Qt.ControlModifier):
                 ang = round(ang / 15.) * 15.  ## 180/12 = 15
-            
+
             ## create rotation transform
             tr = QtGui.QTransform()
             tr.rotate(ang)
-            
+
             ## move ROI so that center point remains stationary after rotate
             cc = self.mapToParent(cs) - (tr.map(cs) + self.state['pos'])
             newState['angle'] = ang
             newState['pos'] = newState['pos'] + cc
-            
+
             ## check boundaries, update
             if self.maxBounds is not None:
                 r = self.stateRect(newState)
@@ -853,12 +853,12 @@ class ROI(GraphicsObject):
             self.setPos(newState['pos'], update=False)
             self.setAngle(ang, update=False)
             #self.state = newState
-            
+
             ## If this is a free-rotate handle, its distance from the center may change.
-            
+
             if h['type'] == 'rf':
                 h['item'].setPos(self.mapFromScene(p1))  ## changes ROI coordinates of handle
-                
+
         elif h['type'] == 'sr':
             if h['center'][0] == h['pos'][0]:
                 scaleAxis = 1
@@ -866,20 +866,20 @@ class ROI(GraphicsObject):
             else:
                 scaleAxis = 0
                 nonScaleAxis=1
-            
+
             try:
                 if lp1.length() == 0 or lp0.length() == 0:
                     return
             except OverflowError:
                 return
-            
+
             ang = newState['angle'] - lp0.angle(lp1)
             if ang is None:
                 return
             if self.rotateSnap or (modifiers & QtCore.Qt.ControlModifier):
                 #ang = round(ang / (np.pi/12.)) * (np.pi/12.)
                 ang = round(ang / 15.) * 15.
-            
+
             hs = abs(h['pos'][scaleAxis] - c[scaleAxis])
             newState['size'][scaleAxis] = lp1.length() / hs
             #if self.scaleSnap or (modifiers & QtCore.Qt.ControlModifier):
@@ -889,11 +889,11 @@ class ROI(GraphicsObject):
                 newState['size'][scaleAxis] = 1
             if self.aspectLocked:
                 newState['size'][nonScaleAxis] = newState['size'][scaleAxis]
-                
+
             c1 = c * newState['size']
             tr = QtGui.QTransform()
             tr.rotate(ang)
-            
+
             cc = self.mapToParent(cs) - (tr.map(c1) + self.state['pos'])
             newState['angle'] = ang
             newState['pos'] = newState['pos'] + cc
@@ -906,15 +906,15 @@ class ROI(GraphicsObject):
             #self.prepareGeometryChange()
             #self.state = newState
             self.setState(newState, update=False)
-        
+
         self.stateChanged(finish=finish)
-    
+
     def stateChanged(self, finish=True):
         """Process changes to the state of the ROI.
         If there are any changes, then the positions of handles are updated accordingly
-        and sigRegionChanged is emitted. If finish is True, then 
+        and sigRegionChanged is emitted. If finish is True, then
         sigRegionChangeFinished will also be emitted."""
-        
+
         changed = False
         if self.lastState is None:
             changed = True
@@ -922,7 +922,7 @@ class ROI(GraphicsObject):
             for k in list(self.state.keys()):
                 if self.state[k] != self.lastState[k]:
                     changed = True
-        
+
         self.prepareGeometryChange()
         if changed:
             ## Move all handles to match the current configuration of the ROI
@@ -933,21 +933,21 @@ class ROI(GraphicsObject):
                 #else:
                 #    trans = self.state['pos']-self.lastState['pos']
                 #    h['item'].setPos(h['pos'] + h['item'].parentItem().mapFromParent(trans))
-                    
+
             self.update()
             self.sigRegionChanged.emit(self)
         elif self.freeHandleMoved:
             self.sigRegionChanged.emit(self)
-            
+
         self.freeHandleMoved = False
         self.lastState = self.stateCopy()
-            
+
         if finish:
             self.stateChangeFinished()
-    
+
     def stateChangeFinished(self):
         self.sigRegionChangeFinished.emit(self)
-    
+
     def stateRect(self, state):
         r = QtCore.QRectF(0, 0, state['size'][0], state['size'][1])
         tr = QtGui.QTransform()
@@ -955,23 +955,23 @@ class ROI(GraphicsObject):
         tr.rotate(-state['angle'])
         r = tr.mapRect(r)
         return r.adjusted(state['pos'][0], state['pos'][1], state['pos'][0], state['pos'][1])
-    
-    
+
+
     def getSnapPosition(self, pos, snap=None):
         ## Given that pos has been requested, return the nearest snap-to position
         ## optionally, snap may be passed in to specify a rectangular snap grid.
         ## override this function for more interesting snap functionality..
-        
+
         if snap is None or snap is True:
             if self.snapSize is None:
                 return pos
             snap = Point(self.snapSize, self.snapSize)
-        
+
         return Point(
             round(pos[0] / snap[0]) * snap[0],
             round(pos[1] / snap[1]) * snap[1]
         )
-    
+
     def boundingRect(self):
         return QtCore.QRectF(0, 0, self.state['size'][0], self.state['size'][1]).normalized()
 
@@ -979,7 +979,7 @@ class ROI(GraphicsObject):
         # p.save()
         # Note: don't use self.boundingRect here, because subclasses may need to redefine it.
         r = QtCore.QRectF(0, 0, self.state['size'][0], self.state['size'][1]).normalized()
-        
+
         p.setRenderHint(QtGui.QPainter.Antialiasing)
         p.setPen(self.currentPen)
         p.translate(r.left(), r.top())
@@ -990,46 +990,46 @@ class ROI(GraphicsObject):
     def getArraySlice(self, data, img, axes=(0,1), returnSlice=True):
         """Return a tuple of slice objects that can be used to slice the region from data covered by this ROI.
         Also returns the transform which maps the ROI into data coordinates.
-        
-        If returnSlice is set to False, the function returns a pair of tuples with the values that would have 
+
+        If returnSlice is set to False, the function returns a pair of tuples with the values that would have
         been used to generate the slice objects. ((ax0Start, ax0Stop), (ax1Start, ax1Stop))
-        
+
         If the slice can not be computed (usually because the scene/transforms are not properly
         constructed yet), then the method returns None.
         """
         #print "getArraySlice"
-        
+
         ## Determine shape of array along ROI axes
         dShape = (data.shape[axes[0]], data.shape[axes[1]])
         #print "  dshape", dShape
-        
+
         ## Determine transform that maps ROI bounding box to image coordinates
         try:
             tr = self.sceneTransform() * fn.invertQTransform(img.sceneTransform())
         except np.linalg.linalg.LinAlgError:
             return None
-            
+
         ## Modify transform to scale from image coords to data coords
         #m = QtGui.QTransform()
         tr.scale(float(dShape[0]) / img.width(), float(dShape[1]) / img.height())
         #tr = tr * m
-        
+
         ## Transform ROI bounds into data bounds
         dataBounds = tr.mapRect(self.boundingRect())
         #print "  boundingRect:", self.boundingRect()
         #print "  dataBounds:", dataBounds
-        
+
         ## Intersect transformed ROI bounds with data bounds
         intBounds = dataBounds.intersected(QtCore.QRectF(0, 0, dShape[0], dShape[1]))
         #print "  intBounds:", intBounds
-        
-        ## Determine index values to use when referencing the array. 
+
+        ## Determine index values to use when referencing the array.
         bounds = (
             (int(min(intBounds.left(), intBounds.right())), int(1+max(intBounds.left(), intBounds.right()))),
             (int(min(intBounds.bottom(), intBounds.top())), int(1+max(intBounds.bottom(), intBounds.top())))
         )
         #print "  bounds:", bounds
-        
+
         if returnSlice:
             ## Create slice objects
             sl = [slice(None)] * data.ndim
@@ -1040,46 +1040,46 @@ class ROI(GraphicsObject):
             return bounds, tr
 
     def getArrayRegion(self, data, img, axes=(0,1), returnMappedCoords=False, **kwds):
-        """Use the position and orientation of this ROI relative to an imageItem 
+        """Use the position and orientation of this ROI relative to an imageItem
         to pull a slice from an array.
-        
+
         =================== ====================================================
         **Arguments**
         data                The array to slice from. Note that this array does
                             *not* have to be the same data that is represented
                             in *img*.
         img                 (ImageItem or other suitable QGraphicsItem)
-                            Used to determine the relationship between the 
+                            Used to determine the relationship between the
                             ROI and the boundaries of *data*.
         axes                (length-2 tuple) Specifies the axes in *data* that
                             correspond to the x and y axes of *img*.
         returnMappedCoords  (bool) If True, the array slice is returned along
                             with a corresponding array of coordinates that were
                             used to extract data from the original array.
-        \**kwds             All keyword arguments are passed to 
+        \**kwds             All keyword arguments are passed to
                             :func:`affineSlice <pyqtgraph.affineSlice>`.
         =================== ====================================================
-        
+
         This method uses :func:`affineSlice <pyqtgraph.affineSlice>` to generate
         the slice from *data* and uses :func:`getAffineSliceParams <pyqtgraph.ROI.getAffineSliceParams>`
         to determine the parameters to pass to :func:`affineSlice <pyqtgraph.affineSlice>`.
-        
-        If *returnMappedCoords* is True, then the method returns a tuple (result, coords) 
+
+        If *returnMappedCoords* is True, then the method returns a tuple (result, coords)
         such that coords is the set of coordinates used to interpolate values from the original
         data, mapped into the parent coordinate system of the image. This is useful, when slicing
         data from images that have been transformed, for determining the location of each value
         in the sliced data.
-        
+
         All extra keyword arguments are passed to :func:`affineSlice <pyqtgraph.affineSlice>`.
         """
-        
+
         shape, vectors, origin = self.getAffineSliceParams(data, img, axes)
         if not returnMappedCoords:
             return fn.affineSlice(data, shape=shape, vectors=vectors, origin=origin, axes=axes, **kwds)
         else:
             kwds['returnCoords'] = True
             result, coords = fn.affineSlice(data, shape=shape, vectors=vectors, origin=origin, axes=axes, **kwds)
-            
+
             ### map coordinates and return
             mapped = fn.transformCoordinates(img.transform(), coords)
             return result, mapped
@@ -1087,22 +1087,22 @@ class ROI(GraphicsObject):
     def getAffineSliceParams(self, data, img, axes=(0,1)):
         """
         Returns the parameters needed to use :func:`affineSlice <pyqtgraph.affineSlice>`
-        (shape, vectors, origin) to extract a subset of *data* using this ROI 
+        (shape, vectors, origin) to extract a subset of *data* using this ROI
         and *img* to specify the subset.
-        
+
         See :func:`getArrayRegion <pyqtgraph.ROI.getArrayRegion>` for more information.
         """
         if self.scene() is not img.scene():
             raise Exception("ROI and target item must be members of the same scene.")
-        
+
         shape = self.state['size']
-        
+
         origin = self.mapToItem(img, QtCore.QPointF(0, 0))
-        
+
         ## vx and vy point in the directions of the slice axes, but must be scaled properly
         vx = self.mapToItem(img, QtCore.QPointF(1, 0)) - origin
         vy = self.mapToItem(img, QtCore.QPointF(0, 1)) - origin
-        
+
         lvx = np.sqrt(vx.x()**2 + vx.y()**2)
         lvy = np.sqrt(vy.x()**2 + vy.y()**2)
         pxLen = img.width() / float(data.shape[axes[0]])
@@ -1110,54 +1110,54 @@ class ROI(GraphicsObject):
         #need pxWidth and pxHeight instead of pxLen ?
         sx =  pxLen / lvx
         sy =  pxLen / lvy
-        
+
         vectors = ((vx.x()*sx, vx.y()*sx), (vy.x()*sy, vy.y()*sy))
         shape = self.state['size']
         shape = [abs(shape[0]/sx), abs(shape[1]/sy)]
-        
+
         origin = (origin.x(), origin.y())
         return shape, vectors, origin
-        
+
     def getGlobalTransform(self, relativeTo=None):
-        """Return global transformation (rotation angle+translation) required to move 
+        """Return global transformation (rotation angle+translation) required to move
         from relative state to current state. If relative state isn't specified,
         then we use the state of the ROI when mouse is pressed."""
         if relativeTo == None:
             relativeTo = self.preMoveState
         st = self.getState()
-        
-        ## this is only allowed because we will be comparing the two 
+
+        ## this is only allowed because we will be comparing the two
         relativeTo['scale'] = relativeTo['size']
         st['scale'] = st['size']
-        
+
         t1 = SRTTransform(relativeTo)
         t2 = SRTTransform(st)
         return t2/t1
-        
-        
+
+
         #st = self.getState()
-        
+
         ### rotation
         #ang = (st['angle']-relativeTo['angle']) * 180. / 3.14159265358
         #rot = QtGui.QTransform()
         #rot.rotate(-ang)
 
-        ### We need to come up with a universal transformation--one that can be applied to other objects 
-        ### such that all maintain alignment. 
+        ### We need to come up with a universal transformation--one that can be applied to other objects
+        ### such that all maintain alignment.
         ### More specifically, we need to turn the ROI's position and angle into
         ### a rotation _around the origin_ and a translation.
-        
+
         #p0 = Point(relativeTo['pos'])
 
         ### base position, rotated
         #p1 = rot.map(p0)
-        
+
         #trans = Point(st['pos']) - p1
         #return trans, ang
 
     def applyGlobalTransform(self, tr):
         st = self.getState()
-        
+
         st['scale'] = st['size']
         st = SRTTransform(st)
         st = (st * tr).saveState()
@@ -1169,18 +1169,18 @@ class Handle(UIGraphicsItem):
     """
     Handle represents a single user-interactable point attached to an ROI. They
     are usually created by a call to one of the ROI.add___Handle() methods.
-    
-    Handles are represented as a square, diamond, or circle, and are drawn with 
+
+    Handles are represented as a square, diamond, or circle, and are drawn with
     fixed pixel size regardless of the scaling of the view they are displayed in.
-    
+
     Handles may be dragged to change the position, size, orientation, or other
     properties of the ROI they are attached to.
-    
-    
+
+
     """
     types = {   ## defines number of sides, start angle for each handle type
         't': (4, np.pi/4),
-        'f': (4, np.pi/4), 
+        'f': (4, np.pi/4),
         's': (4, 0),
         'r': (12, 0),
         'sr': (12, 0),
@@ -1189,7 +1189,7 @@ class Handle(UIGraphicsItem):
 
     sigClicked = QtCore.Signal(object, object)   # self, event
     sigRemoveRequested = QtCore.Signal(object)   # self
-    
+
     def __init__(self, radius, typ=None, pen=(200, 200, 220), parent=None, deletable=False):
         #print "   create item with parent", parent
         #self.bounds = QtCore.QRectF(-1e-10, -1e-10, 2e-10, 2e-10)
@@ -1206,36 +1206,36 @@ class Handle(UIGraphicsItem):
         self.buildPath()
         self._shape = None
         self.menu = self.buildMenu()
-        
+
         UIGraphicsItem.__init__(self, parent=parent)
         self.setAcceptedMouseButtons(QtCore.Qt.NoButton)
         self.deletable = deletable
         if deletable:
-            self.setAcceptedMouseButtons(QtCore.Qt.RightButton)        
+            self.setAcceptedMouseButtons(QtCore.Qt.RightButton)
         #self.updateShape()
         self.setZValue(11)
-            
+
     def connectROI(self, roi):
         ### roi is the "parent" roi, i is the index of the handle in roi.handles
         self.rois.append(roi)
-        
+
     def disconnectROI(self, roi):
         self.rois.remove(roi)
         #for i, r in enumerate(self.roi):
             #if r[0] == roi:
                 #self.roi.pop(i)
-                
+
     #def close(self):
         #for r in self.roi:
             #r.removeHandle(self)
-            
+
     def setDeletable(self, b):
         self.deletable = b
         if b:
             self.setAcceptedMouseButtons(self.acceptedMouseButtons() | QtCore.Qt.RightButton)
         else:
             self.setAcceptedMouseButtons(self.acceptedMouseButtons() & ~QtCore.Qt.RightButton)
-            
+
     def removeClicked(self):
         self.sigRemoveRequested.emit(self)
 
@@ -1247,7 +1247,7 @@ class Handle(UIGraphicsItem):
             for btn in [QtCore.Qt.LeftButton, QtCore.Qt.RightButton, QtCore.Qt.MidButton]:
                 if int(self.acceptedMouseButtons() & btn) > 0 and ev.acceptClicks(btn):
                     hover=True
-                    
+
         if hover:
             self.currentPen = fn.mkPen(255, 255,0)
         else:
@@ -1258,7 +1258,7 @@ class Handle(UIGraphicsItem):
         #else:
             #self.currentPen = self.pen
         #self.update()
-            
+
 
 
     def mouseClickEvent(self, ev):
@@ -1275,43 +1275,43 @@ class Handle(UIGraphicsItem):
                 self.raiseContextMenu(ev)
             self.sigClicked.emit(self, ev)
         else:
-            ev.ignore()        
-            
+            ev.ignore()
+
             #elif self.deletable:
                 #ev.accept()
                 #self.raiseContextMenu(ev)
             #else:
                 #ev.ignore()
-                
+
     def buildMenu(self):
         menu = QtGui.QMenu()
         menu.setTitle("Handle")
-        self.removeAction = menu.addAction("Remove handle", self.removeClicked) 
+        self.removeAction = menu.addAction("Remove handle", self.removeClicked)
         return menu
-        
+
     def getMenu(self):
         return self.menu
 
     def raiseContextMenu(self, ev):
         menu = self.scene().addParentContextMenus(self, self.getMenu(), ev)
-        
+
         ## Make sure it is still ok to remove this handle
         removeAllowed = all([r.checkRemoveHandle(self) for r in self.rois])
         self.removeAction.setEnabled(removeAllowed)
         pos = ev.screenPos()
-        menu.popup(QtCore.QPoint(pos.x(), pos.y()))    
+        menu.popup(QtCore.QPoint(pos.x(), pos.y()))
 
     def mouseDragEvent(self, ev):
         if ev.button() != QtCore.Qt.LeftButton:
             return
         ev.accept()
-        
-        ## Inform ROIs that a drag is happening 
+
+        ## Inform ROIs that a drag is happening
         ##  note: the ROI is informed that the handle has moved using ROI.movePoint
         ##  this is for other (more nefarious) purposes.
         #for r in self.roi:
             #r[0].pointDragEvent(r[1], ev)
-            
+
         if ev.isFinish():
             if self.isMoving:
                 for r in self.rois:
@@ -1323,7 +1323,7 @@ class Handle(UIGraphicsItem):
             self.isMoving = True
             self.startPos = self.scenePos()
             self.cursorOffset = self.scenePos() - ev.buttonDownScenePos()
-            
+
         if self.isMoving:  ## note: isMoving may become False in mid-drag due to right-click.
             pos = ev.scenePos() + self.cursorOffset
             self.movePoint(pos, ev.modifiers(), finish=False)
@@ -1336,7 +1336,7 @@ class Handle(UIGraphicsItem):
         # A handle can be used by multiple ROIs; tell each to update its handle position
         for r in self.rois:
             r.movePoint(self, pos, modifiers, finish=finish, coords='scene')
-        
+
     def buildPath(self):
         size = self.radius
         self.path = QtGui.QPainterPath()
@@ -1349,29 +1349,29 @@ class Handle(UIGraphicsItem):
             if i == 0:
                 self.path.moveTo(x, y)
             else:
-                self.path.lineTo(x, y)            
-            
+                self.path.lineTo(x, y)
+
     def paint(self, p, opt, widget):
         ### determine rotation of transform
         #m = self.sceneTransform()
         ##mi = m.inverted()[0]
         #v = m.map(QtCore.QPointF(1, 0)) - m.map(QtCore.QPointF(0, 0))
         #va = np.arctan2(v.y(), v.x())
-        
+
         ### Determine length of unit vector in painter's coords
         ##size = mi.map(Point(self.radius, self.radius)) - mi.map(Point(0, 0))
         ##size = (size.x()*size.x() + size.y() * size.y()) ** 0.5
         #size = self.radius
-        
+
         #bounds = QtCore.QRectF(-size, -size, size*2, size*2)
         #if bounds != self.bounds:
             #self.bounds = bounds
             #self.prepareGeometryChange()
         p.setRenderHints(p.Antialiasing, True)
         p.setPen(self.currentPen)
-        
+
         #p.rotate(va * 180. / 3.1415926)
-        #p.drawPath(self.path)        
+        #p.drawPath(self.path)
         p.drawPath(self.shape())
         #ang = self.startAng + va
         #dt = 2*np.pi / self.sides
@@ -1382,7 +1382,7 @@ class Handle(UIGraphicsItem):
             #y2 = size * sin(ang+dt)
             #ang += dt
             #p.drawLine(Point(x1, y1), Point(x2, y2))
-            
+
     def shape(self):
         if self._shape is None:
             s = self.generateShape()
@@ -1391,43 +1391,43 @@ class Handle(UIGraphicsItem):
             self._shape = s
             self.prepareGeometryChange()  ## beware--this can cause the view to adjust, which would immediately invalidate the shape.
         return self._shape
-    
+
     def boundingRect(self):
         #print 'roi:', self.roi
         s1 = self.shape()
         #print "   s1:", s1
         #s2 = self.shape()
         #print "   s2:", s2
-        
+
         return self.shape().boundingRect()
-            
+
     def generateShape(self):
         ## determine rotation of transform
         #m = self.sceneTransform()  ## Qt bug: do not access sceneTransform() until we know this object has a scene.
         #mi = m.inverted()[0]
         dt = self.deviceTransform()
-        
+
         if dt is None:
             self._shape = self.path
             return None
-        
+
         v = dt.map(QtCore.QPointF(1, 0)) - dt.map(QtCore.QPointF(0, 0))
         va = np.arctan2(v.y(), v.x())
-        
+
         dti = fn.invertQTransform(dt)
         devPos = dt.map(QtCore.QPointF(0,0))
         tr = QtGui.QTransform()
         tr.translate(devPos.x(), devPos.y())
         tr.rotate(va * 180. / 3.1415926)
-        
+
         return dti.map(tr.map(self.path))
-        
-        
+
+
     def viewTransformChanged(self):
         GraphicsObject.viewTransformChanged(self)
         self._shape = None  ## invalidate shape, recompute later if requested.
         self.update()
-        
+
     #def itemChange(self, change, value):
         #if change == self.ItemScenePositionHasChanged:
             #self.updateShape()
@@ -1451,7 +1451,7 @@ class TestROI(ROI):
 class RectROI(ROI):
     """
     Rectangular ROI subclass with a single scale handle at the top-right corner.
-    
+
     ============== =============================================================
     **Arguments**
     pos            (length-2 sequence) The position of the ROI origin.
@@ -1459,11 +1459,11 @@ class RectROI(ROI):
     size           (length-2 sequence) The size of the ROI. See ROI().
     centered       (bool) If True, scale handles affect the ROI relative to its
                    center, rather than its origin.
-    sideScalers    (bool) If True, extra scale handles are added at the top and 
+    sideScalers    (bool) If True, extra scale handles are added at the top and
                    right edges.
     \**args        All extra keyword arguments are passed to ROI()
     ============== =============================================================
-    
+
     """
     def __init__(self, pos, size, centered=False, sideScalers=False, **args):
         #QtGui.QGraphicsRectItem.__init__(self, 0, 0, size[0], size[1])
@@ -1472,7 +1472,7 @@ class RectROI(ROI):
             center = [0.5, 0.5]
         else:
             center = [0, 0]
-            
+
         #self.addTranslateHandle(center)
         self.addScaleHandle([1, 1], center)
         if sideScalers:
@@ -1484,7 +1484,7 @@ class LineROI(ROI):
     Rectangular ROI subclass with scale-rotate handles on either side. This
     allows the ROI to be positioned as if moving the ends of a line segment.
     A third handle controls the width of the ROI orthogonal to its "line" axis.
-    
+
     ============== =============================================================
     **Arguments**
     pos1           (length-2 sequence) The position of the center of the ROI's
@@ -1494,7 +1494,7 @@ class LineROI(ROI):
     width          (float) The width of the ROI.
     \**args        All extra keyword arguments are passed to ROI()
     ============== =============================================================
-    
+
     """
     def __init__(self, pos1, pos2, width, **args):
         pos1 = Point(pos1)
@@ -1505,22 +1505,22 @@ class LineROI(ROI):
         ra = ang * np.pi / 180.
         c = Point(-width/2. * sin(ra), -width/2. * cos(ra))
         pos1 = pos1 + c
-        
+
         ROI.__init__(self, pos1, size=Point(l, width), angle=ang, **args)
         self.addScaleRotateHandle([0, 0.5], [1, 0.5])
         self.addScaleRotateHandle([1, 0.5], [0, 0.5])
         self.addScaleHandle([0.5, 1], [0.5, 0.5])
-        
 
-        
+
+
 class MultiRectROI(QtGui.QGraphicsObject):
     """
-    Chain of rectangular ROIs connected by handles. 
-    
-    This is generally used to mark a curved path through 
+    Chain of rectangular ROIs connected by handles.
+
+    This is generally used to mark a curved path through
     an image similarly to PolyLineROI. It differs in that each segment
     of the chain is rectangular instead of linear and thus has width.
-    
+
     ============== =============================================================
     **Arguments**
     points         (list of length-2 sequences) The list of points in the path.
@@ -1531,7 +1531,7 @@ class MultiRectROI(QtGui.QGraphicsObject):
     sigRegionChangeFinished = QtCore.Signal(object)
     sigRegionChangeStarted = QtCore.Signal(object)
     sigRegionChanged = QtCore.Signal(object)
-    
+
     def __init__(self, points, width, pen=None, **args):
         QtGui.QGraphicsObject.__init__(self)
         self.pen = pen
@@ -1539,21 +1539,21 @@ class MultiRectROI(QtGui.QGraphicsObject):
         self.lines = []
         if len(points) < 2:
             raise Exception("Must start with at least 2 points")
-        
+
         ## create first segment
         self.addSegment(points[1], connectTo=points[0], scaleHandle=True)
-        
+
         ## create remaining segments
         for p in points[2:]:
             self.addSegment(p)
-        
-        
+
+
     def paint(self, *args):
         pass
-    
+
     def boundingRect(self):
         return QtCore.QRectF()
-        
+
     def roiChangedEvent(self):
         w = self.lines[0].state['size'][1]
         for l in self.lines[1:]:
@@ -1562,20 +1562,20 @@ class MultiRectROI(QtGui.QGraphicsObject):
                 continue
             l.scale([1.0, w/w0], center=[0.5,0.5])
         self.sigRegionChanged.emit(self)
-            
+
     def roiChangeStartedEvent(self):
         self.sigRegionChangeStarted.emit(self)
-        
+
     def roiChangeFinishedEvent(self):
         self.sigRegionChangeFinished.emit(self)
-        
+
     def getHandlePositions(self):
         """Return the positions of all handles in local coordinates."""
         pos = [self.mapFromScene(self.lines[0].getHandles()[0].scenePos())]
         for l in self.lines:
             pos.append(self.mapFromScene(l.getHandles()[1].scenePos()))
         return pos
-        
+
     def getArrayRegion(self, arr, img=None, axes=(0,1)):
         rgns = []
         for l in self.lines:
@@ -1585,7 +1585,7 @@ class MultiRectROI(QtGui.QGraphicsObject):
                 #return None
             rgns.append(rgn)
             #print l.state['size']
-            
+
         ## make sure orthogonal axis is the same size
         ## (sometimes fp errors cause differences)
         ms = min([r.shape[axes[1]] for r in rgns])
@@ -1593,23 +1593,23 @@ class MultiRectROI(QtGui.QGraphicsObject):
         sl[axes[1]] = slice(0,ms)
         rgns = [r[sl] for r in rgns]
         #print [r.shape for r in rgns], axes
-        
+
         return np.concatenate(rgns, axis=axes[0])
-        
+
     def addSegment(self, pos=(0,0), scaleHandle=False, connectTo=None):
         """
         Add a new segment to the ROI connecting from the previous endpoint to *pos*.
         (pos is specified in the parent coordinate system of the MultiRectROI)
         """
-        
+
         ## by default, connect to the previous endpoint
         if connectTo is None:
             connectTo = self.lines[-1].getHandles()[1]
-            
+
         ## create new ROI
         newRoi = ROI((0,0), [1, 5], parent=self, pen=self.pen, **self.roiArgs)
         self.lines.append(newRoi)
-        
+
         ## Add first SR handle
         if isinstance(connectTo, Handle):
             self.lines[-1].addScaleRotateHandle([0, 0.5], [1, 0.5], item=connectTo)
@@ -1617,68 +1617,68 @@ class MultiRectROI(QtGui.QGraphicsObject):
         else:
             h = self.lines[-1].addScaleRotateHandle([0, 0.5], [1, 0.5])
             newRoi.movePoint(h, connectTo, coords='scene')
-            
+
         ## add second SR handle
-        h = self.lines[-1].addScaleRotateHandle([1, 0.5], [0, 0.5]) 
+        h = self.lines[-1].addScaleRotateHandle([1, 0.5], [0, 0.5])
         newRoi.movePoint(h, pos)
-        
+
         ## optionally add scale handle (this MUST come after the two SR handles)
         if scaleHandle:
             newRoi.addScaleHandle([0.5, 1], [0.5, 0.5])
-            
-        newRoi.translatable = False 
-        newRoi.sigRegionChanged.connect(self.roiChangedEvent) 
-        newRoi.sigRegionChangeStarted.connect(self.roiChangeStartedEvent) 
-        newRoi.sigRegionChangeFinished.connect(self.roiChangeFinishedEvent)
-        self.sigRegionChanged.emit(self) 
-    
 
-    def removeSegment(self, index=-1): 
+        newRoi.translatable = False
+        newRoi.sigRegionChanged.connect(self.roiChangedEvent)
+        newRoi.sigRegionChangeStarted.connect(self.roiChangeStartedEvent)
+        newRoi.sigRegionChangeFinished.connect(self.roiChangeFinishedEvent)
+        self.sigRegionChanged.emit(self)
+
+
+    def removeSegment(self, index=-1):
         """Remove a segment from the ROI."""
         roi = self.lines[index]
         self.lines.pop(index)
         self.scene().removeItem(roi)
-        roi.sigRegionChanged.disconnect(self.roiChangedEvent) 
-        roi.sigRegionChangeStarted.disconnect(self.roiChangeStartedEvent) 
+        roi.sigRegionChanged.disconnect(self.roiChangedEvent)
+        roi.sigRegionChangeStarted.disconnect(self.roiChangeStartedEvent)
         roi.sigRegionChangeFinished.disconnect(self.roiChangeFinishedEvent)
-        
+
         self.sigRegionChanged.emit(self)
-        
-        
+
+
 class MultiLineROI(MultiRectROI):
     def __init__(self, *args, **kwds):
         MultiRectROI.__init__(self, *args, **kwds)
         print("Warning: MultiLineROI has been renamed to MultiRectROI. (and MultiLineROI may be redefined in the future)")
-        
+
 class EllipseROI(ROI):
     """
     Elliptical ROI subclass with one scale handle and one rotation handle.
-    
-    
+
+
     ============== =============================================================
     **Arguments**
     pos            (length-2 sequence) The position of the ROI's origin.
     size           (length-2 sequence) The size of the ROI's bounding rectangle.
     \**args        All extra keyword arguments are passed to ROI()
     ============== =============================================================
-    
+
     """
     def __init__(self, pos, size, **args):
         #QtGui.QGraphicsRectItem.__init__(self, 0, 0, size[0], size[1])
         ROI.__init__(self, pos, size, **args)
         self.addRotateHandle([1.0, 0.5], [0.5, 0.5])
         self.addScaleHandle([0.5*2.**-0.5 + 0.5, 0.5*2.**-0.5 + 0.5], [0.5, 0.5])
-            
+
     def paint(self, p, opt, widget):
         r = self.boundingRect()
         p.setRenderHint(QtGui.QPainter.Antialiasing)
         p.setPen(self.currentPen)
-        
+
         p.scale(r.width(), r.height())## workaround for GL bug
         r = QtCore.QRectF(r.x()/r.width(), r.y()/r.height(), 1,1)
-        
+
         p.drawEllipse(r)
-        
+
     def getArrayRegion(self, arr, img=None):
         """
         Return the result of ROI.getArrayRegion() masked by the elliptical shape
@@ -1691,27 +1691,27 @@ class EllipseROI(ROI):
         h = arr.shape[1]
         ## generate an ellipsoidal mask
         mask = np.fromfunction(lambda x,y: (((x+0.5)/(w/2.)-1)**2+ ((y+0.5)/(h/2.)-1)**2)**0.5 < 1, (w, h))
-    
+
         return arr * mask
-    
+
     def shape(self):
         self.path = QtGui.QPainterPath()
         self.path.addEllipse(self.boundingRect())
         return self.path
-        
-        
+
+
 class CircleROI(EllipseROI):
     """
     Circular ROI subclass. Behaves exactly as EllipseROI, but may only be scaled
     proportionally to maintain its aspect ratio.
-    
+
     ============== =============================================================
     **Arguments**
     pos            (length-2 sequence) The position of the ROI's origin.
     size           (length-2 sequence) The size of the ROI's bounding rectangle.
     \**args        All extra keyword arguments are passed to ROI()
     ============== =============================================================
-    
+
     """
     def __init__(self, pos, size, **args):
         ROI.__init__(self, pos, size, **args)
@@ -1722,7 +1722,7 @@ class CircleROI(EllipseROI):
 
 class PolygonROI(ROI):
     ## deprecated. Use PloyLineROI instead.
-    
+
     def __init__(self, positions, pos=None, **args):
         if pos is None:
             pos = [0,0]
@@ -1732,17 +1732,17 @@ class PolygonROI(ROI):
             self.addFreeHandle(p)
         self.setZValue(1000)
         print("Warning: PolygonROI is deprecated. Use PolyLineROI instead.")
-        
-            
+
+
     def listPoints(self):
         return [p['item'].pos() for p in self.handles]
-            
+
     #def movePoint(self, *args, **kargs):
         #ROI.movePoint(self, *args, **kargs)
         #self.prepareGeometryChange()
         #for h in self.handles:
             #h['pos'] = h['item'].pos()
-            
+
     def paint(self, p, *args):
         p.setRenderHint(QtGui.QPainter.Antialiasing)
         p.setPen(self.currentPen)
@@ -1750,20 +1750,20 @@ class PolygonROI(ROI):
             h1 = self.handles[i]['item'].pos()
             h2 = self.handles[i-1]['item'].pos()
             p.drawLine(h1, h2)
-        
+
     def boundingRect(self):
         r = QtCore.QRectF()
         for h in self.handles:
             r |= self.mapFromItem(h['item'], h['item'].boundingRect()).boundingRect()   ## |= gives the union of the two QRectFs
         return r
-    
+
     def shape(self):
         p = QtGui.QPainterPath()
         p.moveTo(self.handles[0]['item'].pos())
         for i in range(len(self.handles)):
             p.lineTo(self.handles[i]['item'].pos())
         return p
-    
+
     def stateCopy(self):
         sc = {}
         sc['pos'] = Point(self.state['pos'])
@@ -1775,9 +1775,9 @@ class PolygonROI(ROI):
 class PolyLineROI(ROI):
     """
     Container class for multiple connected LineSegmentROIs.
-    
+
     This class allows the user to draw paths of multiple line segments.
-    
+
     ============== =============================================================
     **Arguments**
     positions      (list of length-2 sequences) The list of points in the path.
@@ -1785,25 +1785,25 @@ class PolyLineROI(ROI):
                    ROIs, these positions must be expressed in the normal
                    coordinate system of the ROI, rather than (0 to 1) relative
                    to the size of the ROI.
-    closed         (bool) if True, an extra LineSegmentROI is added connecting 
+    closed         (bool) if True, an extra LineSegmentROI is added connecting
                    the beginning and end points.
     \**args        All extra keyword arguments are passed to ROI()
     ============== =============================================================
-    
+
     """
     def __init__(self, positions, closed=False, pos=None, **args):
-        
+
         if pos is None:
             pos = [0,0]
-            
+
         self.closed = closed
         self.segments = []
         ROI.__init__(self, pos, size=[1,1], **args)
-        
+
         self.setPoints(positions)
         #for p in positions:
             #self.addFreeHandle(p)
-         
+
         #start = -1 if self.closed else 0
         #for i in range(start, len(self.handles)-1):
             #self.addSegment(self.handles[i]['item'], self.handles[i+1]['item'])
@@ -1811,27 +1811,27 @@ class PolyLineROI(ROI):
     def setPoints(self, points, closed=None):
         """
         Set the complete sequence of points displayed by this ROI.
-        
+
         ============= =========================================================
         **Arguments**
         points        List of (x,y) tuples specifying handle locations to set.
-        closed        If bool, then this will set whether the ROI is closed 
+        closed        If bool, then this will set whether the ROI is closed
                       (the last point is connected to the first point). If
                       None, then the closed mode is left unchanged.
         ============= =========================================================
-        
+
         """
         if closed is not None:
             self.closed = closed
-        
+
         for p in points:
             self.addFreeHandle(p)
-        
+
         start = -1 if self.closed else 0
         for i in range(start, len(self.handles)-1):
             self.addSegment(self.handles[i]['item'], self.handles[i+1]['item'])
-        
-        
+
+
     def clearPoints(self):
         """
         Remove all handles and segments.
@@ -1849,7 +1849,7 @@ class PolyLineROI(ROI):
         ROI.setState(self, state)
         self.clearPoints()
         self.setPoints(state['points'], closed=state['closed'])
-        
+
     def addSegment(self, h1, h2, index=None):
         seg = LineSegmentROI(handles=(h1, h2), pen=self.pen, parent=self, movable=False)
         if index is None:
@@ -1862,18 +1862,18 @@ class PolyLineROI(ROI):
         for h in seg.handles:
             h['item'].setDeletable(True)
             h['item'].setAcceptedMouseButtons(h['item'].acceptedMouseButtons() | QtCore.Qt.LeftButton) ## have these handles take left clicks too, so that handles cannot be added on top of other handles
-        
+
     def setMouseHover(self, hover):
         ## Inform all the ROI's segments that the mouse is(not) hovering over it
         ROI.setMouseHover(self, hover)
         for s in self.segments:
             s.setMouseHover(hover)
-          
+
     def addHandle(self, info, index=None):
         h = ROI.addHandle(self, info, index=index)
         h.sigRemoveRequested.connect(self.removeHandle)
         return h
-        
+
     def segmentClicked(self, segment, ev=None, pos=None): ## pos should be in this item's coordinate system
         if ev != None:
             pos = segment.mapToParent(ev.pos())
@@ -1883,20 +1883,20 @@ class PolyLineROI(ROI):
             raise Exception("Either an event or a position must be given.")
         h1 = segment.handles[0]['item']
         h2 = segment.handles[1]['item']
-        
+
         i = self.segments.index(segment)
         h3 = self.addFreeHandle(pos, index=self.indexOfHandle(h2))
         self.addSegment(h3, h2, index=i+1)
         segment.replaceHandle(h2, h3)
-        
+
     def removeHandle(self, handle, updateSegments=True):
         ROI.removeHandle(self, handle)
         handle.sigRemoveRequested.disconnect(self.removeHandle)
-        
+
         if not updateSegments:
             return
         segments = handle.rois[:]
-        
+
         if len(segments) == 1:
             self.removeSegment(segments[0])
         else:
@@ -1904,21 +1904,21 @@ class PolyLineROI(ROI):
             handles.remove(handle)
             segments[0].replaceHandle(handle, handles[0])
             self.removeSegment(segments[1])
-        
+
     def removeSegment(self, seg):
         for handle in seg.handles[:]:
             seg.removeHandle(handle['item'])
         self.segments.remove(seg)
         seg.sigClicked.disconnect(self.segmentClicked)
         self.scene().removeItem(seg)
-        
+
     def checkRemoveHandle(self, h):
         ## called when a handle is about to display its context menu
         if self.closed:
             return len(self.handles) > 3
         else:
             return len(self.handles) > 2
-        
+
     def paint(self, p, *args):
         #for s in self.segments:
             #s.update()
@@ -1927,13 +1927,13 @@ class PolyLineROI(ROI):
         #p.drawRect(self.boundingRect())
         #p.drawPath(self.shape())
         pass
-    
+
     def boundingRect(self):
         return self.shape().boundingRect()
         #r = QtCore.QRectF()
         #for h in self.handles:
             #r |= self.mapFromItem(h['item'], h['item'].boundingRect()).boundingRect()   ## |= gives the union of the two QRectFs
-        #return r 
+        #return r
 
     def shape(self):
         p = QtGui.QPainterPath()
@@ -1943,11 +1943,11 @@ class PolyLineROI(ROI):
         for i in range(len(self.handles)):
             p.lineTo(self.handles[i]['item'].pos())
         p.lineTo(self.handles[0]['item'].pos())
-        return p        
+        return p
 
     def getArrayRegion(self, data, img, axes=(0,1), returnMappedCoords=False, **kwds):
         """
-        Return the result of ROI.getArrayRegion(), masked by the shape of the 
+        Return the result of ROI.getArrayRegion(), masked by the shape of the
         ROI. Values outside the ROI shape are set to 0.
         """
         sl = self.getArraySlice(data, img, axes=(0,1))
@@ -1961,7 +1961,7 @@ class PolyLineROI(ROI):
         p.setBrush(fn.mkBrush('w'))
         p.setTransform(self.itemTransform(img)[0])
         bounds = self.mapRectToItem(img, self.boundingRect())
-        p.translate(-bounds.left(), -bounds.top()) 
+        p.translate(-bounds.left(), -bounds.top())
         p.drawPath(self.shape())
         p.end()
         mask = fn.imageToArray(im)[:,:,0].astype(float) / 255.
@@ -1980,47 +1980,47 @@ class PolyLineROI(ROI):
 class LineSegmentROI(ROI):
     """
     ROI subclass with two freely-moving handles defining a line.
-    
+
     ============== =============================================================
     **Arguments**
-    positions      (list of two length-2 sequences) The endpoints of the line 
-                   segment. Note that, unlike the handle positions specified in 
+    positions      (list of two length-2 sequences) The endpoints of the line
+                   segment. Note that, unlike the handle positions specified in
                    other ROIs, these positions must be expressed in the normal
                    coordinate system of the ROI, rather than (0 to 1) relative
                    to the size of the ROI.
     \**args        All extra keyword arguments are passed to ROI()
     ============== =============================================================
     """
-    
+
     def __init__(self, positions=(None, None), pos=None, handles=(None,None), **args):
         if pos is None:
             pos = [0,0]
-            
+
         ROI.__init__(self, pos, [1,1], **args)
         #ROI.__init__(self, positions[0])
         if len(positions) > 2:
             raise Exception("LineSegmentROI must be defined by exactly 2 positions. For more points, use PolyLineROI.")
-        
+
         for i, p in enumerate(positions):
             self.addFreeHandle(p, item=handles[i])
-                
-        
+
+
     def listPoints(self):
         return [p['item'].pos() for p in self.handles]
-            
+
     def paint(self, p, *args):
         p.setRenderHint(QtGui.QPainter.Antialiasing)
         p.setPen(self.currentPen)
         h1 = self.handles[0]['item'].pos()
         h2 = self.handles[1]['item'].pos()
         p.drawLine(h1, h2)
-        
+
     def boundingRect(self):
         return self.shape().boundingRect()
-    
+
     def shape(self):
         p = QtGui.QPainterPath()
-    
+
         h1 = self.handles[0]['item'].pos()
         h2 = self.handles[1]['item'].pos()
         dh = h2-h1
@@ -2029,28 +2029,28 @@ class LineSegmentROI(ROI):
         pxv = self.pixelVectors(dh)[1]
         if pxv is None:
             return p
-            
+
         pxv *= 4
-        
+
         p.moveTo(h1+pxv)
         p.lineTo(h2+pxv)
         p.lineTo(h2-pxv)
         p.lineTo(h1-pxv)
         p.lineTo(h1+pxv)
-      
+
         return p
-    
+
     def getArrayRegion(self, data, img, axes=(0,1)):
         """
-        Use the position of this ROI relative to an imageItem to pull a slice 
+        Use the position of this ROI relative to an imageItem to pull a slice
         from an array.
-        
-        Since this pulls 1D data from a 2D coordinate system, the return value 
+
+        Since this pulls 1D data from a 2D coordinate system, the return value
         will have ndim = data.ndim-1
-        
+
         See ROI.getArrayRegion() for a description of the arguments.
         """
-        
+
         imgPts = [self.mapToItem(img, h['item'].pos()) for h in self.handles]
         rgns = []
         for i in range(len(imgPts)-1):
@@ -2058,9 +2058,9 @@ class LineSegmentROI(ROI):
             o = Point(imgPts[i])
             r = fn.affineSlice(data, shape=(int(d.length()),), vectors=[Point(d.norm())], origin=o, axes=axes, order=1)
             rgns.append(r)
-            
+
         return np.concatenate(rgns, axis=axes[0])
-        
+
 
 class SpiralROI(ROI):
     def __init__(self, pos=None, size=None, **args):
@@ -2074,25 +2074,25 @@ class SpiralROI(ROI):
         self.addRotateFreeHandle([1,0], [0,0], name='r')
         #self.getRadius()
         #QtCore.connect(self, QtCore.SIGNAL('regionChanged'), self.
-        
-        
+
+
     def getRadius(self):
         radius = Point(self.handles[1]['item'].pos()).length()
         #r2 = radius[1]
         #r3 = r2[0]
         return radius
-    
+
     def boundingRect(self):
         r = self.getRadius()
         return QtCore.QRectF(-r*1.1, -r*1.1, 2.2*r, 2.2*r)
         #return self.bounds
-    
+
     #def movePoint(self, *args, **kargs):
         #ROI.movePoint(self, *args, **kargs)
         #self.prepareGeometryChange()
         #for h in self.handles:
             #h['pos'] = h['item'].pos()/self.state['size'][0]
-            
+
     def stateChanged(self, finish=True):
         ROI.stateChanged(self, finish=finish)
         if len(self.handles) > 1:
@@ -2114,16 +2114,16 @@ class SpiralROI(ROI):
                 x0 = x1
                 y0 = y1
                 i += 1
-           
-                
+
+
             return self.path
-    
-        
+
+
     def shape(self):
         p = QtGui.QPainterPath()
         p.addEllipse(self.boundingRect())
         return p
-    
+
     def paint(self, p, *args):
         p.setRenderHint(QtGui.QPainter.Antialiasing)
         #path = self.shape()
@@ -2133,11 +2133,11 @@ class SpiralROI(ROI):
         p.drawPath(self.shape())
         p.setPen(QtGui.QPen(QtGui.QColor(0,0,255)))
         p.drawRect(self.boundingRect())
-        
-    
+
+
 class CrosshairROI(ROI):
     """A crosshair ROI whose position is at the center of the crosshairs. By default, it is scalable, rotatable and translatable."""
-    
+
     def __init__(self, pos=None, size=None, **kargs):
         if size == None:
             #size = [100e-6,100e-6]
@@ -2146,7 +2146,7 @@ class CrosshairROI(ROI):
             pos = [0,0]
         self._shape = None
         ROI.__init__(self, pos, size, **kargs)
-        
+
         self.sigRegionChanged.connect(self.invalidate)
         self.addScaleRotateHandle(Point(1, 0), Point(0, 0))
         self.aspectLocked = True
@@ -2154,18 +2154,18 @@ class CrosshairROI(ROI):
     def invalidate(self):
         self._shape = None
         self.prepareGeometryChange()
-        
+
     def boundingRect(self):
         #size = self.size()
         #return QtCore.QRectF(-size[0]/2., -size[1]/2., size[0], size[1]).normalized()
         return self.shape().boundingRect()
-    
+
     #def getRect(self):
         ### same as boundingRect -- for internal use so that boundingRect can be re-implemented in subclasses
         #size = self.size()
         #return QtCore.QRectF(-size[0]/2., -size[1]/2., size[0], size[1]).normalized()
-        
-    
+
+
     def shape(self):
         if self._shape is None:
             radius = self.getState()['size'][1]
@@ -2179,15 +2179,15 @@ class CrosshairROI(ROI):
             stroker.setWidth(10)
             outline = stroker.createStroke(p)
             self._shape = self.mapFromDevice(outline)
-            
-        
+
+
             ##h1 = self.handles[0]['item'].pos()
             ##h2 = self.handles[1]['item'].pos()
             #w1 = Point(-0.5, 0)*self.size()
             #w2 = Point(0.5, 0)*self.size()
             #h1 = Point(0, -0.5)*self.size()
             #h2 = Point(0, 0.5)*self.size()
-            
+
             #dh = h2-h1
             #dw = w2-w1
             #if dh.length() == 0 or dw.length() == 0:
@@ -2195,29 +2195,29 @@ class CrosshairROI(ROI):
             #pxv = self.pixelVectors(dh)[1]
             #if pxv is None:
                 #return p
-                
+
             #pxv *= 4
-            
+
             #p.moveTo(h1+pxv)
             #p.lineTo(h2+pxv)
             #p.lineTo(h2-pxv)
             #p.lineTo(h1-pxv)
             #p.lineTo(h1+pxv)
-            
+
             #pxv = self.pixelVectors(dw)[1]
             #if pxv is None:
                 #return p
-                
+
             #pxv *= 4
-            
+
             #p.moveTo(w1+pxv)
             #p.lineTo(w2+pxv)
             #p.lineTo(w2-pxv)
             #p.lineTo(w1-pxv)
             #p.lineTo(w1+pxv)
-        
+
         return self._shape
-    
+
     def paint(self, p, *args):
         #p.save()
         #r = self.getRect()
@@ -2229,8 +2229,6 @@ class CrosshairROI(ROI):
         #p.drawLine(0,5, 10,5)
         #p.drawLine(5,0, 5,10)
         #p.restore()
-        
+
         p.drawLine(Point(0, -radius), Point(0, radius))
         p.drawLine(Point(-radius, 0), Point(radius, 0))
-        
-        

--- a/pyqtgraph/graphicsItems/ScaleBar.py
+++ b/pyqtgraph/graphicsItems/ScaleBar.py
@@ -18,7 +18,7 @@ class ScaleBar(GraphicsObject, GraphicsWidgetAnchor):
         GraphicsWidgetAnchor.__init__(self)
         self.setFlag(self.ItemHasNoContents)
         self.setAcceptedMouseButtons(QtCore.Qt.NoButton)
-        
+
         if brush is None:
             brush = getConfigOption('foreground')
         self.brush = fn.mkBrush(brush)
@@ -28,12 +28,12 @@ class ScaleBar(GraphicsObject, GraphicsWidgetAnchor):
         if offset == None:
             offset = (0,0)
         self.offset = offset
-        
+
         self.bar = QtGui.QGraphicsRectItem()
         self.bar.setPen(self.pen)
         self.bar.setBrush(self.brush)
         self.bar.setParentItem(self)
-        
+
         self.text = TextItem(text=fn.siFormat(size, suffix=suffix), anchor=(0.5,1))
         self.text.setParentItem(self)
 
@@ -43,8 +43,8 @@ class ScaleBar(GraphicsObject, GraphicsWidgetAnchor):
             return
         view.sigRangeChanged.connect(self.updateBar)
         self.updateBar()
-        
-        
+
+
     def updateBar(self):
         view = self.parentItem()
         if view is None:
@@ -67,5 +67,3 @@ class ScaleBar(GraphicsObject, GraphicsWidgetAnchor):
             anchor = (anchorx, anchory)
             self.anchor(itemPos=anchor, parentPos=anchor, offset=offset)
         return ret
-
-

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -27,7 +27,7 @@ coords = {
     'd': [(0., -0.5), (-0.4, 0.), (0, 0.5), (0.4, 0)],
     '+': [
         (-0.5, -0.05), (-0.5, 0.05), (-0.05, 0.05), (-0.05, 0.5),
-        (0.05, 0.5), (0.05, 0.05), (0.5, 0.05), (0.5, -0.05), 
+        (0.05, 0.5), (0.05, 0.05), (0.5, 0.05), (0.5, -0.05),
         (0.05, -0.05), (0.05, -0.5), (-0.05, -0.5), (-0.05, -0.05)
     ],
 }
@@ -40,7 +40,7 @@ tr = QtGui.QTransform()
 tr.rotate(45)
 Symbols['x'] = tr.map(Symbols['+'])
 
-    
+
 def drawSymbol(painter, symbol, size, pen, brush):
     if symbol is None:
         return
@@ -53,13 +53,13 @@ def drawSymbol(painter, symbol, size, pen, brush):
         symbol = list(Symbols.values())[symbol % len(Symbols)]
     painter.drawPath(symbol)
 
-    
+
 def renderSymbol(symbol, size, pen, brush, device=None):
     """
     Render a symbol specification to QImage.
     Symbol may be either a QPainterPath or one of the keys in the Symbols dict.
     If *device* is None, a new QPixmap will be returned. Otherwise,
-    the symbol will be rendered into the device specified (See QPainter documentation 
+    the symbol will be rendered into the device specified (See QPainter documentation
     for more information).
     """
     ## Render a spot with the given parameters to a pixmap
@@ -80,33 +80,33 @@ def makeSymbolPixmap(size, pen, brush, symbol):
     ## deprecated
     img = renderSymbol(symbol, size, pen, brush)
     return QtGui.QPixmap(img)
-    
+
 class SymbolAtlas(object):
     """
     Used to efficiently construct a single QPixmap containing all rendered symbols
     for a ScatterPlotItem. This is required for fragment rendering.
-    
+
     Use example:
         atlas = SymbolAtlas()
         sc1 = atlas.getSymbolCoords('o', 5, QPen(..), QBrush(..))
         sc2 = atlas.getSymbolCoords('t', 10, QPen(..), QBrush(..))
         pm = atlas.getAtlas()
-        
+
     """
     def __init__(self):
         # symbol key : QRect(...) coordinates where symbol can be found in atlas.
-        # note that the coordinate list will always be the same list object as 
+        # note that the coordinate list will always be the same list object as
         # long as the symbol is in the atlas, but the coordinates may
         # change if the atlas is rebuilt.
-        # weak value; if all external refs to this list disappear, 
+        # weak value; if all external refs to this list disappear,
         # the symbol will be forgotten.
         self.symbolMap = weakref.WeakValueDictionary()
-        
+
         self.atlasData = None # numpy array of atlas image
         self.atlas = None     # atlas as QPixmap
         self.atlasValid = False
         self.max_width=0
-        
+
     def getSymbolCoords(self, opts):
         """
         Given a list of spot records, return an object representing the coordinates of that symbol within the atlas
@@ -131,7 +131,7 @@ class SymbolAtlas(object):
                     keyi = key
                     sourceRecti = newRectSrc
         return sourceRect
-        
+
     def buildAtlas(self):
         # get rendered array for all symbols, keep track of avg/max width
         rendered = {}
@@ -150,7 +150,7 @@ class SymbolAtlas(object):
             w = arr.shape[0]
             avgWidth += w
             maxWidth = max(maxWidth, w)
-            
+
         nSymbols = len(rendered)
         if nSymbols > 0:
             avgWidth /= nSymbols
@@ -158,10 +158,10 @@ class SymbolAtlas(object):
         else:
             avgWidth = 0
             width = 0
-        
+
         # sort symbols by height
         symbols = sorted(rendered.keys(), key=lambda x: rendered[x].shape[1], reverse=True)
-        
+
         self.atlasRows = []
 
         x = width
@@ -187,7 +187,7 @@ class SymbolAtlas(object):
         self.atlas = None
         self.atlasValid = True
         self.max_width = maxWidth
-    
+
     def getAtlas(self):
         if not self.atlasValid:
             self.buildAtlas()
@@ -197,27 +197,27 @@ class SymbolAtlas(object):
             img = fn.makeQImage(self.atlasData, copy=False, transpose=False)
             self.atlas = QtGui.QPixmap(img)
         return self.atlas
-        
-    
-    
-    
+
+
+
+
 class ScatterPlotItem(GraphicsObject):
     """
     Displays a set of x/y points. Instances of this class are created
     automatically as part of PlotDataItem; these rarely need to be instantiated
     directly.
-    
-    The size, shape, pen, and fill brush may be set for each point individually 
-    or for all points. 
-    
-    
+
+    The size, shape, pen, and fill brush may be set for each point individually
+    or for all points.
+
+
     ========================  ===============================================
     **Signals:**
     sigPlotChanged(self)      Emitted when the data being plotted has changed
     sigClicked(self, points)  Emitted when the curve is clicked. Sends a list
                               of all the points under the mouse pointer.
     ========================  ===============================================
-    
+
     """
     #sigPointClicked = QtCore.Signal(object, object)
     sigClicked = QtCore.Signal(object, object)  ## self, points
@@ -228,17 +228,17 @@ class ScatterPlotItem(GraphicsObject):
         """
         profiler = debug.Profiler()
         GraphicsObject.__init__(self)
-        
+
         self.picture = None   # QPicture used for rendering when pxmode==False
         self.fragmentAtlas = SymbolAtlas()
-        
+
         self.data = np.empty(0, dtype=[('x', float), ('y', float), ('size', float), ('symbol', object), ('pen', object), ('brush', object), ('data', object), ('item', object), ('sourceRect', object), ('targetRect', object), ('width', float)])
         self.bounds = [None, None]  ## caches data bounds
         self._maxSpotWidth = 0      ## maximum size of the scale-variant portion of all spots
         self._maxSpotPxWidth = 0    ## maximum size of the scale-invariant portion of all spots
         self.opts = {
-            'pxMode': True, 
-            'useCache': True,  ## If useCache is False, symbols are re-drawn on every paint. 
+            'pxMode': True,
+            'useCache': True,  ## If useCache is False, symbols are re-drawn on every paint.
             'antialias': getConfigOption('antialias'),
             'name': None,
         }
@@ -252,14 +252,14 @@ class ScatterPlotItem(GraphicsObject):
         profiler('setData')
 
         #self.setCacheMode(self.DeviceCoordinateCache)
-        
+
     def setData(self, *args, **kargs):
         """
         **Ordered Arguments:**
-        
+
         * If there is only one unnamed argument, it will be interpreted like the 'spots' argument.
         * If there are two unnamed arguments, they will be interpreted as sequences of x and y values.
-        
+
         ====================== ===============================================================================================
         **Keyword Arguments:**
         *spots*                Optional list of dicts. Each dict specifies parameters for a single spot:
@@ -285,8 +285,8 @@ class ScatterPlotItem(GraphicsObject):
                                it is in the item's local coordinate system.
         *data*                 a list of python objects used to uniquely identify each spot.
         *identical*            *Deprecated*. This functionality is handled automatically now.
-        *antialias*            Whether to draw symbols with antialiasing. Note that if pxMode is True, symbols are 
-                               always rendered with antialiasing (since the rendered symbols can be cached, this 
+        *antialias*            Whether to draw symbols with antialiasing. Note that if pxMode is True, symbols are
+                               always rendered with antialiasing (since the rendered symbols can be cached, this
                                incurs very little performance cost)
         *name*                 The name of this item. Names are used for automatically
                                generating LegendItem entries and by some exporters.
@@ -298,10 +298,10 @@ class ScatterPlotItem(GraphicsObject):
 
     def addPoints(self, *args, **kargs):
         """
-        Add new points to the scatter plot. 
+        Add new points to the scatter plot.
         Arguments are the same as setData()
         """
-        
+
         ## deal with non-keyword arguments
         if len(args) == 1:
             kargs['spots'] = args[0]
@@ -310,7 +310,7 @@ class ScatterPlotItem(GraphicsObject):
             kargs['y'] = args[1]
         elif len(args) > 2:
             raise Exception('Only accepts up to two non-keyword arguments.')
-        
+
         ## convert 'pos' argument to 'x' and 'y'
         if 'pos' in kargs:
             pos = kargs['pos']
@@ -329,7 +329,7 @@ class ScatterPlotItem(GraphicsObject):
                         y.append(p[1])
                 kargs['x'] = x
                 kargs['y'] = y
-        
+
         ## determine how many spots we have
         if 'spots' in kargs:
             numPts = len(kargs['spots'])
@@ -339,16 +339,16 @@ class ScatterPlotItem(GraphicsObject):
             kargs['x'] = []
             kargs['y'] = []
             numPts = 0
-        
+
         ## Extend record array
         oldData = self.data
         self.data = np.empty(len(oldData)+numPts, dtype=self.data.dtype)
         ## note that np.empty initializes object fields to None and string fields to ''
-        
+
         self.data[:len(oldData)] = oldData
         #for i in range(len(oldData)):
             #oldData[i]['item']._data = self.data[i]  ## Make sure items have proper reference to new array
-            
+
         newData = self.data[len(oldData):]
         newData['size'] = -1  ## indicates to use default size
 
@@ -376,12 +376,12 @@ class ScatterPlotItem(GraphicsObject):
         elif 'y' in kargs:
             newData['x'] = kargs['x']
             newData['y'] = kargs['y']
-        
+
         if 'pxMode' in kargs:
             self.setPxMode(kargs['pxMode'])
         if 'antialias' in kargs:
             self.opts['antialias'] = kargs['antialias']
-            
+
         ## Set any extra parameters provided in keyword arguments
         for k in ['pen', 'brush', 'symbol', 'size']:
             if k in kargs:
@@ -397,32 +397,32 @@ class ScatterPlotItem(GraphicsObject):
         self.invalidate()
         self.updateSpots(newData)
         self.sigPlotChanged.emit(self)
-        
+
     def invalidate(self):
         ## clear any cached drawing state
         self.picture = None
         self.update()
-        
+
     def getData(self):
-        return self.data['x'], self.data['y']    
-        
+        return self.data['x'], self.data['y']
+
     def setPoints(self, *args, **kargs):
         ##Deprecated; use setData
         return self.setData(*args, **kargs)
-        
+
     def implements(self, interface=None):
         ints = ['plotData']
         if interface is None:
             return ints
         return interface in ints
-    
+
     def name(self):
         return self.opts.get('name', None)
-    
+
     def setPen(self, *args, **kargs):
-        """Set the pen(s) used to draw the outline around each spot. 
+        """Set the pen(s) used to draw the outline around each spot.
         If a list or array is provided, then the pen for each spot will be set separately.
-        Otherwise, the arguments are passed to pg.mkPen and used as the default pen for 
+        Otherwise, the arguments are passed to pg.mkPen and used as the default pen for
         all spots which do not have a pen explicitly set."""
         update = kargs.pop('update', True)
         dataSet = kargs.pop('dataSet', self.data)
@@ -436,19 +436,19 @@ class ScatterPlotItem(GraphicsObject):
             dataSet['pen'] = pens
         else:
             self.opts['pen'] = fn.mkPen(*args, **kargs)
-        
+
         dataSet['sourceRect'] = None
         if update:
             self.updateSpots(dataSet)
-        
+
     def setBrush(self, *args, **kargs):
-        """Set the brush(es) used to fill the interior of each spot. 
+        """Set the brush(es) used to fill the interior of each spot.
         If a list or array is provided, then the brush for each spot will be set separately.
-        Otherwise, the arguments are passed to pg.mkBrush and used as the default brush for 
+        Otherwise, the arguments are passed to pg.mkBrush and used as the default brush for
         all spots which do not have a brush explicitly set."""
         update = kargs.pop('update', True)
         dataSet = kargs.pop('dataSet', self.data)
-            
+
         if len(args) == 1 and (isinstance(args[0], np.ndarray) or isinstance(args[0], list)):
             brushes = args[0]
             if 'mask' in kargs and kargs['mask'] is not None:
@@ -459,19 +459,19 @@ class ScatterPlotItem(GraphicsObject):
         else:
             self.opts['brush'] = fn.mkBrush(*args, **kargs)
             #self._spotPixmap = None
-        
+
         dataSet['sourceRect'] = None
         if update:
             self.updateSpots(dataSet)
 
     def setSymbol(self, symbol, update=True, dataSet=None, mask=None):
-        """Set the symbol(s) used to draw each spot. 
+        """Set the symbol(s) used to draw each spot.
         If a list or array is provided, then the symbol for each spot will be set separately.
-        Otherwise, the argument will be used as the default symbol for 
+        Otherwise, the argument will be used as the default symbol for
         all spots which do not have a symbol explicitly set."""
         if dataSet is None:
             dataSet = self.data
-            
+
         if isinstance(symbol, np.ndarray) or isinstance(symbol, list):
             symbols = symbol
             if mask is not None:
@@ -482,19 +482,19 @@ class ScatterPlotItem(GraphicsObject):
         else:
             self.opts['symbol'] = symbol
             self._spotPixmap = None
-        
+
         dataSet['sourceRect'] = None
         if update:
             self.updateSpots(dataSet)
-    
+
     def setSize(self, size, update=True, dataSet=None, mask=None):
-        """Set the size(s) used to draw each spot. 
+        """Set the size(s) used to draw each spot.
         If a list or array is provided, then the size for each spot will be set separately.
-        Otherwise, the argument will be used as the default size for 
+        Otherwise, the argument will be used as the default size for
         all spots which do not have a size explicitly set."""
         if dataSet is None:
             dataSet = self.data
-            
+
         if isinstance(size, np.ndarray) or isinstance(size, list):
             sizes = size
             if mask is not None:
@@ -505,21 +505,21 @@ class ScatterPlotItem(GraphicsObject):
         else:
             self.opts['size'] = size
             self._spotPixmap = None
-            
+
         dataSet['sourceRect'] = None
         if update:
             self.updateSpots(dataSet)
-        
+
     def setPointData(self, data, dataSet=None, mask=None):
         if dataSet is None:
             dataSet = self.data
-            
+
         if isinstance(data, np.ndarray) or isinstance(data, list):
             if mask is not None:
                 data = data[mask]
             if len(data) != len(dataSet):
                 raise Exception("Length of meta data does not match number of points (%d != %d)" % (len(data), len(dataSet)))
-        
+
         ## Bug: If data is a numpy record array, then items from that array must be copied to dataSet one at a time.
         ## (otherwise they are converted to tuples and thus lose their field names.
         if isinstance(data, np.ndarray) and (data.dtype.fields is not None)and len(data.dtype.fields) > 1:
@@ -527,14 +527,14 @@ class ScatterPlotItem(GraphicsObject):
                 dataSet['data'][i] = rec
         else:
             dataSet['data'] = data
-        
+
     def setPxMode(self, mode):
         if self.opts['pxMode'] == mode:
             return
-            
+
         self.opts['pxMode'] = mode
         self.invalidate()
-        
+
     def updateSpots(self, dataSet=None):
         if dataSet is None:
             dataSet = self.data
@@ -547,9 +547,9 @@ class ScatterPlotItem(GraphicsObject):
                 opts = self.getSpotOpts(dataSet[mask])
                 sourceRect = self.fragmentAtlas.getSymbolCoords(opts)
                 dataSet['sourceRect'][mask] = sourceRect
-                
+
             self.fragmentAtlas.getAtlas() # generate atlas so source widths are available.
-            
+
             dataSet['width'] = np.array(list(imap(QtCore.QRectF.width, dataSet['sourceRect'])))/2
             dataSet['targetRect'] = None
             self._maxSpotPxWidth = self.fragmentAtlas.max_width
@@ -585,9 +585,9 @@ class ScatterPlotItem(GraphicsObject):
             recs['pen'][np.equal(recs['pen'], None)] = fn.mkPen(self.opts['pen'])
             recs['brush'][np.equal(recs['brush'], None)] = fn.mkBrush(self.opts['brush'])
             return recs
-            
-            
-        
+
+
+
     def measureSpotSizes(self, dataSet):
         for rec in dataSet:
             ## keep track of the maximum spot size and pixel size
@@ -605,8 +605,8 @@ class ScatterPlotItem(GraphicsObject):
             self._maxSpotWidth = max(self._maxSpotWidth, width)
             self._maxSpotPxWidth = max(self._maxSpotPxWidth, pxWidth)
         self.bounds = [None, None]
-    
-    
+
+
     def clear(self):
         """Remove all spots from the scatter plot"""
         #self.clearItems()
@@ -617,23 +617,23 @@ class ScatterPlotItem(GraphicsObject):
     def dataBounds(self, ax, frac=1.0, orthoRange=None):
         if frac >= 1.0 and orthoRange is None and self.bounds[ax] is not None:
             return self.bounds[ax]
-        
+
         #self.prepareGeometryChange()
         if self.data is None or len(self.data) == 0:
             return (None, None)
-        
+
         if ax == 0:
             d = self.data['x']
             d2 = self.data['y']
         elif ax == 1:
             d = self.data['y']
             d2 = self.data['x']
-        
+
         if orthoRange is not None:
             mask = (d2 >= orthoRange[0]) * (d2 <= orthoRange[1])
             d = d[mask]
             d2 = d2[mask]
-            
+
         if frac >= 1.0:
             self.bounds[ax] = (np.nanmin(d) - self._maxSpotWidth*0.7072, np.nanmax(d) + self._maxSpotWidth*0.7072)
             return self.bounds[ax]
@@ -656,11 +656,11 @@ class ScatterPlotItem(GraphicsObject):
         if ymn is None or ymx is None:
             ymn = 0
             ymx = 0
-        
+
         px = py = 0.0
         pxPad = self.pixelPadding()
         if pxPad > 0:
-            # determine length of pixel in local x, y directions    
+            # determine length of pixel in local x, y directions
             px, py = self.pixelVectors()
             try:
                 px = 0 if px is None else px.length()
@@ -670,7 +670,7 @@ class ScatterPlotItem(GraphicsObject):
                 py = 0 if py is None else py.length()
             except OverflowError:
                 py = 0
-            
+
             # return bounds expanded by pixel size
             px *= pxPad
             py *= pxPad
@@ -688,7 +688,7 @@ class ScatterPlotItem(GraphicsObject):
 
 
     def mapPointsToDevice(self, pts):
-        # Map point locations to device        
+        # Map point locations to device
         tr = self.deviceTransform()
         if tr is None:
             return None
@@ -699,7 +699,7 @@ class ScatterPlotItem(GraphicsObject):
         pts = fn.transformCoordinates(tr, pts)
         pts -= self.data['width']
         pts = np.clip(pts, -2**30, 2**30) ## prevent Qt segmentation fault.
-        
+
         return pts
 
     def getViewMask(self, pts):
@@ -713,48 +713,48 @@ class ScatterPlotItem(GraphicsObject):
         mask = ((pts[0] + w > viewBounds.left()) &
                 (pts[0] - w < viewBounds.right()) &
                 (pts[1] + w > viewBounds.top()) &
-                (pts[1] - w < viewBounds.bottom())) ## remove out of view points 
+                (pts[1] - w < viewBounds.bottom())) ## remove out of view points
         return mask
-        
-        
+
+
     @debug.warnOnException  ## raising an exception here causes crash
     def paint(self, p, *args):
 
         #p.setPen(fn.mkPen('r'))
         #p.drawRect(self.boundingRect())
-        
+
         if self._exportOpts is not False:
             aa = self._exportOpts.get('antialias', True)
             scale = self._exportOpts.get('resolutionScale', 1.0)  ## exporting to image; pixel resolution may have changed
         else:
             aa = self.opts['antialias']
             scale = 1.0
-            
+
         if self.opts['pxMode'] is True:
             p.resetTransform()
-            
+
             # Map point coordinates to device
             pts = np.vstack([self.data['x'], self.data['y']])
             pts = self.mapPointsToDevice(pts)
             if pts is None:
                 return
-            
+
             # Cull points that are outside view
             viewMask = self.getViewMask(pts)
             #pts = pts[:,mask]
             #data = self.data[mask]
-            
+
             if self.opts['useCache'] and self._exportOpts is False:
                 # Draw symbols from pre-rendered atlas
                 atlas = self.fragmentAtlas.getAtlas()
-                
+
                 # Update targetRects if necessary
                 updateMask = viewMask & np.equal(self.data['targetRect'], None)
                 if np.any(updateMask):
                     updatePts = pts[:,updateMask]
                     width = self.data[updateMask]['width']*2
                     self.data['targetRect'][updateMask] = list(imap(QtCore.QRectF, updatePts[0,:], updatePts[1,:], width, width))
-                
+
                 data = self.data[viewMask]
                 if USE_PYSIDE or USE_PYQT5:
                     list(imap(p.drawPixmap, data['targetRect'], repeat(atlas), data['sourceRect']))
@@ -782,16 +782,16 @@ class ScatterPlotItem(GraphicsObject):
                     p2.translate(rec['x'], rec['y'])
                     drawSymbol(p2, *self.getSpotOpts(rec, scale))
                 p2.end()
-                
+
             p.setRenderHint(p.Antialiasing, aa)
             self.picture.play(p)
-        
+
     def points(self):
         for rec in self.data:
             if rec['item'] is None:
                 rec['item'] = SpotItem(rec, self)
         return self.data['item']
-        
+
     def pointsAt(self, pos):
         x = pos.x()
         y = pos.y()
@@ -814,7 +814,7 @@ class ScatterPlotItem(GraphicsObject):
                 #print "No hit:", (x, y), (sx, sy)
                 #print "       ", (sx-s2x, sy-s2y), (sx+s2x, sy+s2y)
         return pts[::-1]
-            
+
 
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.LeftButton:
@@ -833,7 +833,7 @@ class ScatterPlotItem(GraphicsObject):
 class SpotItem(object):
     """
     Class referring to individual spots in a scatter plot.
-    These can be retrieved by calling ScatterPlotItem.points() or 
+    These can be retrieved by calling ScatterPlotItem.points() or
     by connecting to the ScatterPlotItem's click signals.
     """
 
@@ -844,34 +844,34 @@ class SpotItem(object):
         #self.setParentItem(plot)
         #self.setPos(QtCore.QPointF(data['x'], data['y']))
         #self.updateItem()
-    
+
     def data(self):
         """Return the user data associated with this spot."""
         return self._data['data']
-    
+
     def size(self):
-        """Return the size of this spot. 
+        """Return the size of this spot.
         If the spot has no explicit size set, then return the ScatterPlotItem's default size instead."""
         if self._data['size'] == -1:
             return self._plot.opts['size']
         else:
             return self._data['size']
-    
+
     def pos(self):
         return Point(self._data['x'], self._data['y'])
-        
+
     def viewPos(self):
         return self._plot.mapToView(self.pos())
-    
+
     def setSize(self, size):
-        """Set the size of this spot. 
-        If the size is set to -1, then the ScatterPlotItem's default size 
+        """Set the size of this spot.
+        If the size is set to -1, then the ScatterPlotItem's default size
         will be used instead."""
         self._data['size'] = size
         self.updateItem()
-    
+
     def symbol(self):
-        """Return the symbol of this spot. 
+        """Return the symbol of this spot.
         If the spot has no explicit symbol set, then return the ScatterPlotItem's default symbol instead.
         """
         symbol = self._data['symbol']
@@ -883,7 +883,7 @@ class SpotItem(object):
         except:
             pass
         return symbol
-    
+
     def setSymbol(self, symbol):
         """Set the symbol for this spot.
         If the symbol is set to '', then the ScatterPlotItem's default symbol will be used instead."""
@@ -895,35 +895,35 @@ class SpotItem(object):
         if pen is None:
             pen = self._plot.opts['pen']
         return fn.mkPen(pen)
-    
+
     def setPen(self, *args, **kargs):
         """Set the outline pen for this spot"""
         pen = fn.mkPen(*args, **kargs)
         self._data['pen'] = pen
         self.updateItem()
-    
+
     def resetPen(self):
         """Remove the pen set for this spot; the scatter plot's default pen will be used instead."""
         self._data['pen'] = None  ## Note this is NOT the same as calling setPen(None)
         self.updateItem()
-    
+
     def brush(self):
         brush = self._data['brush']
         if brush is None:
             brush = self._plot.opts['brush']
         return fn.mkBrush(brush)
-    
+
     def setBrush(self, *args, **kargs):
         """Set the fill brush for this spot"""
         brush = fn.mkBrush(*args, **kargs)
         self._data['brush'] = brush
         self.updateItem()
-    
+
     def resetBrush(self):
         """Remove the brush set for this spot; the scatter plot's default brush will be used instead."""
         self._data['brush'] = None  ## Note this is NOT the same as calling setBrush(None)
         self.updateItem()
-    
+
     def setData(self, data):
         """Set the user-data associated with this spot"""
         self._data['data'] = data
@@ -938,14 +938,14 @@ class SpotItem(object):
         #QtGui.QGraphicsPixmapItem.__init__(self)
         #self.setFlags(self.flags() | self.ItemIgnoresTransformations)
         #SpotItem.__init__(self, data, plot)
-    
+
     #def setPixmap(self, pixmap):
         #QtGui.QGraphicsPixmapItem.setPixmap(self, pixmap)
         #self.setOffset(-pixmap.width()/2.+0.5, -pixmap.height()/2.)
-    
+
     #def updateItem(self):
         #symbolOpts = (self._data['pen'], self._data['brush'], self._data['size'], self._data['symbol'])
-        
+
         ### If all symbol options are default, use default pixmap
         #if symbolOpts == (None, None, -1, ''):
             #pixmap = self._plot.defaultSpotPixmap()

--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -5,7 +5,7 @@ from .. import functions as fn
 
 class TextItem(UIGraphicsItem):
     """
-    GraphicsItem displaying unscaled text (the text will always appear normal even inside a scaled ViewBox). 
+    GraphicsItem displaying unscaled text (the text will always appear normal even inside a scaled ViewBox).
     """
     def __init__(self, text='', color=(200,200,200), html=None, anchor=(0,0), border=None, fill=None, angle=0):
         """
@@ -22,11 +22,11 @@ class TextItem(UIGraphicsItem):
         *fill*          A brush to use when filling within the border
         ==============  =================================================================================
         """
-        
+
         ## not working yet
-        #*angle*      Angle in degrees to rotate text (note that the rotation assigned in this item's 
+        #*angle*      Angle in degrees to rotate text (note that the rotation assigned in this item's
                      #transformation will be ignored)
-                     
+
         self.anchor = Point(anchor)
         #self.angle = 0
         UIGraphicsItem.__init__(self)
@@ -45,8 +45,8 @@ class TextItem(UIGraphicsItem):
 
     def setText(self, text, color=(200,200,200)):
         """
-        Set the text and color of this item. 
-        
+        Set the text and color of this item.
+
         This method sets the plain text of the item; see also setHtml().
         """
         color = fn.mkColor(color)
@@ -55,72 +55,72 @@ class TextItem(UIGraphicsItem):
         self.updateText()
         #html = '<span style="color: #%s; text-align: center;">%s</span>' % (color, text)
         #self.setHtml(html)
-        
+
     def updateAnchor(self):
         pass
         #self.resetTransform()
         #self.translate(0, 20)
-        
+
     def setPlainText(self, *args):
         """
-        Set the plain text to be rendered by this item. 
-        
+        Set the plain text to be rendered by this item.
+
         See QtGui.QGraphicsTextItem.setPlainText().
         """
         self.textItem.setPlainText(*args)
         self.updateText()
-        
+
     def setHtml(self, *args):
         """
-        Set the HTML code to be rendered by this item. 
-        
+        Set the HTML code to be rendered by this item.
+
         See QtGui.QGraphicsTextItem.setHtml().
         """
         self.textItem.setHtml(*args)
         self.updateText()
-        
+
     def setTextWidth(self, *args):
         """
         Set the width of the text.
-        
+
         If the text requires more space than the width limit, then it will be
         wrapped into multiple lines.
-        
+
         See QtGui.QGraphicsTextItem.setTextWidth().
         """
         self.textItem.setTextWidth(*args)
         self.updateText()
-        
+
     def setFont(self, *args):
         """
-        Set the font for this text. 
-        
+        Set the font for this text.
+
         See QtGui.QGraphicsTextItem.setFont().
         """
         self.textItem.setFont(*args)
         self.updateText()
-        
+
     #def setAngle(self, angle):
         #self.angle = angle
         #self.updateText()
-        
-        
+
+
     def updateText(self):
-        
+
         ## Needed to maintain font size when rendering to image with increased resolution
         self.textItem.resetTransform()
         #self.textItem.rotate(self.angle)
         if self._exportOpts is not False and 'resolutionScale' in self._exportOpts:
             s = self._exportOpts['resolutionScale']
             self.textItem.scale(s, s)
-        
+
         #br = self.textItem.mapRectToParent(self.textItem.boundingRect())
         self.textItem.setPos(0,0)
         br = self.textItem.boundingRect()
         apos = self.textItem.mapToParent(Point(br.width()*self.anchor.x(), br.height()*self.anchor.y()))
         #print br, apos
         self.textItem.setPos(-apos.x(), -apos.y())
-        
+
     #def textBoundingRect(self):
         ### return the bounds of the text box in device coordinates
         #pos = self.mapToDevice(QtCore.QPointF(0,0))
@@ -135,18 +135,16 @@ class TextItem(UIGraphicsItem):
 
     def boundingRect(self):
         return self.textItem.mapToParent(self.textItem.boundingRect()).boundingRect()
-        
+
     def paint(self, p, *args):
         tr = p.transform()
         if self.lastTransform is not None:
             if tr != self.lastTransform:
                 self.viewRangeChanged()
         self.lastTransform = tr
-        
+
         if self.border.style() != QtCore.Qt.NoPen or self.fill.style() != QtCore.Qt.NoBrush:
             p.setPen(self.border)
             p.setBrush(self.fill)
             p.setRenderHint(p.Antialiasing, True)
             p.drawPolygon(self.textItem.mapToParent(self.textItem.boundingRect()))
-        
-        

--- a/pyqtgraph/graphicsItems/UIGraphicsItem.py
+++ b/pyqtgraph/graphicsItems/UIGraphicsItem.py
@@ -8,18 +8,18 @@ __all__ = ['UIGraphicsItem']
 class UIGraphicsItem(GraphicsObject):
     """
     Base class for graphics items with boundaries relative to a GraphicsView or ViewBox.
-    The purpose of this class is to allow the creation of GraphicsItems which live inside 
+    The purpose of this class is to allow the creation of GraphicsItems which live inside
     a scalable view, but whose boundaries will always stay fixed relative to the view's boundaries.
     For example: GridItem, InfiniteLine
-    
+
     The view can be specified on initialization or it can be automatically detected when the item is painted.
-    
+
     NOTE: Only the item's boundingRect is affected; the item is not transformed in any way. Use viewRangeChanged
     to respond to changes in the view.
     """
-    
+
     #sigViewChanged = QtCore.Signal(object)  ## emitted whenever the viewport coords have changed
-    
+
     def __init__(self, bounds=None, parent=None):
         """
         ============== =============================================================================
@@ -30,52 +30,52 @@ class UIGraphicsItem(GraphicsObject):
         """
         GraphicsObject.__init__(self, parent)
         self.setFlag(self.ItemSendsScenePositionChanges)
-            
+
         if bounds is None:
             self._bounds = QtCore.QRectF(0, 0, 1, 1)
         else:
             self._bounds = bounds
-            
+
         self._boundingRect = None
         self._updateView()
-        
+
     def paint(self, *args):
         ## check for a new view object every time we paint.
         #self.updateView()
         pass
-    
+
     def itemChange(self, change, value):
         ret = GraphicsObject.itemChange(self, change, value)
-            
+
         ## workaround for pyqt bug:
         ## http://www.riverbankcomputing.com/pipermail/pyqt/2012-August/031818.html
         if not USE_PYSIDE and change == self.ItemParentChange and isinstance(ret, QtGui.QGraphicsItem):
             ret = sip.cast(ret, QtGui.QGraphicsItem)
-        
+
         if change == self.ItemScenePositionHasChanged:
             self.setNewBounds()
         return ret
-    
+
     #def updateView(self):
         ### called to see whether this item has a new view to connect to
-        
+
         ### check for this item's current viewbox or view widget
         #view = self.getViewBox()
         #if view is None:
             ##print "  no view"
             #return
-            
+
         #if self._connectedView is not None and view is self._connectedView():
             ##print "  already have view", view
             #return
-            
+
         ### disconnect from previous view
         #if self._connectedView is not None:
             #cv = self._connectedView()
             #if cv is not None:
                 ##print "disconnect:", self
                 #cv.sigRangeChanged.disconnect(self.viewRangeChanged)
-            
+
         ### connect to new view
         ##print "connect:", self
         #view.sigRangeChanged.connect(self.viewRangeChanged)
@@ -90,7 +90,7 @@ class UIGraphicsItem(GraphicsObject):
             else:
                 self._boundingRect = br
         return QtCore.QRectF(self._boundingRect)
-    
+
     def dataBounds(self, axis, frac=1.0, orthoRange=None):
         """Called by ViewBox for determining the auto-range bounds.
         By default, UIGraphicsItems are excluded from autoRange."""
@@ -100,7 +100,7 @@ class UIGraphicsItem(GraphicsObject):
         """Called when the view widget/viewbox is resized/rescaled"""
         self.setNewBounds()
         self.update()
-        
+
     def setNewBounds(self):
         """Update the item's bounding rect to match the viewport"""
         self._boundingRect = None  ## invalidate bounding rect, regenerate later if needed.
@@ -110,7 +110,7 @@ class UIGraphicsItem(GraphicsObject):
     def setPos(self, *args):
         GraphicsObject.setPos(self, *args)
         self.setNewBounds()
-        
+
     def mouseShape(self):
         """Return the shape of this item after expanding by 2 pixels"""
         shape = self.shape()
@@ -119,6 +119,3 @@ class UIGraphicsItem(GraphicsObject):
         stroker.setWidh(2)
         ds2 = stroker.createStroke(ds).united(ds)
         return self.mapFromDevice(ds2)
-        
-        
-        

--- a/pyqtgraph/graphicsItems/VTickGroup.py
+++ b/pyqtgraph/graphicsItems/VTickGroup.py
@@ -12,10 +12,10 @@ __all__ = ['VTickGroup']
 class VTickGroup(UIGraphicsItem):
     """
     **Bases:** :class:`UIGraphicsItem <pyqtgraph.UIGraphicsItem>`
-    
+
     Draws a set of tick marks which always occupy the same vertical range of the view,
     but have x coordinates relative to the data within the view.
-    
+
     """
     def __init__(self, xvals=None, yrange=None, pen=None):
         """
@@ -33,29 +33,29 @@ class VTickGroup(UIGraphicsItem):
             yrange = [0, 1]
         if xvals is None:
             xvals = []
-            
+
         UIGraphicsItem.__init__(self)
-            
+
         if pen is None:
             pen = (200, 200, 200)
-            
+
         self.path = QtGui.QGraphicsPathItem()
-        
+
         self.ticks = []
         self.xvals = []
         self.yrange = [0,1]
         self.setPen(pen)
         self.setYRange(yrange)
         self.setXVals(xvals)
-        
+
     def setPen(self, *args, **kwargs):
         """Set the pen to use for drawing ticks. Can be specified as any arguments valid
-        for :func:`mkPen<pyqtgraph.mkPen>`"""        
+        for :func:`mkPen<pyqtgraph.mkPen>`"""
         self.pen = fn.mkPen(*args, **kwargs)
 
     def setXVals(self, vals):
-        """Set the x values for the ticks. 
-        
+        """Set the x values for the ticks.
+
         ==============   =====================================================================
         **Arguments:**
         vals             A list of x values (in data/plot coordinates) at which to draw ticks.
@@ -64,29 +64,29 @@ class VTickGroup(UIGraphicsItem):
         self.xvals = vals
         self.rebuildTicks()
         #self.valid = False
-        
+
     def setYRange(self, vals):
-        """Set the y range [low, high] that the ticks are drawn on. 0 is the bottom of 
+        """Set the y range [low, high] that the ticks are drawn on. 0 is the bottom of
         the view, 1 is the top."""
         self.yrange = vals
         self.rebuildTicks()
-        
+
     def dataBounds(self, *args, **kargs):
         return None  ## item should never affect view autoscaling
-            
+
     def yRange(self):
         return self.yrange
-            
+
     def rebuildTicks(self):
         self.path = QtGui.QPainterPath()
         yrange = self.yRange()
         for x in self.xvals:
             self.path.moveTo(x, 0.)
             self.path.lineTo(x, 1.)
-        
+
     def paint(self, p, *args):
         UIGraphicsItem.paint(self, p, *args)
-        
+
         br = self.boundingRect()
         h = br.height()
         br.setY(br.y() + self.yrange[0] * h)
@@ -95,5 +95,3 @@ class VTickGroup(UIGraphicsItem):
         p.scale(1.0, br.height())
         p.setPen(self.pen)
         p.drawPath(self.path)
-
-    

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -35,21 +35,21 @@ class WeakList(object):
             i -= 1
 
 class ChildGroup(ItemGroup):
-    
+
     def __init__(self, parent):
         ItemGroup.__init__(self, parent)
-        
-        # Used as callback to inform ViewBox when items are added/removed from 
-        # the group. 
-        # Note 1: We would prefer to override itemChange directly on the 
+
+        # Used as callback to inform ViewBox when items are added/removed from
+        # the group.
+        # Note 1: We would prefer to override itemChange directly on the
         #         ViewBox, but this causes crashes on PySide.
         # Note 2: We might also like to use a signal rather than this callback
-        #         mechanism, but this causes a different PySide crash.        
+        #         mechanism, but this causes a different PySide crash.
         self.itemsChangedListeners = WeakList()
- 
+
         # excempt from telling view when transform changes
         self._GraphicsObject__inform_view_on_change = False
-    
+
     def itemChange(self, change, value):
         ret = ItemGroup.itemChange(self, change, value)
         if change == self.ItemChildAddedChange or change == self.ItemChildRemovedChange:
@@ -68,19 +68,19 @@ class ChildGroup(ItemGroup):
 class ViewBox(GraphicsWidget):
     """
     **Bases:** :class:`GraphicsWidget <pyqtgraph.GraphicsWidget>`
-    
-    Box that allows internal scaling/panning of children by mouse drag. 
+
+    Box that allows internal scaling/panning of children by mouse drag.
     This class is usually created automatically as part of a :class:`PlotItem <pyqtgraph.PlotItem>` or :class:`Canvas <pyqtgraph.canvas.Canvas>` or with :func:`GraphicsLayout.addViewBox() <pyqtgraph.GraphicsLayout.addViewBox>`.
-    
+
     Features:
-    
+
     * Scaling contents by mouse or auto-scale when contents change
     * View linking--multiple views display the same data ranges
     * Configurable by context menu
     * Item coordinate mapping methods
-    
+
     """
-    
+
     sigYRangeChanged = QtCore.Signal(object, object)
     sigXRangeChanged = QtCore.Signal(object, object)
     sigRangeChangedManually = QtCore.Signal(object)
@@ -89,20 +89,20 @@ class ViewBox(GraphicsWidget):
     sigStateChanged = QtCore.Signal(object)
     sigTransformChanged = QtCore.Signal(object)
     sigResized = QtCore.Signal(object)
-    
+
     ## mouse modes
     PanMode = 3
     RectMode = 1
-    
+
     ## axes
     XAxis = 0
     YAxis = 1
     XYAxes = 2
-    
+
     ## for linking views together
     NamedViews = weakref.WeakValueDictionary()   # name: ViewBox
     AllViews = weakref.WeakKeyDictionary()       # ViewBox: None
-    
+
     def __init__(self, parent=None, border=None, lockAspect=False, enableMouse=True, invertY=False, enableMenu=True, name=None, invertX=False):
         """
         ==============  =============================================================
@@ -115,15 +115,15 @@ class ViewBox(GraphicsWidget):
         *enableMouse*   (bool) Whether mouse can be used to scale/pan the view
         *invertY*       (bool) See :func:`invertY <pyqtgraph.ViewBox.invertY>`
         *invertX*       (bool) See :func:`invertX <pyqtgraph.ViewBox.invertX>`
-        *enableMenu*    (bool) Whether to display a context menu when 
+        *enableMenu*    (bool) Whether to display a context menu when
                         right-clicking on the ViewBox background.
         *name*          (str) Used to register this ViewBox so that it appears
                         in the "Link axis" dropdown inside other ViewBox
                         context menus. This allows the user to manually link
-                        the axes of any other view to this one. 
+                        the axes of any other view to this one.
         ==============  =============================================================
         """
-        
+
         GraphicsWidget.__init__(self, parent)
         self.name = None
         self.linksBlocked = False
@@ -134,63 +134,63 @@ class ViewBox(GraphicsWidget):
         self._autoRangeNeedsUpdate = True ## indicates auto-range needs to be recomputed.
 
         self._lastScene = None  ## stores reference to the last known scene this view was a part of.
-        
+
         self.state = {
-            
+
             ## separating targetRange and viewRange allows the view to be resized
             ## while keeping all previously viewed contents visible
             'targetRange': [[0,1], [0,1]],   ## child coord. range visible [[xmin, xmax], [ymin, ymax]]
             'viewRange': [[0,1], [0,1]],     ## actual range viewed
-        
+
             'yInverted': invertY,
             'xInverted': invertX,
             'aspectLocked': False,    ## False if aspect is unlocked, otherwise float specifies the locked ratio.
-            'autoRange': [True, True],  ## False if auto range is disabled, 
+            'autoRange': [True, True],  ## False if auto range is disabled,
                                           ## otherwise float gives the fraction of data that is visible
             'autoPan': [False, False],         ## whether to only pan (do not change scaling) when auto-range is enabled
-            'autoVisibleOnly': [False, False], ## whether to auto-range only to the visible portion of a plot 
+            'autoVisibleOnly': [False, False], ## whether to auto-range only to the visible portion of a plot
             'linkedViews': [None, None],  ## may be None, "viewName", or weakref.ref(view)
                                           ## a name string indicates that the view *should* link to another, but no view with that name exists yet.
-            
+
             'mouseEnabled': [enableMouse, enableMouse],
-            'mouseMode': ViewBox.PanMode if getConfigOption('leftButtonPan') else ViewBox.RectMode,  
+            'mouseMode': ViewBox.PanMode if getConfigOption('leftButtonPan') else ViewBox.RectMode,
             'enableMenu': enableMenu,
             'wheelScaleFactor': -1.0 / 8.0,
 
             'background': None,
-            
+
             # Limits
             'limits': {
-                'xLimits': [None, None],   # Maximum and minimum visible X values 
-                'yLimits': [None, None],   # Maximum and minimum visible Y values  
+                'xLimits': [None, None],   # Maximum and minimum visible X values
+                'yLimits': [None, None],   # Maximum and minimum visible Y values
                 'xRange': [None, None],   # Maximum and minimum X range
-                'yRange': [None, None],   # Maximum and minimum Y range 
+                'yRange': [None, None],   # Maximum and minimum Y range
                 }
-            
+
         }
         self._updatingRange = False  ## Used to break recursive loops. See updateAutoRange.
         self._itemBoundsCache = weakref.WeakKeyDictionary()
-        
+
         self.locateGroup = None  ## items displayed when using ViewBox.locate(item)
-        
+
         self.setFlag(self.ItemClipsChildrenToShape)
         self.setFlag(self.ItemIsFocusable, True)  ## so we can receive key presses
-        
+
         ## childGroup is required so that ViewBox has local coordinates similar to device coordinates.
         ## this is a workaround for a Qt + OpenGL bug that causes improper clipping
         ## https://bugreports.qt.nokia.com/browse/QTBUG-23723
         self.childGroup = ChildGroup(self)
         self.childGroup.itemsChangedListeners.append(self)
-        
+
         self.background = QtGui.QGraphicsRectItem(self.rect())
         self.background.setParentItem(self)
         self.background.setZValue(-1e6)
         self.background.setPen(fn.mkPen(None))
         self.updateBackground()
-        
+
         #self.useLeftButtonPan = pyqtgraph.getConfigOption('leftButtonPan') # normally use left button to pan
         # this also enables capture of keyPressEvents.
-        
+
         ## Make scale box that is shown when dragging on the view
         self.rbScaleBox = QtGui.QGraphicsRectItem(0, 0, 1, 1)
         self.rbScaleBox.setPen(fn.mkPen((255,255,100), width=1))
@@ -198,36 +198,36 @@ class ViewBox(GraphicsWidget):
         self.rbScaleBox.setZValue(1e9)
         self.rbScaleBox.hide()
         self.addItem(self.rbScaleBox, ignoreBounds=True)
-        
+
         ## show target rect for debugging
         self.target = QtGui.QGraphicsRectItem(0, 0, 1, 1)
         self.target.setPen(fn.mkPen('r'))
         self.target.setParentItem(self)
         self.target.hide()
-        
+
         self.axHistory = [] # maintain a history of zoom locations
         self.axHistoryPointer = -1 # pointer into the history. Allows forward/backward movement, not just "undo"
-        
+
         self.setZValue(-100)
         self.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding))
-        
+
         self.setAspectLocked(lockAspect)
-        
+
         self.border = fn.mkPen(border)
         self.menu = ViewBoxMenu(self)
-        
+
         self.register(name)
         if name is None:
             self.updateViewLists()
-        
+
     def register(self, name):
         """
-        Add this ViewBox to the registered list of views. 
-        
+        Add this ViewBox to the registered list of views.
+
         This allows users to manually link the axes of any other ViewBox to
-        this one. The specified *name* will appear in the drop-down lists for 
+        this one. The specified *name* will appear in the drop-down lists for
         axis linking in the context menus of all other views.
-        
+
         The same can be accomplished by initializing the ViewBox with the *name* attribute.
         """
         ViewBox.AllViews[self] = None
@@ -255,7 +255,7 @@ class ViewBox(GraphicsWidget):
 
     def implements(self, interface):
         return interface == 'ViewBox'
-        
+
     # removed due to https://bugreports.qt-project.org/browse/PYSIDE-86
     #def itemChange(self, change, value):
         ## Note: Calling QWidget.itemChange causes segv in python 3 + PyQt
@@ -270,9 +270,9 @@ class ViewBox(GraphicsWidget):
             #if scene is not None and hasattr(scene, 'sigPrepareForPaint'):
                 #scene.sigPrepareForPaint.connect(self.prepareForPaint)
         #return ret
-        
+
     def checkSceneChange(self):
-        # ViewBox needs to receive sigPrepareForPaint from its scene before 
+        # ViewBox needs to receive sigPrepareForPaint from its scene before
         # being painted. However, we have no way of being informed when the
         # scene has changed in order to make this connection. The usual way
         # to do this is via itemChange(), but bugs prevent this approach
@@ -287,20 +287,20 @@ class ViewBox(GraphicsWidget):
             scene.sigPrepareForPaint.connect(self.prepareForPaint)
         self.prepareForPaint()
         self._lastScene = scene
-            
-            
-        
+
+
+
 
     def prepareForPaint(self):
         #autoRangeEnabled = (self.state['autoRange'][0] is not False) or (self.state['autoRange'][1] is not False)
         # don't check whether auto range is enabled here--only check when setting dirty flag.
-        if self._autoRangeNeedsUpdate: # and autoRangeEnabled: 
+        if self._autoRangeNeedsUpdate: # and autoRangeEnabled:
             self.updateAutoRange()
         if self._matrixNeedsUpdate:
             self.updateMatrix()
-        
+
     def getState(self, copy=True):
-        """Return the current state of the ViewBox. 
+        """Return the current state of the ViewBox.
         Linked views are always converted to view names in the returned state."""
         state = self.state.copy()
         views = []
@@ -316,7 +316,7 @@ class ViewBox(GraphicsWidget):
             return deepcopy(state)
         else:
             return state
-        
+
     def setState(self, state):
         """Restore the state of this ViewBox.
         (see also getState)"""
@@ -324,7 +324,7 @@ class ViewBox(GraphicsWidget):
         self.setXLink(state['linkedViews'][0])
         self.setYLink(state['linkedViews'][1])
         del state['linkedViews']
-        
+
         self.state.update(state)
         #self.updateMatrix()
         self.updateViewRange()
@@ -333,9 +333,9 @@ class ViewBox(GraphicsWidget):
     def setBackgroundColor(self, color):
         """
         Set the background color of the ViewBox.
-        
+
         If color is None, then no background will be drawn.
-        
+
         Added in version 0.9.9
         """
         self.background.setVisible(color is not None)
@@ -366,10 +366,10 @@ class ViewBox(GraphicsWidget):
             self.setMouseMode(ViewBox.PanMode)
         else:
             raise Exception('graphicsItems:ViewBox:setLeftButtonAction: unknown mode = %s (Options are "pan" and "rect")' % mode)
-            
+
     def innerSceneItem(self):
         return self.childGroup
-    
+
     def setMouseEnabled(self, x=None, y=None):
         """
         Set whether each axis is enabled for mouse interaction. *x*, *y* arguments must be True or False.
@@ -380,17 +380,17 @@ class ViewBox(GraphicsWidget):
         if y is not None:
             self.state['mouseEnabled'][1] = y
         self.sigStateChanged.emit(self)
-            
+
     def mouseEnabled(self):
         return self.state['mouseEnabled'][:]
-        
+
     def setMenuEnabled(self, enableMenu=True):
         self.state['enableMenu'] = enableMenu
         self.sigStateChanged.emit(self)
 
     def menuEnabled(self):
-        return self.state.get('enableMenu', True)       
-    
+        return self.state.get('enableMenu', True)
+
     def addItem(self, item, ignoreBounds=False):
         """
         Add a QGraphicsItem to this view. The view will include this item when determining how to set its range
@@ -406,7 +406,7 @@ class ViewBox(GraphicsWidget):
             self.addedItems.append(item)
         self.updateAutoRange()
         #print "addItem:", item, item.boundingRect()
-        
+
     def removeItem(self, item):
         """Remove an item from this view."""
         try:
@@ -421,7 +421,7 @@ class ViewBox(GraphicsWidget):
             self.removeItem(i)
         for ch in self.childGroup.childItems():
             ch.setParentItem(None)
-        
+
     def resizeEvent(self, ev):
         self.linkedXChanged()
         self.linkedYChanged()
@@ -431,7 +431,7 @@ class ViewBox(GraphicsWidget):
         self.sigStateChanged.emit(self)
         self.background.setRect(self.rect())
         self.sigResized.emit(self)
-        
+
     def viewRange(self):
         """Return a the view's visible range as a list: [[xmin, xmax], [ymin, ymax]]"""
         return [x[:] for x in self.state['viewRange']]  ## return copy
@@ -445,13 +445,13 @@ class ViewBox(GraphicsWidget):
         except:
             print("make qrectf failed:", self.state['viewRange'])
             raise
-    
+
     def targetRange(self):
         return [x[:] for x in self.state['targetRange']]  ## return copy
-    
-    def targetRect(self):  
+
+    def targetRect(self):
         """
-        Return the region which has been requested to be visible. 
+        Return the region which has been requested to be visible.
         (this is not necessarily the same as the region that is *actually* visible--
         resizing and aspect ratio constraints can cause targetRect() and viewRect() to differ)
         """
@@ -473,30 +473,30 @@ class ViewBox(GraphicsWidget):
     def setRange(self, rect=None, xRange=None, yRange=None, padding=None, update=True, disableAutoRange=True):
         """
         Set the visible range of the ViewBox.
-        Must specify at least one of *rect*, *xRange*, or *yRange*. 
-        
+        Must specify at least one of *rect*, *xRange*, or *yRange*.
+
         ================== =====================================================================
         **Arguments:**
         *rect*             (QRectF) The full range that should be visible in the view box.
         *xRange*           (min,max) The range that should be visible along the x-axis.
         *yRange*           (min,max) The range that should be visible along the y-axis.
-        *padding*          (float) Expand the view by a fraction of the requested range. 
+        *padding*          (float) Expand the view by a fraction of the requested range.
                            By default, this value is set between 0.02 and 0.1 depending on
                            the size of the ViewBox.
-        *update*           (bool) If True, update the range of the ViewBox immediately. 
+        *update*           (bool) If True, update the range of the ViewBox immediately.
                            Otherwise, the update is deferred until before the next render.
         *disableAutoRange* (bool) If True, auto-ranging is diabled. Otherwise, it is left
                            unchanged.
         ================== =====================================================================
-        
+
         """
         #print self.name, "ViewBox.setRange", rect, xRange, yRange, padding
         #import traceback
         #traceback.print_stack()
-        
+
         changes = {}   # axes
         setRequested = [False, False]
-        
+
         if rect is not None:
             changes = {0: [rect.left(), rect.right()], 1: [rect.top(), rect.bottom()]}
             setRequested = [True, True]
@@ -510,27 +510,27 @@ class ViewBox(GraphicsWidget):
         if len(changes) == 0:
             print(rect)
             raise Exception("Must specify at least one of rect, xRange, or yRange. (gave rect=%s)" % str(type(rect)))
-        
+
         # Update axes one at a time
         changed = [False, False]
         for ax, range in changes.items():
             mn = min(range)
             mx = max(range)
-            
-            # If we requested 0 range, try to preserve previous scale. 
+
+            # If we requested 0 range, try to preserve previous scale.
             # Otherwise just pick an arbitrary scale.
-            if mn == mx:   
+            if mn == mx:
                 dy = self.state['viewRange'][ax][1] - self.state['viewRange'][ax][0]
                 if dy == 0:
                     dy = 1
                 mn -= dy*0.5
                 mx += dy*0.5
                 xpad = 0.0
-                
+
             # Make sure no nan/inf get through
             if not all(np.isfinite([mn, mx])):
                 raise Exception("Cannot set range [%s, %s]" % (str(mn), str(mx)))
-            
+
             # Apply padding
             if padding is None:
                 xpad = self.suggestPadding(ax)
@@ -539,20 +539,20 @@ class ViewBox(GraphicsWidget):
             p = (mx-mn) * xpad
             mn -= p
             mx += p
-            
+
             # Set target range
             if self.state['targetRange'][ax] != [mn, mx]:
                 self.state['targetRange'][ax] = [mn, mx]
                 changed[ax] = True
-                
-        # Update viewRange to match targetRange as closely as possible while 
+
+        # Update viewRange to match targetRange as closely as possible while
         # accounting for aspect ratio constraint
         lockX, lockY = setRequested
         if lockX and lockY:
             lockX = False
             lockY = False
         self.updateViewRange(lockX, lockY)
-            
+
         # Disable auto-range for each axis that was requested to be set
         if disableAutoRange:
             xOff = False if setRequested[0] else None
@@ -564,14 +564,14 @@ class ViewBox(GraphicsWidget):
         if any(changed):
             #if update and self.matrixNeedsUpdate:
                 #self.updateMatrix(changed)
-            #return 
-        
+            #return
+
             self.sigStateChanged.emit(self)
-            
+
             # Update target rect for debugging
             if self.target.isVisible():
                 self.target.setRect(self.mapRectFromItem(self.childGroup, self.targetRect()))
-                
+
         # If ortho axes have auto-visible-only, update them now
         # Note that aspect ratio constraints and auto-visible probably do not work together..
         if changed[0] and self.state['autoVisibleOnly'][1] and (self.state['autoRange'][0] is not False):
@@ -580,14 +580,14 @@ class ViewBox(GraphicsWidget):
         elif changed[1] and self.state['autoVisibleOnly'][0] and (self.state['autoRange'][1] is not False):
             self._autoRangeNeedsUpdate = True
             #self.updateAutoRange()
-            
+
         ## Update view matrix only if requested
         #if update:
             #self.updateMatrix(changed)
         ## Otherwise, indicate that the matrix needs to be updated
         #else:
             #self.matrixNeedsUpdate = True
-            
+
         ## Inform linked views that the range has changed <<This should be moved>>
         #for ax, range in changes.items():
             #link = self.linkedView(ax)
@@ -595,18 +595,18 @@ class ViewBox(GraphicsWidget):
                 #link.linkedViewChanged(self, ax)
 
 
-            
+
     def setYRange(self, min, max, padding=None, update=True):
         """
-        Set the visible Y range of the view to [*min*, *max*]. 
+        Set the visible Y range of the view to [*min*, *max*].
         The *padding* argument causes the range to be set larger by the fraction specified.
         (by default, this value is between 0.02 and 0.1 depending on the size of the ViewBox)
         """
         self.setRange(yRange=[min, max], update=update, padding=padding)
-        
+
     def setXRange(self, min, max, padding=None, update=True):
         """
-        Set the visible X range of the view to [*min*, *max*]. 
+        Set the visible X range of the view to [*min*, *max*].
         The *padding* argument causes the range to be set larger by the fraction specified.
         (by default, this value is between 0.02 and 0.1 depending on the size of the ViewBox)
         """
@@ -615,9 +615,9 @@ class ViewBox(GraphicsWidget):
     def autoRange(self, padding=None, items=None, item=None):
         """
         Set the range of the view box to make all children visible.
-        Note that this is not the same as enableAutoRange, which causes the view to 
+        Note that this is not the same as enableAutoRange, which causes the view to
         automatically auto-range whenever its contents are changed.
-        
+
         ==============  ============================================================
         **Arguments:**
         padding         The fraction of the total data range to add on to the final
@@ -632,10 +632,10 @@ class ViewBox(GraphicsWidget):
         else:
             print("Warning: ViewBox.autoRange(item=__) is deprecated. Use 'items' argument instead.")
             bounds = self.mapFromItemToView(item, item.boundingRect()).boundingRect()
-            
+
         if bounds is not None:
             self.setRange(bounds, padding=padding)
-            
+
     def suggestPadding(self, axis):
         l = self.width() if axis==0 else self.height()
         if l > 0:
@@ -643,31 +643,31 @@ class ViewBox(GraphicsWidget):
         else:
             padding = 0.02
         return padding
-    
+
     def setLimits(self, **kwds):
         """
         Set limits that constrain the possible view ranges.
-        
-        **Panning limits**. The following arguments define the region within the 
+
+        **Panning limits**. The following arguments define the region within the
         viewbox coordinate system that may be accessed by panning the view.
-        
+
         =========== ============================================================
         xMin        Minimum allowed x-axis value
         xMax        Maximum allowed x-axis value
         yMin        Minimum allowed y-axis value
         yMax        Maximum allowed y-axis value
-        =========== ============================================================        
-        
+        =========== ============================================================
+
         **Scaling limits**. These arguments prevent the view being zoomed in or
         out too far.
-        
+
         =========== ============================================================
         minXRange   Minimum allowed left-to-right span across the view.
         maxXRange   Maximum allowed left-to-right span across the view.
         minYRange   Minimum allowed top-to-bottom span across the view.
         maxYRange   Maximum allowed top-to-bottom span across the view.
         =========== ============================================================
-        
+
         Added in version 0.9.9
         """
         update = False
@@ -691,19 +691,19 @@ class ViewBox(GraphicsWidget):
                 if kwd in kwds and self.state['limits'][lname][mnmx] != kwds[kwd]:
                     self.state['limits'][lname][mnmx] = kwds[kwd]
                     update = True
-                    
+
         if update:
             self.updateViewRange()
-                    
-            
-            
-            
+
+
+
+
     def scaleBy(self, s=None, center=None, x=None, y=None):
         """
         Scale by *s* around given center point (or center of view).
         *s* may be a Point or tuple (x, y).
-        
-        Optionally, x or y may be specified individually. This allows the other 
+
+        Optionally, x or y may be specified individually. This allows the other
         axis to be left unaffected (note that using a scale factor of 1.0 may
         cause slight changes due to floating-point error).
         """
@@ -711,7 +711,7 @@ class ViewBox(GraphicsWidget):
             scale = Point(s)
         else:
             scale = [x, y]
-        
+
         affect = [True, True]
         if scale[0] is None and scale[1] is None:
             return
@@ -721,9 +721,9 @@ class ViewBox(GraphicsWidget):
         elif scale[1] is None:
             affect[1] = False
             scale[1] = 1.0
-            
+
         scale = Point(scale)
-            
+
         if self.state['aspectLocked'] is not False:
             scale[0] = scale[1]
 
@@ -732,21 +732,21 @@ class ViewBox(GraphicsWidget):
             center = Point(vr.center())
         else:
             center = Point(center)
-        
+
         tl = center + (vr.topLeft()-center) * scale
         br = center + (vr.bottomRight()-center) * scale
-        
+
         if not affect[0]:
             self.setYRange(tl.y(), br.y(), padding=0)
         elif not affect[1]:
             self.setXRange(tl.x(), br.x(), padding=0)
         else:
             self.setRange(QtCore.QRectF(tl, br), padding=0)
-        
+
     def translateBy(self, t=None, x=None, y=None):
         """
         Translate the view by *t*, which may be a Point or tuple (x, y).
-        
+
         Alternately, x or y may be specified independently, leaving the other
         axis unchanged (note that using a translation of 0 may still cause
         small changes due to floating-point error).
@@ -762,9 +762,9 @@ class ViewBox(GraphicsWidget):
                 y = vr.top()+y, vr.bottom()+y
             if x is not None or y is not None:
                 self.setRange(xRange=x, yRange=y, padding=0)
-            
-        
-        
+
+
+
     def enableAutoRange(self, axis=None, enable=True, x=None, y=None):
         """
         Enable (or disable) auto-range for *axis*, which may be ViewBox.XAxis, ViewBox.YAxis, or ViewBox.XYAxes for both
@@ -777,7 +777,7 @@ class ViewBox(GraphicsWidget):
         #if not enable:
             #import traceback
             #traceback.print_stack()
-        
+
         # support simpler interface:
         if x is not None or y is not None:
             if x is not None:
@@ -785,15 +785,15 @@ class ViewBox(GraphicsWidget):
             if y is not None:
                 self.enableAutoRange(ViewBox.YAxis, y)
             return
-        
+
         if enable is True:
             enable = 1.0
-        
+
         if axis is None:
             axis = ViewBox.XYAxes
-        
+
         needAutoRangeUpdate = False
-        
+
         if axis == ViewBox.XYAxes or axis == 'xy':
             axes = [0, 1]
         elif axis == ViewBox.XAxis or axis == 'x':
@@ -802,14 +802,14 @@ class ViewBox(GraphicsWidget):
             axes = [1]
         else:
             raise Exception('axis argument must be ViewBox.XAxis, ViewBox.YAxis, or ViewBox.XYAxes.')
-        
+
         for ax in axes:
             if self.state['autoRange'][ax] != enable:
                 # If we are disabling, do one last auto-range to make sure that
                 # previously scheduled auto-range changes are enacted
                 if enable is False and self._autoRangeNeedsUpdate:
                     self.updateAutoRange()
-                
+
                 self.state['autoRange'][ax] = enable
                 self._autoRangeNeedsUpdate |= (enable is not False)
                 self.update()
@@ -817,7 +817,7 @@ class ViewBox(GraphicsWidget):
 
         #if needAutoRangeUpdate:
         #    self.updateAutoRange()
-        
+
         self.sigStateChanged.emit(self)
 
     def disableAutoRange(self, axis=None):
@@ -844,30 +844,30 @@ class ViewBox(GraphicsWidget):
             self.state['autoVisibleOnly'][1] = y
             if y is True:
                 self.state['autoVisibleOnly'][0] = False
-        
+
         if x is not None or y is not None:
             self.updateAutoRange()
 
     def updateAutoRange(self):
         ## Break recursive loops when auto-ranging.
-        ## This is needed because some items change their size in response 
+        ## This is needed because some items change their size in response
         ## to a view change.
         if self._updatingRange:
             return
-        
+
         self._updatingRange = True
         try:
             targetRect = self.viewRange()
             if not any(self.state['autoRange']):
                 return
-                
+
             fractionVisible = self.state['autoRange'][:]
             for i in [0,1]:
                 if type(fractionVisible[i]) is bool:
                     fractionVisible[i] = 1.0
 
             childRange = None
-            
+
             order = [0,1]
             if self.state['autoVisibleOnly'][0] is True:
                 order = [1,0]
@@ -880,11 +880,11 @@ class ViewBox(GraphicsWidget):
                     oRange = [None, None]
                     oRange[ax] = targetRect[1-ax]
                     childRange = self.childrenBounds(frac=fractionVisible, orthoRange=oRange)
-                    
+
                 else:
                     if childRange is None:
                         childRange = self.childrenBounds(frac=fractionVisible)
-                
+
                 ## Make corrections to range
                 xr = childRange[ax]
                 if xr is not None:
@@ -903,28 +903,28 @@ class ViewBox(GraphicsWidget):
                 return
             args['padding'] = 0
             args['disableAutoRange'] = False
-            
+
              # check for and ignore bad ranges
             for k in ['xRange', 'yRange']:
                 if k in args:
                     if not np.all(np.isfinite(args[k])):
                         r = args.pop(k)
                         #print("Warning: %s is invalid: %s" % (k, str(r))
-                        
+
             self.setRange(**args)
         finally:
             self._autoRangeNeedsUpdate = False
             self._updatingRange = False
-        
+
     def setXLink(self, view):
         """Link this view's X axis to another view. (see LinkView)"""
         self.linkView(self.XAxis, view)
-        
+
     def setYLink(self, view):
         """Link this view's Y axis to another view. (see LinkView)"""
         self.linkView(self.YAxis, view)
-        
-        
+
+
     def linkView(self, axis, view):
         """
         Link X or Y axes of two views and unlink any previously connected axes. *axis* must be ViewBox.XAxis or ViewBox.YAxis.
@@ -956,8 +956,8 @@ class ViewBox(GraphicsWidget):
             except (TypeError, RuntimeError):
                 ## This can occur if the view has been deleted already
                 pass
-            
-        
+
+
         if view is None or isinstance(view, basestring):
             self.state['linkedViews'][axis] = view
         else:
@@ -970,10 +970,10 @@ class ViewBox(GraphicsWidget):
             else:
                 if self.autoRangeEnabled()[axis] is False:
                     slot()
-        
-            
+
+
         self.sigStateChanged.emit(self)
-        
+
     def blockLink(self, b):
         self.linksBlocked = b  ## prevents recursive plot-change propagation
 
@@ -986,7 +986,7 @@ class ViewBox(GraphicsWidget):
         ## called when y range of linked view has changed
         view = self.linkedView(1)
         self.linkedViewChanged(view, ViewBox.YAxis)
-        
+
     def linkedView(self, ax):
         ## Return the linked view for axis *ax*.
         ## this method _always_ returns either a ViewBox or None.
@@ -999,19 +999,19 @@ class ViewBox(GraphicsWidget):
     def linkedViewChanged(self, view, axis):
         if self.linksBlocked or view is None:
             return
-        
+
         #print self.name, "ViewBox.linkedViewChanged", axis, view.viewRange()[axis]
         vr = view.viewRect()
         vg = view.screenGeometry()
         sg = self.screenGeometry()
         if vg is None or sg is None:
             return
-        
+
         view.blockLink(True)
         try:
             if axis == ViewBox.XAxis:
                 overlap = min(sg.right(), vg.right()) - max(sg.left(), vg.left())
-                if overlap < min(vg.width()/3, sg.width()/3):  ## if less than 1/3 of views overlap, 
+                if overlap < min(vg.width()/3, sg.width()/3):  ## if less than 1/3 of views overlap,
                                                                ## then just replicate the view
                     x1 = vr.left()
                     x2 = vr.right()
@@ -1026,7 +1026,7 @@ class ViewBox(GraphicsWidget):
                 self.setXRange(x1, x2, padding=0)
             else:
                 overlap = min(sg.bottom(), vg.bottom()) - max(sg.top(), vg.top())
-                if overlap < min(vg.height()/3, sg.height()/3):  ## if less than 1/3 of views overlap, 
+                if overlap < min(vg.height()/3, sg.height()/3):  ## if less than 1/3 of views overlap,
                                                                  ## then just replicate the view
                     y1 = vr.top()
                     y2 = vr.bottom()
@@ -1041,8 +1041,8 @@ class ViewBox(GraphicsWidget):
                 self.setYRange(y1, y2, padding=0)
         finally:
             view.blockLink(False)
-        
-        
+
+
     def screenGeometry(self):
         """return the screen geometry of the viewbox"""
         v = self.getViewWidget()
@@ -1053,13 +1053,13 @@ class ViewBox(GraphicsWidget):
         pos = v.mapToGlobal(v.pos())
         wr.adjust(pos.x(), pos.y(), pos.x(), pos.y())
         return wr
-        
-    
+
+
 
     def itemsChanged(self):
         ## called when items are added/removed from self.childGroup
         self.updateAutoRange()
-        
+
     def itemBoundsChanged(self, item):
         self._itemBoundsCache.pop(item, None)
         if (self.state['autoRange'][0] is not False) or (self.state['autoRange'][1] is not False):
@@ -1073,7 +1073,7 @@ class ViewBox(GraphicsWidget):
         """
         if self.state['yInverted'] == b:
             return
-        
+
         self.state['yInverted'] = b
         self._matrixNeedsUpdate = True # updateViewRange won't detect this for us
         self.updateViewRange()
@@ -1082,14 +1082,14 @@ class ViewBox(GraphicsWidget):
 
     def yInverted(self):
         return self.state['yInverted']
-        
+
     def invertX(self, b=True):
         """
         By default, the positive x-axis points rightward on the screen. Use invertX(True) to reverse the x-axis.
         """
         if self.state['xInverted'] == b:
             return
-        
+
         self.state['xInverted'] = b
         #self.updateMatrix(changed=(False, True))
         self.updateViewRange()
@@ -1098,14 +1098,14 @@ class ViewBox(GraphicsWidget):
 
     def xInverted(self):
         return self.state['xInverted']
-        
+
     def setAspectLocked(self, lock=True, ratio=1):
         """
         If the aspect ratio is locked, view scaling must always preserve the aspect ratio.
         By default, the ratio is set to 1; x and y both have the same scaling.
         This ratio can be overridden (xScale/yScale), or use None to lock in the current ratio.
         """
-        
+
         if not lock:
             if self.state['aspectLocked'] == False:
                 return
@@ -1125,16 +1125,16 @@ class ViewBox(GraphicsWidget):
             if ratio != currentRatio:  ## If this would change the current range, do that now
                 #self.setRange(0, self.state['viewRange'][0][0], self.state['viewRange'][0][1])
                 self.updateViewRange()
-        
+
         self.updateAutoRange()
         self.updateViewRange()
         self.sigStateChanged.emit(self)
-        
+
     def childTransform(self):
         """
         Return the transform that maps from child(item in the childGroup) coordinates to local coordinates.
         (This maps from inside the viewbox to outside)
-        """ 
+        """
         if self._matrixNeedsUpdate:
             self.updateMatrix()
         m = self.childGroup.transform()
@@ -1159,7 +1159,7 @@ class ViewBox(GraphicsWidget):
     def mapViewToScene(self, obj):
         """Maps from the coordinate system displayed inside the ViewBox to scene coordinates"""
         return self.mapToScene(self.mapFromView(obj))
-    
+
     def mapFromItemToView(self, item, obj):
         """Maps *obj* from the local coordinate system of *item* to the view coordinates"""
         return self.childGroup.mapFromItem(item, obj)
@@ -1172,21 +1172,21 @@ class ViewBox(GraphicsWidget):
 
     def mapViewToDevice(self, obj):
         return self.mapToDevice(self.mapFromView(obj))
-        
+
     def mapDeviceToView(self, obj):
         return self.mapToView(self.mapFromDevice(obj))
-        
+
     def viewPixelSize(self):
         """Return the (width, height) of a screen pixel in view coordinates."""
         o = self.mapToView(Point(0,0))
         px, py = [Point(self.mapToView(v) - o) for v in self.pixelVectors()]
         return (px.length(), py.length())
-        
-        
+
+
     def itemBoundingRect(self, item):
         """Return the bounding rect of the item in view coordinates"""
         return self.mapSceneToView(item.sceneBoundingRect()).boundingRect()
-    
+
     #def viewScale(self):
         #vr = self.viewRect()
         ##print "viewScale:", self.range
@@ -1195,7 +1195,7 @@ class ViewBox(GraphicsWidget):
         #if xd == 0 or yd == 0:
             #print "Warning: 0 range in view:", xd, yd
             #return np.array([1,1])
-        
+
         ##cs = self.canvas().size()
         #cs = self.boundingRect()
         #scale = np.array([cs.width() / xd, cs.height() / yd])
@@ -1209,16 +1209,16 @@ class ViewBox(GraphicsWidget):
             mask[:] = 0
             mask[axis] = mv
         s = ((mask * 0.02) + 1) ** (ev.delta() * self.state['wheelScaleFactor']) # actual scaling factor
-        
+
         center = Point(fn.invertQTransform(self.childGroup.transform()).map(ev.pos()))
         #center = ev.pos()
-        
+
         self._resetTarget()
         self.scaleBy(s, center)
         self.sigRangeChangedManually.emit(self.state['mouseEnabled'])
         ev.accept()
 
-        
+
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.RightButton and self.menuEnabled():
             ev.accept()
@@ -1238,7 +1238,7 @@ class ViewBox(GraphicsWidget):
     def mouseDragEvent(self, ev, axis=None):
         ## if axis is specified, event will only affect that axis.
         ev.accept()  ## we accept all buttons
-        
+
         pos = ev.pos()
         lastPos = ev.lastPos()
         dif = pos - lastPos
@@ -1270,7 +1270,7 @@ class ViewBox(GraphicsWidget):
                 tr = self.mapToView(tr) - self.mapToView(Point(0,0))
                 x = tr.x() if mask[0] == 1 else None
                 y = tr.y() if mask[1] == 1 else None
-                
+
                 self._resetTarget()
                 if x is not None or y is not None:
                     self.translateBy(x=x, y=y)
@@ -1279,18 +1279,18 @@ class ViewBox(GraphicsWidget):
             #print "vb.rightDrag"
             if self.state['aspectLocked'] is not False:
                 mask[0] = 0
-            
+
             dif = ev.screenPos() - ev.lastScreenPos()
             dif = np.array([dif.x(), dif.y()])
             dif[0] *= -1
             s = ((mask * 0.02) + 1) ** dif
-            
+
             tr = self.childGroup.transform()
             tr = fn.invertQTransform(tr)
-            
+
             x = s[0] if mouseEnabled[0] == 1 else None
             y = s[1] if mouseEnabled[1] == 1 else None
-            
+
             center = Point(tr.map(ev.buttonDownPos(QtCore.Qt.RightButton)))
             self._resetTarget()
             self.scaleBy(x=x, y=y, center=center)
@@ -1304,14 +1304,14 @@ class ViewBox(GraphicsWidget):
         ctrl-A : zooms out to the default "full" view of the plot
         ctrl-+ : moves forward in the zooming stack (if it exists)
         ctrl-- : moves backward in the zooming stack (if it exists)
-         
+
         """
         #print ev.key()
         #print 'I intercepted a key press, but did not accept it'
-        
+
         ## not implemented yet ?
         #self.keypress.sigkeyPressEvent.emit()
-        
+
         ev.accept()
         if ev.text() == '-':
             self.scaleHistory(-1)
@@ -1329,7 +1329,7 @@ class ViewBox(GraphicsWidget):
         if ptr != self.axHistoryPointer:
             self.axHistoryPointer = ptr
             self.showAxRect(self.axHistory[ptr])
-            
+
 
     def updateScaleBox(self, p1, p2):
         r = QtCore.QRectF(p1, p2)
@@ -1346,7 +1346,7 @@ class ViewBox(GraphicsWidget):
     #def mouseRect(self):
         #vs = self.viewScale()
         #vr = self.state['viewRange']
-        ## Convert positions from screen (view) pixel coordinates to axis coordinates 
+        ## Convert positions from screen (view) pixel coordinates to axis coordinates
         #ax = QtCore.QRectF(self.pressPos[0]/vs[0]+vr[0][0], -(self.pressPos[1]/vs[1]-vr[1][1]),
             #(self.mousePos[0]-self.pressPos[0])/vs[0], -(self.mousePos[1]-self.pressPos[1])/vs[1])
         #return(ax)
@@ -1355,14 +1355,14 @@ class ViewBox(GraphicsWidget):
         """Return a list of all children and grandchildren of this ViewBox"""
         if item is None:
             item = self.childGroup
-        
+
         children = [item]
         for ch in item.childItems():
             children.extend(self.allChildren(ch))
         return children
-        
-        
-    
+
+
+
     def childrenBounds(self, frac=None, orthoRange=(None,None), items=None):
         """Return the bounding range of all children.
         [[xmin, xmax], [ymin, ymax]]
@@ -1371,19 +1371,19 @@ class ViewBox(GraphicsWidget):
         profiler = debug.Profiler()
         if items is None:
             items = self.addedItems
-        
+
         ## measure pixel dimensions in view box
         px, py = [v.length() if v is not None else 0 for v in self.childGroup.pixelVectors()]
-        
+
         ## First collect all boundary information
         itemBounds = []
         for item in items:
             if not item.isVisible():
                 continue
-        
+
             useX = True
             useY = True
-            
+
             if hasattr(item, 'dataBounds'):
                 #bounds = self._itemBoundsCache.get(item, None)
                 #if bounds is None:
@@ -1401,23 +1401,23 @@ class ViewBox(GraphicsWidget):
 
                 bounds = QtCore.QRectF(xr[0], yr[0], xr[1]-xr[0], yr[1]-yr[0])
                 bounds = self.mapFromItemToView(item, bounds).boundingRect()
-                
+
                 if not any([useX, useY]):
                     continue
-                
+
                 ## If we are ignoring only one axis, we need to check for rotations
                 if useX != useY:  ##   !=  means  xor
                     ang = round(item.transformAngle())
                     if ang == 0 or ang == 180:
                         pass
                     elif ang == 90 or ang == 270:
-                        useX, useY = useY, useX 
+                        useX, useY = useY, useX
                     else:
                         ## Item is rotated at non-orthogonal angle, ignore bounds entirely.
                         ## Not really sure what is the expected behavior in this case.
-                        continue  ## need to check for item rotations and decide how best to apply this boundary. 
-                
-                
+                        continue  ## need to check for item rotations and decide how best to apply this boundary.
+
+
                 itemBounds.append((bounds, useX, useY, pxPad))
                     #self._itemBoundsCache[item] = (bounds, useX, useY)
                 #else:
@@ -1429,9 +1429,9 @@ class ViewBox(GraphicsWidget):
                     bounds = item.boundingRect()
                 bounds = self.mapFromItemToView(item, bounds).boundingRect()
                 itemBounds.append((bounds, True, True, 0))
-        
+
         #print itemBounds
-        
+
         ## determine tentative new range
         range = [None, None]
         for bounds, useX, useY, px in itemBounds:
@@ -1446,9 +1446,9 @@ class ViewBox(GraphicsWidget):
                 else:
                     range[0] = [bounds.left(), bounds.right()]
             profiler()
-        
+
         #print "range", range
-        
+
         ## Now expand any bounds that have a pixel margin
         ## This must be done _after_ we have a good estimate of the new range
         ## to ensure that the pixel size is roughly accurate.
@@ -1471,7 +1471,7 @@ class ViewBox(GraphicsWidget):
                 range[1][1] = max(range[1][1], bounds.bottom() + px*pxSize)
 
         return range
-        
+
     def childrenBoundingRect(self, *args, **kwds):
         range = self.childrenBounds(*args, **kwds)
         tr = self.targetRange()
@@ -1479,31 +1479,31 @@ class ViewBox(GraphicsWidget):
             range[0] = tr[0]
         if range[1] is None:
             range[1] = tr[1]
-            
+
         bounds = QtCore.QRectF(range[0][0], range[1][0], range[0][1]-range[0][0], range[1][1]-range[1][0])
         return bounds
-            
+
     def updateViewRange(self, forceX=False, forceY=False):
-        ## Update viewRange to match targetRange as closely as possible, given 
-        ## aspect ratio constraints. The *force* arguments are used to indicate 
+        ## Update viewRange to match targetRange as closely as possible, given
+        ## aspect ratio constraints. The *force* arguments are used to indicate
         ## which axis (if any) should be unchanged when applying constraints.
         viewRange = [self.state['targetRange'][0][:], self.state['targetRange'][1][:]]
         changed = [False, False]
-        
+
         #-------- Make correction for aspect ratio constraint ----------
-        
+
         # aspect is (widget w/h) / (view range w/h)
         aspect = self.state['aspectLocked']  # size ratio / view ratio
         tr = self.targetRect()
         bounds = self.rect()
         if aspect is not False and 0 not in [aspect, tr.height(), bounds.height(), bounds.width()]:
-            
+
             ## This is the view range aspect ratio we have requested
             targetRatio = tr.width() / tr.height() if tr.height() != 0 else 1
             ## This is the view range aspect ratio we need to obey aspect constraint
             viewRatio = (bounds.width() / bounds.height() if bounds.height() != 0 else 1) / aspect
             viewRatio = 1 if viewRatio == 0 else viewRatio
-            
+
             # Decide which range to keep unchanged
             #print self.name, "aspect:", aspect, "changed:", changed, "auto:", self.state['autoRange']
             if forceX:
@@ -1511,11 +1511,11 @@ class ViewBox(GraphicsWidget):
             elif forceY:
                 ax = 1
             else:
-                # if we are not required to keep a particular axis unchanged, 
+                # if we are not required to keep a particular axis unchanged,
                 # then make the entire target range visible
                 ax = 0 if targetRatio > viewRatio else 1
-            
-            if ax == 0:  
+
+            if ax == 0:
                 ## view range needs to be taller than target
                 dy = 0.5 * (tr.width() / viewRatio - tr.height())
                 if dy != 0:
@@ -1528,27 +1528,27 @@ class ViewBox(GraphicsWidget):
                     changed[0] = True
                 viewRange[0] = [self.state['targetRange'][0][0] - dx, self.state['targetRange'][0][1] + dx]
 
-            
+
         # ----------- Make corrections for view limits -----------
-        
+
         limits = (self.state['limits']['xLimits'], self.state['limits']['yLimits'])
         minRng = [self.state['limits']['xRange'][0], self.state['limits']['yRange'][0]]
         maxRng = [self.state['limits']['xRange'][1], self.state['limits']['yRange'][1]]
-        
+
         for axis in [0, 1]:
             if limits[axis][0] is None and limits[axis][1] is None and minRng[axis] is None and maxRng[axis] is None:
                 continue
-            
+
             # max range cannot be larger than bounds, if they are given
             if limits[axis][0] is not None and limits[axis][1] is not None:
                 if maxRng[axis] is not None:
                     maxRng[axis] = min(maxRng[axis], limits[axis][1]-limits[axis][0])
                 else:
                     maxRng[axis] = limits[axis][1]-limits[axis][0]
-            
+
             #print "\nLimits for axis %d: range=%s min=%s max=%s" % (axis, limits[axis], minRng[axis], maxRng[axis])
             #print "Starting range:", viewRange[axis]
-            
+
             # Apply xRange, yRange
             diff = viewRange[axis][1] - viewRange[axis][0]
             if maxRng[axis] is not None and diff > maxRng[axis]:
@@ -1559,12 +1559,12 @@ class ViewBox(GraphicsWidget):
                 changed[axis] = True
             else:
                 delta = 0
-            
+
             viewRange[axis][0] -= delta/2.
             viewRange[axis][1] += delta/2.
-            
+
             #print "after applying min/max:", viewRange[axis]
-               
+
             # Apply xLimits, yLimits
             mn, mx = limits[axis]
             if mn is not None and viewRange[axis][0] < mn:
@@ -1577,23 +1577,23 @@ class ViewBox(GraphicsWidget):
                 viewRange[axis][0] += delta
                 viewRange[axis][1] += delta
                 changed[axis] = True
-            
+
             #print "after applying edge limits:", viewRange[axis]
 
         changed = [(viewRange[i][0] != self.state['viewRange'][i][0]) or (viewRange[i][1] != self.state['viewRange'][i][1]) for i in (0,1)]
         self.state['viewRange'] = viewRange
-        
+
         # emit range change signals
         if changed[0]:
             self.sigXRangeChanged.emit(self, tuple(self.state['viewRange'][0]))
         if changed[1]:
             self.sigYRangeChanged.emit(self, tuple(self.state['viewRange'][1]))
-        
+
         if any(changed):
             self.sigRangeChanged.emit(self, self.state['viewRange'])
             self.update()
             self._matrixNeedsUpdate = True
-        
+
             # Inform linked views that the range has changed
             for ax in [0, 1]:
                 if not changed[ax]:
@@ -1601,11 +1601,11 @@ class ViewBox(GraphicsWidget):
                 link = self.linkedView(ax)
                 if link is not None:
                     link.linkedViewChanged(self, ax)
-        
+
     def updateMatrix(self, changed=None):
         ## Make the childGroup's transform match the requested viewRange.
         bounds = self.rect()
-        
+
         vr = self.viewRect()
         if vr.height() == 0 or vr.width() == 0:
             return
@@ -1615,30 +1615,30 @@ class ViewBox(GraphicsWidget):
         if self.state['xInverted']:
             scale = scale * Point(-1, 1)
         m = QtGui.QTransform()
-        
+
         ## First center the viewport at 0
         center = bounds.center()
         m.translate(center.x(), center.y())
-            
+
         ## Now scale and translate properly
         m.scale(scale[0], scale[1])
         st = Point(vr.center())
         m.translate(-st[0], -st[1])
-        
+
         self.childGroup.setTransform(m)
-        
+
         self.sigTransformChanged.emit(self)  ## segfaults here: 1
         self._matrixNeedsUpdate = False
 
     def paint(self, p, opt, widget):
         self.checkSceneChange()
-        
+
         if self.border is not None:
             bounds = self.shape()
             p.setPen(self.border)
             #p.fillRect(bounds, QtGui.QColor(0, 0, 0))
             p.drawPath(bounds)
-            
+
         #p.setPen(fn.mkPen('r'))
         #path = QtGui.QPainterPath()
         #path.addRect(self.targetRect())
@@ -1652,29 +1652,29 @@ class ViewBox(GraphicsWidget):
         else:
             self.background.show()
             self.background.setBrush(fn.mkBrush(bg))
-            
-            
+
+
     def updateViewLists(self):
         try:
             self.window()
         except RuntimeError:  ## this view has already been deleted; it will probably be collected shortly.
             return
-            
+
         def cmpViews(a, b):
             wins = 100 * cmp(a.window() is self.window(), b.window() is self.window())
             alpha = cmp(a.name, b.name)
             return wins + alpha
-            
+
         ## make a sorted list of all named views
         nv = list(ViewBox.NamedViews.values())
         #print "new view list:", nv
         sortList(nv, cmpViews) ## see pyqtgraph.python2_3.sortList
-        
+
         if self in nv:
             nv.remove(self)
-            
+
         self.menu.setViewList(nv)
-        
+
         for ax in [0,1]:
             link = self.state['linkedViews'][ax]
             if isinstance(link, basestring):     ## axis has not been linked yet; see if it's possible now
@@ -1690,7 +1690,7 @@ class ViewBox(GraphicsWidget):
         #print "Update:", ViewBox.NamedViews.keys()
         for v in ViewBox.AllViews:
             v.updateViewLists()
-            
+
 
     @staticmethod
     def forgetView(vid, name):
@@ -1713,7 +1713,7 @@ class ViewBox(GraphicsWidget):
         for k in ViewBox.AllViews:
             if isQObjectAlive(k) and getConfigOption('crashWarning'):
                 sys.stderr.write('Warning: ViewBox should be closed before application exit.\n')
-                
+
             try:
                 k.destroyed.disconnect()
             except RuntimeError:  ## signal is already disconnected.
@@ -1722,7 +1722,7 @@ class ViewBox(GraphicsWidget):
                 pass
             except AttributeError:  # PySide has deleted signal
                 pass
-            
+
     def locate(self, item, timeout=3.0, children=False):
         """
         Temporarily display the bounding rect of an item and lines connecting to the center of the view.
@@ -1730,16 +1730,16 @@ class ViewBox(GraphicsWidget):
         if allChildren is True, then the bounding rect of all item's children will be shown instead.
         """
         self.clearLocate()
-        
+
         if item.scene() is not self.scene():
             raise Exception("Item does not share a scene with this ViewBox.")
-        
+
         c = self.viewRect().center()
         if children:
             br = self.mapFromItemToView(item, item.childrenBoundingRect()).boundingRect()
         else:
             br = self.mapFromItemToView(item, item.boundingRect()).boundingRect()
-        
+
         g = ItemGroup()
         g.setParentItem(self.childGroup)
         self.locateGroup = g
@@ -1750,11 +1750,11 @@ class ViewBox(GraphicsWidget):
             line = QtGui.QGraphicsLineItem(c.x(), c.y(), p.x(), p.y())
             line.setParentItem(g)
             g.lines.append(line)
-            
+
         for item in g.childItems():
             item.setPen(fn.mkPen(color='y', width=3))
         g.setZValue(1000000)
-        
+
         if children:
             g.path = QtGui.QGraphicsPathItem(g.childrenShape())
         else:
@@ -1762,9 +1762,9 @@ class ViewBox(GraphicsWidget):
         g.path.setParentItem(g)
         g.path.setPen(fn.mkPen('g'))
         g.path.setZValue(100)
-        
+
         QtCore.QTimer.singleShot(timeout*1000, self.clearLocate)
-    
+
     def clearLocate(self):
         if self.locateGroup is None:
             return

--- a/pyqtgraph/graphicsItems/ViewBox/axisCtrlTemplate_pyqt.py
+++ b/pyqtgraph/graphicsItems/ViewBox/axisCtrlTemplate_pyqt.py
@@ -99,4 +99,3 @@ class Ui_Form(object):
         self.visibleOnlyCheck.setText(_translate("Form", "Visible Data Only", None))
         self.autoPanCheck.setToolTip(_translate("Form", "<html><head/><body><p>When checked, the axis will automatically pan to center on the current data, but the scale along this axis will not change.</p></body></html>", None))
         self.autoPanCheck.setText(_translate("Form", "Auto Pan Only", None))
-

--- a/pyqtgraph/graphicsItems/ViewBox/axisCtrlTemplate_pyqt5.py
+++ b/pyqtgraph/graphicsItems/ViewBox/axisCtrlTemplate_pyqt5.py
@@ -86,4 +86,3 @@ class Ui_Form(object):
         self.visibleOnlyCheck.setText(_translate("Form", "Visible Data Only"))
         self.autoPanCheck.setToolTip(_translate("Form", "<html><head/><body><p>When checked, the axis will automatically pan to center on the current data, but the scale along this axis will not change.</p></body></html>"))
         self.autoPanCheck.setText(_translate("Form", "Auto Pan Only"))
-

--- a/pyqtgraph/graphicsItems/ViewBox/axisCtrlTemplate_pyside.py
+++ b/pyqtgraph/graphicsItems/ViewBox/axisCtrlTemplate_pyside.py
@@ -85,4 +85,3 @@ class Ui_Form(object):
         self.visibleOnlyCheck.setText(QtGui.QApplication.translate("Form", "Visible Data Only", None, QtGui.QApplication.UnicodeUTF8))
         self.autoPanCheck.setToolTip(QtGui.QApplication.translate("Form", "<html><head/><body><p>When checked, the axis will automatically pan to center on the current data, but the scale along this axis will not change.</p></body></html>", None, QtGui.QApplication.UnicodeUTF8))
         self.autoPanCheck.setText(QtGui.QApplication.translate("Form", "Auto Pan Only", None, QtGui.QApplication.UnicodeUTF8))
-

--- a/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
@@ -16,33 +16,33 @@ def init_viewbox():
     """Helper function to init the ViewBox
     """
     global win, vb
-    
+
     win = pg.GraphicsWindow()
     win.ci.layout.setContentsMargins(0,0,0,0)
     win.resize(200, 200)
     win.show()
     vb = win.addViewBox()
-    
+
     # set range before viewbox is shown
     vb.setRange(xRange=[0, 10], yRange=[0, 10], padding=0)
-    
+
     # required to make mapFromView work properly.
     qtest.qWaitForWindowShown(win)
-    
+
     g = pg.GridItem()
     vb.addItem(g)
-    
+
     app.processEvents()
-    
+
 def test_ViewBox():
     init_viewbox()
-    
+
     w = vb.geometry().width()
     h = vb.geometry().height()
     view1 = QRectF(0, 0, 10, 10)
     size1 = QRectF(0, h, w, -h)
     assertMapping(vb, view1, size1)
-    
+
     # test resize
     win.resize(400, 400)
     app.processEvents()
@@ -50,10 +50,10 @@ def test_ViewBox():
     h = vb.geometry().height()
     size1 = QRectF(0, h, w, -h)
     assertMapping(vb, view1, size1)
-    
+
     # now lock aspect
     vb.setAspectLocked()
-    
+
     # test wide resize
     win.resize(800, 400)
     app.processEvents()
@@ -62,7 +62,7 @@ def test_ViewBox():
     view1 = QRectF(-5, 0, 20, 10)
     size1 = QRectF(0, h, w, -h)
     assertMapping(vb, view1, size1)
-    
+
     # test tall resize
     win.resize(400, 800)
     app.processEvents()

--- a/pyqtgraph/graphicsItems/__init__.py
+++ b/pyqtgraph/graphicsItems/__init__.py
@@ -9,7 +9,7 @@
         #files.append(f)
     #elif f[-3:] == '.py' and f != '__init__.py':
         #files.append(f[:-3])
-    
+
 #for modName in files:
     #mod = __import__(modName, globals(), locals(), fromlist=['*'])
     #if hasattr(mod, '__all__'):

--- a/pyqtgraph/graphicsItems/tests/test_GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_GraphicsItem.py
@@ -25,7 +25,7 @@ def test_getViewWidget_deleted():
     item = pg.InfiniteLine()
     view.addItem(item)
     assert item.getViewWidget() is view
-    
+
     # Arrange to have Qt automatically delete the view widget
     obj = pg.QtGui.QWidget()
     view.setParent(obj)
@@ -43,5 +43,3 @@ def test_getViewWidget_deleted():
     #view.addItem(item)
     #del view
     #gc.collect()
-    
-    

--- a/pyqtgraph/graphicsItems/tests/test_ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_ScatterPlotItem.py
@@ -4,7 +4,7 @@ app = pg.mkQApp()
 plot = pg.plot()
 app.processEvents()
 
-# set view range equal to its bounding rect. 
+# set view range equal to its bounding rect.
 # This causes plots to look the same regardless of pxMode.
 plot.setRange(rect=plot.boundingRect())
 
@@ -17,14 +17,14 @@ def test_scatterplotitem():
             plot.addItem(s)
             s.setData(x=np.array([10,40,20,30])+i*100, y=np.array([40,60,10,30])+j*100, pxMode=pxMode)
             s.addPoints(x=np.array([60, 70])+i*100, y=np.array([60, 70])+j*100, size=[20, 30])
-            
+
             # Test uniform spot updates
             s.setSize(10)
             s.setBrush('r')
             s.setPen('g')
             s.setSymbol('+')
             app.processEvents()
-            
+
             # Test list spot updates
             s.setSize([10] * 6)
             s.setBrush([pg.mkBrush('r')] * 6)
@@ -59,28 +59,28 @@ def test_init_spots():
         {'pos': (1, 2), 'pen': None, 'brush': None, 'data': 'zzz'},
     ]
     s = pg.ScatterPlotItem(spots=spots)
-    
+
     # Check we can display without errors
     plot.addItem(s)
     app.processEvents()
     plot.clear()
-    
+
     # check data is correct
     spots = s.points()
-    
+
     defPen = pg.mkPen(pg.getConfigOption('foreground'))
 
     assert spots[0].pos().x() == 0
     assert spots[0].pos().y() == 1
     assert spots[0].pen() == defPen
     assert spots[0].data() is None
-    
+
     assert spots[1].pos().x() == 1
     assert spots[1].pos().y() == 2
     assert spots[1].pen() == pg.mkPen(None)
     assert spots[1].brush() == pg.mkBrush(None)
     assert spots[1].data() == 'zzz'
-    
+
 
 if __name__ == '__main__':
     test_scatterplotitem()

--- a/pyqtgraph/graphicsWindows.py
+++ b/pyqtgraph/graphicsWindows.py
@@ -20,8 +20,8 @@ def mkQApp():
 
 class GraphicsWindow(GraphicsLayoutWidget):
     """
-    Convenience subclass of :class:`GraphicsLayoutWidget 
-    <pyqtgraph.GraphicsLayoutWidget>`. This class is intended for use from 
+    Convenience subclass of :class:`GraphicsLayoutWidget
+    <pyqtgraph.GraphicsLayoutWidget>`. This class is intended for use from
     the interactive python prompt.
     """
     def __init__(self, title=None, size=(800,600), **kargs):
@@ -31,7 +31,7 @@ class GraphicsWindow(GraphicsLayoutWidget):
         if title is not None:
             self.setWindowTitle(title)
         self.show()
-        
+
 
 class TabWindow(QtGui.QMainWindow):
     def __init__(self, title=None, size=(800,600)):
@@ -43,13 +43,13 @@ class TabWindow(QtGui.QMainWindow):
         if title is not None:
             self.setWindowTitle(title)
         self.show()
-        
+
     def __getattr__(self, attr):
         if hasattr(self.cw, attr):
             return getattr(self.cw, attr)
         else:
             raise NameError(attr)
-    
+
 
 class PlotWindow(PlotWidget):
     def __init__(self, title=None, **kargs):

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -20,7 +20,7 @@ if USE_PYSIDE:
     from .ImageViewTemplate_pyside import *
 else:
     from .ImageViewTemplate_pyqt import *
-    
+
 from ..graphicsItems.ImageItem import *
 from ..graphicsItems.ROI import *
 from ..graphicsItems.LinearRegionItem import *
@@ -47,63 +47,63 @@ class ImageView(QtGui.QWidget):
     """
     Widget used for display and analysis of image data.
     Implements many features:
-    
+
     * Displays 2D and 3D image data. For 3D data, a z-axis
       slider is displayed allowing the user to select which frame is displayed.
     * Displays histogram of image data with movable region defining the dark/light levels
-    * Editable gradient provides a color lookup table 
+    * Editable gradient provides a color lookup table
     * Frame slider may also be moved using left/right arrow keys as well as pgup, pgdn, home, and end.
     * Basic analysis features including:
-    
+
         * ROI and embedded plot for measuring image values across frames
-        * Image normalization / background subtraction 
-    
+        * Image normalization / background subtraction
+
     Basic Usage::
-    
+
         imv = pg.ImageView()
         imv.show()
         imv.setImage(data)
-        
+
     **Keyboard interaction**
-    
+
     * left/right arrows step forward/backward 1 frame when pressed,
       seek at 20fps when held.
     * up/down arrows seek at 100fps
     * pgup/pgdn seek at 1000fps
     * home/end seek immediately to the first/last frame
-    * space begins playing frames. If time values (in seconds) are given 
+    * space begins playing frames. If time values (in seconds) are given
       for each frame, then playback is in realtime.
     """
     sigTimeChanged = QtCore.Signal(object, object)
     sigProcessingChanged = QtCore.Signal(object)
-    
+
     def __init__(self, parent=None, name="ImageView", view=None, imageItem=None, *args):
         """
         By default, this class creates an :class:`ImageItem <pyqtgraph.ImageItem>` to display image data
-        and a :class:`ViewBox <pyqtgraph.ViewBox>` to contain the ImageItem. 
-        
+        and a :class:`ViewBox <pyqtgraph.ViewBox>` to contain the ImageItem.
+
         ============= =========================================================
-        **Arguments** 
+        **Arguments**
         parent        (QWidget) Specifies the parent widget to which
                       this ImageView will belong. If None, then the ImageView
                       is created with no parent.
         name          (str) The name used to register both the internal ViewBox
                       and the PlotItem used to display ROI data. See the *name*
-                      argument to :func:`ViewBox.__init__() 
+                      argument to :func:`ViewBox.__init__()
                       <pyqtgraph.ViewBox.__init__>`.
         view          (ViewBox or PlotItem) If specified, this will be used
-                      as the display area that contains the displayed image. 
-                      Any :class:`ViewBox <pyqtgraph.ViewBox>`, 
-                      :class:`PlotItem <pyqtgraph.PlotItem>`, or other 
+                      as the display area that contains the displayed image.
+                      Any :class:`ViewBox <pyqtgraph.ViewBox>`,
+                      :class:`PlotItem <pyqtgraph.PlotItem>`, or other
                       compatible object is acceptable.
         imageItem     (ImageItem) If specified, this object will be used to
                       display the image. Must be an instance of ImageItem
                       or other compatible object.
         ============= =========================================================
-        
-        Note: to display axis ticks inside the ImageView, instantiate it 
+
+        Note: to display axis ticks inside the ImageView, instantiate it
         with a PlotItem instance as its view::
-                
+
             pg.ImageView(view=pg.PlotItem())
         """
         QtGui.QWidget.__init__(self, parent, *args)
@@ -116,9 +116,9 @@ class ImageView(QtGui.QWidget):
         self.ui = Ui_Form()
         self.ui.setupUi(self)
         self.scene = self.ui.graphicsView.scene()
-        
+
         self.ignoreTimeLine = False
-        
+
         if view is None:
             self.view = ViewBox()
         else:
@@ -126,18 +126,18 @@ class ImageView(QtGui.QWidget):
         self.ui.graphicsView.setCentralItem(self.view)
         self.view.setAspectLocked(True)
         self.view.invertY()
-        
+
         if imageItem is None:
             self.imageItem = ImageItem()
         else:
             self.imageItem = imageItem
         self.view.addItem(self.imageItem)
         self.currentIndex = 0
-        
+
         self.ui.histogram.setImageItem(self.imageItem)
-        
+
         self.menu = None
-        
+
         self.ui.normGroup.hide()
 
         self.roi = PlotROI(10)
@@ -156,17 +156,17 @@ class ImageView(QtGui.QWidget):
         self.ui.roiPlot.addItem(self.timeLine)
         self.ui.splitter.setSizes([self.height()-35, 35])
         self.ui.roiPlot.hideAxis('left')
-        
+
         self.keysPressed = {}
         self.playTimer = QtCore.QTimer()
         self.playRate = 0
         self.lastPlayTime = 0
-        
+
         self.normRgn = LinearRegionItem()
         self.normRgn.setZValue(0)
         self.ui.roiPlot.addItem(self.normRgn)
         self.normRgn.hide()
-            
+
         ## wrap functions from view box
         for fn in ['addItem', 'removeItem']:
             setattr(self, fn, getattr(self.view, fn))
@@ -187,21 +187,21 @@ class ImageView(QtGui.QWidget):
         self.ui.normFrameCheck.clicked.connect(self.updateNorm)
         self.ui.normTimeRangeCheck.clicked.connect(self.updateNorm)
         self.playTimer.timeout.connect(self.timeout)
-        
+
         self.normProxy = SignalProxy(self.normRgn.sigRegionChanged, slot=self.updateNorm)
         self.normRoi.sigRegionChangeFinished.connect(self.updateNorm)
-        
+
         self.ui.roiPlot.registerPlot(self.name + '_ROI')
         self.view.register(self.name)
-        
+
         self.noRepeatKeys = [QtCore.Qt.Key_Right, QtCore.Qt.Key_Left, QtCore.Qt.Key_Up, QtCore.Qt.Key_Down, QtCore.Qt.Key_PageUp, QtCore.Qt.Key_PageDown]
-        
+
         self.roiClicked() ## initialize roi plot to correct shape / visibility
 
     def setImage(self, img, autoRange=True, autoLevels=True, levels=None, axes=None, xvals=None, pos=None, scale=None, transform=None, autoHistogramRange=True):
         """
         Set the image to be displayed in the widget.
-        
+
         ================== =======================================================================
         **Arguments:**
         img                (numpy array) the image to be displayed.
@@ -212,9 +212,9 @@ class ImageView(QtGui.QWidget):
         levels             (min, max); the white and black level values to use.
         axes               Dictionary indicating the interpretation for each axis.
                            This is only needed to override the default guess. Format is::
-                       
+
                                {'t':0, 'x':1, 'y':2, 'c':3};
-        
+
         pos                Change the position of the displayed image
         scale              Change the scale of the displayed image
         transform          Set the transform of the displayed image. This option overrides *pos*
@@ -224,20 +224,20 @@ class ImageView(QtGui.QWidget):
         ================== =======================================================================
         """
         profiler = debug.Profiler()
-        
+
         if hasattr(img, 'implements') and img.implements('MetaArray'):
             img = img.asarray()
-        
+
         if not isinstance(img, np.ndarray):
             required = ['dtype', 'max', 'min', 'ndim', 'shape', 'size']
             if not all([hasattr(img, attr) for attr in required]):
                 raise TypeError("Image must be NumPy array or any object "
                                 "that provides compatible attributes/methods:\n"
                                 "  %s" % str(required))
-        
+
         self.image = img
         self.imageDisp = None
-        
+
         if xvals is not None:
             self.tVals = xvals
         elif hasattr(img, 'xvals'):
@@ -247,9 +247,9 @@ class ImageView(QtGui.QWidget):
                 self.tVals = np.arange(img.shape[0])
         else:
             self.tVals = np.arange(img.shape[0])
-        
+
         profiler()
-        
+
         if axes is None:
             if img.ndim == 2:
                 self.axes = {'t': None, 'x': 0, 'y': 1, 'c': None}
@@ -270,7 +270,7 @@ class ImageView(QtGui.QWidget):
                 self.axes[axes[i]] = i
         else:
             raise Exception("Can not interpret axis specification %s. Must be like {'t': 2, 'x': 0, 'y': 1} or ('t', 'x', 'y', 'c')" % (str(axes)))
-            
+
         for x in ['t', 'x', 'y', 'c']:
             self.axes[x] = self.axes.get(x, None)
 
@@ -282,7 +282,7 @@ class ImageView(QtGui.QWidget):
             self.autoLevels()
         if levels is not None:  ## this does nothing since getProcessedImage sets these values again.
             self.setLevels(*levels)
-            
+
         if self.ui.roiBtn.isChecked():
             self.roiChanged()
 
@@ -327,7 +327,7 @@ class ImageView(QtGui.QWidget):
     def clear(self):
         self.image = None
         self.imageItem.clear()
-        
+
     def play(self, rate):
         """Begin automatically stepping frames forward at the given rate (in fps).
         This can also be accessed by pressing the spacebar."""
@@ -336,11 +336,11 @@ class ImageView(QtGui.QWidget):
         if rate == 0:
             self.playTimer.stop()
             return
-            
+
         self.lastPlayTime = ptime.time()
         if not self.playTimer.isActive():
             self.playTimer.start(16)
-            
+
     def autoLevels(self):
         """Set the min/max intensity levels automatically to match the image data."""
         self.setLevels(self.levelMin, self.levelMax)
@@ -353,18 +353,18 @@ class ImageView(QtGui.QWidget):
         """Auto scale and pan the view around the image such that the image fills the view."""
         image = self.getProcessedImage()
         self.view.autoRange()
-        
+
     def getProcessedImage(self):
         """Returns the image data after it has been processed by any normalization options in use.
-        This method also sets the attributes self.levelMin and self.levelMax 
+        This method also sets the attributes self.levelMin and self.levelMax
         to indicate the range of data in the image."""
         if self.imageDisp is None:
             image = self.normalize(self.image)
             self.imageDisp = image
             self.levelMin, self.levelMax = list(map(float, self.quickMinMax(self.imageDisp)))
-            
+
         return self.imageDisp
-        
+
     def close(self):
         """Closes the widget nicely, making sure to clear the graphics scene and release memory."""
         self.ui.roiPlot.close()
@@ -373,7 +373,7 @@ class ImageView(QtGui.QWidget):
         del self.image
         del self.imageDisp
         self.setParent(None)
-        
+
     def keyPressEvent(self, ev):
         #print ev.key()
         if ev.key() == QtCore.Qt.Key_Space:
@@ -415,7 +415,7 @@ class ImageView(QtGui.QWidget):
             self.evalKeyState()
         else:
             QtGui.QWidget.keyReleaseEvent(self, ev)
-        
+
     def evalKeyState(self):
         if len(self.keysPressed) == 1:
             key = list(self.keysPressed.keys())[0]
@@ -438,7 +438,7 @@ class ImageView(QtGui.QWidget):
                 self.play(1000)
         else:
             self.play(0)
-        
+
     def timeout(self):
         now = ptime.time()
         dt = now - self.lastPlayTime
@@ -450,7 +450,7 @@ class ImageView(QtGui.QWidget):
             if self.currentIndex+n > self.image.shape[0]:
                 self.play(0)
             self.jumpFrames(n)
-        
+
     def setCurrentIndex(self, ind):
         """Set the currently displayed frame index."""
         self.currentIndex = np.clip(ind, 0, self.getProcessedImage().shape[0]-1)
@@ -470,18 +470,18 @@ class ImageView(QtGui.QWidget):
         self.autoLevels()
         self.roiChanged()
         self.sigProcessingChanged.emit(self)
-    
+
     def updateNorm(self):
         if self.ui.normTimeRangeCheck.isChecked():
             self.normRgn.show()
         else:
             self.normRgn.hide()
-        
+
         if self.ui.normROICheck.isChecked():
             self.normRoi.show()
         else:
             self.normRoi.hide()
-        
+
         if not self.ui.normOffRadio.isChecked():
             self.imageDisp = None
             self.updateImage()
@@ -513,7 +513,7 @@ class ImageView(QtGui.QWidget):
             self.ui.roiPlot.setMouseEnabled(False, False)
             self.roiCurve.hide()
             self.ui.roiPlot.hideAxis('left')
-            
+
         if self.hasTimeAxis():
             showRoiPlot = True
             mn = self.tVals.min()
@@ -527,13 +527,13 @@ class ImageView(QtGui.QWidget):
         else:
             self.timeLine.hide()
             #self.ui.roiPlot.hide()
-            
+
         self.ui.roiPlot.setVisible(showRoiPlot)
 
     def roiChanged(self):
         if self.image is None:
             return
-            
+
         image = self.getProcessedImage()
         if image.ndim == 2:
             axes = (0, 1)
@@ -569,12 +569,12 @@ class ImageView(QtGui.QWidget):
         """
         Process *image* using the normalization options configured in the
         control panel.
-        
+
         This can be repurposed to process any data through the same filter.
         """
         if self.ui.normOffRadio.isChecked():
             return image
-            
+
         div = self.ui.normDivideRadio.isChecked()
         norm = image.view(np.ndarray).copy()
         #if div:
@@ -583,7 +583,7 @@ class ImageView(QtGui.QWidget):
             #norm = zeros(image.shape)
         if div:
             norm = norm.astype(np.float32)
-            
+
         if self.ui.normTimeRangeCheck.isChecked() and image.ndim == 3:
             (sind, start) = self.timeIndex(self.normRgn.lines[0])
             (eind, end) = self.timeIndex(self.normRgn.lines[1])
@@ -594,7 +594,7 @@ class ImageView(QtGui.QWidget):
                 norm /= n
             else:
                 norm -= n
-                
+
         if self.ui.normFrameCheck.isChecked() and image.ndim == 3:
             n = image.mean(axis=1).mean(axis=1)
             n.shape = n.shape + (1, 1)
@@ -602,7 +602,7 @@ class ImageView(QtGui.QWidget):
                 norm /= n
             else:
                 norm -= n
-            
+
         if self.ui.normROICheck.isChecked() and image.ndim == 3:
             n = self.normRoi.getArrayRegion(norm, self.imageItem, (1, 2)).mean(axis=1).mean(axis=1)
             n = n[:,np.newaxis,np.newaxis]
@@ -611,9 +611,9 @@ class ImageView(QtGui.QWidget):
                 norm /= n
             else:
                 norm -= n
-                
+
         return norm
-        
+
     def timeLineChanged(self):
         #(ind, time) = self.timeIndex(self.ui.timeSlider)
         if self.ignoreTimeLine:
@@ -631,9 +631,9 @@ class ImageView(QtGui.QWidget):
         ## Redraw image on screen
         if self.image is None:
             return
-            
+
         image = self.getProcessedImage()
-        
+
         if autoHistogramRange:
             self.ui.histogram.setHistogramRange(self.levelMin, self.levelMax)
         if self.axes['t'] is None:
@@ -641,15 +641,15 @@ class ImageView(QtGui.QWidget):
         else:
             self.ui.roiPlot.show()
             self.imageItem.updateImage(image[self.currentIndex])
-            
-            
+
+
     def timeIndex(self, slider):
         ## Return the time and frame index indicated by a slider
         if self.image is None:
             return (0,0)
-        
+
         t = slider.value()
-        
+
         xv = self.tVals
         if xv is None:
             ind = int(t)
@@ -666,15 +666,15 @@ class ImageView(QtGui.QWidget):
     def getView(self):
         """Return the ViewBox (or other compatible object) which displays the ImageItem"""
         return self.view
-        
+
     def getImageItem(self):
         """Return the ImageItem for this ImageView."""
         return self.imageItem
-        
+
     def getRoiPlot(self):
         """Return the ROI PlotWidget for this ImageView"""
         return self.ui.roiPlot
-       
+
     def getHistogramWidget(self):
         """Return the HistogramLUTWidget for this ImageView"""
         return self.ui.histogram
@@ -696,13 +696,13 @@ class ImageView(QtGui.QWidget):
             self.updateImage()
         else:
             self.imageItem.save(fileName)
-            
+
     def exportClicked(self):
         fileName = QtGui.QFileDialog.getSaveFileName()
         if fileName == '':
             return
         self.export(fileName)
-        
+
     def buildMenu(self):
         self.menu = QtGui.QMenu()
         self.normAction = QtGui.QAction("Normalization", self.menu)
@@ -712,9 +712,8 @@ class ImageView(QtGui.QWidget):
         self.exportAction = QtGui.QAction("Export", self.menu)
         self.exportAction.triggered.connect(self.exportClicked)
         self.menu.addAction(self.exportAction)
-        
+
     def menuClicked(self):
         if self.menu is None:
             self.buildMenu()
         self.menu.popup(QtGui.QCursor.pos())
-        

--- a/pyqtgraph/metaarray/MetaArray.py
+++ b/pyqtgraph/metaarray/MetaArray.py
@@ -6,7 +6,7 @@ Distributed under MIT/X11 license. See license.txt for more infomation.
 
 MetaArray is an array class based on numpy.ndarray that allows storage of per-axis meta data
 such as axis values, names, units, column names, etc. It also enables several
-new methods for slicing and indexing the array based on this meta data. 
+new methods for slicing and indexing the array based on this meta data.
 More info at http://www.scipy.org/Cookbook/MetaArray
 """
 
@@ -56,41 +56,41 @@ class sliceGenerator(object):
     def __getslice__(self, arg):
         return arg
 SLICER = sliceGenerator()
-    
+
 
 class MetaArray(object):
     """N-dimensional array with meta data such as axis titles, units, and column names.
-  
+
     May be initialized with a file name, a tuple representing the dimensions of the array,
     or any arguments that could be passed on to numpy.array()
-  
+
     The info argument sets the metadata for the entire array. It is composed of a list
-    of axis descriptions where each axis may have a name, title, units, and a list of column 
+    of axis descriptions where each axis may have a name, title, units, and a list of column
     descriptions. An additional dict at the end of the axis list may specify parameters
     that apply to values in the entire array.
-  
+
     For example:
         A 2D array of altitude values for a topographical map might look like
             info=[
-        {'name': 'lat', 'title': 'Lattitude'}, 
-        {'name': 'lon', 'title': 'Longitude'}, 
+        {'name': 'lat', 'title': 'Lattitude'},
+        {'name': 'lon', 'title': 'Longitude'},
         {'title': 'Altitude', 'units': 'm'}
       ]
         In this case, every value in the array represents the altitude in feet at the lat, lon
-        position represented by the array index. All of the following return the 
+        position represented by the array index. All of the following return the
         value at lat=10, lon=5:
             array[10, 5]
             array['lon':5, 'lat':10]
             array['lat':10][5]
         Now suppose we want to combine this data with another array of equal dimensions that
-        represents the average rainfall for each location. We could easily store these as two 
+        represents the average rainfall for each location. We could easily store these as two
         separate arrays or combine them into a 3D array with this description:
             info=[
         {'name': 'vals', 'cols': [
-          {'name': 'altitude', 'units': 'm'}, 
+          {'name': 'altitude', 'units': 'm'},
           {'name': 'rainfall', 'units': 'cm/year'}
         ]},
-        {'name': 'lat', 'title': 'Lattitude'}, 
+        {'name': 'lat', 'title': 'Lattitude'},
         {'name': 'lon', 'title': 'Longitude'}
       ]
         We can now access the altitude values with array[0] or array['altitude'], and the
@@ -102,7 +102,7 @@ class MetaArray(object):
         Notice that in the second example, there is no need for an extra (4th) axis description
         since the actual values are described (name and units) in the column info for the first axis.
     """
-  
+
     version = '2'
 
     # Default hdf5 compression to use when writing
@@ -112,22 +112,22 @@ class MetaArray(object):
     # (so by default, we use no compression)
     # May also be a tuple (filter, opts), such as ('gzip', 3)
     defaultCompression = None
-    
+
     ## Types allowed as axis or column names
     nameTypes = [basestring, tuple]
     @staticmethod
     def isNameType(var):
         return any([isinstance(var, t) for t in MetaArray.nameTypes])
-        
-        
-    ## methods to wrap from embedded ndarray / HDF5 
+
+
+    ## methods to wrap from embedded ndarray / HDF5
     wrapMethods = set(['__eq__', '__ne__', '__le__', '__lt__', '__ge__', '__gt__'])
-  
+
     def __init__(self, data=None, info=None, dtype=None, file=None, copy=False, **kwargs):
         object.__init__(self)
         #self._infoOwned = False
         self._isHDF = False
-        
+
         if file is not None:
             self._data = None
             self.readFile(file, **kwargs)
@@ -145,7 +145,7 @@ class MetaArray(object):
 
         ## run sanity checks on info structure
         self.checkInfo()
-    
+
     def checkInfo(self):
         info = self._info
         if info is None:
@@ -181,20 +181,20 @@ class MetaArray(object):
                         info[i]['cols'] = list(info[i]['cols'])
                     if len(info[i]['cols']) != self.shape[i]:
                         raise Exception('Length of column list for axis %d does not match data. (given %d, but should be %d)' % (i, len(info[i]['cols']), self.shape[i]))
-   
+
     def implements(self, name=None):
         ## Rather than isinstance(obj, MetaArray) use object.implements('MetaArray')
         if name is None:
             return ['MetaArray']
         else:
             return name == 'MetaArray'
-    
+
     #def __array_finalize__(self,obj):
-        ### array_finalize is called every time a MetaArray is created 
+        ### array_finalize is called every time a MetaArray is created
         ### (whereas __new__ is not necessarily called every time)
-        
+
         ### obj is the object from which this array was generated (for example, when slicing or view()ing)
-        
+
         ## We use the getattr method to set a default if 'obj' doesn't have the 'info' attribute
         ##print "Create new MA from object", str(type(obj))
         ##import traceback
@@ -206,19 +206,19 @@ class MetaArray(object):
             #self._info = getattr(obj, '_info', [{}]*(obj.ndim+1))
             #self._infoOwned = False  ## Do not make changes to _info until it is copied at least once
         ##print "  self info:", self._info
-      
+
         ## We could have checked first whether self._info was already defined:
         ##if not hasattr(self, 'info'):
         ##    self._info = getattr(obj, 'info', {})
-    
-  
+
+
     def __getitem__(self, ind):
         #print "getitem:", ind
-        
+
         ## should catch scalar requests as early as possible to speed things up (?)
-        
+
         nInd = self._interpretIndexes(ind)
-        
+
         #a = np.ndarray.__getitem__(self, nInd)
         a = self._data[nInd]
         if len(nInd) == self.ndim:
@@ -226,7 +226,7 @@ class MetaArray(object):
                 return a
         #if type(a) != type(self._data) and not isinstance(a, np.ndarray):  ## indexing returned single value
             #return a
-        
+
         ## indexing returned a sub-array; generate new info array to go with it
         #print "   new MA:", type(a), a.shape
         info = []
@@ -267,37 +267,37 @@ class MetaArray(object):
                             extraInfo['name'] = str(name) + ': ' + str(colName)
                         else:
                             extraInfo['name'] = name
-                        
-                        
+
+
                 #print "Lost info:", newInfo
                 #a._info[i] = None
                 #if 'name' in newInfo:
                     #a._info[-1][newInfo['name']] = newInfo
         info.append(extraInfo)
-        
+
         #self._infoOwned = False
         #while None in a._info:
             #a._info.remove(None)
         return MetaArray(a, info=info)
-  
+
     @property
     def ndim(self):
         return len(self.shape)  ## hdf5 objects do not have ndim property.
-            
+
     @property
     def shape(self):
         return self._data.shape
-        
+
     @property
     def dtype(self):
         return self._data.dtype
-        
+
     def __len__(self):
         return len(self._data)
-        
+
     def __getslice__(self, *args):
         return self.__getitem__(slice(*args))
-  
+
     def __setitem__(self, ind, val):
         nInd = self._interpretIndexes(ind)
         try:
@@ -305,23 +305,23 @@ class MetaArray(object):
         except:
             print(self, nInd, val)
             raise
-        
+
     def __getattr__(self, attr):
         if attr in self.wrapMethods:
             return getattr(self._data, attr)
         else:
             raise AttributeError(attr)
             #return lambda *args, **kwargs: MetaArray(getattr(a.view(ndarray), attr)(*args, **kwargs)
-        
+
     def __eq__(self, b):
         return self._binop('__eq__', b)
-        
+
     def __ne__(self, b):
         return self._binop('__ne__', b)
         #if isinstance(b, MetaArray):
             #b = b.asarray()
         #return self.asarray() != b
-        
+
     def __sub__(self, b):
         return self._binop('__sub__', b)
         #if isinstance(b, MetaArray):
@@ -333,13 +333,13 @@ class MetaArray(object):
 
     def __mul__(self, b):
         return self._binop('__mul__', b)
-        
+
     def __div__(self, b):
         return self._binop('__div__', b)
-        
+
     def __truediv__(self, b):
         return self._binop('__truediv__', b)
-        
+
     def _binop(self, op, b):
         if isinstance(b, MetaArray):
             b = b.asarray()
@@ -348,24 +348,24 @@ class MetaArray(object):
         if c.shape != a.shape:
             raise Exception("Binary operators with MetaArray must return an array of the same shape (this shape is %s, result shape was %s)" % (a.shape, c.shape))
         return MetaArray(c, info=self.infoCopy())
-        
+
     def asarray(self):
         if isinstance(self._data, np.ndarray):
             return self._data
         else:
             return np.array(self._data)
-            
+
     def __array__(self):
-        ## supports np.array(metaarray_instance) 
+        ## supports np.array(metaarray_instance)
         return self.asarray()
-            
+
     def view(self, typ):
         ## deprecated; kept for backward compatibility
         if typ is np.ndarray:
             return self.asarray()
         else:
             raise Exception('invalid view type: %s' % str(typ))
-  
+
     def axisValues(self, axis):
         """Return the list of values for an axis"""
         ax = self._interpretAxis(axis)
@@ -373,25 +373,25 @@ class MetaArray(object):
             return self._info[ax]['values']
         else:
             raise Exception('Array axis %s (%d) has no associated values.' % (str(axis), ax))
-  
+
     def xvals(self, axis):
         """Synonym for axisValues()"""
         return self.axisValues(axis)
-        
+
     def axisHasValues(self, axis):
         ax = self._interpretAxis(axis)
         return 'values' in self._info[ax]
-        
+
     def axisHasColumns(self, axis):
         ax = self._interpretAxis(axis)
         return 'cols' in self._info[ax]
-  
+
     def axisUnits(self, axis):
         """Return the units for axis"""
         ax = self._info[self._interpretAxis(axis)]
         if 'units' in ax:
             return ax['units']
-        
+
     def hasColumn(self, axis, col):
         ax = self._info[self._interpretAxis(axis)]
         if 'cols' in ax:
@@ -399,7 +399,7 @@ class MetaArray(object):
                 if c['name'] == col:
                     return True
         return False
-        
+
     def listColumns(self, axis=None):
         """Return a list of column names for axis. If axis is not specified, then return a dict of {axisName: (column names), ...}."""
         if axis is None:
@@ -414,14 +414,14 @@ class MetaArray(object):
         else:
             axis = self._interpretAxis(axis)
             return [c['name'] for c in self._info[axis]['cols']]
-        
+
     def columnName(self, axis, col):
         ax = self._info[self._interpretAxis(axis)]
         return ax['cols'][col]['name']
-        
+
     def axisName(self, n):
         return self._info[n].get('name', n)
-        
+
     def columnUnits(self, axis, column):
         """Return the units for column in axis"""
         ax = self._info[self._interpretAxis(axis)]
@@ -432,11 +432,11 @@ class MetaArray(object):
             raise Exception("Axis %s has no column named %s" % (str(axis), str(column)))
         else:
             raise Exception("Axis %s has no column definitions" % str(axis))
-  
+
     def rowsort(self, axis, key=0):
         """Return this object with all records sorted along axis using key as the index to the values to compare. Does not yet modify meta info."""
         ## make sure _info is copied locally before modifying it!
-    
+
         keyList = self[key]
         order = keyList.argsort()
         if type(axis) == int:
@@ -445,11 +445,11 @@ class MetaArray(object):
         elif isinstance(axis, basestring):
             ind = (slice(axis, order),)
         return self[tuple(ind)]
-  
+
     def append(self, val, axis):
         """Return this object with val appended along axis. Does not yet combine meta info."""
         ## make sure _info is copied locally before modifying it!
-    
+
         s = list(self.shape)
         axis = self._interpretAxis(axis)
         s[axis] += 1
@@ -460,25 +460,25 @@ class MetaArray(object):
         ind[axis] = -1
         n[tuple(ind)] = val
         return n
-  
+
     def extend(self, val, axis):
         """Return the concatenation along axis of this object and val. Does not yet combine meta info."""
         ## make sure _info is copied locally before modifying it!
-    
+
         axis = self._interpretAxis(axis)
         return MetaArray(np.concatenate(self, val, axis), info=self._info)
-  
+
     def infoCopy(self, axis=None):
         """Return a deep copy of the axis meta info for this object"""
         if axis is None:
             return copy.deepcopy(self._info)
         else:
             return copy.deepcopy(self._info[self._interpretAxis(axis)])
-  
+
     def copy(self):
         return MetaArray(self._data.copy(), info=self.infoCopy())
-  
-  
+
+
     def _interpretIndexes(self, ind):
         #print "interpret", ind
         if not isinstance(ind, tuple):
@@ -488,7 +488,7 @@ class MetaArray(object):
             ## everything else can just be converted to a length-1 tuple
             else:
                 ind = (ind,)
-                
+
         nInd = [slice(None)]*self.ndim
         numOk = True  ## Named indices not started yet; numbered sill ok
         for i in range(0,len(ind)):
@@ -504,16 +504,16 @@ class MetaArray(object):
             if isNamed:
                 numOk = False
         return tuple(nInd)
-      
+
     def _interpretAxis(self, axis):
         if isinstance(axis, basestring) or isinstance(axis, tuple):
             return self._getAxis(axis)
         else:
             return axis
-  
+
     def _interpretIndex(self, ind, pos, numOk):
         #print "Interpreting index", ind, pos, numOk
-        
+
         ## should probably check for int first to speed things up..
         if type(ind) is int:
             if not numOk:
@@ -531,12 +531,12 @@ class MetaArray(object):
                 #print "    ..not a real slice"
                 axis = self._interpretAxis(ind.start)
                 #print "    axis is", axis
-                
+
                 ## x[Axis:Column]
                 if MetaArray.isNameType(ind.stop):
                     #print "    column name, column is ", self._getIndex(axis, ind.stop)
                     index = self._getIndex(axis, ind.stop)
-                    
+
                 ## x[Axis:min:max]
                 elif (isinstance(ind.stop, float) or isinstance(ind.step, float)) and ('values' in self._info[axis]):
                     #print "    axis value range"
@@ -548,7 +548,7 @@ class MetaArray(object):
                         mask = (self.xvals(axis) >= ind.stop) * (self.xvals(axis) < ind.step)
                     ##print "mask:", mask
                     index = mask
-                    
+
                 ## x[Axis:columnIndex]
                 elif isinstance(ind.stop, int) or isinstance(ind.step, int):
                     #print "    normal slice after named axis"
@@ -556,7 +556,7 @@ class MetaArray(object):
                         index = ind.stop
                     else:
                         index = slice(ind.stop, ind.step)
-                    
+
                 ## x[Axis: [list]]
                 elif type(ind.stop) is list:
                     #print "    list of indexes from named axis"
@@ -570,7 +570,7 @@ class MetaArray(object):
                             ## unrecognized type, try just passing on to array
                             index = ind.stop
                             break
-                
+
                 else:
                     #print "    other type.. forward on to array for handling", type(ind.stop)
                     index = ind.stop
@@ -590,14 +590,14 @@ class MetaArray(object):
                 raise Exception("string and integer indexes may not follow named indexes")
             #print "  normal numerical index"
             return (pos, ind, False)
-  
+
     def _getAxis(self, name):
         for i in range(0, len(self._info)):
             axis = self._info[i]
             if 'name' in axis and axis['name'] == name:
                 return i
         raise Exception("No axis named %s.\n  info=%s" % (name, self._info))
-  
+
     def _getIndex(self, axis, name):
         ax = self._info[axis]
         if ax is not None and 'cols' in ax:
@@ -605,10 +605,10 @@ class MetaArray(object):
                 if 'name' in ax['cols'][i] and ax['cols'][i]['name'] == name:
                     return i
         raise Exception("Axis %d has no column named %s.\n  info=%s" % (axis, name, self._info))
-  
+
     def _axisCopy(self, i):
         return copy.deepcopy(self._info[i])
-  
+
     def _axisSlice(self, i, cols):
         #print "axisSlice", i, cols
         if 'cols' in self._info[i] or 'values' in self._info[i]:
@@ -626,7 +626,7 @@ class MetaArray(object):
             ax = self._info[i]
         #print "     ", ax
         return ax
-  
+
     def prettyInfo(self):
         s = ''
         titles = []
@@ -643,7 +643,7 @@ class MetaArray(object):
             titles.append(axs)
             if len(axs) > maxl:
                 maxl = len(axs)
-        
+
         for i in range(min(self.ndim, len(self._info)-1)):
             ax = self._info[i]
             axs = titles[i]
@@ -665,7 +665,7 @@ class MetaArray(object):
             s += axs + "\n"
         s += str(self._info[-1])
         return s
-  
+
     def __repr__(self):
         return "%s\n-----------------------------------------------\n%s" % (self.view(np.ndarray).__repr__(), self.prettyInfo())
 
@@ -686,7 +686,7 @@ class MetaArray(object):
 
     def mean(self, axis=None, *args, **kargs):
         return self.axisCollapsingFn('mean', axis, *args, **kargs)
-            
+
 
     def min(self, axis=None, *args, **kargs):
         return self.axisCollapsingFn('min', axis, *args, **kargs)
@@ -699,12 +699,12 @@ class MetaArray(object):
             order = args[0]
         else:
             order = args
-        
+
         order = [self._interpretAxis(ax) for ax in order]
         infoOrder = order  + list(range(len(order), len(self._info)))
         info = [self._info[i] for i in infoOrder]
         order = order + list(range(len(order), self.ndim))
-        
+
         try:
             if self._isHDF:
                 return MetaArray(np.array(self._data).transpose(order), info=info)
@@ -719,14 +719,14 @@ class MetaArray(object):
         """Load the data and meta info stored in *filename*
         Different arguments are allowed depending on the type of file.
         For HDF5 files:
-        
+
             *writable* (bool) if True, then any modifications to data in the array will be stored to disk.
             *readAllData* (bool) if True, then all data in the array is immediately read from disk
                           and the file is closed (this is the default for files < 500MB). Otherwise, the file will
-                          be left open and data will be read only as requested (this is 
+                          be left open and data will be read only as requested (this is
                           the default for files >= 500MB).
-        
-        
+
+
         """
         ## decide which read function to use
         with open(filename, 'rb') as fd:
@@ -788,7 +788,7 @@ class MetaArray(object):
             subarr = np.fromstring(fd.read(), dtype=meta['type'])
             subarr.shape = meta['shape']
         self._data = subarr
-            
+
     def _readData2(self, fd, meta, mmap=False, subset=None, **kwds):
         ## read in axis values
         dynAxis = None
@@ -845,21 +845,21 @@ class MetaArray(object):
                         break
                 if line == '':
                     break
-                    
+
                 ## evaluate line
                 inf = eval(line)
-                
+
                 ## read data block
                 #print "read %d bytes as %s" % (inf['len'], meta['type'])
                 if meta['type'] == 'object':
                     data = pickle.loads(fd.read(inf['len']))
                 else:
                     data = np.fromstring(fd.read(inf['len']), dtype=meta['type'])
-                
+
                 if data.size != frameSize * inf['numFrames']:
                     #print data.size, frameSize, inf['numFrames']
                     raise Exception("Wrong frame size in MetaArray file! (frame %d)" % n)
-                    
+
                 ## read in data block
                 shape = list(frameShape)
                 shape[dynAxis] = inf['numFrames']
@@ -882,7 +882,7 @@ class MetaArray(object):
                 else:
                     #data = data[subset].copy()  ## what's this for??
                     frames.append(data)
-                
+
                 n += inf['numFrames']
                 if 'xVals' in inf:
                     xVals.extend(inf['xVals'])
@@ -901,10 +901,10 @@ class MetaArray(object):
     def _readHDF5(self, fileName, readAllData=None, writable=False, **kargs):
         if 'close' in kargs and readAllData is None: ## for backward compatibility
             readAllData = kargs['close']
-       
+
         if readAllData is True and writable is True:
             raise Exception("Incompatible arguments: readAllData=True and writable=True")
-        
+
         if not HAVE_HDF5:
             try:
                 assert writable==False
@@ -913,36 +913,36 @@ class MetaArray(object):
                 return
             except:
                 raise Exception("The file '%s' is HDF5-formatted, but the HDF5 library (h5py) was not found." % fileName)
-        
+
         ## by default, readAllData=True for files < 500MB
         if readAllData is None:
             size = os.stat(fileName).st_size
             readAllData = (size < 500e6)
-        
+
         if writable is True:
             mode = 'r+'
         else:
             mode = 'r'
         f = h5py.File(fileName, mode)
-        
+
         ver = f.attrs['MetaArray']
         if ver > MetaArray.version:
             print("Warning: This file was written with MetaArray version %s, but you are using version %s. (Will attempt to read anyway)" % (str(ver), str(MetaArray.version)))
         meta = MetaArray.readHDF5Meta(f['info'])
         self._info = meta
-        
+
         if writable or not readAllData:  ## read all data, convert to ndarray, close file
             self._data = f['data']
             self._openFile = f
         else:
             self._data = f['data'][:]
             f.close()
-            
+
     def _readHDF5Remote(self, fileName):
         ## Used to read HDF5 files via remote process.
         ## This is needed in the case that HDF5 is not importable due to the use of python-dbg.
         proc = getattr(MetaArray, '_hdf5Process', None)
-        
+
         if proc == False:
             raise Exception('remote read failed')
         if proc == None:
@@ -958,8 +958,8 @@ class MetaArray(object):
         #print MetaArray._hdf5Process
         #import inspect
         #print MetaArray, id(MetaArray), inspect.getmodule(MetaArray)
-        
-        
+
+
 
     @staticmethod
     def mapHDF5Array(data, writable=False):
@@ -971,14 +971,14 @@ class MetaArray(object):
         if off is None:
             raise Exception("This dataset uses chunked storage; it can not be memory-mapped. (store using mappable=True)")
         return np.memmap(filename=data.file.filename, offset=off, dtype=data.dtype, shape=data.shape, mode=mode)
-        
+
 
 
 
     @staticmethod
     def readHDF5Meta(root, mmap=False):
         data = {}
-        
+
         ## Pull list of values from attributes and child objects
         for k in root.attrs:
             val = root.attrs[k]
@@ -1000,10 +1000,10 @@ class MetaArray(object):
             else:
                 raise Exception("Don't know what to do with type '%s'" % str(type(obj)))
             data[k] = val
-        
+
         typ = root.attrs['_metaType_']
         del data['_metaType_']
-        
+
         if typ == 'dict':
             return data
         elif typ == 'list' or typ == 'tuple':
@@ -1015,7 +1015,7 @@ class MetaArray(object):
             return d2
         else:
             raise Exception("Don't understand metaType '%s'" % typ)
-        
+
 
     def write(self, fileName, **opts):
         """Write this object to a file. The object can be restored by calling MetaArray(file=fileName)
@@ -1024,7 +1024,7 @@ class MetaArray(object):
             compression: None, 'gzip' (good compression), 'lzf' (fast compression), etc.
             chunks: bool or tuple specifying chunk shape
         """
-        
+
         if USE_HDF5 and HAVE_HDF5:
             return self.writeHDF5(fileName, **opts)
         else:
@@ -1037,7 +1037,7 @@ class MetaArray(object):
         if f.attrs['MetaArray'] != MetaArray.version:
             raise Exception("The file %s was created with a different version of MetaArray. Will not modify." % fileName)
         del f['info']
-        
+
         self.writeHDF5Meta(f, 'info', self._info)
         f.close()
 
@@ -1050,13 +1050,13 @@ class MetaArray(object):
         else:
             copts = None
 
-        dsOpts = {  
+        dsOpts = {
             'compression': comp,
             'chunks': True,
         }
         if copts is not None:
             dsOpts['compression_opts'] = copts
-        
+
         ## if there is an appendable axis, then we can guess the desired chunk shape (optimized for appending)
         appAxis = opts.get('appendAxis', None)
         if appAxis is not None:
@@ -1064,7 +1064,7 @@ class MetaArray(object):
             cs = [min(100000, x) for x in self.shape]
             cs[appAxis] = 1
             dsOpts['chunks'] = tuple(cs)
-            
+
         ## if there are columns, then we can guess a different chunk shape
         ## (read one column at a time)
         else:
@@ -1073,21 +1073,21 @@ class MetaArray(object):
                 if 'cols' in self._info[i]:
                     cs[i] = 1
             dsOpts['chunks'] = tuple(cs)
-        
+
         ## update options if they were passed in
         for k in dsOpts:
             if k in opts:
                 dsOpts[k] = opts[k]
-        
-        
+
+
         ## If mappable is in options, it disables chunking/compression
         if opts.get('mappable', False):
             dsOpts = {
                 'chunks': None,
                 'compression': None
             }
-        
-            
+
+
         ## set maximum shape to allow expansion along appendAxis
         append = False
         if appAxis is not None:
@@ -1099,12 +1099,12 @@ class MetaArray(object):
             dsOpts['maxshape'] = tuple(maxShape)
         else:
             dsOpts['maxshape'] = None
-            
+
         if append:
             f = h5py.File(fileName, 'r+')
             if f.attrs['MetaArray'] != MetaArray.version:
                 raise Exception("The file %s was created with a different version of MetaArray. Will not modify." % fileName)
-            
+
             ## resize data and write in new values
             data = f['data']
             shape = list(data.shape)
@@ -1113,7 +1113,7 @@ class MetaArray(object):
             sl = [slice(None)] * len(data.shape)
             sl[ax] = slice(-self.shape[ax], None)
             data[tuple(sl)] = self.view(np.ndarray)
-            
+
             ## add axis values if they are present.
             axInfo = f['info'][str(ax)]
             if 'values' in axInfo:
@@ -1129,7 +1129,7 @@ class MetaArray(object):
             f.attrs['MetaArray'] = MetaArray.version
             #print dsOpts
             f.create_dataset('data', data=self.view(np.ndarray), **dsOpts)
-            
+
             ## dsOpts is used when storing meta data whenever an array is encountered
             ## however, 'chunks' will no longer be valid for these arrays if it specifies a chunk shape.
             ## 'maxshape' is right-out.
@@ -1165,20 +1165,20 @@ class MetaArray(object):
                 root.attrs[name] = repr(data)
             except:
                 print("Can not store meta data of type '%s' in HDF5. (key is '%s')" % (str(type(data)), str(name)))
-                raise 
+                raise
 
-        
+
     def writeMa(self, fileName, appendAxis=None, newFile=False):
         """Write an old-style .ma file"""
         meta = {'shape':self.shape, 'type':str(self.dtype), 'info':self.infoCopy(), 'version':MetaArray.version}
         axstrs = []
-        
+
         ## copy out axis values for dynamic axis if requested
         if appendAxis is not None:
             if MetaArray.isNameType(appendAxis):
                 appendAxis = self._interpretAxis(appendAxis)
-            
-            
+
+
             ax = meta['info'][appendAxis]
             ax['values_len'] = 'dynamic'
             if 'values' in ax:
@@ -1187,7 +1187,7 @@ class MetaArray(object):
                 del ax['values']
             else:
                 dynXVals = None
-                
+
         ## Generate axis data string, modify axis info so we know how to read it back in later
         for ax in meta['info']:
             if 'values' in ax:
@@ -1195,12 +1195,12 @@ class MetaArray(object):
                 ax['values_len'] = len(axstrs[-1])
                 ax['values_type'] = str(ax['values'].dtype)
                 del ax['values']
-                
+
         ## Decide whether to output the meta block for a new file
         if not newFile:
             ## If the file does not exist or its size is 0, then we must write the header
             newFile = (not os.path.exists(fileName))  or  (os.stat(fileName).st_size == 0)
-        
+
         ## write data to file
         if appendAxis is None or newFile:
             fd = open(fileName, 'wb')
@@ -1209,7 +1209,7 @@ class MetaArray(object):
                 fd.write(ax)
         else:
             fd = open(fileName, 'ab')
-        
+
         if self.dtype != object:
             dataStr = self.view(np.ndarray).tostring()
         else:
@@ -1222,7 +1222,7 @@ class MetaArray(object):
             fd.write('\n'+str(frameInfo)+'\n')
         fd.write(dataStr)
         fd.close()
-        
+
     def writeCsv(self, fileName=None):
         """Write 2D array to CSV file or return the string if no filename is given"""
         if self.ndim > 2:
@@ -1246,11 +1246,11 @@ class MetaArray(object):
             file.close()
         else:
             return ret
-        
+
 
 
 #class H5MetaList():
-    
+
 
 #def rewriteContiguous(fileName, newName):
     #"""Rewrite a dynamic array file as contiguous"""
@@ -1271,7 +1271,7 @@ class MetaArray(object):
                     #frameSize *= ax['values_len']
                     #del ax['values_len']
                     #del ax['values_type']
-                    
+
         ### No axes are dynamic, just read the entire array in at once
         #if dynAxis is None:
             #raise Exception('Array has no dynamic axes.')
@@ -1294,27 +1294,27 @@ class MetaArray(object):
                         #break
                 #if line == '':
                     #break
-                    
+
                 ### evaluate line
                 #inf = eval(line)
-                
+
                 ### read data block
                 ##print "read %d bytes as %s" % (inf['len'], meta['type'])
                 #if meta['type'] == 'object':
                     #data = pickle.loads(fd.read(inf['len']))
                 #else:
                     #data = fromstring(fd.read(inf['len']), dtype=meta['type'])
-                
+
                 #if data.size != frameSize * inf['numFrames']:
                     ##print data.size, frameSize, inf['numFrames']
                     #raise Exception("Wrong frame size in MetaArray file! (frame %d)" % n)
-                    
+
                 ### read in data block
                 #shape = list(frameShape)
                 #shape[dynAxis] = inf['numFrames']
                 #data.shape = shape
                 #frames.append(data)
-                
+
                 #n += inf['numFrames']
                 #if 'xVals' in inf:
                     #xVals.extend(inf['xVals'])
@@ -1326,24 +1326,24 @@ class MetaArray(object):
         #subarr = subarr.view(subtype)
         #subarr._info = meta['info']
         #return subarr
-    
 
 
-  
-  
+
+
+
 if __name__ == '__main__':
     ## Create an array with every option possible
-    
+
     arr = np.zeros((2, 5, 3, 5), dtype=int)
     for i in range(arr.shape[0]):
         for j in range(arr.shape[1]):
             for k in range(arr.shape[2]):
                 for l in range(arr.shape[3]):
                     arr[i,j,k,l] = (i+1)*1000 + (j+1)*100 + (k+1)*10 + (l+1)
-        
+
     info = [
-        axis('Axis1'), 
-        axis('Axis2', values=[1,2,3,4,5]), 
+        axis('Axis1'),
+        axis('Axis2', values=[1,2,3,4,5]),
         axis('Axis3', cols=[
             ('Ax3Col1'),
             ('Ax3Col2', 'mV', 'Axis3 Column2'),
@@ -1351,149 +1351,148 @@ if __name__ == '__main__':
         {'name': 'Axis4', 'values': np.array([1.1, 1.2, 1.3, 1.4, 1.5]), 'units': 's'},
         {'extra': 'info'}
     ]
-    
+
     ma = MetaArray(arr, info=info)
-    
+
     print("====  Original Array =======")
     print(ma)
     print("\n\n")
-    
+
     #### Tests follow:
-    
-    
+
+
     #### Index/slice tests: check that all values and meta info are correct after slice
     print("\n -- normal integer indexing\n")
-    
+
     print("\n  ma[1]")
     print(ma[1])
-    
+
     print("\n  ma[1, 2:4]")
     print(ma[1, 2:4])
-    
+
     print("\n  ma[1, 1:5:2]")
     print(ma[1, 1:5:2])
-    
+
     print("\n -- named axis indexing\n")
-    
+
     print("\n  ma['Axis2':3]")
     print(ma['Axis2':3])
-    
+
     print("\n  ma['Axis2':3:5]")
     print(ma['Axis2':3:5])
-    
+
     print("\n  ma[1, 'Axis2':3]")
     print(ma[1, 'Axis2':3])
-    
+
     print("\n  ma[:, 'Axis2':3]")
     print(ma[:, 'Axis2':3])
-    
+
     print("\n  ma['Axis2':3, 'Axis4':0:2]")
     print(ma['Axis2':3, 'Axis4':0:2])
-    
-    
+
+
     print("\n -- column name indexing\n")
-    
+
     print("\n  ma['Axis3':'Ax3Col1']")
     print(ma['Axis3':'Ax3Col1'])
-    
+
     print("\n  ma['Axis3':('Ax3','Col3')]")
     print(ma['Axis3':('Ax3','Col3')])
-    
+
     print("\n  ma[:, :, 'Ax3Col2']")
     print(ma[:, :, 'Ax3Col2'])
-    
+
     print("\n  ma[:, :, ('Ax3','Col3')]")
     print(ma[:, :, ('Ax3','Col3')])
-    
-    
+
+
     print("\n -- axis value range indexing\n")
-    
+
     print("\n  ma['Axis2':1.5:4.5]")
     print(ma['Axis2':1.5:4.5])
-    
+
     print("\n  ma['Axis4':1.15:1.45]")
     print(ma['Axis4':1.15:1.45])
-    
+
     print("\n  ma['Axis4':1.15:1.25]")
     print(ma['Axis4':1.15:1.25])
-    
-    
-    
+
+
+
     print("\n -- list indexing\n")
-    
+
     print("\n  ma[:, [0,2,4]]")
     print(ma[:, [0,2,4]])
-    
+
     print("\n  ma['Axis4':[0,2,4]]")
     print(ma['Axis4':[0,2,4]])
-    
+
     print("\n  ma['Axis3':[0, ('Ax3','Col3')]]")
     print(ma['Axis3':[0, ('Ax3','Col3')]])
-    
-    
-    
+
+
+
     print("\n -- boolean indexing\n")
-    
+
     print("\n  ma[:, array([True, True, False, True, False])]")
     print(ma[:, np.array([True, True, False, True, False])])
-    
+
     print("\n  ma['Axis4':array([True, False, False, False])]")
     print(ma['Axis4':np.array([True, False, False, False])])
-    
-    
-    
-    
-    
-    #### Array operations 
+
+
+
+
+
+    #### Array operations
     #  - Concatenate
     #  - Append
     #  - Extend
     #  - Rowsort
-    
-    
-    
-    
+
+
+
+
     #### File I/O tests
-    
+
     print("\n================  File I/O Tests  ===================\n")
     import tempfile
     tf = tempfile.mktemp()
     tf = 'test.ma'
     # write whole array
-    
+
     print("\n  -- write/read test")
     ma.write(tf)
     ma2 = MetaArray(file=tf)
-    
+
     #print ma2
     print("\nArrays are equivalent:", (ma == ma2).all())
     #print "Meta info is equivalent:", ma.infoCopy() == ma2.infoCopy()
     os.remove(tf)
-    
+
     # CSV write
-    
+
     # append mode
-    
-    
+
+
     print("\n================append test (%s)===============" % tf)
     ma['Axis2':0:2].write(tf, appendAxis='Axis2')
     for i in range(2,ma.shape[1]):
         ma['Axis2':[i]].write(tf, appendAxis='Axis2')
-    
+
     ma2 = MetaArray(file=tf)
-    
+
     #print ma2
     print("\nArrays are equivalent:", (ma == ma2).all())
     #print "Meta info is equivalent:", ma.infoCopy() == ma2.infoCopy()
-    
-    os.remove(tf)    
-    
-    
-    
+
+    os.remove(tf)
+
+
+
     ## memmap test
     print("\n==========Memmap test============")
     ma.write(tf, mappable=True)
     ma2 = MetaArray(file=tf, mmap=True)
     print("\nArrays are equivalent:", (ma == ma2).all())
-    os.remove(tf)    
-    
+    os.remove(tf)

--- a/pyqtgraph/multiprocess/bootstrap.py
+++ b/pyqtgraph/multiprocess/bootstrap.py
@@ -17,11 +17,11 @@ if __name__ == '__main__':
         while len(sys.path) > 0:
             sys.path.pop()
         sys.path.extend(path)
-        
+
     if opts.pop('pyside', False):
         import PySide
-        
-    
+
+
     targetStr = opts.pop('targetStr')
     target = pickle.loads(targetStr)  ## unpickling the target should import everything we need
     target(**opts)  ## Send all other options to the target function

--- a/pyqtgraph/multiprocess/parallelizer.py
+++ b/pyqtgraph/multiprocess/parallelizer.py
@@ -11,21 +11,21 @@ class CanceledError(Exception):
 class Parallelize(object):
     """
     Class for ultra-simple inline parallelization on multi-core CPUs
-    
+
     Example::
-    
+
         ## Here is the serial (single-process) task:
-        
+
         tasks = [1, 2, 4, 8]
         results = []
         for task in tasks:
             result = processTask(task)
             results.append(result)
         print(results)
-        
-        
+
+
         ## Here is the parallelized version:
-        
+
         tasks = [1, 2, 4, 8]
         results = []
         with Parallelize(tasks, workers=4, results=results) as tasker:
@@ -33,8 +33,8 @@ class Parallelize(object):
                 result = processTask(task)
                 tasker.results.append(result)
         print(results)
-        
-        
+
+
     The only major caveat is that *result* in the example above must be picklable,
     since it is automatically sent via pipe back to the parent process.
     """
@@ -43,22 +43,22 @@ class Parallelize(object):
         """
         ===============  ===================================================================
         **Arguments:**
-        tasks            list of objects to be processed (Parallelize will determine how to 
+        tasks            list of objects to be processed (Parallelize will determine how to
                          distribute the tasks). If unspecified, then each worker will receive
                          a single task with a unique id number.
-        workers          number of worker processes or None to use number of CPUs in the 
+        workers          number of worker processes or None to use number of CPUs in the
                          system
         progressDialog   optional dict of arguments for ProgressDialog
                          to update while tasks are processed
         randomReseed     If True, each forked process will reseed its random number generator
                          to ensure independent results. Works with the built-in random
                          and numpy.random.
-        kwds             objects to be shared by proxy with child processes (they will 
+        kwds             objects to be shared by proxy with child processes (they will
                          appear as attributes of the tasker)
         ===============  ===================================================================
         """
-        
-        ## Generate progress dialog. 
+
+        ## Generate progress dialog.
         ## Note that we want to avoid letting forked child processes play with progress dialogs..
         self.showProgress = False
         if progressDialog is not None:
@@ -67,7 +67,7 @@ class Parallelize(object):
                 progressDialog = {'labelText': progressDialog}
             from ..widgets.ProgressDialog import ProgressDialog
             self.progressDlg = ProgressDialog(**progressDialog)
-        
+
         if workers is None:
             workers = self.suggestedWorkerCount()
         if not hasattr(os, 'fork'):
@@ -79,26 +79,26 @@ class Parallelize(object):
         self.reseed = randomReseed
         self.kwds = kwds.copy()
         self.kwds['_taskStarted'] = self._taskStarted
-        
+
     def __enter__(self):
         self.proc = None
-        if self.workers == 1: 
+        if self.workers == 1:
             return self.runSerial()
         else:
             return self.runParallel()
-    
+
     def __exit__(self, *exc_info):
-        
-        if self.proc is not None:  ## worker 
+
+        if self.proc is not None:  ## worker
             exceptOccurred = exc_info[0] is not None ## hit an exception during processing.
-                
+
             try:
                 if exceptOccurred:
                     sys.excepthook(*exc_info)
             finally:
                 #print os.getpid(), 'exit'
                 os._exit(1 if exceptOccurred else 0)
-                
+
         else:  ## parent
             if self.showProgress:
                 self.progressDlg.__exit__(None, None, None)
@@ -110,17 +110,17 @@ class Parallelize(object):
         self.progress = {os.getpid(): []}
         return Tasker(self, None, self.tasks, self.kwds)
 
-    
+
     def runParallel(self):
         self.childs = []
-        
+
         ## break up tasks into one set per worker
         workers = self.workers
         chunks = [[] for i in xrange(workers)]
         i = 0
         for i in range(len(self.tasks)):
             chunks[i%workers].append(self.tasks[i])
-        
+
         ## fork and assign tasks to each worker
         for i in range(workers):
             proc = ForkedProcess(target=None, preProxy=self.kwds, randomReseed=self.reseed)
@@ -129,20 +129,20 @@ class Parallelize(object):
                 return Tasker(self, proc, chunks[i], proc.forkedProxies)
             else:
                 self.childs.append(proc)
-        
+
         ## Keep track of the progress of each worker independently.
         self.progress = dict([(ch.childPid, []) for ch in self.childs])
         ## for each child process, self.progress[pid] is a list
         ## of task indexes. The last index is the task currently being
         ## processed; all others are finished.
-            
-            
+
+
         try:
             if self.showProgress:
                 self.progressDlg.__enter__()
                 self.progressDlg.setMaximum(len(self.tasks))
             ## process events from workers until all have exited.
-                
+
             activeChilds = self.childs[:]
             self.exitCodes = []
             pollInterval = 0.01
@@ -173,21 +173,21 @@ class Parallelize(object):
                                 #print "Ignored system call interruption"
                             else:
                                 raise
-                    
+
                     #print [ch.childPid for ch in activeChilds]
-                    
+
                 if self.showProgress and self.progressDlg.wasCanceled():
                     for ch in activeChilds:
                         ch.kill()
                     raise CanceledError()
-                    
+
                 ## adjust polling interval--prefer to get exactly 1 event per poll cycle.
                 if waitingChildren > 1:
                     pollInterval *= 0.7
                 elif waitingChildren == 0:
                     pollInterval /= 0.7
                 pollInterval = max(min(pollInterval, 0.5), 0.0005) ## but keep it within reasonable limits
-                
+
                 time.sleep(pollInterval)
         finally:
             if self.showProgress:
@@ -198,8 +198,8 @@ class Parallelize(object):
             if code != 0:
                 raise Exception("Error occurred in parallel-executed subprocess (console output may have more information).")
         return []  ## no tasks for parent process.
-    
-    
+
+
     @staticmethod
     def suggestedWorkerCount():
         if 'linux' in sys.platform:
@@ -208,7 +208,7 @@ class Parallelize(object):
             try:
                 cores = {}
                 pid = None
-                
+
                 for line in open('/proc/cpuinfo'):
                     m = re.match(r'physical id\s+:\s+(\d+)', line)
                     if m is not None:
@@ -219,10 +219,10 @@ class Parallelize(object):
                 return sum(cores.values())
             except:
                 return multiprocessing.cpu_count()
-                
+
         else:
             return multiprocessing.cpu_count()
-        
+
     def _taskStarted(self, pid, i, **kwds):
         ## called remotely by tasker to indicate it has started working on task i
         #print pid, 'reported starting task', i
@@ -233,8 +233,8 @@ class Parallelize(object):
                 if self.progressDlg.wasCanceled():
                     raise CanceledError()
         self.progress[pid].append(i)
-    
-    
+
+
 class Tasker(object):
     def __init__(self, parallelizer, process, tasks, kwds):
         self.proc = process
@@ -242,7 +242,7 @@ class Tasker(object):
         self.tasks = tasks
         for k, v in kwds.iteritems():
             setattr(self, k, v)
-        
+
     def __iter__(self):
         ## we could fix this up such that tasks are retrieved from the parent process one at a time..
         for i, task in enumerate(self.tasks):
@@ -253,31 +253,31 @@ class Tasker(object):
         if self.proc is not None:
             #print os.getpid(), 'no more tasks'
             self.proc.close()
-    
+
     def process(self):
         """
         Process requests from parent.
-        Usually it is not necessary to call this unless you would like to 
+        Usually it is not necessary to call this unless you would like to
         receive messages (such as exit requests) during an iteration.
         """
         if self.proc is not None:
             self.proc.processRequests()
-    
+
     def numWorkers(self):
         """
         Return the number of parallel workers
         """
         return self.par.workers
-    
+
 #class Parallelizer:
     #"""
     #Use::
-    
+
         #p = Parallelizer()
         #with p(4) as i:
             #p.finish(do_work(i))
         #print p.results()
-    
+
     #"""
     #def __init__(self):
         #pass
@@ -286,7 +286,7 @@ class Tasker(object):
         #self.replies = []
         #self.conn = None  ## indicates this is the parent process
         #return Session(self, n)
-            
+
     #def finish(self, data):
         #if self.conn is None:
             #self.replies.append((self.i, data))
@@ -294,15 +294,15 @@ class Tasker(object):
             ##print "send", self.i, data
             #self.conn.send((self.i, data))
             #os._exit(0)
-            
+
     #def result(self):
         #print self.replies
-        
+
 #class Session:
     #def __init__(self, par, n):
         #self.par = par
         #self.n = n
-        
+
     #def __enter__(self):
         #self.childs = []
         #for i in range(1, self.n):
@@ -319,9 +319,9 @@ class Tasker(object):
                 #c2.close()
         #self.par.i = 0
         #return 0
-            
-        
-        
+
+
+
     #def __exit__(self, *exc_info):
         #if exc_info[0] is not None:
             #sys.excepthook(*exc_info)
@@ -329,4 +329,3 @@ class Tasker(object):
             #self.par.replies.extend([conn.recv() for conn in self.childs])
         #else:
             #self.par.finish(None)
-        

--- a/pyqtgraph/multiprocess/remoteproxy.py
+++ b/pyqtgraph/multiprocess/remoteproxy.py
@@ -21,31 +21,31 @@ class NoResultError(Exception):
     because the call has not yet returned."""
     pass
 
-    
+
 class RemoteEventHandler(object):
     """
-    This class handles communication between two processes. One instance is present on 
+    This class handles communication between two processes. One instance is present on
     each process and listens for communication from the other process. This enables
-    (amongst other things) ObjectProxy instances to look up their attributes and call 
+    (amongst other things) ObjectProxy instances to look up their attributes and call
     their methods.
-    
+
     This class is responsible for carrying out actions on behalf of the remote process.
     Each instance holds one end of a Connection which allows python
     objects to be passed between processes.
-    
+
     For the most common operations, see _import(), close(), and transfer()
-    
+
     To handle and respond to incoming requests, RemoteEventHandler requires that its
     processRequests method is called repeatedly (this is usually handled by the Process
     classes defined in multiprocess.processes).
-    
-    
-    
-    
+
+
+
+
     """
     handlers = {}   ## maps {process ID : handler}. This allows unpickler to determine which process
                     ## an object proxy belongs to
-                         
+
     def __init__(self, connection, name, pid, debug=False):
         self.debug = debug
         self.conn = connection
@@ -55,11 +55,11 @@ class RemoteEventHandler(object):
                           ##   if 'error', then result will be (exception, formatted exceprion)
                           ##   where exception may be None if it could not be passed through the Connection.
         self.resultLock = threading.RLock()
-                          
+
         self.proxies = {} ## maps {weakref(proxy): proxyId}; used to inform the remote process when a proxy has been deleted.
         self.proxyLock = threading.RLock()
-        
-        ## attributes that affect the behavior of the proxy. 
+
+        ## attributes that affect the behavior of the proxy.
         ## See ObjectProxy._setProxyOptions for description
         self.proxyOptions = {
             'callSync': 'sync',      ## 'sync', 'async', 'off'
@@ -70,16 +70,16 @@ class RemoteEventHandler(object):
             'noProxyTypes': [ type(None), str, int, float, tuple, list, dict, LocalObjectProxy, ObjectProxy ],
         }
         self.optsLock = threading.RLock()
-        
+
         self.nextRequestId = 0
         self.exited = False
-        
+
         # Mutexes to help prevent issues when multiple threads access the same RemoteEventHandler
         self.processLock = threading.RLock()
         self.sendLock = threading.RLock()
-        
+
         RemoteEventHandler.handlers[pid] = self  ## register this handler as the one communicating with pid
-    
+
     @classmethod
     def getHandler(cls, pid):
         try:
@@ -87,16 +87,16 @@ class RemoteEventHandler(object):
         except:
             print(pid, cls.handlers)
             raise
-    
+
     def debugMsg(self, msg):
         if not self.debug:
             return
-        cprint.cout(self.debug, "[%d] %s\n" % (os.getpid(), str(msg)), -1) 
-    
+        cprint.cout(self.debug, "[%d] %s\n" % (os.getpid(), str(msg)), -1)
+
     def getProxyOption(self, opt):
         with self.optsLock:
             return self.proxyOptions[opt]
-        
+
     def setProxyOptions(self, **kwds):
         """
         Set the default behavior options for object proxies.
@@ -104,20 +104,20 @@ class RemoteEventHandler(object):
         """
         with self.optsLock:
             self.proxyOptions.update(kwds)
-    
+
     def processRequests(self):
         """Process all pending requests from the pipe, return
         after no more events are immediately available. (non-blocking)
         Returns the number of events processed.
         """
         with self.processLock:
-            
+
             if self.exited:
                 self.debugMsg('  processRequests: exited already; raise ClosedError.')
                 raise ClosedError()
-            
+
             numProcessed = 0
-            
+
             while self.conn.poll():
                 #try:
                     #poll = self.conn.poll()
@@ -126,7 +126,7 @@ class RemoteEventHandler(object):
                 #except IOError:  # this can happen if the remote process dies.
                                 ## might it also happen in other circumstances?
                     #raise ClosedError()
-                        
+
                 try:
                     self.handleRequest()
                     numProcessed += 1
@@ -143,19 +143,19 @@ class RemoteEventHandler(object):
                 except:
                     print("Error in process %s" % self.name)
                     sys.excepthook(*sys.exc_info())
-                    
+
             if numProcessed > 0:
                 self.debugMsg('processRequests: finished %d requests' % numProcessed)
             return numProcessed
-    
+
     def handleRequest(self):
-        """Handle a single request from the remote process. 
+        """Handle a single request from the remote process.
         Blocks until a request is available."""
         result = None
         while True:
             try:
-                ## args, kwds are double-pickled to ensure this recv() call never fails                
-                cmd, reqId, nByteMsgs, optStr = self.conn.recv() 
+                ## args, kwds are double-pickled to ensure this recv() call never fails
+                cmd, reqId, nByteMsgs, optStr = self.conn.recv()
                 break
             except EOFError:
                 self.debugMsg('  handleRequest: got EOFError from recv; raise ClosedError.')
@@ -168,9 +168,9 @@ class RemoteEventHandler(object):
                 else:
                     self.debugMsg('  handleRequest: got IOError %d from recv (%s); raise ClosedError.' % (err.errno, err.strerror))
                     raise ClosedError()
-        
+
         self.debugMsg("  handleRequest: received %s %s" % (str(cmd), str(reqId)))
-            
+
         ## read byte messages following the main request
         byteData = []
         if nByteMsgs > 0:
@@ -190,19 +190,19 @@ class RemoteEventHandler(object):
                     else:
                         self.debugMsg("    handleRequest: got IOError while reading byte messages; raise ClosedError.")
                         raise ClosedError()
-            
-        
+
+
         try:
             if cmd == 'result' or cmd == 'error':
                 resultId = reqId
                 reqId = None  ## prevents attempt to return information from this request
                               ## (this is already a return from a previous request)
-            
+
             opts = pickle.loads(optStr)
             self.debugMsg("    handleRequest: id=%s opts=%s" % (str(reqId), str(opts)))
             #print os.getpid(), "received request:", cmd, reqId, opts
             returnType = opts.get('returnType', 'auto')
-            
+
             if cmd == 'result':
                 with self.resultLock:
                     self.results[resultId] = ('result', opts['result'])
@@ -215,8 +215,8 @@ class RemoteEventHandler(object):
                 obj = opts['obj']
                 fnargs = opts['args']
                 fnkwds = opts['kwds']
-                
-                ## If arrays were sent as byte messages, they must be re-inserted into the 
+
+                ## If arrays were sent as byte messages, they must be re-inserted into the
                 ## arguments
                 if len(byteData) > 0:
                     for i,arg in enumerate(fnargs):
@@ -229,7 +229,7 @@ class RemoteEventHandler(object):
                             ind = arg[1]
                             dtype, shape = arg[2]
                             fnkwds[k] = np.fromstring(byteData[ind], dtype=dtype).reshape(shape)
-                
+
                 if len(fnkwds) == 0:  ## need to do this because some functions do not allow keyword arguments.
                     try:
                         result = obj(*fnargs)
@@ -238,7 +238,7 @@ class RemoteEventHandler(object):
                         raise
                 else:
                     result = obj(*fnargs, **fnkwds)
-                    
+
             elif cmd == 'getObjValue':
                 result = opts['obj']  ## has already been unpickled into its local value
                 returnType = 'value'
@@ -253,7 +253,7 @@ class RemoteEventHandler(object):
                 name = opts['module']
                 fromlist = opts.get('fromlist', [])
                 mod = builtins.__import__(name, fromlist=fromlist)
-                
+
                 if len(fromlist) == 0:
                     parts = name.lstrip('.').split('.')
                     result = mod
@@ -261,25 +261,25 @@ class RemoteEventHandler(object):
                         result = getattr(result, part)
                 else:
                     result = map(mod.__getattr__, fromlist)
-                
+
             elif cmd == 'del':
                 LocalObjectProxy.releaseProxyId(opts['proxyId'])
                 #del self.proxiedObjects[opts['objId']]
-                
+
             elif cmd == 'close':
                 if reqId is not None:
                     result = True
                     returnType = 'value'
-                    
+
             exc = None
         except:
             exc = sys.exc_info()
 
-            
-            
+
+
         if reqId is not None:
             if exc is None:
-                self.debugMsg("    handleRequest: sending return value for %d: %s" % (reqId, str(result))) 
+                self.debugMsg("    handleRequest: sending return value for %d: %s" % (reqId, str(result)))
                 #print "returnValue:", returnValue, result
                 if returnType == 'auto':
                     with self.optsLock:
@@ -287,19 +287,19 @@ class RemoteEventHandler(object):
                     result = self.autoProxy(result, noProxyTypes)
                 elif returnType == 'proxy':
                     result = LocalObjectProxy(result)
-                
+
                 try:
                     self.replyResult(reqId, result)
                 except:
                     sys.excepthook(*sys.exc_info())
                     self.replyError(reqId, *sys.exc_info())
             else:
-                self.debugMsg("    handleRequest: returning exception for %d" % reqId) 
+                self.debugMsg("    handleRequest: returning exception for %d" % reqId)
                 self.replyError(reqId, *exc)
-                    
+
         elif exc is not None:
             sys.excepthook(*exc)
-    
+
         if cmd == 'close':
             if opts.get('noCleanup', False) is True:
                 os._exit(0)  ## exit immediately, do not pass GO, do not collect $200.
@@ -307,12 +307,12 @@ class RemoteEventHandler(object):
                              ## normally be invoked at exit)
             else:
                 raise ClosedError()
-        
-    
-    
+
+
+
     def replyResult(self, reqId, result):
         self.send(request='result', reqId=reqId, callSync='off', opts=dict(result=result))
-    
+
     def replyError(self, reqId, *exc):
         print("error: %s %s %s" % (self.name, str(reqId), str(exc[1])))
         excStr = traceback.format_exception(*exc)
@@ -320,13 +320,13 @@ class RemoteEventHandler(object):
             self.send(request='error', reqId=reqId, callSync='off', opts=dict(exception=exc[1], excString=excStr))
         except:
             self.send(request='error', reqId=reqId, callSync='off', opts=dict(exception=None, excString=excStr))
-    
+
     def send(self, request, opts=None, reqId=None, callSync='sync', timeout=10, returnType=None, byteData=None, **kwds):
         """Send a request or return packet to the remote process.
         Generally it is not necessary to call this method directly; it is for internal use.
         (The docstring has information that is nevertheless useful to the programmer
         as it describes the internal protocol used to communicate between processes)
-        
+
         ==============  ====================================================================
         **Arguments:**
         request         String describing the type of request being sent (see below)
@@ -344,21 +344,21 @@ class RemoteEventHandler(object):
                         to the remote process.
                         This is used to send large arrays without the cost of pickling.
         ==============  ====================================================================
-        
+
         Description of request strings and options allowed for each:
-        
+
         =============  =============  ========================================================
         request        option         description
         -------------  -------------  --------------------------------------------------------
         getObjAttr                    Request the remote process return (proxy to) an
                                       attribute of an object.
-                       obj            reference to object whose attribute should be 
+                       obj            reference to object whose attribute should be
                                       returned
                        attr           string name of attribute to return
                        returnValue    bool or 'auto' indicating whether to return a proxy or
-                                      the actual value. 
-                       
-        callObj                       Request the remote process call a function or 
+                                      the actual value.
+
+        callObj                       Request the remote process call a function or
                                       method. If a request ID is given, then the call's
                                       return value will be sent back (or information
                                       about the error that occurred while running the
@@ -367,53 +367,53 @@ class RemoteEventHandler(object):
                        args           tuple of arguments to pass to callable
                        kwds           dict of keyword arguments to pass to callable
                        returnValue    bool or 'auto' indicating whether to return a proxy or
-                                      the actual value. 
-                       
+                                      the actual value.
+
         getObjValue                   Request the remote process return the value of
                                       a proxied object (must be picklable)
                        obj            reference to object whose value should be returned
-                       
+
         transfer                      Copy an object to the remote process and request
                                       it return a proxy for the new object.
                        obj            The object to transfer.
-                       
+
         import                        Request the remote process import new symbols
                                       and return proxy(ies) to the imported objects
                        module         the string name of the module to import
                        fromlist       optional list of string names to import from module
-                       
-        del                           Inform the remote process that a proxy has been 
-                                      released (thus the remote process may be able to 
+
+        del                           Inform the remote process that a proxy has been
+                                      released (thus the remote process may be able to
                                       release the original object)
-                       proxyId        id of proxy which is no longer referenced by 
+                       proxyId        id of proxy which is no longer referenced by
                                       remote host
-                                      
+
         close                         Instruct the remote process to stop its event loop
-                                      and exit. Optionally, this request may return a 
+                                      and exit. Optionally, this request may return a
                                       confirmation.
-            
-        result                        Inform the remote process that its request has 
-                                      been processed                        
+
+        result                        Inform the remote process that its request has
+                                      been processed
                        result         return value of a request
-                       
+
         error                         Inform the remote process that its request failed
-                       exception      the Exception that was raised (or None if the 
+                       exception      the Exception that was raised (or None if the
                                       exception could not be pickled)
-                       excString      string-formatted version of the exception and 
+                       excString      string-formatted version of the exception and
                                       traceback
         =============  =====================================================================
         """
         if self.exited:
             self.debugMsg('  send: exited already; raise ClosedError.')
             raise ClosedError()
-        
+
         with self.sendLock:
             #if len(kwds) > 0:
                 #print "Warning: send() ignored args:", kwds
-                
+
             if opts is None:
                 opts = {}
-            
+
             assert callSync in ['off', 'sync', 'async'], 'callSync must be one of "off", "sync", or "async"'
             if reqId is None:
                 if callSync != 'off': ## requested return value; use the next available request ID
@@ -422,12 +422,12 @@ class RemoteEventHandler(object):
             else:
                 ## If requestId is provided, this _must_ be a response to a previously received request.
                 assert request in ['result', 'error']
-            
+
             if returnType is not None:
                 opts['returnType'] = returnType
-                
+
             #print os.getpid(), "send request:", request, reqId, opts
-            
+
             ## double-pickle args to ensure that at least status and request ID get through
             try:
                 optStr = pickle.dumps(opts)
@@ -436,62 +436,62 @@ class RemoteEventHandler(object):
                 print(opts)
                 print("=======================================")
                 raise
-            
+
             nByteMsgs = 0
             if byteData is not None:
                 nByteMsgs = len(byteData)
-                
+
             ## Send primary request
             request = (request, reqId, nByteMsgs, optStr)
             self.debugMsg('send request: cmd=%s nByteMsgs=%d id=%s opts=%s' % (str(request[0]), nByteMsgs, str(reqId), str(opts)))
             self.conn.send(request)
-            
+
             ## follow up by sending byte messages
             if byteData is not None:
                 for obj in byteData:  ## Remote process _must_ be prepared to read the same number of byte messages!
                     self.conn.send_bytes(obj)
                 self.debugMsg('  sent %d byte messages' % len(byteData))
-            
+
             self.debugMsg('  call sync: %s' % callSync)
             if callSync == 'off':
                 return
-            
+
         req = Request(self, reqId, description=str(request), timeout=timeout)
         if callSync == 'async':
             return req
-            
+
         if callSync == 'sync':
             try:
                 return req.result()
             except NoResultError:
                 return req
-        
+
     def close(self, callSync='off', noCleanup=False, **kwds):
         try:
             self.send(request='close', opts=dict(noCleanup=noCleanup), callSync=callSync, **kwds)
             self.exited = True
         except ClosedError:
             pass
-    
+
     def getResult(self, reqId):
         ## raises NoResultError if the result is not available yet
         #print self.results.keys(), os.getpid()
         with self.resultLock:
             haveResult = reqId in self.results
-        
+
         if not haveResult:
             try:
                 self.processRequests()
-            except ClosedError:  ## even if remote connection has closed, we may have 
+            except ClosedError:  ## even if remote connection has closed, we may have
                                  ## received new data during this call to processRequests()
                 pass
-        
+
         with self.resultLock:
             if reqId not in self.results:
                 raise NoResultError()
             status, result = self.results.pop(reqId)
-        
-        if status == 'result': 
+
+        if status == 'result':
             return result
         elif status == 'error':
             #print ''.join(result)
@@ -504,50 +504,50 @@ class RemoteEventHandler(object):
             else:
                 print(''.join(excStr))
                 raise Exception("Error getting result. See above for exception from remote process.")
-                
+
         else:
             raise Exception("Internal error.")
-    
+
     def _import(self, mod, **kwds):
         """
         Request the remote process import a module (or symbols from a module)
-        and return the proxied results. Uses built-in __import__() function, but 
+        and return the proxied results. Uses built-in __import__() function, but
         adds a bit more processing:
-        
+
             _import('module')  =>  returns module
-            _import('module.submodule')  =>  returns submodule 
+            _import('module.submodule')  =>  returns submodule
                                              (note this differs from behavior of __import__)
             _import('module', fromlist=[name1, name2, ...])  =>  returns [module.name1, module.name2, ...]
                                              (this also differs from behavior of __import__)
-            
+
         """
         return self.send(request='import', callSync='sync', opts=dict(module=mod), **kwds)
-        
+
     def getObjAttr(self, obj, attr, **kwds):
         return self.send(request='getObjAttr', opts=dict(obj=obj, attr=attr), **kwds)
-        
+
     def getObjValue(self, obj, **kwds):
         return self.send(request='getObjValue', opts=dict(obj=obj), **kwds)
-        
+
     def callObj(self, obj, args, kwds, **opts):
         opts = opts.copy()
         args = list(args)
-        
+
         ## Decide whether to send arguments by value or by proxy
         with self.optsLock:
             noProxyTypes = opts.pop('noProxyTypes', None)
             if noProxyTypes is None:
                 noProxyTypes = self.proxyOptions['noProxyTypes']
-                
+
             autoProxy = opts.pop('autoProxy', self.proxyOptions['autoProxy'])
-        
+
         if autoProxy is True:
             args = [self.autoProxy(v, noProxyTypes) for v in args]
             for k, v in kwds.iteritems():
                 opts[k] = self.autoProxy(v, noProxyTypes)
-        
+
         byteMsgs = []
-        
+
         ## If there are arrays in the arguments, send those as byte messages.
         ## We do this because pickling arrays is too expensive.
         for i,arg in enumerate(args):
@@ -558,18 +558,18 @@ class RemoteEventHandler(object):
             if v.__class__ == np.ndarray:
                 kwds[k] = ("__byte_message__", len(byteMsgs), (v.dtype, v.shape))
                 byteMsgs.append(v)
-        
+
         return self.send(request='callObj', opts=dict(obj=obj, args=args, kwds=kwds), byteData=byteMsgs, **opts)
 
     def registerProxy(self, proxy):
         with self.proxyLock:
             ref = weakref.ref(proxy, self.deleteProxy)
             self.proxies[ref] = proxy._proxyId
-    
+
     def deleteProxy(self, ref):
         with self.proxyLock:
             proxyId = self.proxies.pop(ref)
-            
+
         try:
             self.send(request='del', opts=dict(proxyId=proxyId), callSync='off')
         except IOError:  ## if remote process has closed down, there is no need to send delete requests anymore
@@ -577,23 +577,23 @@ class RemoteEventHandler(object):
 
     def transfer(self, obj, **kwds):
         """
-        Transfer an object by value to the remote host (the object must be picklable) 
+        Transfer an object by value to the remote host (the object must be picklable)
         and return a proxy for the new remote object.
         """
         if obj.__class__ is np.ndarray:
             opts = {'dtype': obj.dtype, 'shape': obj.shape}
-            return self.send(request='transferArray', opts=opts, byteData=[obj], **kwds)            
+            return self.send(request='transferArray', opts=opts, byteData=[obj], **kwds)
         else:
             return self.send(request='transfer', opts=dict(obj=obj), **kwds)
-        
+
     def autoProxy(self, obj, noProxyTypes):
         ## Return object wrapped in LocalObjectProxy _unless_ its type is in noProxyTypes.
         for typ in noProxyTypes:
             if isinstance(obj, typ):
                 return obj
         return LocalObjectProxy(obj)
-        
-        
+
+
 class Request(object):
     """
     Request objects are returned when calling an ObjectProxy in asynchronous mode
@@ -608,24 +608,24 @@ class Request(object):
         self.gotResult = False
         self._result = None
         self.timeout = timeout
-        
+
     def result(self, block=True, timeout=None):
         """
-        Return the result for this request. 
-        
+        Return the result for this request.
+
         If block is True, wait until the result has arrived or *timeout* seconds passes.
         If the timeout is reached, raise NoResultError. (use timeout=None to disable)
         If block is False, raise NoResultError immediately if the result has not arrived yet.
-        
+
         If the process's connection has closed before the result arrives, raise ClosedError.
         """
-        
+
         if self.gotResult:
             return self._result
-            
+
         if timeout is None:
-            timeout = self.timeout 
-        
+            timeout = self.timeout
+
         if block:
             start = time.time()
             while not self.hasResult():
@@ -642,55 +642,55 @@ class Request(object):
             self._result = self.proc.getResult(self.reqId)  ## raises NoResultError if result is not available yet
             self.gotResult = True
             return self._result
-        
+
     def hasResult(self):
         """Returns True if the result for this request has arrived."""
         try:
             self.result(block=False)
         except NoResultError:
             pass
-        
+
         return self.gotResult
 
 class LocalObjectProxy(object):
     """
     Used for wrapping local objects to ensure that they are send by proxy to a remote host.
     Note that 'proxy' is just a shorter alias for LocalObjectProxy.
-    
+
     For example::
-    
+
         data = [1,2,3,4,5]
         remotePlot.plot(data)         ## by default, lists are pickled and sent by value
         remotePlot.plot(proxy(data))  ## force the object to be sent by proxy
-    
+
     """
     nextProxyId = 0
     proxiedObjects = {}  ## maps {proxyId: object}
-    
-    
+
+
     @classmethod
     def registerObject(cls, obj):
         ## assign it a unique ID so we can keep a reference to the local object
-        
+
         pid = cls.nextProxyId
         cls.nextProxyId += 1
         cls.proxiedObjects[pid] = obj
         #print "register:", cls.proxiedObjects
         return pid
-    
+
     @classmethod
     def lookupProxyId(cls, pid):
         return cls.proxiedObjects[pid]
-    
+
     @classmethod
     def releaseProxyId(cls, pid):
         del cls.proxiedObjects[pid]
-        #print "release:", cls.proxiedObjects 
-    
+        #print "release:", cls.proxiedObjects
+
     def __init__(self, obj, **opts):
         """
         Create a 'local' proxy object that, when sent to a remote host,
-        will appear as a normal ObjectProxy to *obj*. 
+        will appear as a normal ObjectProxy to *obj*.
         Any extra keyword arguments are passed to proxy._setProxyOptions()
         on the remote side.
         """
@@ -700,14 +700,14 @@ class LocalObjectProxy(object):
         #self.handler = handler
         self.obj = obj
         self.opts = opts
-        
+
     def __reduce__(self):
         ## a proxy is being pickled and sent to a remote process.
         ## every time this happens, a new proxy will be generated in the remote process,
         ## so we keep a new ID so we can track when each is released.
         pid = LocalObjectProxy.registerObject(self.obj)
         return (unpickleObjectProxy, (self.processId, pid, self.typeStr, None, self.opts))
-        
+
 ## alias
 proxy = LocalObjectProxy
 
@@ -723,52 +723,52 @@ def unpickleObjectProxy(processId, proxyId, typeStr, attributes=None, opts=None)
         if opts is not None:
             proxy._setProxyOptions(**opts)
         return proxy
-    
+
 class ObjectProxy(object):
     """
     Proxy to an object stored by the remote process. Proxies are created
     by calling Process._import(), Process.transfer(), or by requesting/calling
     attributes on existing proxy objects.
-    
+
     For the most part, this object can be used exactly as if it
     were a local object::
-    
+
         rsys = proc._import('sys')   # returns proxy to sys module on remote process
         rsys.stdout                  # proxy to remote sys.stdout
         rsys.stdout.write            # proxy to remote sys.stdout.write
         rsys.stdout.write('hello')   # calls sys.stdout.write('hello') on remote machine
                                      # and returns the result (None)
-    
+
     When calling a proxy to a remote function, the call can be made synchronous
     (result of call is returned immediately), asynchronous (result is returned later),
     or return can be disabled entirely::
-    
+
         ros = proc._import('os')
-        
+
         ## synchronous call; result is returned immediately
         pid = ros.getpid()
-        
+
         ## asynchronous call
         request = ros.getpid(_callSync='async')
         while not request.hasResult():
             time.sleep(0.01)
         pid = request.result()
-        
+
         ## disable return when we know it isn't needed
         rsys.stdout.write('hello', _callSync='off')
-    
+
     Additionally, values returned from a remote function call are automatically
-    returned either by value (must be picklable) or by proxy. 
+    returned either by value (must be picklable) or by proxy.
     This behavior can be forced::
-    
+
         rnp = proc._import('numpy')
         arrProxy = rnp.array([1,2,3,4], _returnType='proxy')
         arrValue = rnp.array([1,2,3,4], _returnType='value')
-    
-    The default callSync and returnType behaviors (as well as others) can be set 
-    for each proxy individually using ObjectProxy._setProxyOptions() or globally using 
-    proc.setProxyOptions(). 
-    
+
+    The default callSync and returnType behaviors (as well as others) can be set
+    for each proxy individually using ObjectProxy._setProxyOptions() or globally using
+    proc.setProxyOptions().
+
     """
     def __init__(self, processId, proxyId, typeStr='', parent=None):
         object.__init__(self)
@@ -777,60 +777,60 @@ class ObjectProxy(object):
         self.__dict__['_typeStr'] = typeStr
         self.__dict__['_proxyId'] = proxyId
         self.__dict__['_attributes'] = ()
-        ## attributes that affect the behavior of the proxy. 
+        ## attributes that affect the behavior of the proxy.
         ## in all cases, a value of None causes the proxy to ask
         ## its parent event handler to make the decision
         self.__dict__['_proxyOptions'] = {
-            'callSync': None,      ## 'sync', 'async', None 
+            'callSync': None,      ## 'sync', 'async', None
             'timeout': None,       ## float, None
             'returnType': None,    ## 'proxy', 'value', 'auto', None
             'deferGetattr': None,  ## True, False, None
             'noProxyTypes': None,  ## list of types to send by value instead of by proxy
         }
-        
+
         self.__dict__['_handler'] = RemoteEventHandler.getHandler(processId)
         self.__dict__['_handler'].registerProxy(self)  ## handler will watch proxy; inform remote process when the proxy is deleted.
-    
+
     def _setProxyOptions(self, **kwds):
         """
         Change the behavior of this proxy. For all options, a value of None
         will cause the proxy to instead use the default behavior defined
         by its parent Process.
-        
+
         Options are:
-        
+
         =============  =============================================================
-        callSync       'sync', 'async', 'off', or None. 
+        callSync       'sync', 'async', 'off', or None.
                        If 'async', then calling methods will return a Request object
-                       which can be used to inquire later about the result of the 
+                       which can be used to inquire later about the result of the
                        method call.
                        If 'sync', then calling a method
                        will block until the remote process has returned its result
                        or the timeout has elapsed (in this case, a Request object
                        is returned instead).
-                       If 'off', then the remote process is instructed _not_ to 
+                       If 'off', then the remote process is instructed _not_ to
                        reply and the method call will return None immediately.
-        returnType     'auto', 'proxy', 'value', or None. 
+        returnType     'auto', 'proxy', 'value', or None.
                        If 'proxy', then the value returned when calling a method
                        will be a proxy to the object on the remote process.
                        If 'value', then attempt to pickle the returned object and
                        send it back.
                        If 'auto', then the decision is made by consulting the
                        'noProxyTypes' option.
-        autoProxy      bool or None. If True, arguments to __call__ are 
-                       automatically converted to proxy unless their type is 
+        autoProxy      bool or None. If True, arguments to __call__ are
+                       automatically converted to proxy unless their type is
                        listed in noProxyTypes (see below). If False, arguments
                        are left untouched. Use proxy(obj) to manually convert
-                       arguments before sending. 
-        timeout        float or None. Length of time to wait during synchronous 
+                       arguments before sending.
+        timeout        float or None. Length of time to wait during synchronous
                        requests before returning a Request object instead.
-        deferGetattr   True, False, or None. 
-                       If False, all attribute requests will be sent to the remote 
+        deferGetattr   True, False, or None.
+                       If False, all attribute requests will be sent to the remote
                        process immediately and will block until a response is
                        received (or timeout has elapsed).
                        If True, requesting an attribute from the proxy returns a
                        new proxy immediately. The remote process is _not_ contacted
-                       to make this request. This is faster, but it is possible to 
+                       to make this request. This is faster, but it is possible to
                        request an attribute that does not exist on the proxied
                        object. In this case, AttributeError will not be raised
                        until an attempt is made to look up the attribute on the
@@ -840,37 +840,37 @@ class ObjectProxy(object):
         =============  =============================================================
         """
         self._proxyOptions.update(kwds)
-    
+
     def _getValue(self):
         """
         Return the value of the proxied object
         (the remote object must be picklable)
         """
         return self._handler.getObjValue(self)
-        
+
     def _getProxyOption(self, opt):
         val = self._proxyOptions[opt]
         if val is None:
             return self._handler.getProxyOption(opt)
         return val
-    
+
     def _getProxyOptions(self):
         return dict([(k, self._getProxyOption(k)) for k in self._proxyOptions])
-    
+
     def __reduce__(self):
         return (unpickleObjectProxy, (self._processId, self._proxyId, self._typeStr, self._attributes))
-    
+
     def __repr__(self):
         #objRepr = self.__getattr__('__repr__')(callSync='value')
         return "<ObjectProxy for process %d, object 0x%x: %s >" % (self._processId, self._proxyId, self._typeStr)
-        
-        
+
+
     def __getattr__(self, attr, **kwds):
         """
         Calls __getattr__ on the remote object and returns the attribute
         by value or by proxy depending on the options set (see
         ObjectProxy._setProxyOptions and RemoteEventHandler.setProxyOptions)
-        
+
         If the option 'deferGetattr' is True for this proxy, then a new proxy object
         is returned _without_ asking the remote object whether the named attribute exists.
         This can save time when making multiple chained attribute requests,
@@ -886,216 +886,216 @@ class ObjectProxy(object):
         else:
             #opts = self._getProxyOptions()
             return self._handler.getObjAttr(self, attr, **opts)
-    
+
     def _deferredAttr(self, attr):
         return DeferredObjectProxy(self, attr)
-    
+
     def __call__(self, *args, **kwds):
         """
         Attempts to call the proxied object from the remote process.
         Accepts extra keyword arguments:
-        
+
             _callSync    'off', 'sync', or 'async'
             _returnType   'value', 'proxy', or 'auto'
-        
+
         If the remote call raises an exception on the remote process,
         it will be re-raised on the local process.
-        
+
         """
         opts = self._getProxyOptions()
         for k in opts:
             if '_'+k in kwds:
                 opts[k] = kwds.pop('_'+k)
         return self._handler.callObj(obj=self, args=args, kwds=kwds, **opts)
-    
-    
+
+
     ## Explicitly proxy special methods. Is there a better way to do this??
-    
+
     def _getSpecialAttr(self, attr):
         ## this just gives us an easy way to change the behavior of the special methods
         return self._deferredAttr(attr)
-    
+
     def __getitem__(self, *args):
         return self._getSpecialAttr('__getitem__')(*args)
-    
+
     def __setitem__(self, *args):
         return self._getSpecialAttr('__setitem__')(*args, _callSync='off')
-        
+
     def __setattr__(self, *args):
         return self._getSpecialAttr('__setattr__')(*args, _callSync='off')
-        
+
     def __str__(self, *args):
         return self._getSpecialAttr('__str__')(*args, _returnType='value')
-        
+
     def __len__(self, *args):
         return self._getSpecialAttr('__len__')(*args)
-    
+
     def __add__(self, *args):
         return self._getSpecialAttr('__add__')(*args)
-    
+
     def __sub__(self, *args):
         return self._getSpecialAttr('__sub__')(*args)
-        
+
     def __div__(self, *args):
         return self._getSpecialAttr('__div__')(*args)
-        
+
     def __truediv__(self, *args):
         return self._getSpecialAttr('__truediv__')(*args)
-        
+
     def __floordiv__(self, *args):
         return self._getSpecialAttr('__floordiv__')(*args)
-        
+
     def __mul__(self, *args):
         return self._getSpecialAttr('__mul__')(*args)
-        
+
     def __pow__(self, *args):
         return self._getSpecialAttr('__pow__')(*args)
-        
+
     def __iadd__(self, *args):
         return self._getSpecialAttr('__iadd__')(*args, _callSync='off')
-    
+
     def __isub__(self, *args):
         return self._getSpecialAttr('__isub__')(*args, _callSync='off')
-        
+
     def __idiv__(self, *args):
         return self._getSpecialAttr('__idiv__')(*args, _callSync='off')
-        
+
     def __itruediv__(self, *args):
         return self._getSpecialAttr('__itruediv__')(*args, _callSync='off')
-        
+
     def __ifloordiv__(self, *args):
         return self._getSpecialAttr('__ifloordiv__')(*args, _callSync='off')
-        
+
     def __imul__(self, *args):
         return self._getSpecialAttr('__imul__')(*args, _callSync='off')
-        
+
     def __ipow__(self, *args):
         return self._getSpecialAttr('__ipow__')(*args, _callSync='off')
-        
+
     def __rshift__(self, *args):
         return self._getSpecialAttr('__rshift__')(*args)
-        
+
     def __lshift__(self, *args):
         return self._getSpecialAttr('__lshift__')(*args)
-        
+
     def __irshift__(self, *args):
         return self._getSpecialAttr('__irshift__')(*args, _callSync='off')
-        
+
     def __ilshift__(self, *args):
         return self._getSpecialAttr('__ilshift__')(*args, _callSync='off')
-        
+
     def __eq__(self, *args):
         return self._getSpecialAttr('__eq__')(*args)
-    
+
     def __ne__(self, *args):
         return self._getSpecialAttr('__ne__')(*args)
-        
+
     def __lt__(self, *args):
         return self._getSpecialAttr('__lt__')(*args)
-    
+
     def __gt__(self, *args):
         return self._getSpecialAttr('__gt__')(*args)
-        
+
     def __le__(self, *args):
         return self._getSpecialAttr('__le__')(*args)
-    
+
     def __ge__(self, *args):
         return self._getSpecialAttr('__ge__')(*args)
-        
+
     def __and__(self, *args):
         return self._getSpecialAttr('__and__')(*args)
-        
+
     def __or__(self, *args):
         return self._getSpecialAttr('__or__')(*args)
-        
+
     def __xor__(self, *args):
         return self._getSpecialAttr('__xor__')(*args)
-        
+
     def __iand__(self, *args):
         return self._getSpecialAttr('__iand__')(*args, _callSync='off')
-        
+
     def __ior__(self, *args):
         return self._getSpecialAttr('__ior__')(*args, _callSync='off')
-        
+
     def __ixor__(self, *args):
         return self._getSpecialAttr('__ixor__')(*args, _callSync='off')
-        
+
     def __mod__(self, *args):
         return self._getSpecialAttr('__mod__')(*args)
-        
+
     def __radd__(self, *args):
         return self._getSpecialAttr('__radd__')(*args)
-    
+
     def __rsub__(self, *args):
         return self._getSpecialAttr('__rsub__')(*args)
-        
+
     def __rdiv__(self, *args):
         return self._getSpecialAttr('__rdiv__')(*args)
-        
+
     def __rfloordiv__(self, *args):
         return self._getSpecialAttr('__rfloordiv__')(*args)
-        
+
     def __rtruediv__(self, *args):
         return self._getSpecialAttr('__rtruediv__')(*args)
-        
+
     def __rmul__(self, *args):
         return self._getSpecialAttr('__rmul__')(*args)
-        
+
     def __rpow__(self, *args):
         return self._getSpecialAttr('__rpow__')(*args)
-        
+
     def __rrshift__(self, *args):
         return self._getSpecialAttr('__rrshift__')(*args)
-        
+
     def __rlshift__(self, *args):
         return self._getSpecialAttr('__rlshift__')(*args)
-        
+
     def __rand__(self, *args):
         return self._getSpecialAttr('__rand__')(*args)
-        
+
     def __ror__(self, *args):
         return self._getSpecialAttr('__ror__')(*args)
-        
+
     def __rxor__(self, *args):
         return self._getSpecialAttr('__ror__')(*args)
-        
+
     def __rmod__(self, *args):
         return self._getSpecialAttr('__rmod__')(*args)
-        
+
     def __hash__(self):
         ## Required for python3 since __eq__ is defined.
         return id(self)
-        
+
 class DeferredObjectProxy(ObjectProxy):
     """
     This class represents an attribute (or sub-attribute) of a proxied object.
     It is used to speed up attribute requests. Take the following scenario::
-    
+
         rsys = proc._import('sys')
         rsys.stdout.write('hello')
-        
-    For this simple example, a total of 4 synchronous requests are made to 
-    the remote process: 
-    
+
+    For this simple example, a total of 4 synchronous requests are made to
+    the remote process:
+
     1) import sys
     2) getattr(sys, 'stdout')
     3) getattr(stdout, 'write')
     4) write('hello')
-    
+
     This takes a lot longer than running the equivalent code locally. To
     speed things up, we can 'defer' the two attribute lookups so they are
     only carried out when neccessary::
-    
+
         rsys = proc._import('sys')
         rsys._setProxyOptions(deferGetattr=True)
         rsys.stdout.write('hello')
-        
-    This example only makes two requests to the remote process; the two 
-    attribute lookups immediately return DeferredObjectProxy instances 
-    immediately without contacting the remote process. When the call 
+
+    This example only makes two requests to the remote process; the two
+    attribute lookups immediately return DeferredObjectProxy instances
+    immediately without contacting the remote process. When the call
     to write() is made, all attribute requests are processed at the same time.
-    
-    Note that if the attributes requested do not exist on the remote object, 
+
+    Note that if the attributes requested do not exist on the remote object,
     making the call to write() will raise an AttributeError.
     """
     def __init__(self, parentProxy, attribute):
@@ -1105,13 +1105,12 @@ class DeferredObjectProxy(ObjectProxy):
         self.__dict__['_parent'] = parentProxy  ## make sure parent stays alive
         self.__dict__['_attributes'] = parentProxy._attributes + (attribute,)
         self.__dict__['_proxyOptions'] = parentProxy._proxyOptions.copy()
-    
+
     def __repr__(self):
         return ObjectProxy.__repr__(self) + '.' + '.'.join(self._attributes)
-    
+
     def _undefer(self):
         """
         Return a non-deferred ObjectProxy referencing the same object
         """
         return self._parent.__getattr__(self._attributes[-1], _deferGetattr=False)
-

--- a/pyqtgraph/numpy_fix.py
+++ b/pyqtgraph/numpy_fix.py
@@ -1,6 +1,6 @@
 try:
     import numpy as np
-    
+
     ## Wrap np.concatenate to catch and avoid a segmentation fault bug
     ## (numpy trac issue #2084)
     if not hasattr(np, 'concatenate_orig'):
@@ -14,9 +14,8 @@ try:
         if any([dt != dtypes[0] for dt in dtypes[1:]]):
             raise TypeError("Cannot concatenate structured arrays of different dtype.")
         return np.concatenate_orig(vals, *args, **kwds)
-    
+
     np.concatenate = concatenate
-    
+
 except ImportError:
     pass
-

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -26,17 +26,17 @@ GLOptions = {
         GL_CULL_FACE: False,
         'glBlendFunc': (GL_SRC_ALPHA, GL_ONE),
     },
-}    
+}
 
 
 class GLGraphicsItem(QtCore.QObject):
     _nextId = 0
-    
+
     def __init__(self, parentItem=None):
         QtCore.QObject.__init__(self)
         self._id = GLGraphicsItem._nextId
         GLGraphicsItem._nextId += 1
-        
+
         self.__parent = None
         self.__view = None
         self.__children = set()
@@ -45,7 +45,7 @@ class GLGraphicsItem(QtCore.QObject):
         self.setParentItem(parentItem)
         self.setDepthValue(0)
         self.__glOpts = {}
-        
+
     def setParentItem(self, item):
         """Set this item's parent in the scenegraph hierarchy."""
         if self.__parent is not None:
@@ -53,20 +53,20 @@ class GLGraphicsItem(QtCore.QObject):
         if item is not None:
             item.__children.add(self)
         self.__parent = item
-        
+
         if self.__parent is not None and self.view() is not self.__parent.view():
             if self.view() is not None:
                 self.view().removeItem(self)
             self.__parent.view().addItem(self)
-    
+
     def setGLOptions(self, opts):
         """
         Set the OpenGL state options to use immediately before drawing this item.
         (Note that subclasses must call setupGLState before painting for this to work)
-        
+
         The simplest way to invoke this method is to pass in the name of
         a predefined set of options (see the GLOptions variable):
-        
+
         ============= ======================================================
         opaque        Enables depth testing and disables blending
         translucent   Enables depth testing and blending
@@ -75,27 +75,27 @@ class GLGraphicsItem(QtCore.QObject):
         additive      Disables depth testing, enables blending.
                       Colors are added together, so sorting is not required.
         ============= ======================================================
-        
-        It is also possible to specify any arbitrary settings as a dictionary. 
-        This may consist of {'functionName': (args...)} pairs where functionName must 
-        be a callable attribute of OpenGL.GL, or {GL_STATE_VAR: bool} pairs 
+
+        It is also possible to specify any arbitrary settings as a dictionary.
+        This may consist of {'functionName': (args...)} pairs where functionName must
+        be a callable attribute of OpenGL.GL, or {GL_STATE_VAR: bool} pairs
         which will be interpreted as calls to glEnable or glDisable(GL_STATE_VAR).
-        
+
         For example::
-            
+
             {
                 GL_ALPHA_TEST: True,
                 GL_CULL_FACE: False,
                 'glBlendFunc': (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA),
             }
-            
-        
+
+
         """
         if isinstance(opts, basestring):
             opts = GLOptions[opts]
         self.__glOpts = opts.copy()
         self.update()
-        
+
     def updateGLOptions(self, opts):
         """
         Modify the OpenGL state options to use immediately before drawing this item.
@@ -103,22 +103,22 @@ class GLGraphicsItem(QtCore.QObject):
         Values may also be None, in which case the key will be ignored.
         """
         self.__glOpts.update(opts)
-        
-    
+
+
     def parentItem(self):
         """Return a this item's parent in the scenegraph hierarchy."""
         return self.__parent
-        
+
     def childItems(self):
         """Return a list of this item's children in the scenegraph hierarchy."""
         return list(self.__children)
-        
+
     def _setView(self, v):
         self.__view = v
-        
+
     def view(self):
         return self.__view
-        
+
     def setDepthValue(self, value):
         """
         Sets the depth value of this item. Default is 0.
@@ -128,11 +128,11 @@ class GLGraphicsItem(QtCore.QObject):
         The depthValue does NOT affect the position of the item or the values it imparts to the GL depth buffer.
         """
         self.__depthValue = value
-        
+
     def depthValue(self):
         """Return the depth value of this item. See setDepthValue for more information."""
         return self.__depthValue
-        
+
     def setTransform(self, tr):
         """Set the local transform for this object.
         Must be a :class:`Transform3D <pyqtgraph.Transform3D>` instance. This transform
@@ -140,34 +140,34 @@ class GLGraphicsItem(QtCore.QObject):
         system of its parent."""
         self.__transform = Transform3D(tr)
         self.update()
-        
+
     def resetTransform(self):
         """Reset this item's transform to an identity transformation."""
         self.__transform.setToIdentity()
         self.update()
-        
+
     def applyTransform(self, tr, local):
         """
-        Multiply this object's transform by *tr*. 
+        Multiply this object's transform by *tr*.
         If local is True, then *tr* is multiplied on the right of the current transform::
-        
+
             newTransform = transform * tr
-            
+
         If local is False, then *tr* is instead multiplied on the left::
-        
+
             newTransform = tr * transform
         """
         if local:
             self.setTransform(self.transform() * tr)
         else:
             self.setTransform(tr * self.transform())
-        
+
     def transform(self):
         """Return this item's transform object."""
         return self.__transform
-        
+
     def viewTransform(self):
-        """Return the transform mapping this item's local coordinate system to the 
+        """Return the transform mapping this item's local coordinate system to the
         view coordinate system."""
         tr = self.__transform
         p = self
@@ -177,7 +177,7 @@ class GLGraphicsItem(QtCore.QObject):
                 break
             tr = p.transform() * tr
         return Transform3D(tr)
-        
+
     def translate(self, dx, dy, dz, local=False):
         """
         Translate the object by (*dx*, *dy*, *dz*) in its parent's coordinate system.
@@ -186,17 +186,17 @@ class GLGraphicsItem(QtCore.QObject):
         tr = Transform3D()
         tr.translate(dx, dy, dz)
         self.applyTransform(tr, local=local)
-        
+
     def rotate(self, angle, x, y, z, local=False):
         """
         Rotate the object around the axis specified by (x,y,z).
         *angle* is in degrees.
-        
+
         """
         tr = Transform3D()
         tr.rotate(angle, x, y, z)
         self.applyTransform(tr, local=local)
-    
+
     def scale(self, x, y, z, local=True):
         """
         Scale the object by (*dx*, *dy*, *dz*) in its local coordinate system.
@@ -205,41 +205,41 @@ class GLGraphicsItem(QtCore.QObject):
         tr = Transform3D()
         tr.scale(x, y, z)
         self.applyTransform(tr, local=local)
-    
-    
+
+
     def hide(self):
-        """Hide this item. 
+        """Hide this item.
         This is equivalent to setVisible(False)."""
         self.setVisible(False)
-        
+
     def show(self):
         """Make this item visible if it was previously hidden.
         This is equivalent to setVisible(True)."""
         self.setVisible(True)
-    
+
     def setVisible(self, vis):
         """Set the visibility of this item."""
         self.__visible = vis
         self.update()
-        
+
     def visible(self):
         """Return True if the item is currently set to be visible.
         Note that this does not guarantee that the item actually appears in the
         view, as it may be obscured or outside of the current view area."""
         return self.__visible
-    
-    
+
+
     def initializeGL(self):
         """
-        Called after an item is added to a GLViewWidget. 
+        Called after an item is added to a GLViewWidget.
         The widget's GL context is made current before this method is called.
         (So this would be an appropriate time to generate lists, upload textures, etc.)
         """
         pass
-    
+
     def setupGLState(self):
         """
-        This method is responsible for preparing the GL state options needed to render 
+        This method is responsible for preparing the GL state options needed to render
         this item (blending, depth testing, etc). The method is called immediately before painting the item.
         """
         for k,v in self.__glOpts.items():
@@ -253,7 +253,7 @@ class GLGraphicsItem(QtCore.QObject):
                     glEnable(k)
                 else:
                     glDisable(k)
-    
+
     def paint(self):
         """
         Called by the GLViewWidget to draw this item.
@@ -261,40 +261,37 @@ class GLGraphicsItem(QtCore.QObject):
         but the caller will take care of pushing/popping.
         """
         self.setupGLState()
-        
+
     def update(self):
         """
-        Indicates that this item needs to be redrawn, and schedules an update 
+        Indicates that this item needs to be redrawn, and schedules an update
         with the view it is displayed in.
         """
         v = self.view()
         if v is None:
             return
         v.update()
-        
+
     def mapToParent(self, point):
         tr = self.transform()
         if tr is None:
             return point
         return tr.map(point)
-        
+
     def mapFromParent(self, point):
         tr = self.transform()
         if tr is None:
             return point
         return tr.inverted()[0].map(point)
-        
+
     def mapToView(self, point):
         tr = self.viewTransform()
         if tr is None:
             return point
         return tr.map(point)
-        
+
     def mapFromView(self, point):
         tr = self.viewTransform()
         if tr is None:
             return point
         return tr.inverted()[0].map(point)
-        
-        
-        

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -17,24 +17,24 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         - Export options
 
     """
-    
+
     def __init__(self, parent=None):
         global ShareWidget
 
         if ShareWidget is None:
             ## create a dummy widget to allow sharing objects (textures, shaders, etc) between views
             ShareWidget = QtOpenGL.QGLWidget()
-            
+
         QtOpenGL.QGLWidget.__init__(self, parent, ShareWidget)
-        
+
         self.setFocusPolicy(QtCore.Qt.ClickFocus)
-        
+
         self.opts = {
             'center': Vector(0,0,0),  ## will always appear at the center of the widget
             'distance': 10.0,         ## distance of camera from center
             'fov':  60,               ## horizontal field of view in degrees
             'elevation':  30,         ## camera's angle of elevation in degrees
-            'azimuth': 45,            ## camera's azimuthal angle in degrees 
+            'azimuth': 45,            ## camera's azimuthal angle in degrees
                                       ## (rotation around z-axis 0 points along x-axis)
             'viewport': None,         ## glViewport params; None == whole widget
         }
@@ -44,7 +44,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         self.keysPressed = {}
         self.keyTimer = QtCore.QTimer()
         self.keyTimer.timeout.connect(self.evalKeyState)
-        
+
         self.makeCurrent()
 
     def addItem(self, item):
@@ -55,20 +55,20 @@ class GLViewWidget(QtOpenGL.QGLWidget):
                 item.initializeGL()
             except:
                 self.checkOpenGLVersion('Error while adding item %s to GLViewWidget.' % str(item))
-                
+
         item._setView(self)
         #print "set view", item, self, item.view()
         self.update()
-        
+
     def removeItem(self, item):
         self.items.remove(item)
         item._setView(None)
         self.update()
-        
-        
+
+
     def initializeGL(self):
         self.resizeGL(self.width(), self.height())
-        
+
     def setBackgroundColor(self, *args, **kwds):
         """
         Set the background color of the widget. Accepts the same arguments as
@@ -76,14 +76,14 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         """
         self.opts['bgcolor'] = fn.glColor(*args, **kwds)
         self.update()
-        
+
     def getViewport(self):
         vp = self.opts['viewport']
         if vp is None:
             return (0, 0, self.width(), self.height())
         else:
             return vp
-        
+
     def resizeGL(self, w, h):
         pass
         #glViewport(*self.getViewport())
@@ -100,7 +100,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         # Xw = (Xnd + 1) * width/2 + X
         if region is None:
             region = (0, 0, self.width(), self.height())
-        
+
         x0, y0, w, h = self.getViewport()
         dist = self.opts['distance']
         fov = self.opts['fov']
@@ -121,14 +121,14 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         tr = QtGui.QMatrix4x4()
         tr.frustum(left, right, bottom, top, nearClip, farClip)
         return tr
-        
+
     def setModelview(self):
         glMatrixMode(GL_MODELVIEW)
         glLoadIdentity()
         m = self.viewMatrix()
         a = np.array(m.copyDataTo()).reshape((4,4))
         glMultMatrixf(a.transpose())
-        
+
     def viewMatrix(self):
         tr = QtGui.QMatrix4x4()
         tr.translate( 0.0, 0.0, -self.opts['distance'])
@@ -141,10 +141,10 @@ class GLViewWidget(QtOpenGL.QGLWidget):
     def itemsAt(self, region=None):
         """
         Return a list of the items displayed in the region (x, y, w, h)
-        relative to the widget.        
+        relative to the widget.
         """
         region = (region[0], self.height()-(region[1]+region[3]), region[2], region[3])
-        
+
         #buf = np.zeros(100000, dtype=np.uint)
         buf = glSelectBuffer(100000)
         try:
@@ -153,14 +153,14 @@ class GLViewWidget(QtOpenGL.QGLWidget):
             glPushName(0)
             self._itemNames = {}
             self.paintGL(region=region, useItemNames=True)
-            
+
         finally:
             hits = glRenderMode(GL_RENDER)
-            
+
         items = [(h.near, h.names[0]) for h in hits]
         items.sort(key=lambda i: i[0])
         return [self._itemNames[i[1]] for i in items]
-    
+
     def paintGL(self, region=None, viewport=None, useItemNames=False):
         """
         viewport specifies the arguments to glViewport. If None, then we use self.opts['viewport']
@@ -177,7 +177,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         glClearColor(*bgcolor)
         glClear( GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT )
         self.drawItemTree(useItemNames=useItemNames)
-        
+
     def drawItemTree(self, item=None, useItemNames=False):
         if item is None:
             items = [x for x in self.items if x.parentItem() is None]
@@ -206,7 +206,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
                             print(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)
                         else:
                             print(msg)
-                    
+
                 finally:
                     glPopAttrib()
             else:
@@ -220,7 +220,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
                 finally:
                     glMatrixMode(GL_MODELVIEW)
                     glPopMatrix()
-            
+
     def setCameraPosition(self, pos=None, distance=None, elevation=None, azimuth=None):
         if distance is not None:
             self.opts['distance'] = distance
@@ -229,22 +229,22 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         if azimuth is not None:
             self.opts['azimuth'] = azimuth
         self.update()
-        
-        
-        
+
+
+
     def cameraPosition(self):
         """Return current position of camera based on center, dist, elevation, and azimuth"""
         center = self.opts['center']
         dist = self.opts['distance']
         elev = self.opts['elevation'] * np.pi/180.
         azim = self.opts['azimuth'] * np.pi/180.
-        
+
         pos = Vector(
             center.x() + dist * np.cos(elev) * np.cos(azim),
             center.y() + dist * np.cos(elev) * np.sin(azim),
             center.z() + dist * np.sin(elev)
         )
-        
+
         return pos
 
     def orbit(self, azim, elev):
@@ -253,17 +253,17 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         #self.opts['elevation'] += elev
         self.opts['elevation'] = np.clip(self.opts['elevation'] + elev, -90, 90)
         self.update()
-        
+
     def pan(self, dx, dy, dz, relative=False):
         """
-        Moves the center (look-at) position while holding the camera in place. 
-        
+        Moves the center (look-at) position while holding the camera in place.
+
         If relative=True, then the coordinates are interpreted such that x
         if in the global xy plane and points to the right side of the view, y is
         in the global xy plane and orthogonal to x, and z points in the global z
         direction. Distances are scaled roughly such that a value of 1.0 moves
         by one pixel on screen.
-        
+
         """
         if not relative:
             self.opts['center'] += QtGui.QVector3D(dx, dy, dz)
@@ -278,7 +278,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
             yVec = QtGui.QVector3D.crossProduct(xVec, zVec).normalized()
             self.opts['center'] = self.opts['center'] + xVec * xScale * dx + yVec * xScale * dy + zVec * xScale * dz
         self.update()
-        
+
     def pixelSize(self, pos):
         """
         Return the approximate size of a screen pixel at the location pos
@@ -292,14 +292,14 @@ class GLViewWidget(QtOpenGL.QGLWidget):
             dist = (pos-cam).length()
         xDist = dist * 2. * np.tan(0.5 * self.opts['fov'] * np.pi / 180.)
         return xDist / self.width()
-        
+
     def mousePressEvent(self, ev):
         self.mousePos = ev.pos()
-        
+
     def mouseMoveEvent(self, ev):
         diff = ev.pos() - self.mousePos
         self.mousePos = ev.pos()
-        
+
         if ev.buttons() == QtCore.Qt.LeftButton:
             self.orbit(-diff.x(), diff.y())
             #print self.opts['azimuth'], self.opts['elevation']
@@ -308,21 +308,21 @@ class GLViewWidget(QtOpenGL.QGLWidget):
                 self.pan(diff.x(), 0, diff.y(), relative=True)
             else:
                 self.pan(diff.x(), diff.y(), 0, relative=True)
-        
+
     def mouseReleaseEvent(self, ev):
         pass
         # Example item selection code:
         #region = (ev.pos().x()-5, ev.pos().y()-5, 10, 10)
         #print(self.itemsAt(region))
-        
+
         ## debugging code: draw the picking region
         #glViewport(*self.getViewport())
         #glClear( GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT )
         #region = (region[0], self.height()-(region[1]+region[3]), region[2], region[3])
         #self.paintGL(region=region)
         #self.swapBuffers()
-        
-        
+
+
     def wheelEvent(self, ev):
         delta = 0
         if not USE_PYQT5:
@@ -344,7 +344,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
                 return
             self.keysPressed[ev.key()] = 1
             self.evalKeyState()
-      
+
     def keyReleaseEvent(self, ev):
         if ev.key() in self.noRepeatKeys:
             ev.accept()
@@ -355,7 +355,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
             except:
                 self.keysPressed = {}
             self.evalKeyState()
-        
+
     def evalKeyState(self):
         speed = 2.0
         if len(self.keysPressed) > 0:
@@ -385,9 +385,9 @@ class GLViewWidget(QtOpenGL.QGLWidget):
             raise Exception(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)
         else:
             raise
-            
 
-            
+
+
     def readQImage(self):
         """
         Read the current buffer pixels out as a QImage.
@@ -399,22 +399,22 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         pixels[:] = 128
         pixels[...,0] = 50
         pixels[...,3] = 255
-        
+
         glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels)
-        
+
         # swap B,R channels for Qt
         tmp = pixels[...,0].copy()
         pixels[...,0] = pixels[...,2]
         pixels[...,2] = tmp
         pixels = pixels[::-1] # flip vertical
-        
+
         img = fn.makeQImage(pixels, transpose=False)
         return img
-        
-        
+
+
     def renderToArray(self, size, format=GL_BGRA, type=GL_UNSIGNED_BYTE, textureSize=1024, padding=256):
         w,h = map(int, size)
-        
+
         self.makeCurrent()
         tex = None
         fb = None
@@ -422,21 +422,21 @@ class GLViewWidget(QtOpenGL.QGLWidget):
             output = np.empty((w, h, 4), dtype=np.ubyte)
             fb = glfbo.glGenFramebuffers(1)
             glfbo.glBindFramebuffer(glfbo.GL_FRAMEBUFFER, fb )
-            
+
             glEnable(GL_TEXTURE_2D)
             tex = glGenTextures(1)
             glBindTexture(GL_TEXTURE_2D, tex)
             texwidth = textureSize
             data = np.zeros((texwidth,texwidth,4), dtype=np.ubyte)
-            
+
             ## Test texture dimensions first
             glTexImage2D(GL_PROXY_TEXTURE_2D, 0, GL_RGBA, texwidth, texwidth, 0, GL_RGBA, GL_UNSIGNED_BYTE, None)
             if glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_WIDTH) == 0:
                 raise Exception("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % shape[:2])
             ## create teture
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texwidth, texwidth, 0, GL_RGBA, GL_UNSIGNED_BYTE, data.transpose((1,0,2)))
-            
-            self.opts['viewport'] = (0, 0, w, h)  # viewport is the complete image; this ensures that paintGL(region=...) 
+
+            self.opts['viewport'] = (0, 0, w, h)  # viewport is the complete image; this ensures that paintGL(region=...)
                                                   # is interpreted correctly.
             p2 = 2 * padding
             for x in range(-padding, w-padding, texwidth-p2):
@@ -445,17 +445,17 @@ class GLViewWidget(QtOpenGL.QGLWidget):
                     y2 = min(y+texwidth, h+padding)
                     w2 = x2-x
                     h2 = y2-y
-                    
+
                     ## render to texture
                     glfbo.glFramebufferTexture2D(glfbo.GL_FRAMEBUFFER, glfbo.GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex, 0)
-                    
+
                     self.paintGL(region=(x, h-y-h2, w2, h2), viewport=(0, 0, w2, h2))  # only render sub-region
-                    
+
                     ## read texture back to array
                     data = glGetTexImage(GL_TEXTURE_2D, 0, format, type)
                     data = np.fromstring(data, dtype=np.ubyte).reshape(texwidth,texwidth,4).transpose(1,0,2)[:, ::-1]
                     output[x+padding:x2-padding, y+padding:y2-padding] = data[padding:w2-padding, -(h2-padding):-padding]
-                    
+
         finally:
             self.opts['viewport'] = None
             glfbo.glBindFramebuffer(glfbo.GL_FRAMEBUFFER, 0)
@@ -464,8 +464,5 @@ class GLViewWidget(QtOpenGL.QGLWidget):
                 glDeleteTextures([tex])
             if fb is not None:
                 glfbo.glDeleteFramebuffers([fb])
-            
+
         return output
-        
-        
-        

--- a/pyqtgraph/opengl/MeshData.py
+++ b/pyqtgraph/opengl/MeshData.py
@@ -7,18 +7,18 @@ from ..python2_3 import xrange
 class MeshData(object):
     """
     Class for storing and operating on 3D mesh data. May contain:
-    
+
     - list of vertex locations
     - list of edges
     - list of triangles
     - colors per vertex, edge, or tri
     - normals per vertex or tri
-    
+
     This class handles conversion between the standard [list of vertexes, list of faces]
     format (suitable for use with glDrawElements) and 'indexed' [list of vertexes] format
     (suitable for use with glDrawArrays). It will automatically compute face normal
-    vectors as well as averaged vertex normal vectors. 
-    
+    vectors as well as averaged vertex normal vectors.
+
     The class attempts to be as efficient as possible in caching conversion results and
     avoiding unnecessary conversions.
     """
@@ -37,40 +37,40 @@ class MeshData(object):
                         interpreted as (Nf, 3, 4) array of colors.
         faceColors      (Nf, 4) array of face colors.
         ==============  =====================================================
-        
+
         All arguments are optional.
         """
         self._vertexes = None  # (Nv,3) array of vertex coordinates
         self._vertexesIndexedByFaces = None   #  (Nf, 3, 3) array of vertex coordinates
         self._vertexesIndexedByEdges = None   #  (Ne, 2, 3) array of vertex coordinates
-        
+
         ## mappings between vertexes, faces, and edges
         self._faces = None   # Nx3 array of indexes into self._vertexes specifying three vertexes for each face
         self._edges = None   # Nx2 array of indexes into self._vertexes specifying two vertexes per edge
         self._vertexFaces = None  ## maps vertex ID to a list of face IDs (inverse mapping of _faces)
         self._vertexEdges = None  ## maps vertex ID to a list of edge IDs (inverse mapping of _edges)
-        
+
         ## Per-vertex data
         self._vertexNormals = None                # (Nv, 3) array of normals, one per vertex
         self._vertexNormalsIndexedByFaces = None  # (Nf, 3, 3) array of normals
         self._vertexColors = None                 # (Nv, 3) array of colors
         self._vertexColorsIndexedByFaces = None   # (Nf, 3, 4) array of colors
         self._vertexColorsIndexedByEdges = None   # (Nf, 2, 4) array of colors
-        
+
         ## Per-face data
         self._faceNormals = None                # (Nf, 3) array of face normals
         self._faceNormalsIndexedByFaces = None  # (Nf, 3, 3) array of face normals
         self._faceColors = None                 # (Nf, 4) array of face colors
         self._faceColorsIndexedByFaces = None   # (Nf, 3, 4) array of face colors
         self._faceColorsIndexedByEdges = None   # (Ne, 2, 4) array of face colors
-        
+
         ## Per-edge data
         self._edgeColors = None                # (Ne, 4) array of edge colors
         self._edgeColorsIndexedByEdges = None  # (Ne, 2, 4) array of edge colors
         #self._meshColor = (1, 1, 1, 0.1)  # default color to use if no face/edge/vertex colors are given
-        
-        
-        
+
+
+
         if vertexes is not None:
             if faces is None:
                 self.setVertexes(vertexes, indexed='faces')
@@ -85,23 +85,23 @@ class MeshData(object):
                     self.setVertexColors(vertexColors)
                 if faceColors is not None:
                     self.setFaceColors(faceColors)
-            
+
     def faces(self):
         """Return an array (Nf, 3) of vertex indexes, three per triangular face in the mesh.
-        
+
         If faces have not been computed for this mesh, the function returns None.
         """
         return self._faces
-    
+
     def edges(self):
         """Return an array (Nf, 3) of vertex indexes, two per edge in the mesh."""
         if self._edges is None:
             self._computeEdges()
         return self._edges
-        
+
     def setFaces(self, faces):
         """Set the (Nf, 3) array of faces. Each rown in the array contains
-        three indexes into the vertex array, specifying the three corners 
+        three indexes into the vertex array, specifying the three corners
         of a triangular face."""
         self._faces = faces
         self._edges = None
@@ -110,9 +110,9 @@ class MeshData(object):
         self.resetNormals()
         self._vertexColorsIndexedByFaces = None
         self._faceColorsIndexedByFaces = None
-    
+
     def vertexes(self, indexed=None):
-        """Return an array (N,3) of the positions of vertexes in the mesh. 
+        """Return an array (N,3) of the positions of vertexes in the mesh.
         By default, each unique vertex appears only once in the array.
         If indexed is 'faces', then the array will instead contain three vertexes
         per face in the mesh (and a single vertex may appear more than once in the array)."""
@@ -126,7 +126,7 @@ class MeshData(object):
             return self._vertexesIndexedByFaces
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
-        
+
     def setVertexes(self, verts=None, indexed=None, resetNormals=True):
         """
         Set the array (Nv, 3) of vertex coordinates.
@@ -145,37 +145,37 @@ class MeshData(object):
                 self._vertexesIndexedByFaces = verts
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
-        
+
         if resetNormals:
             self.resetNormals()
-    
+
     def resetNormals(self):
         self._vertexNormals = None
         self._vertexNormalsIndexedByFaces = None
         self._faceNormals = None
         self._faceNormalsIndexedByFaces = None
-        
+
     def hasFaceIndexedData(self):
         """Return True if this object already has vertex positions indexed by face"""
         return self._vertexesIndexedByFaces is not None
-    
+
     def hasEdgeIndexedData(self):
         return self._vertexesIndexedByEdges is not None
-    
+
     def hasVertexColor(self):
         """Return True if this data set has vertex color information"""
         for v in (self._vertexColors, self._vertexColorsIndexedByFaces, self._vertexColorsIndexedByEdges):
             if v is not None:
                 return True
         return False
-        
+
     def hasFaceColor(self):
         """Return True if this data set has face color information"""
         for v in (self._faceColors, self._faceColorsIndexedByFaces, self._faceColorsIndexedByEdges):
             if v is not None:
                 return True
         return False
-    
+
     def faceNormals(self, indexed=None):
         """
         Return an array (Nf, 3) of normal vectors for each face.
@@ -186,7 +186,7 @@ class MeshData(object):
         if self._faceNormals is None:
             v = self.vertexes(indexed='faces')
             self._faceNormals = np.cross(v[:,1]-v[:,0], v[:,2]-v[:,0])
-        
+
         if indexed is None:
             return self._faceNormals
         elif indexed == 'faces':
@@ -197,7 +197,7 @@ class MeshData(object):
             return self._faceNormalsIndexedByFaces
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
-        
+
     def vertexNormals(self, indexed=None):
         """
         Return an array of normal vectors.
@@ -218,19 +218,19 @@ class MeshData(object):
                 norm = norms.sum(axis=0)       ## sum normals
                 norm /= (norm**2).sum()**0.5  ## and re-normalize
                 self._vertexNormals[vindex] = norm
-                
+
         if indexed is None:
             return self._vertexNormals
         elif indexed == 'faces':
             return self._vertexNormals[self.faces()]
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
-        
+
     def vertexColors(self, indexed=None):
         """
         Return an array (Nv, 4) of vertex colors.
         If indexed=='faces', then instead return an indexed array
-        (Nf, 3, 4). 
+        (Nf, 3, 4).
         """
         if indexed is None:
             return self._vertexColors
@@ -240,7 +240,7 @@ class MeshData(object):
             return self._vertexColorsIndexedByFaces
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
-        
+
     def setVertexColors(self, colors, indexed=None):
         """
         Set the vertex color array (Nv, 4).
@@ -255,13 +255,13 @@ class MeshData(object):
             self._vertexColorsIndexedByFaces = colors
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
-        
+
     def faceColors(self, indexed=None):
         """
         Return an array (Nf, 4) of face colors.
         If indexed=='faces', then instead return an indexed array
         (Nf, 3, 4)  (note this is just the same array with each color
-        repeated three times). 
+        repeated three times).
         """
         if indexed is None:
             return self._faceColors
@@ -273,7 +273,7 @@ class MeshData(object):
             return self._faceColorsIndexedByFaces
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
-        
+
     def setFaceColors(self, colors, indexed=None):
         """
         Set the face color array (Nf, 4).
@@ -288,7 +288,7 @@ class MeshData(object):
             self._faceColorsIndexedByFaces = colors
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
-        
+
     def faceCount(self):
         """
         Return the number of faces in the mesh.
@@ -297,19 +297,19 @@ class MeshData(object):
             return self._faces.shape[0]
         elif self._vertexesIndexedByFaces is not None:
             return self._vertexesIndexedByFaces.shape[0]
-        
+
     def edgeColors(self):
         return self._edgeColors
-        
+
     #def _setIndexedFaces(self, faces, vertexColors=None, faceColors=None):
         #self._vertexesIndexedByFaces = faces
         #self._vertexColorsIndexedByFaces = vertexColors
         #self._faceColorsIndexedByFaces = faceColors
-        
+
     def _computeUnindexedVertexes(self):
         ## Given (Nv, 3, 3) array of vertexes-indexed-by-face, convert backward to unindexed vertexes
-        ## This is done by collapsing into a list of 'unique' vertexes (difference < 1e-14) 
-        
+        ## This is done by collapsing into a list of 'unique' vertexes (difference < 1e-14)
+
         ## I think generally this should be discouraged..
         faces = self._vertexesIndexedByFaces
         verts = {}  ## used to remember the index of each vertex position
@@ -334,7 +334,7 @@ class MeshData(object):
                 self._vertexFaces[index].append(i)  # keep track of which vertexes belong to which faces
                 self._faces[i,j] = index
         self._vertexes = np.array(self._vertexes, dtype=float)
-    
+
     #def _setUnindexedFaces(self, faces, vertexes, vertexColors=None, faceColors=None):
         #self._vertexes = vertexes #[QtGui.QVector3D(*v) for v in vertexes]
         #self._faces = faces.astype(np.uint)
@@ -356,20 +356,20 @@ class MeshData(object):
                 for ind in face:
                     self._vertexFaces[ind].append(i)
         return self._vertexFaces
-        
+
     #def reverseNormals(self):
         #"""
         #Reverses the direction of all normal vectors.
         #"""
         #pass
-        
+
     #def generateEdgesFromFaces(self):
         #"""
         #Generate a set of edges by listing all the edges of faces and removing any duplicates.
         #Useful for displaying wireframe meshes.
         #"""
         #pass
-        
+
     def _computeEdges(self):
         if not self.hasFaceIndexedData:
             ## generate self._edges from self._faces
@@ -379,11 +379,11 @@ class MeshData(object):
             edges['i'][nf:2*nf] = self._faces[:,1:3]
             edges['i'][-nf:,0] = self._faces[:,2]
             edges['i'][-nf:,1] = self._faces[:,0]
-            
+
             # sort per-edge
             mask = edges['i'][:,0] > edges['i'][:,1]
             edges['i'][mask] = edges['i'][mask][:,::-1]
-            
+
             # remove duplicate entries
             self._edges = np.unique(edges)['i']
             #print self._edges
@@ -400,8 +400,8 @@ class MeshData(object):
             self._edges = edges
         else:
             raise Exception("MeshData cannot generate edges--no faces in this data.")
-        
-        
+
+
     def save(self):
         """Serialize this mesh to a string appropriate for disk storage"""
         import pickle
@@ -409,20 +409,20 @@ class MeshData(object):
             names = ['_vertexes', '_faces']
         else:
             names = ['_vertexesIndexedByFaces']
-            
+
         if self._vertexColors is not None:
             names.append('_vertexColors')
         elif self._vertexColorsIndexedByFaces is not None:
             names.append('_vertexColorsIndexedByFaces')
-            
+
         if self._faceColors is not None:
             names.append('_faceColors')
         elif self._faceColorsIndexedByFaces is not None:
             names.append('_faceColorsIndexedByFaces')
-            
+
         state = dict([(n,getattr(self, n)) for n in names])
         return pickle.dumps(state)
-        
+
     def restore(self, state):
         """Restore the state of a mesh previously saved using save()"""
         import pickle
@@ -443,37 +443,37 @@ class MeshData(object):
         for a spherical surface.
         """
         verts = np.empty((rows+1, cols, 3), dtype=float)
-        
+
         ## compute vertexes
         phi = (np.arange(rows+1) * np.pi / rows).reshape(rows+1, 1)
         s = radius * np.sin(phi)
         verts[...,2] = radius * np.cos(phi)
-        th = ((np.arange(cols) * 2 * np.pi / cols).reshape(1, cols)) 
+        th = ((np.arange(cols) * 2 * np.pi / cols).reshape(1, cols))
         if offset:
             th = th + ((np.pi / cols) * np.arange(rows+1).reshape(rows+1,1))  ## rotate each row by 1/2 column
         verts[...,0] = s * np.cos(th)
         verts[...,1] = s * np.sin(th)
         verts = verts.reshape((rows+1)*cols, 3)[cols-1:-(cols-1)]  ## remove redundant vertexes from top and bottom
-        
+
         ## compute faces
         faces = np.empty((rows*cols*2, 3), dtype=np.uint)
         rowtemplate1 = ((np.arange(cols).reshape(cols, 1) + np.array([[0, 1, 0]])) % cols) + np.array([[0, 0, cols]])
         rowtemplate2 = ((np.arange(cols).reshape(cols, 1) + np.array([[0, 1, 1]])) % cols) + np.array([[cols, 0, cols]])
         for row in range(rows):
-            start = row * cols * 2 
+            start = row * cols * 2
             faces[start:start+cols] = rowtemplate1 + row * cols
             faces[start+cols:start+(cols*2)] = rowtemplate2 + row * cols
         faces = faces[cols:-cols]  ## cut off zero-area triangles at top and bottom
-        
+
         ## adjust for redundant vertexes that were removed from top and bottom
         vmin = cols-1
         faces[faces<vmin] = vmin
-        faces -= vmin  
+        faces -= vmin
         vmax = verts.shape[0]-1
         faces[faces>vmax] = vmax
-        
+
         return MeshData(vertexes=verts, faces=faces)
-        
+
     @staticmethod
     def cylinder(rows, cols, radius=[1.0, 1.0], length=1.0, offset=False):
         """
@@ -498,9 +498,8 @@ class MeshData(object):
         rowtemplate1 = ((np.arange(cols).reshape(cols, 1) + np.array([[0, 1, 0]])) % cols) + np.array([[0, 0, cols]])
         rowtemplate2 = ((np.arange(cols).reshape(cols, 1) + np.array([[0, 1, 1]])) % cols) + np.array([[cols, 0, cols]])
         for row in range(rows):
-            start = row * cols * 2 
+            start = row * cols * 2
             faces[start:start+cols] = rowtemplate1 + row * cols
             faces[start+cols:start+(cols*2)] = rowtemplate2 + row * cols
-        
+
         return MeshData(vertexes=verts, faces=faces)
-        

--- a/pyqtgraph/opengl/__init__.py
+++ b/pyqtgraph/opengl/__init__.py
@@ -4,16 +4,16 @@ from .GLViewWidget import GLViewWidget
 #from .. import importAll
 #importAll('items', globals(), locals())
 
-from .items.GLGridItem import * 
-from .items.GLBarGraphItem import * 
-from .items.GLScatterPlotItem import *                                                                                                                      
-from .items.GLMeshItem import *                                                                                                                             
-from .items.GLLinePlotItem import *                                                                                                                         
-from .items.GLAxisItem import *                                                                                                                             
-from .items.GLImageItem import *                                                                                                                            
-from .items.GLSurfacePlotItem import *                                                                                                                      
-from .items.GLBoxItem import *                                                                                                                              
-from .items.GLVolumeItem import *                                                                                                                           
+from .items.GLGridItem import *
+from .items.GLBarGraphItem import *
+from .items.GLScatterPlotItem import *
+from .items.GLMeshItem import *
+from .items.GLLinePlotItem import *
+from .items.GLAxisItem import *
+from .items.GLImageItem import *
+from .items.GLSurfacePlotItem import *
+from .items.GLBoxItem import *
+from .items.GLVolumeItem import *
 
 from .MeshData import MeshData
 ## for backward compatibility:

--- a/pyqtgraph/opengl/glInfo.py
+++ b/pyqtgraph/opengl/glInfo.py
@@ -12,5 +12,3 @@ class GLTest(QtOpenGL.QGLWidget):
         print("Extensions: " + glGetString(GL_EXTENSIONS))
 
 GLTest()
-
-

--- a/pyqtgraph/opengl/items/GLAxisItem.py
+++ b/pyqtgraph/opengl/items/GLAxisItem.py
@@ -7,11 +7,11 @@ __all__ = ['GLAxisItem']
 class GLAxisItem(GLGraphicsItem):
     """
     **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
-    
-    Displays three lines indicating origin and orientation of local coordinate system. 
-    
+
+    Displays three lines indicating origin and orientation of local coordinate system.
+
     """
-    
+
     def __init__(self, size=None, antialias=True, glOptions='translucent'):
         GLGraphicsItem.__init__(self)
         if size is None:
@@ -19,7 +19,7 @@ class GLAxisItem(GLGraphicsItem):
         self.antialias = antialias
         self.setSize(size=size)
         self.setGLOptions(glOptions)
-    
+
     def setSize(self, x=None, y=None, z=None, size=None):
         """
         Set the size of the axes (in its local coordinate system; this does not affect the transform)
@@ -31,24 +31,24 @@ class GLAxisItem(GLGraphicsItem):
             z = size.z()
         self.__size = [x,y,z]
         self.update()
-        
+
     def size(self):
         return self.__size[:]
-    
-    
+
+
     def paint(self):
 
         #glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
         #glEnable( GL_BLEND )
         #glEnable( GL_ALPHA_TEST )
         self.setupGLState()
-        
+
         if self.antialias:
             glEnable(GL_LINE_SMOOTH)
             glHint(GL_LINE_SMOOTH_HINT, GL_NICEST)
-            
+
         glBegin( GL_LINES )
-        
+
         x,y,z = self.size()
         glColor4f(0, 1, 0, .6)  # z is green
         glVertex3f(0, 0, 0)

--- a/pyqtgraph/opengl/items/GLBarGraphItem.py
+++ b/pyqtgraph/opengl/items/GLBarGraphItem.py
@@ -22,8 +22,5 @@ class GLBarGraphItem(GLMeshItem):
         verts = cubeVerts * size + pos
         faces = cubeFaces + (np.arange(nCubes) * 8).reshape(nCubes,1,1)
         md = MeshData(verts.reshape(nCubes*8,3), faces.reshape(nCubes*12,3))
-        
-        GLMeshItem.__init__(self, meshdata=md, shader='shaded', smooth=False)
 
-        
-        
+        GLMeshItem.__init__(self, meshdata=md, shader='shaded', smooth=False)

--- a/pyqtgraph/opengl/items/GLBoxItem.py
+++ b/pyqtgraph/opengl/items/GLBoxItem.py
@@ -8,7 +8,7 @@ __all__ = ['GLBoxItem']
 class GLBoxItem(GLGraphicsItem):
     """
     **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
-    
+
     Displays a wire-frame box.
     """
     def __init__(self, size=None, color=None, glOptions='translucent'):
@@ -20,7 +20,7 @@ class GLBoxItem(GLGraphicsItem):
             color = (255,255,255,80)
         self.setColor(color)
         self.setGLOptions(glOptions)
-    
+
     def setSize(self, x=None, y=None, z=None, size=None):
         """
         Set the size of the box (in its local coordinate system; this does not affect the transform)
@@ -32,17 +32,17 @@ class GLBoxItem(GLGraphicsItem):
             z = size.z()
         self.__size = [x,y,z]
         self.update()
-        
+
     def size(self):
         return self.__size[:]
-    
+
     def setColor(self, *args):
         """Set the color of the box. Arguments are the same as those accepted by functions.mkColor()"""
         self.__color = fn.Color(*args)
-        
+
     def color(self):
         return self.__color
-    
+
     def paint(self):
         #glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
         #glEnable( GL_BLEND )
@@ -51,9 +51,9 @@ class GLBoxItem(GLGraphicsItem):
         #glEnable( GL_POINT_SMOOTH )
         #glDisable( GL_DEPTH_TEST )
         self.setupGLState()
-        
+
         glBegin( GL_LINES )
-        
+
         glColor4f(*self.color().glColor())
         x,y,z = self.size()
         glVertex3f(0, 0, 0)
@@ -73,7 +73,7 @@ class GLBoxItem(GLGraphicsItem):
         glVertex3f(0, y, z)
         glVertex3f(x, 0, z)
         glVertex3f(x, y, z)
-        
+
         glVertex3f(0, 0, 0)
         glVertex3f(x, 0, 0)
         glVertex3f(0, y, 0)
@@ -82,7 +82,5 @@ class GLBoxItem(GLGraphicsItem):
         glVertex3f(x, 0, z)
         glVertex3f(0, y, z)
         glVertex3f(x, y, z)
-        
+
         glEnd()
-        
-        

--- a/pyqtgraph/opengl/items/GLGridItem.py
+++ b/pyqtgraph/opengl/items/GLGridItem.py
@@ -9,10 +9,10 @@ __all__ = ['GLGridItem']
 class GLGridItem(GLGraphicsItem):
     """
     **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
-    
-    Displays a wire-grame grid. 
+
+    Displays a wire-grame grid.
     """
-    
+
     def __init__(self, size=None, color=None, antialias=True, glOptions='translucent'):
         GLGraphicsItem.__init__(self)
         self.setGLOptions(glOptions)
@@ -21,7 +21,7 @@ class GLGridItem(GLGraphicsItem):
             size = QtGui.QVector3D(20,20,1)
         self.setSize(size=size)
         self.setSpacing(1, 1, 1)
-    
+
     def setSize(self, x=None, y=None, z=None, size=None):
         """
         Set the size of the axes (in its local coordinate system; this does not affect the transform)
@@ -33,7 +33,7 @@ class GLGridItem(GLGraphicsItem):
             z = size.z()
         self.__size = [x,y,z]
         self.update()
-        
+
     def size(self):
         return self.__size[:]
 
@@ -47,26 +47,26 @@ class GLGridItem(GLGraphicsItem):
             y = spacing.y()
             z = spacing.z()
         self.__spacing = [x,y,z]
-        self.update() 
-        
+        self.update()
+
     def spacing(self):
         return self.__spacing[:]
-        
+
     def paint(self):
         self.setupGLState()
-        
+
         if self.antialias:
             glEnable(GL_LINE_SMOOTH)
             glEnable(GL_BLEND)
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
             glHint(GL_LINE_SMOOTH_HINT, GL_NICEST)
-            
+
         glBegin( GL_LINES )
-        
+
         x,y,z = self.size()
         xs,ys,zs = self.spacing()
-        xvals = np.arange(-x/2., x/2. + xs*0.001, xs) 
-        yvals = np.arange(-y/2., y/2. + ys*0.001, ys) 
+        xvals = np.arange(-x/2., x/2. + xs*0.001, xs)
+        yvals = np.arange(-y/2., y/2. + ys*0.001, ys)
         glColor4f(1, 1, 1, .3)
         for x in xvals:
             glVertex3f(x, yvals[0], 0)
@@ -74,5 +74,5 @@ class GLGridItem(GLGraphicsItem):
         for y in yvals:
             glVertex3f(xvals[0], y, 0)
             glVertex3f(xvals[-1], y, 0)
-        
+
         glEnd()

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -8,37 +8,37 @@ __all__ = ['GLImageItem']
 class GLImageItem(GLGraphicsItem):
     """
     **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
-    
+
     Displays image data as a textured quad.
     """
-    
-    
+
+
     def __init__(self, data, smooth=False, glOptions='translucent'):
         """
-        
+
         ==============  =======================================================================================
         **Arguments:**
         data            Volume data to be rendered. *Must* be 3D numpy array (x, y, RGBA) with dtype=ubyte.
                         (See functions.makeRGBA)
-        smooth          (bool) If True, the volume slices are rendered with linear interpolation 
+        smooth          (bool) If True, the volume slices are rendered with linear interpolation
         ==============  =======================================================================================
         """
-        
+
         self.smooth = smooth
         self._needUpdate = False
         GLGraphicsItem.__init__(self)
         self.setData(data)
         self.setGLOptions(glOptions)
-        
+
     def initializeGL(self):
         glEnable(GL_TEXTURE_2D)
         self.texture = glGenTextures(1)
-        
+
     def setData(self, data):
         self.data = data
         self._needUpdate = True
         self.update()
-        
+
     def _updateTexture(self):
         glBindTexture(GL_TEXTURE_2D, self.texture)
         if self.smooth:
@@ -51,15 +51,15 @@ class GLImageItem(GLGraphicsItem):
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER)
         #glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_BORDER)
         shape = self.data.shape
-        
+
         ## Test texture dimensions first
         glTexImage2D(GL_PROXY_TEXTURE_2D, 0, GL_RGBA, shape[0], shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, None)
         if glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_WIDTH) == 0:
             raise Exception("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % shape[:2])
-        
+
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, shape[0], shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, self.data.transpose((1,0,2)))
         glDisable(GL_TEXTURE_2D)
-        
+
         #self.lists = {}
         #for ax in [0,1,2]:
             #for d in [-1, 1]:
@@ -69,15 +69,15 @@ class GLImageItem(GLGraphicsItem):
                 #self.drawVolume(ax, d)
                 #glEndList()
 
-                
+
     def paint(self):
         if self._needUpdate:
             self._updateTexture()
         glEnable(GL_TEXTURE_2D)
         glBindTexture(GL_TEXTURE_2D, self.texture)
-        
+
         self.setupGLState()
-        
+
         #glEnable(GL_DEPTH_TEST)
         ##glDisable(GL_CULL_FACE)
         #glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
@@ -96,4 +96,3 @@ class GLImageItem(GLGraphicsItem):
         glVertex3f(0, self.data.shape[1], 0)
         glEnd()
         glDisable(GL_TEXTURE_3D)
-                

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -9,7 +9,7 @@ __all__ = ['GLLinePlotItem']
 
 class GLLinePlotItem(GLGraphicsItem):
     """Draws line plots in 3D."""
-    
+
     def __init__(self, **kwds):
         """All keyword arguments are passed to setData()"""
         GLGraphicsItem.__init__(self)
@@ -20,13 +20,13 @@ class GLLinePlotItem(GLGraphicsItem):
         self.width = 1.
         self.color = (1.0,1.0,1.0,1.0)
         self.setData(**kwds)
-    
+
     def setData(self, **kwds):
         """
-        Update the data displayed by this item. All arguments are optional; 
-        for example it is allowed to update vertex positions while leaving 
+        Update the data displayed by this item. All arguments are optional;
+        for example it is allowed to update vertex positions while leaving
         colors unchanged, etc.
-        
+
         ====================  ==================================================
         **Arguments:**
         ------------------------------------------------------------------------
@@ -55,7 +55,7 @@ class GLLinePlotItem(GLGraphicsItem):
 
     def initializeGL(self):
         pass
-        
+
     #def setupGLState(self):
         #"""Prepare OpenGL state for drawing. This function is called immediately before painting."""
         ##glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)  ## requires z-sorting to render properly.
@@ -63,24 +63,24 @@ class GLLinePlotItem(GLGraphicsItem):
         #glEnable( GL_BLEND )
         #glEnable( GL_ALPHA_TEST )
         #glDisable( GL_DEPTH_TEST )
-        
+
         ##glEnable( GL_POINT_SMOOTH )
 
         ##glHint(GL_POINT_SMOOTH_HINT, GL_NICEST)
         ##glPointParameterfv(GL_POINT_DISTANCE_ATTENUATION, (0, 0, -1e-3))
         ##glPointParameterfv(GL_POINT_SIZE_MAX, (65500,))
         ##glPointParameterfv(GL_POINT_SIZE_MIN, (0,))
-        
+
     def paint(self):
         if self.pos is None:
             return
         self.setupGLState()
-        
+
         glEnableClientState(GL_VERTEX_ARRAY)
 
         try:
             glVertexPointerf(self.pos)
-            
+
             if isinstance(self.color, np.ndarray):
                 glEnableClientState(GL_COLOR_ARRAY)
                 glColorPointerf(self.color)
@@ -91,22 +91,20 @@ class GLLinePlotItem(GLGraphicsItem):
                     glColor4f(*self.color)
             glLineWidth(self.width)
             #glPointSize(self.width)
-            
+
             if self.antialias:
                 glEnable(GL_LINE_SMOOTH)
                 glEnable(GL_BLEND)
                 glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
                 glHint(GL_LINE_SMOOTH_HINT, GL_NICEST)
-                
+
             if self.mode == 'line_strip':
                 glDrawArrays(GL_LINE_STRIP, 0, int(self.pos.size / self.pos.shape[-1]))
             elif self.mode == 'lines':
                 glDrawArrays(GL_LINES, 0, int(self.pos.size / self.pos.shape[-1]))
             else:
                 raise Exception("Unknown line mode '%s'. (must be 'lines' or 'line_strip')" % self.mode)
-                
+
         finally:
             glDisableClientState(GL_COLOR_ARRAY)
             glDisableClientState(GL_VERTEX_ARRAY)
-    
-        

--- a/pyqtgraph/opengl/items/GLMeshItem.py
+++ b/pyqtgraph/opengl/items/GLMeshItem.py
@@ -13,28 +13,28 @@ __all__ = ['GLMeshItem']
 class GLMeshItem(GLGraphicsItem):
     """
     **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
-    
-    Displays a 3D triangle mesh. 
+
+    Displays a 3D triangle mesh.
     """
     def __init__(self, **kwds):
         """
         ============== =====================================================
         **Arguments:**
-        meshdata       MeshData object from which to determine geometry for 
+        meshdata       MeshData object from which to determine geometry for
                        this item.
-        color          Default face color used if no vertex or face colors 
+        color          Default face color used if no vertex or face colors
                        are specified.
         edgeColor      Default edge color to use if no edge colors are
                        specified in the mesh data.
-        drawEdges      If True, a wireframe mesh will be drawn. 
+        drawEdges      If True, a wireframe mesh will be drawn.
                        (default=False)
         drawFaces      If True, mesh faces are drawn. (default=True)
         shader         Name of shader program to use when drawing faces.
                        (None for no shader)
         smooth         If True, normal vectors are computed for each vertex
                        and interpolated within each face.
-        computeNormals If False, then computation of normal vectors is 
-                       disabled. This can provide a performance boost for 
+        computeNormals If False, then computation of normal vectors is
+                       disabled. This can provide a performance boost for
                        meshes that do not make use of normals.
         ============== =====================================================
         """
@@ -48,42 +48,42 @@ class GLMeshItem(GLGraphicsItem):
             'smooth': True,
             'computeNormals': True,
         }
-        
+
         GLGraphicsItem.__init__(self)
         glopts = kwds.pop('glOptions', 'opaque')
         self.setGLOptions(glopts)
         shader = kwds.pop('shader', None)
         self.setShader(shader)
-        
+
         self.setMeshData(**kwds)
-        
+
         ## storage for data compiled from MeshData object
         self.vertexes = None
         self.normals = None
         self.colors = None
         self.faces = None
-        
+
     def setShader(self, shader):
         """Set the shader used when rendering faces in the mesh. (see the GL shaders example)"""
         self.opts['shader'] = shader
         self.update()
-        
+
     def shader(self):
         shader = self.opts['shader']
         if isinstance(shader, shaders.ShaderProgram):
             return shader
         else:
             return shaders.getShaderProgram(shader)
-        
+
     def setColor(self, c):
         """Set the default color to use when no vertex or face colors are specified."""
         self.opts['color'] = c
         self.update()
-        
+
     def setMeshData(self, **kwds):
         """
         Set mesh data for this item. This can be invoked two ways:
-        
+
         1. Specify *meshdata* argument with a new MeshData object
         2. Specify keyword arguments to be passed to MeshData(..) to create a new instance.
         """
@@ -96,19 +96,19 @@ class GLMeshItem(GLGraphicsItem):
                 except KeyError:
                     pass
             md = MeshData(**opts)
-        
+
         self.opts['meshdata'] = md
         self.opts.update(kwds)
         self.meshDataChanged()
         self.update()
-        
-    
+
+
     def meshDataChanged(self):
         """
         This method must be called to inform the item that the MeshData object
         has been altered.
         """
-        
+
         self.vertexes = None
         self.faces = None
         self.normals = None
@@ -116,13 +116,13 @@ class GLMeshItem(GLGraphicsItem):
         self.edges = None
         self.edgeColors = None
         self.update()
-    
+
     def parseMeshData(self):
         ## interpret vertex / normal data before drawing
         ## This can:
         ##   - automatically generate normals if they were not specified
         ##   - pull vertexes/noormals/faces from MeshData if that was specified
-        
+
         if self.vertexes is not None and self.normals is not None:
             return
         #if self.opts['normals'] is None:
@@ -151,7 +151,7 @@ class GLMeshItem(GLGraphicsItem):
                     self.colors = md.vertexColors(indexed='faces')
                 elif md.hasFaceColor():
                     self.colors = md.faceColors(indexed='faces')
-                    
+
             if self.opts['drawEdges']:
                 if not md.hasFaceIndexedData():
                     self.edges = md.edges()
@@ -160,12 +160,12 @@ class GLMeshItem(GLGraphicsItem):
                     self.edges = md.edges()
                     self.edgeVerts = md.vertexes(indexed='faces')
             return
-    
+
     def paint(self):
         self.setupGLState()
-        
-        self.parseMeshData()        
-        
+
+        self.parseMeshData()
+
         if self.opts['drawFaces']:
             with self.shader():
                 verts = self.vertexes
@@ -177,7 +177,7 @@ class GLMeshItem(GLGraphicsItem):
                 glEnableClientState(GL_VERTEX_ARRAY)
                 try:
                     glVertexPointerf(verts)
-                    
+
                     if self.colors is None:
                         color = self.opts['color']
                         if isinstance(color, QtGui.QColor):
@@ -187,12 +187,12 @@ class GLMeshItem(GLGraphicsItem):
                     else:
                         glEnableClientState(GL_COLOR_ARRAY)
                         glColorPointerf(color)
-                    
-                    
+
+
                     if norms is not None:
                         glEnableClientState(GL_NORMAL_ARRAY)
                         glNormalPointerf(norms)
-                    
+
                     if faces is None:
                         glDrawArrays(GL_TRIANGLES, 0, np.product(verts.shape[:-1]))
                     else:
@@ -202,14 +202,14 @@ class GLMeshItem(GLGraphicsItem):
                     glDisableClientState(GL_NORMAL_ARRAY)
                     glDisableClientState(GL_VERTEX_ARRAY)
                     glDisableClientState(GL_COLOR_ARRAY)
-            
+
         if self.opts['drawEdges']:
             verts = self.edgeVerts
             edges = self.edges
             glEnableClientState(GL_VERTEX_ARRAY)
             try:
                 glVertexPointerf(verts)
-                
+
                 if self.edgeColors is None:
                     color = self.opts['edgeColor']
                     if isinstance(color, QtGui.QColor):
@@ -224,4 +224,3 @@ class GLMeshItem(GLGraphicsItem):
             finally:
                 glDisableClientState(GL_VERTEX_ARRAY)
                 glDisableClientState(GL_COLOR_ARRAY)
-            

--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -9,7 +9,7 @@ __all__ = ['GLScatterPlotItem']
 
 class GLScatterPlotItem(GLGraphicsItem):
     """Draws points at a list of 3D positions."""
-    
+
     def __init__(self, **kwds):
         GLGraphicsItem.__init__(self)
         glopts = kwds.pop('glOptions', 'additive')
@@ -20,22 +20,22 @@ class GLScatterPlotItem(GLGraphicsItem):
         self.pxMode = True
         #self.vbo = {}      ## VBO does not appear to improve performance very much.
         self.setData(**kwds)
-    
+
     def setData(self, **kwds):
         """
-        Update the data displayed by this item. All arguments are optional; 
-        for example it is allowed to update spot positions while leaving 
+        Update the data displayed by this item. All arguments are optional;
+        for example it is allowed to update spot positions while leaving
         colors unchanged, etc.
-        
+
         ====================  ==================================================
         **Arguments:**
         pos                   (N,3) array of floats specifying point locations.
         color                 (N,4) array of floats (0.0-1.0) specifying
                               spot colors OR a tuple of floats specifying
                               a single color for all spots.
-        size                  (N,) array of floats specifying spot sizes or 
+        size                  (N,) array of floats specifying spot sizes or
                               a single value to apply to all spots.
-        pxMode                If True, spot sizes are expressed in pixels. 
+        pxMode                If True, spot sizes are expressed in pixels.
                               Otherwise, they are expressed in item coordinates.
         ====================  ==================================================
         """
@@ -43,18 +43,18 @@ class GLScatterPlotItem(GLGraphicsItem):
         for k in kwds.keys():
             if k not in args:
                 raise Exception('Invalid keyword argument: %s (allowed arguments are %s)' % (k, str(args)))
-            
+
         args.remove('pxMode')
         for arg in args:
             if arg in kwds:
                 setattr(self, arg, kwds[arg])
                 #self.vbo.pop(arg, None)
-                
+
         self.pxMode = kwds.get('pxMode', self.pxMode)
         self.update()
 
     def initializeGL(self):
-        
+
         ## Generate texture for rendering points
         w = 64
         def fn(x,y):
@@ -65,21 +65,21 @@ class GLScatterPlotItem(GLGraphicsItem):
         pData[:,:,3] = np.fromfunction(fn, pData.shape[:2])
         #print pData.shape, pData.min(), pData.max()
         pData = pData.astype(np.ubyte)
-        
+
         if getattr(self, "pointTexture", None) is None:
             self.pointTexture = glGenTextures(1)
         glActiveTexture(GL_TEXTURE0)
         glEnable(GL_TEXTURE_2D)
         glBindTexture(GL_TEXTURE_2D, self.pointTexture)
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pData.shape[0], pData.shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, pData)
-        
+
         self.shader = shaders.getShaderProgram('pointSprite')
-        
+
     #def getVBO(self, name):
         #if name not in self.vbo:
             #self.vbo[name] = vbo.VBO(getattr(self, name).astype('f'))
         #return self.vbo[name]
-        
+
     #def setupGLState(self):
         #"""Prepare OpenGL state for drawing. This function is called immediately before painting."""
         ##glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)  ## requires z-sorting to render properly.
@@ -87,23 +87,23 @@ class GLScatterPlotItem(GLGraphicsItem):
         #glEnable( GL_BLEND )
         #glEnable( GL_ALPHA_TEST )
         #glDisable( GL_DEPTH_TEST )
-        
+
         ##glEnable( GL_POINT_SMOOTH )
 
         ##glHint(GL_POINT_SMOOTH_HINT, GL_NICEST)
         ##glPointParameterfv(GL_POINT_DISTANCE_ATTENUATION, (0, 0, -1e-3))
         ##glPointParameterfv(GL_POINT_SIZE_MAX, (65500,))
         ##glPointParameterfv(GL_POINT_SIZE_MIN, (0,))
-        
+
     def paint(self):
         self.setupGLState()
-        
+
         glEnable(GL_POINT_SPRITE)
-        
+
         glActiveTexture(GL_TEXTURE0)
         glEnable( GL_TEXTURE_2D )
         glBindTexture(GL_TEXTURE_2D, self.pointTexture)
-    
+
         glTexEnvi(GL_POINT_SPRITE, GL_COORD_REPLACE, GL_TRUE)
         #glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)    ## use texture color exactly
         #glTexEnvf( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE )  ## texture modulates current color
@@ -112,8 +112,8 @@ class GLScatterPlotItem(GLGraphicsItem):
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
         glEnable(GL_PROGRAM_POINT_SIZE)
-        
-            
+
+
         with self.shader:
             #glUniform1i(self.shader.uniform('texture'), 0)  ## inform the shader which texture to use
             glEnableClientState(GL_VERTEX_ARRAY)
@@ -122,7 +122,7 @@ class GLScatterPlotItem(GLGraphicsItem):
                 #if pos.ndim > 2:
                     #pos = pos.reshape((reduce(lambda a,b: a*b, pos.shape[:-1]), pos.shape[-1]))
                 glVertexPointerf(pos)
-            
+
                 if isinstance(self.color, np.ndarray):
                     glEnableClientState(GL_COLOR_ARRAY)
                     glColorPointerf(self.color)
@@ -131,7 +131,7 @@ class GLScatterPlotItem(GLGraphicsItem):
                         glColor4f(*fn.glColor(self.color))
                     else:
                         glColor4f(*self.color)
-                
+
                 if not self.pxMode or isinstance(self.size, np.ndarray):
                     glEnableClientState(GL_NORMAL_ARRAY)
                     norm = np.empty(pos.shape)
@@ -141,7 +141,7 @@ class GLScatterPlotItem(GLGraphicsItem):
                         gpos = self.mapToView(pos.transpose()).transpose()
                         pxSize = self.view().pixelSize(gpos)
                         norm[...,0] = self.size / pxSize
-                    
+
                     glNormalPointerf(norm)
                 else:
                     glNormal3f(self.size, 0, 0)  ## vertex shader uses norm.x to determine point size
@@ -152,32 +152,27 @@ class GLScatterPlotItem(GLGraphicsItem):
                 glDisableClientState(GL_VERTEX_ARRAY)
                 glDisableClientState(GL_COLOR_ARRAY)
                 #posVBO.unbind()
-                
+
         #for i in range(len(self.pos)):
             #pos = self.pos[i]
-            
+
             #if isinstance(self.color, np.ndarray):
                 #color = self.color[i]
             #else:
                 #color = self.color
             #if isinstance(self.color, QtGui.QColor):
                 #color = fn.glColor(self.color)
-                
+
             #if isinstance(self.size, np.ndarray):
                 #size = self.size[i]
             #else:
                 #size = self.size
-                
+
             #pxSize = self.view().pixelSize(QtGui.QVector3D(*pos))
-            
+
             #glPointSize(size / pxSize)
             #glBegin( GL_POINTS )
             #glColor4f(*color)  # x is blue
             ##glNormal3f(size, 0, 0)
             #glVertex3f(*pos)
             #glEnd()
-
-        
-        
-        
-        

--- a/pyqtgraph/opengl/items/GLSurfacePlotItem.py
+++ b/pyqtgraph/opengl/items/GLSurfacePlotItem.py
@@ -11,7 +11,7 @@ __all__ = ['GLSurfacePlotItem']
 class GLSurfacePlotItem(GLMeshItem):
     """
     **Bases:** :class:`GLMeshItem <pyqtgraph.opengl.GLMeshItem>`
-    
+
     Displays a surface plot on a regular x,y grid
     """
     def __init__(self, x=None, y=None, z=None, colors=None, **kwds):
@@ -19,7 +19,7 @@ class GLSurfacePlotItem(GLMeshItem):
         The x, y, z, and colors arguments are passed to setData().
         All other keyword arguments are passed to GLMeshItem.__init__().
         """
-        
+
         self._x = None
         self._y = None
         self._z = None
@@ -27,15 +27,15 @@ class GLSurfacePlotItem(GLMeshItem):
         self._vertexes = None
         self._meshdata = MeshData()
         GLMeshItem.__init__(self, meshdata=self._meshdata, **kwds)
-        
+
         self.setData(x, y, z, colors)
-        
-        
-        
+
+
+
     def setData(self, x=None, y=None, z=None, colors=None):
         """
-        Update the data in this surface plot. 
-        
+        Update the data in this surface plot.
+
         ==============  =====================================================================
         **Arguments:**
         x,y             1D arrays of values specifying the x,y positions of vertexes in the
@@ -44,24 +44,24 @@ class GLSurfacePlotItem(GLMeshItem):
         z               2D array of height values for each grid vertex.
         colors          (width, height, 4) array of vertex colors.
         ==============  =====================================================================
-        
+
         All arguments are optional.
-        
-        Note that if vertex positions are updated, the normal vectors for each triangle must 
+
+        Note that if vertex positions are updated, the normal vectors for each triangle must
         be recomputed. This is somewhat expensive if the surface was initialized with smooth=False
-        and very expensive if smooth=True. For faster performance, initialize with 
+        and very expensive if smooth=True. For faster performance, initialize with
         computeNormals=False and use per-vertex colors or a normal-independent shader program.
         """
         if x is not None:
             if self._x is None or len(x) != len(self._x):
                 self._vertexes = None
             self._x = x
-        
+
         if y is not None:
             if self._y is None or len(y) != len(self._y):
                 self._vertexes = None
             self._y = y
-        
+
         if z is not None:
             #if self._x is None:
                 #self._x = np.arange(z.shape[0])
@@ -69,7 +69,7 @@ class GLSurfacePlotItem(GLMeshItem):
             #if self._y is None:
                 #self._y = np.arange(z.shape[1])
                 #self._vertexes = None
-                
+
             if self._x is not None and z.shape[0] != len(self._x):
                 raise Exception('Z values must have shape (len(x), len(y))')
             if self._y is not None and z.shape[1] != len(self._y):
@@ -77,17 +77,17 @@ class GLSurfacePlotItem(GLMeshItem):
             self._z = z
             if self._vertexes is not None and self._z.shape != self._vertexes.shape[:2]:
                 self._vertexes = None
-        
+
         if colors is not None:
             self._colors = colors
             self._meshdata.setVertexColors(colors)
-        
+
         if self._z is None:
             return
-        
+
         updateMesh = False
         newVertexes = False
-        
+
         ## Generate vertex and face array
         if self._vertexes is None:
             newVertexes = True
@@ -95,7 +95,7 @@ class GLSurfacePlotItem(GLMeshItem):
             self.generateFaces()
             self._meshdata.setFaces(self._faces)
             updateMesh = True
-        
+
         ## Copy x, y, z data into vertex array
         if newVertexes or x is not None:
             if x is None:
@@ -105,7 +105,7 @@ class GLSurfacePlotItem(GLMeshItem):
                     x = self._x
             self._vertexes[:, :, 0] = x.reshape(len(x), 1)
             updateMesh = True
-        
+
         if newVertexes or y is not None:
             if y is None:
                 if self._y is None:
@@ -114,17 +114,17 @@ class GLSurfacePlotItem(GLMeshItem):
                     y = self._y
             self._vertexes[:, :, 1] = y.reshape(1, len(y))
             updateMesh = True
-        
+
         if newVertexes or z is not None:
             self._vertexes[...,2] = self._z
             updateMesh = True
-        
+
         ## Update MeshData
         if updateMesh:
             self._meshdata.setVertexes(self._vertexes.reshape(self._vertexes.shape[0]*self._vertexes.shape[1], 3))
             self.meshDataChanged()
-        
-        
+
+
     def generateFaces(self):
         cols = self._z.shape[1]-1
         rows = self._z.shape[0]-1
@@ -132,7 +132,7 @@ class GLSurfacePlotItem(GLMeshItem):
         rowtemplate1 = np.arange(cols).reshape(cols, 1) + np.array([[0, 1, cols+1]])
         rowtemplate2 = np.arange(cols).reshape(cols, 1) + np.array([[cols+1, 1, cols+2]])
         for row in range(rows):
-            start = row * cols * 2 
+            start = row * cols * 2
             faces[start:start+cols] = rowtemplate1 + row * (cols+1)
             faces[start+cols:start+(cols*2)] = rowtemplate2 + row * (cols+1)
         self._faces = faces

--- a/pyqtgraph/opengl/items/GLVolumeItem.py
+++ b/pyqtgraph/opengl/items/GLVolumeItem.py
@@ -9,21 +9,21 @@ __all__ = ['GLVolumeItem']
 class GLVolumeItem(GLGraphicsItem):
     """
     **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
-    
-    Displays volumetric data. 
+
+    Displays volumetric data.
     """
-    
-    
+
+
     def __init__(self, data, sliceDensity=1, smooth=True, glOptions='translucent'):
         """
         ==============  =======================================================================================
         **Arguments:**
         data            Volume data to be rendered. *Must* be 4D numpy array (x, y, z, RGBA) with dtype=ubyte.
         sliceDensity    Density of slices to render through the volume. A value of 1 means one slice per voxel.
-        smooth          (bool) If True, the volume slices are rendered with linear interpolation 
+        smooth          (bool) If True, the volume slices are rendered with linear interpolation
         ==============  =======================================================================================
         """
-        
+
         self.sliceDensity = sliceDensity
         self.smooth = smooth
         self.data = None
@@ -32,12 +32,12 @@ class GLVolumeItem(GLGraphicsItem):
         GLGraphicsItem.__init__(self)
         self.setGLOptions(glOptions)
         self.setData(data)
-        
+
     def setData(self, data):
         self.data = data
         self._needUpload = True
         self.update()
-        
+
     def _uploadData(self):
         glEnable(GL_TEXTURE_3D)
         if self.texture is None:
@@ -53,15 +53,15 @@ class GLVolumeItem(GLGraphicsItem):
         glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER)
         glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_BORDER)
         shape = self.data.shape
-        
+
         ## Test texture dimensions first
         glTexImage3D(GL_PROXY_TEXTURE_3D, 0, GL_RGBA, shape[0], shape[1], shape[2], 0, GL_RGBA, GL_UNSIGNED_BYTE, None)
         if glGetTexLevelParameteriv(GL_PROXY_TEXTURE_3D, 0, GL_TEXTURE_WIDTH) == 0:
             raise Exception("OpenGL failed to create 3D texture (%dx%dx%d); too large for this hardware." % shape[:3])
-        
+
         glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, shape[0], shape[1], shape[2], 0, GL_RGBA, GL_UNSIGNED_BYTE, self.data.transpose((2,1,0,3)))
         glDisable(GL_TEXTURE_3D)
-        
+
         self.lists = {}
         for ax in [0,1,2]:
             for d in [-1, 1]:
@@ -70,21 +70,21 @@ class GLVolumeItem(GLGraphicsItem):
                 glNewList(l, GL_COMPILE)
                 self.drawVolume(ax, d)
                 glEndList()
-        
+
         self._needUpload = False
-        
+
     def paint(self):
         if self.data is None:
             return
-        
+
         if self._needUpload:
             self._uploadData()
-        
+
         self.setupGLState()
-        
+
         glEnable(GL_TEXTURE_3D)
         glBindTexture(GL_TEXTURE_3D, self.texture)
-        
+
         #glEnable(GL_DEPTH_TEST)
         #glDisable(GL_CULL_FACE)
         #glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
@@ -101,13 +101,13 @@ class GLVolumeItem(GLGraphicsItem):
         d = 1 if cam[ax] > 0 else -1
         glCallList(self.lists[(ax,d)])  ## draw axes
         glDisable(GL_TEXTURE_3D)
-                
+
     def drawVolume(self, ax, d):
         N = 5
-        
+
         imax = [0,1,2]
         imax.remove(ax)
-        
+
         tp = [[0,0,0],[0,0,0],[0,0,0],[0,0,0]]
         vp = [[0,0,0],[0,0,0],[0,0,0],[0,0,0]]
         nudge = [0.5/x for x in self.data.shape]
@@ -119,7 +119,7 @@ class GLVolumeItem(GLGraphicsItem):
         tp[2][imax[1]] = 1-nudge[imax[1]]
         tp[3][imax[0]] = 0+nudge[imax[0]]
         tp[3][imax[1]] = 1-nudge[imax[1]]
-        
+
         vp[0][imax[0]] = 0
         vp[0][imax[1]] = 0
         vp[1][imax[0]] = self.data.shape[imax[0]]
@@ -132,25 +132,25 @@ class GLVolumeItem(GLGraphicsItem):
         r = list(range(slices))
         if d == -1:
             r = r[::-1]
-            
+
         glBegin(GL_QUADS)
         tzVals = np.linspace(nudge[ax], 1.0-nudge[ax], slices)
         vzVals = np.linspace(0, self.data.shape[ax], slices)
         for i in r:
             z = tzVals[i]
             w = vzVals[i]
-            
+
             tp[0][ax] = z
             tp[1][ax] = z
             tp[2][ax] = z
             tp[3][ax] = z
-            
+
             vp[0][ax] = w
             vp[1][ax] = w
             vp[2][ax] = w
             vp[3][ax] = w
-            
-            
+
+
             glTexCoord3f(*tp[0])
             glVertex3f(*vp[0])
             glTexCoord3f(*tp[1])
@@ -160,37 +160,37 @@ class GLVolumeItem(GLGraphicsItem):
             glTexCoord3f(*tp[3])
             glVertex3f(*vp[3])
         glEnd()
-        
-        
-        
-        
-        
-        
-        
-        
-        
+
+
+
+
+
+
+
+
+
         ## Interesting idea:
-        ## remove projection/modelview matrixes, recreate in texture coords. 
+        ## remove projection/modelview matrixes, recreate in texture coords.
         ## it _sorta_ works, but needs tweaking.
         #mvm = glGetDoublev(GL_MODELVIEW_MATRIX)
         #pm = glGetDoublev(GL_PROJECTION_MATRIX)
         #m = QtGui.QMatrix4x4(mvm.flatten()).inverted()[0]
         #p = QtGui.QMatrix4x4(pm.flatten()).inverted()[0]
-        
+
         #glMatrixMode(GL_PROJECTION)
         #glPushMatrix()
         #glLoadIdentity()
         #N=1
         #glOrtho(-N,N,-N,N,-100,100)
-        
+
         #glMatrixMode(GL_MODELVIEW)
         #glLoadIdentity()
-        
-        
+
+
         #glMatrixMode(GL_TEXTURE)
         #glLoadIdentity()
         #glMultMatrixf(m.copyDataTo())
-        
+
         #view = self.view()
         #w = view.width()
         #h = view.height()
@@ -200,14 +200,14 @@ class GLVolumeItem(GLGraphicsItem):
         #farClip = dist * 5.
         #r = nearClip * np.tan(fov)
         #t = r * h / w
-        
+
         #p = QtGui.QMatrix4x4()
         #p.frustum( -r, r, -t, t, nearClip, farClip)
         #glMultMatrixf(p.inverted()[0].copyDataTo())
-        
-        
+
+
         #glBegin(GL_QUADS)
-        
+
         #M=1
         #for i in range(500):
             #z = i/500.
@@ -225,6 +225,3 @@ class GLVolumeItem(GLGraphicsItem):
 
         #glMatrixMode(GL_PROJECTION)
         #glPopMatrix()
-        
-        
-

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -12,7 +12,7 @@ def initShaders():
     global Shaders
     Shaders = [
         ShaderProgram(None, []),
-        
+
         ## increases fragment alpha as the normal turns orthogonal to the view
         ## this is useful for viewing shells that enclose a volume (such as isosurfaces)
         ShaderProgram('balloon', [
@@ -35,10 +35,10 @@ def initShaders():
                 }
             """)
         ]),
-        
+
         ## colors fragments based on face normals relative to view
         ## This means that the colors will change depending on how the view is rotated
-        ShaderProgram('viewNormalColor', [   
+        ShaderProgram('viewNormalColor', [
             VertexShader("""
                 varying vec3 normal;
                 void main() {
@@ -60,9 +60,9 @@ def initShaders():
                 }
             """)
         ]),
-        
+
         ## colors fragments based on absolute face normals.
-        ShaderProgram('normalColor', [   
+        ShaderProgram('normalColor', [
             VertexShader("""
                 varying vec3 normal;
                 void main() {
@@ -84,10 +84,10 @@ def initShaders():
                 }
             """)
         ]),
-        
-        ## very simple simulation of lighting. 
+
+        ## very simple simulation of lighting.
         ## The light source position is always relative to the camera.
-        ShaderProgram('shaded', [   
+        ShaderProgram('shaded', [
             VertexShader("""
                 varying vec3 normal;
                 void main() {
@@ -111,9 +111,9 @@ def initShaders():
                 }
             """)
         ]),
-        
+
         ## colors get brighter near edges of object
-        ShaderProgram('edgeHilight', [   
+        ShaderProgram('edgeHilight', [
             VertexShader("""
                 varying vec3 normal;
                 void main() {
@@ -136,7 +136,7 @@ def initShaders():
                 }
             """)
         ]),
-        
+
         ## colors fragments by z-value.
         ## This is useful for coloring surface plots by height.
         ## This shader uses a uniform called "colorMap" to determine how to map the colors:
@@ -165,17 +165,17 @@ def initShaders():
                     if (colorMap[2] != 1.0)
                         color.x = pow(color.x, colorMap[2]);
                     color.x = color.x < 0. ? 0. : (color.x > 1. ? 1. : color.x);
-                    
+
                     color.y = colorMap[3] * (pos.z + colorMap[4]);
                     if (colorMap[5] != 1.0)
                         color.y = pow(color.y, colorMap[5]);
                     color.y = color.y < 0. ? 0. : (color.y > 1. ? 1. : color.y);
-                    
+
                     color.z = colorMap[6] * (pos.z + colorMap[7]);
                     if (colorMap[8] != 1.0)
                         color.z = pow(color.z, colorMap[8]);
                     color.z = color.z < 0. ? 0. : (color.z > 1. ? 1. : color.z);
-                    
+
                     color.w = 1.0;
                     gl_FragColor = color;
                 }
@@ -193,7 +193,7 @@ def initShaders():
                     gl_FrontColor=gl_Color;
                     gl_PointSize = gl_Normal.x;
                     gl_Position = ftransform();
-                } 
+                }
             """),
             #FragmentShader("""
                 ##version 120
@@ -208,7 +208,7 @@ def initShaders():
 
 
 CompiledShaderPrograms = {}
-    
+
 def getShaderProgram(name):
     return ShaderProgram.names[name]
 
@@ -217,7 +217,7 @@ class Shader(object):
         self.shaderType = shaderType
         self.code = code
         self.compiled = None
-        
+
     def shader(self):
         if self.compiled is None:
             try:
@@ -260,17 +260,17 @@ class Shader(object):
 class VertexShader(Shader):
     def __init__(self, code):
         Shader.__init__(self, GL_VERTEX_SHADER, code)
-        
+
 class FragmentShader(Shader):
     def __init__(self, code):
         Shader.__init__(self, GL_FRAGMENT_SHADER, code)
-        
-        
-        
+
+
+
 
 class ShaderProgram(object):
     names = {}
-    
+
     def __init__(self, name, shaders, uniforms=None):
         self.name = name
         ShaderProgram.names[name] = self
@@ -278,12 +278,12 @@ class ShaderProgram(object):
         self.prog = None
         self.blockData = {}
         self.uniformData = {}
-        
+
         ## parse extra options from the shader definition
         if uniforms is not None:
             for k,v in uniforms.items():
                 self[k] = v
-        
+
     def setBlockData(self, blockName, data):
         if data is None:
             del self.blockData[blockName]
@@ -295,10 +295,10 @@ class ShaderProgram(object):
             del self.uniformData[uniformName]
         else:
             self.uniformData[uniformName] = data
-            
+
     def __setitem__(self, item, val):
         self.setUniformData(item, val)
-        
+
     def __delitem__(self, item):
         self.setUniformData(item, None)
 
@@ -311,11 +311,11 @@ class ShaderProgram(object):
                 self.prog = -1
                 raise
         return self.prog
-        
+
     def __enter__(self):
         if len(self.shaders) > 0 and self.program() != -1:
             glUseProgram(self.program())
-            
+
             try:
                 ## load uniform values into program
                 for uniformName, data in self.uniformData.items():
@@ -323,44 +323,44 @@ class ShaderProgram(object):
                     if loc == -1:
                         raise Exception('Could not find uniform variable "%s"' % uniformName)
                     glUniform1fv(loc, len(data), data)
-                    
+
                 ### bind buffer data to program blocks
                 #if len(self.blockData) > 0:
                     #bindPoint = 1
                     #for blockName, data in self.blockData.items():
                         ### Program should have a uniform block declared:
-                        ### 
+                        ###
                         ### layout (std140) uniform blockName {
                         ###     vec4 diffuse;
                         ### };
-                        
+
                         ### pick any-old binding point. (there are a limited number of these per-program
                         #bindPoint = 1
-                        
+
                         ### get the block index for a uniform variable in the shader
                         #blockIndex = glGetUniformBlockIndex(self.program(), blockName)
-                        
+
                         ### give the shader block a binding point
                         #glUniformBlockBinding(self.program(), blockIndex, bindPoint)
-                        
+
                         ### create a buffer
                         #buf = glGenBuffers(1)
                         #glBindBuffer(GL_UNIFORM_BUFFER, buf)
                         #glBufferData(GL_UNIFORM_BUFFER, size, data, GL_DYNAMIC_DRAW)
                         ### also possible to use glBufferSubData to fill parts of the buffer
-                        
+
                         ### bind buffer to the same binding point
                         #glBindBufferBase(GL_UNIFORM_BUFFER, bindPoint, buf)
             except:
                 glUseProgram(0)
                 raise
-                    
-            
-        
+
+
+
     def __exit__(self, *args):
         if len(self.shaders) > 0:
             glUseProgram(0)
-        
+
     def uniform(self, name):
         """Return the location integer for a uniform variable in this program"""
         return glGetUniformLocation(self.program(), name.encode('utf_8'))
@@ -371,32 +371,32 @@ class ShaderProgram(object):
         #indices = []
         #for i in range(count):
             #indices.append(glGetActiveUniformBlockiv(self.program(), blockIndex, GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES))
-        
+
 class HeightColorShader(ShaderProgram):
     def __enter__(self):
         ## Program should have a uniform block declared:
-        ## 
+        ##
         ## layout (std140) uniform blockName {
         ##     vec4 diffuse;
         ##     vec4 ambient;
         ## };
-        
+
         ## pick any-old binding point. (there are a limited number of these per-program
         bindPoint = 1
-        
+
         ## get the block index for a uniform variable in the shader
         blockIndex = glGetUniformBlockIndex(self.program(), "blockName")
-        
+
         ## give the shader block a binding point
         glUniformBlockBinding(self.program(), blockIndex, bindPoint)
-        
+
         ## create a buffer
         buf = glGenBuffers(1)
         glBindBuffer(GL_UNIFORM_BUFFER, buf)
         glBufferData(GL_UNIFORM_BUFFER, size, data, GL_DYNAMIC_DRAW)
         ## also possible to use glBufferSubData to fill parts of the buffer
-        
+
         ## bind buffer to the same binding point
         glBindBufferBase(GL_UNIFORM_BUFFER, bindPoint, buf)
-        
+
 initShaders()

--- a/pyqtgraph/parametertree/ParameterItem.py
+++ b/pyqtgraph/parametertree/ParameterItem.py
@@ -4,17 +4,17 @@ import os, weakref, re
 
 class ParameterItem(QtGui.QTreeWidgetItem):
     """
-    Abstract ParameterTree item. 
+    Abstract ParameterTree item.
     Used to represent the state of a Parameter from within a ParameterTree.
-    
+
     - Sets first column of item to name
     - generates context menu if item is renamable or removable
     - handles child added / removed events
     - provides virtual functions for handling changes from parameter
-    
+
     For more ParameterItem types, see ParameterTree.parameterTypes module.
     """
-    
+
     def __init__(self, param, depth=0):
         title = param.opts.get('title', None)
         if title is None:
@@ -24,7 +24,7 @@ class ParameterItem(QtGui.QTreeWidgetItem):
         self.param = param
         self.param.registerItem(self)  ## let parameter know this item is connected to it (for debugging)
         self.depth = depth
-        
+
         param.sigValueChanged.connect(self.valueChanged)
         param.sigChildAdded.connect(self.childAdded)
         param.sigChildRemoved.connect(self.childRemoved)
@@ -33,9 +33,9 @@ class ParameterItem(QtGui.QTreeWidgetItem):
         param.sigDefaultChanged.connect(self.defaultChanged)
         param.sigOptionsChanged.connect(self.optsChanged)
         param.sigParentChanged.connect(self.parentChanged)
-        
+
         opts = param.opts
-        
+
         ## Generate context menu for renaming/removing parameter
         self.contextMenu = QtGui.QMenu()
         self.contextMenu.addSeparator()
@@ -47,70 +47,70 @@ class ParameterItem(QtGui.QTreeWidgetItem):
             self.contextMenu.addAction('Rename').triggered.connect(self.editName)
         if opts.get('removable', False):
             self.contextMenu.addAction("Remove").triggered.connect(self.requestRemove)
-        
+
         ## handle movable / dropEnabled options
         if opts.get('movable', False):
             flags |= QtCore.Qt.ItemIsDragEnabled
         if opts.get('dropEnabled', False):
             flags |= QtCore.Qt.ItemIsDropEnabled
         self.setFlags(flags)
-        
+
         ## flag used internally during name editing
         self.ignoreNameColumnChange = False
-    
-    
+
+
     def valueChanged(self, param, val):
         ## called when the parameter's value has changed
         pass
-    
+
     def isFocusable(self):
         """Return True if this item should be included in the tab-focus order"""
         return False
-        
+
     def setFocus(self):
         """Give input focus to this item.
         Can be reimplemented to display editor widgets, etc.
         """
         pass
-    
+
     def focusNext(self, forward=True):
         """Give focus to the next (or previous) focusable item in the parameter tree"""
         self.treeWidget().focusNext(self, forward=forward)
-        
-    
+
+
     def treeWidgetChanged(self):
         """Called when this item is added or removed from a tree.
-        Expansion, visibility, and column widgets must all be configured AFTER 
+        Expansion, visibility, and column widgets must all be configured AFTER
         the item is added to a tree, not during __init__.
         """
         self.setHidden(not self.param.opts.get('visible', True))
         self.setExpanded(self.param.opts.get('expanded', True))
-        
+
     def childAdded(self, param, child, pos):
         item = child.makeTreeItem(depth=self.depth+1)
         self.insertChild(pos, item)
         item.treeWidgetChanged()
-        
+
         for i, ch in enumerate(child):
             item.childAdded(child, ch, i)
-        
+
     def childRemoved(self, param, child):
         for i in range(self.childCount()):
             item = self.child(i)
             if item.param is child:
                 self.takeChild(i)
                 break
-                
+
     def parentChanged(self, param, parent):
         ## called when the parameter's parent has changed.
         pass
-                
+
     def contextMenuEvent(self, ev):
         if not self.param.opts.get('removable', False) and not self.param.opts.get('renamable', False):
             return
-            
+
         self.contextMenu.popup(ev.globalPos())
-        
+
     def columnChangedEvent(self, col):
         """Called when the text in a column has been edited (or otherwise changed).
         By default, we only use changes to column 0 to rename the parameter.
@@ -123,22 +123,22 @@ class ParameterItem(QtGui.QTreeWidgetItem):
             except Exception:
                 self.setText(0, self.param.name())
                 raise
-                
+
             try:
                 self.ignoreNameColumnChange = True
                 self.nameChanged(self, newName)  ## If the parameter rejects the name change, we need to set it back.
             finally:
                 self.ignoreNameColumnChange = False
-                
+
     def nameChanged(self, param, name):
         ## called when the parameter's name has changed.
         if self.param.opts.get('title', None) is None:
             self.setText(0, name)
-    
+
     def limitsChanged(self, param, limits):
         """Called when the parameter's limits have changed"""
         pass
-    
+
     def defaultChanged(self, param, default):
         """Called when the parameter's default value has changed"""
         pass
@@ -149,10 +149,10 @@ class ParameterItem(QtGui.QTreeWidgetItem):
         #print opts
         if 'visible' in opts:
             self.setHidden(not opts['visible'])
-        
+
     def editName(self):
         self.treeWidget().editItem(self, 0)
-        
+
     def selected(self, sel):
         """Called when this item has been selected (sel=True) OR deselected (sel=False)"""
         pass

--- a/pyqtgraph/parametertree/ParameterSystem.py
+++ b/pyqtgraph/parametertree/ParameterSystem.py
@@ -5,14 +5,14 @@ from .SystemSolver import SystemSolver
 
 class ParameterSystem(GroupParameter):
     """
-    ParameterSystem is a subclass of GroupParameter that manages a tree of 
+    ParameterSystem is a subclass of GroupParameter that manages a tree of
     sub-parameters with a set of interdependencies--changing any one parameter
     may affect other parameters in the system.
-    
+
     See parametertree/SystemSolver for more information.
-    
-    NOTE: This API is experimental and may change substantially across minor 
-    version numbers. 
+
+    NOTE: This API is experimental and may change substantially across minor
+    version numbers.
     """
     def __init__(self, *args, **kwds):
         GroupParameter.__init__(self, *args, **kwds)
@@ -23,10 +23,10 @@ class ParameterSystem(GroupParameter):
             self.setSystem(sys)
         self._ignoreChange = [] # params whose changes should be ignored temporarily
         self.sigTreeStateChanged.connect(self.updateSystem)
-        
+
     def setSystem(self, sys):
         self._system = sys
-        
+
         # auto-generate defaults to match child parameters
         defaults = {}
         vals = {}
@@ -35,7 +35,7 @@ class ParameterSystem(GroupParameter):
             constraints = ''
             if hasattr(sys, '_' + name):
                 constraints += 'n'
-                
+
             if not param.readonly():
                 constraints += 'f'
                 if 'n' in constraints:
@@ -47,19 +47,19 @@ class ParameterSystem(GroupParameter):
                     vals[name] = param.value()
                     ch = param.addChild(dict(name='fixed', type='bool', value=True, readonly=True))
                     #self._fixParams.append(ch)
-                
+
             defaults[name] = [None, param.type(), None, constraints]
-        
+
         sys.defaultState.update(defaults)
         sys.reset()
         for name, value in vals.items():
             setattr(sys, name, value)
-        
+
         self.updateAllParams()
-    
+
     def updateSystem(self, param, changes):
         changes = [ch for ch in changes if ch[0] not in self._ignoreChange]
-        
+
         #resets = [ch[0] for ch in changes if ch[1] == 'setToDefault']
         sets = [ch[0] for ch in changes if ch[1] == 'value']
         #for param in resets:
@@ -68,7 +68,7 @@ class ParameterSystem(GroupParameter):
         for param in sets:
             #if param in resets:
                 #continue
-            
+
             #if param in self._fixParams:
                 #param.parent().setWritable(param.value())
             #else:
@@ -80,9 +80,9 @@ class ParameterSystem(GroupParameter):
                     setattr(self._system, parent.name(), None)
             else:
                 setattr(self._system, param.name(), param.value())
-            
+
         self.updateAllParams()
-    
+
     def updateAllParams(self):
         try:
             self.sigTreeStateChanged.disconnect(self.updateSystem)
@@ -99,7 +99,7 @@ class ParameterSystem(GroupParameter):
                     self.updateParamState(param, 'autoUnset')
         finally:
             self.sigTreeStateChanged.connect(self.updateSystem)
-                
+
     def updateParamState(self, param, state):
         if state == 'autoSet':
             bg = fn.mkBrush((200, 255, 200, 255))
@@ -113,15 +113,11 @@ class ParameterSystem(GroupParameter):
             bg = fn.mkBrush('y')
             bold = True
             readonly = False
-            
+
         param.setReadonly(readonly)
-        
+
         #for item in param.items:
             #item.setBackground(0, bg)
             #f = item.font(0)
             #f.setWeight(f.Bold if bold else f.Normal)
             #item.setFont(0, f)
-            
-            
-            
-

--- a/pyqtgraph/parametertree/ParameterTree.py
+++ b/pyqtgraph/parametertree/ParameterTree.py
@@ -3,12 +3,12 @@ from ..widgets.TreeWidget import TreeWidget
 import os, weakref, re
 from .ParameterItem import ParameterItem
 #import functions as fn
-        
-            
+
+
 
 class ParameterTree(TreeWidget):
     """Widget used to display or control data from a hierarchy of Parameters"""
-    
+
     def __init__(self, parent=None, showHeader=True):
         """
         ============== ========================================================
@@ -30,34 +30,34 @@ class ParameterTree(TreeWidget):
         self.itemChanged.connect(self.itemChangedEvent)
         self.lastSel = None
         self.setRootIsDecorated(False)
-        
+
     def setParameters(self, param, showTop=True):
         """
         Set the top-level :class:`Parameter <pyqtgraph.parametertree.Parameter>`
         to be displayed in this ParameterTree.
 
-        If *showTop* is False, then the top-level parameter is hidden and only 
-        its children will be visible. This is a convenience method equivalent 
+        If *showTop* is False, then the top-level parameter is hidden and only
+        its children will be visible. This is a convenience method equivalent
         to::
-        
+
             tree.clear()
             tree.addParameters(param, showTop)
         """
         self.clear()
         self.addParameters(param, showTop=showTop)
-        
+
     def addParameters(self, param, root=None, depth=0, showTop=True):
         """
         Adds one top-level :class:`Parameter <pyqtgraph.parametertree.Parameter>`
-        to the view. 
-        
+        to the view.
+
         ============== ==========================================================
-        **Arguments:** 
-        param          The :class:`Parameter <pyqtgraph.parametertree.Parameter>` 
+        **Arguments:**
+        param          The :class:`Parameter <pyqtgraph.parametertree.Parameter>`
                        to add.
         root           The item within the tree to which *param* should be added.
                        By default, *param* is added as a top-level item.
-        showTop        If False, then *param* will be hidden, and only its 
+        showTop        If False, then *param* will be hidden, and only its
                        children will be visible in the tree.
         ============== ==========================================================
         """
@@ -72,16 +72,16 @@ class ParameterTree(TreeWidget):
                 depth -= 1
         root.addChild(item)
         item.treeWidgetChanged()
-            
+
         for ch in param:
             self.addParameters(ch, root=item, depth=depth+1)
 
     def clear(self):
         """
-        Remove all parameters from the tree.        
+        Remove all parameters from the tree.
         """
-        self.invisibleRootItem().takeChildren()        
-            
+        self.invisibleRootItem().takeChildren()
+
     def focusNext(self, item, forward=True):
         """Give input focus to the next (or previous) item after *item*
         """
@@ -110,12 +110,12 @@ class ParameterTree(TreeWidget):
                 index = root.indexOfChild(startItem) + 1
             else:
                 index = root.indexOfChild(startItem) - 1
-            
+
         if forward:
             inds = list(range(index, root.childCount()))
         else:
             inds = list(range(index, -1, -1))
-            
+
         for i in inds:
             item = root.child(i)
             if hasattr(item, 'isFocusable') and item.isFocusable():
@@ -130,11 +130,11 @@ class ParameterTree(TreeWidget):
         item = self.currentItem()
         if hasattr(item, 'contextMenuEvent'):
             item.contextMenuEvent(ev)
-            
+
     def itemChangedEvent(self, item, col):
         if hasattr(item, 'columnChangedEvent'):
             item.columnChangedEvent(col)
-            
+
     def selectionChanged(self, *args):
         sel = self.selectedItems()
         if len(sel) != 1:
@@ -148,7 +148,7 @@ class ParameterTree(TreeWidget):
         if hasattr(sel[0], 'selected'):
             sel[0].selected(True)
         return TreeWidget.selectionChanged(self, *args)
-        
+
     def wheelEvent(self, ev):
         self.clearSelection()
         return TreeWidget.wheelEvent(self, ev)

--- a/pyqtgraph/parametertree/SystemSolver.py
+++ b/pyqtgraph/parametertree/SystemSolver.py
@@ -3,67 +3,67 @@ import numpy as np
 
 class SystemSolver(object):
     """
-    This abstract class is used to formalize and manage user interaction with a 
+    This abstract class is used to formalize and manage user interaction with a
     complex system of equations (related to "constraint satisfaction problems").
     It is often the case that devices must be controlled
-    through a large number of free variables, and interactions between these 
+    through a large number of free variables, and interactions between these
     variables make the system difficult to manage and conceptualize as a user
     interface. This class does _not_ attempt to numerically solve the system
     of equations. Rather, it provides a framework for subdividing the system
-    into manageable pieces and specifying closed-form solutions to these small 
+    into manageable pieces and specifying closed-form solutions to these small
     pieces.
-    
+
     For an example, see the simple Camera class below.
-    
+
     Theory of operation: Conceptualize the system as 1) a set of variables
-    whose values may be either user-specified or automatically generated, and 
-    2) a set of functions that define *how* each variable should be generated. 
+    whose values may be either user-specified or automatically generated, and
+    2) a set of functions that define *how* each variable should be generated.
     When a variable is accessed (as an instance attribute), the solver first
     checks to see if it already has a value (either user-supplied, or cached
-    from a previous calculation). If it does not, then the solver calls a 
+    from a previous calculation). If it does not, then the solver calls a
     method on itself (the method must be named `_variableName`) that will
     either return the calculated value (which usually involves acccessing
     other variables in the system), or raise RuntimeError if it is unable to
     calculate the value (usually because the user has not provided sufficient
-    input to fully constrain the system). 
-    
-    Each method that calculates a variable value may include multiple 
-    try/except blocks, so that if one method generates a RuntimeError, it may 
-    fall back on others. 
-    In this way, the system may be solved by recursively searching the tree of 
+    input to fully constrain the system).
+
+    Each method that calculates a variable value may include multiple
+    try/except blocks, so that if one method generates a RuntimeError, it may
+    fall back on others.
+    In this way, the system may be solved by recursively searching the tree of
     possible relationships between variables. This allows the user flexibility
-    in deciding which variables are the most important to specify, while 
+    in deciding which variables are the most important to specify, while
     avoiding the apparent combinatorial explosion of calculation pathways
     that must be considered by the developer.
-    
-    Solved values are cached for efficiency, and automatically cleared when 
+
+    Solved values are cached for efficiency, and automatically cleared when
     a state change invalidates the cache. The rules for this are simple: any
     time a value is set, it invalidates the cache *unless* the previous value
-    was None (which indicates that no other variable has yet requested that 
+    was None (which indicates that no other variable has yet requested that
     value). More complex cache management may be defined in subclasses.
-    
-    
+
+
     Subclasses must define:
-    
-    1) The *defaultState* class attribute: This is a dict containing a 
+
+    1) The *defaultState* class attribute: This is a dict containing a
        description of the variables in the system--their default values,
        data types, and the ways they can be constrained. The format is::
-       
+
            { name: [value, type, constraint, allowed_constraints], ...}
-       
+
        * *value* is the default value. May be None if it has not been specified
          yet.
        * *type* may be float, int, bool, np.ndarray, ...
        * *constraint* may be None, single value, or (min, max)
-            * None indicates that the value is not constrained--it may be 
+            * None indicates that the value is not constrained--it may be
               automatically generated if the value is requested.
-       * *allowed_constraints* is a string composed of (n)one, (f)ixed, and (r)ange. 
-       
+       * *allowed_constraints* is a string composed of (n)one, (f)ixed, and (r)ange.
+
        Note: do not put mutable objects inside defaultState!
-       
-    2) For each variable that may be automatically determined, a method must 
+
+    2) For each variable that may be automatically determined, a method must
        be defined with the name `_variableName`. This method may either return
-       the 
+       the
     """
 
     defaultState = OrderedDict()
@@ -72,7 +72,7 @@ class SystemSolver(object):
         self.__dict__['_vars'] = OrderedDict()
         self.__dict__['_currentGets'] = set()
         self.reset()
-        
+
     def reset(self):
         """
         Reset all variables in the solver to their default state.
@@ -85,14 +85,14 @@ class SystemSolver(object):
         if name in self._vars:
             return self.get(name)
         raise AttributeError(name)
-    
+
     def __setattr__(self, name, value):
         """
-        Set the value of a state variable. 
+        Set the value of a state variable.
         If None is given for the value, then the constraint will also be set to None.
         If a tuple is given for a scalar variable, then the tuple is used as a range constraint instead of a value.
         Otherwise, the constraint is set to 'fixed'.
-        
+
         """
         # First check this is a valid attribute
         if name in self._vars:
@@ -108,14 +108,14 @@ class SystemSolver(object):
                 object.__setattr__(self, name, value)
             else:
                 raise AttributeError(name)
-        
+
     def get(self, name):
         """
-        Return the value for parameter *name*. 
-        
+        Return the value for parameter *name*.
+
         If the value has not been specified, then attempt to compute it from
         other interacting parameters.
-        
+
         If no value can be determined, then raise RuntimeError.
         """
         if name in self._currentGets:
@@ -134,29 +134,29 @@ class SystemSolver(object):
                 v = self.set(name, v)
         finally:
             self._currentGets.remove(name)
-        
+
         return v
-    
+
     def set(self, name, value=None, constraint=True):
         """
         Set a variable *name* to *value*. The actual set value is returned (in
         some cases, the value may be cast into another type).
-        
-        If *value* is None, then the value is left to be determined in the 
+
+        If *value* is None, then the value is left to be determined in the
         future. At any time, the value may be re-assigned arbitrarily unless
         a constraint is given.
-        
-        If *constraint* is True (the default), then supplying a value that 
+
+        If *constraint* is True (the default), then supplying a value that
         violates a previously specified constraint will raise an exception.
-        
+
         If *constraint* is 'fixed', then the value is set (if provided) and
         the variable will not be updated automatically in the future.
 
-        If *constraint* is a tuple, then the value is constrained to be within the 
-        given (min, max). Either constraint may be None to disable 
+        If *constraint* is a tuple, then the value is constrained to be within the
+        given (min, max). Either constraint may be None to disable
         it. In some cases, a constraint cannot be satisfied automatically,
         and the user will be forced to resolve the constraint manually.
-        
+
         If *constraint* is None, then any constraints are removed for the variable.
         """
         var = self._vars[name]
@@ -175,28 +175,28 @@ class SystemSolver(object):
             var[2] = constraint
         elif constraint is not True:
             raise TypeError("constraint must be None, True, 'fixed', or tuple. (got %s)" % constraint)
-        
+
         # type checking / massaging
         if var[1] is np.ndarray:
             value = np.array(value, dtype=float)
         elif var[1] in (int, float, tuple) and value is not None:
             value = var[1](value)
-            
+
         # constraint checks
         if constraint is True and not self.check_constraint(name, value):
             raise ValueError("Setting %s = %s violates constraint %s" % (name, value, var[2]))
-        
+
         # invalidate other dependent values
         if var[0] is not None:
-            # todo: we can make this more clever..(and might need to) 
+            # todo: we can make this more clever..(and might need to)
             # we just know that a value of None cannot have dependencies
-            # (because if anyone else had asked for this value, it wouldn't be 
+            # (because if anyone else had asked for this value, it wouldn't be
             # None anymore)
             self.resetUnfixed()
-            
+
         var[0] = value
         return value
-    
+
     def check_constraint(self, name, value):
         c = self._vars[name][2]
         if c is None or value is None:
@@ -206,7 +206,7 @@ class SystemSolver(object):
                     (c[1] is None or c[1] >= value))
         else:
             return value == c
-    
+
     def saveState(self):
         """
         Return a serializable description of the solver's current state.
@@ -215,7 +215,7 @@ class SystemSolver(object):
         for name, var in self._vars.items():
             state[name] = (var[0], var[2])
         return state
-    
+
     def restoreState(self, state):
         """
         Restore the state of all values and constraints in the solver.
@@ -223,7 +223,7 @@ class SystemSolver(object):
         self.reset()
         for name, var in state.items():
             self.set(name, var[0], var[1])
-    
+
     def resetUnfixed(self):
         """
         For any variable that does not have a fixed value, reset
@@ -232,11 +232,11 @@ class SystemSolver(object):
         for var in self._vars.values():
             if var[2] != 'fixed':
                 var[0] = None
-                
+
     def solve(self):
         for k in self._vars:
             getattr(self, k)
-                
+
     def __repr__(self):
         state = OrderedDict()
         for name, var in self._vars.items():
@@ -250,28 +250,28 @@ class SystemSolver(object):
 
 
 if __name__ == '__main__':
-    
+
     class Camera(SystemSolver):
         """
-        Consider a simple SLR camera. The variables we will consider that 
+        Consider a simple SLR camera. The variables we will consider that
         affect the camera's behavior while acquiring a photo are aperture, shutter speed,
         ISO, and flash (of course there are many more, but let's keep the example simple).
 
         In rare cases, the user wants to manually specify each of these variables and
         no more work needs to be done to take the photo. More often, the user wants to
-        specify more interesting constraints like depth of field, overall exposure, 
+        specify more interesting constraints like depth of field, overall exposure,
         or maximum allowed ISO value.
 
         If we add a simple light meter measurement into this system and an 'exposure'
-        variable that indicates the desired exposure (0 is "perfect", -1 is one stop 
+        variable that indicates the desired exposure (0 is "perfect", -1 is one stop
         darker, etc), then the system of equations governing the camera behavior would
         have the following variables:
 
             aperture, shutter, iso, flash, exposure, light meter
 
-        The first four variables are the "outputs" of the system (they directly drive 
-        the camera), the last is a constant (the camera itself cannot affect the 
-        reading on the light meter), and 'exposure' specifies a desired relationship 
+        The first four variables are the "outputs" of the system (they directly drive
+        the camera), the last is a constant (the camera itself cannot affect the
+        reading on the light meter), and 'exposure' specifies a desired relationship
         between other variables in the system.
 
         So the question is: how can I formalize a system like this as a user interface?
@@ -285,15 +285,15 @@ if __name__ == '__main__':
                             iso, aperture, and flash
             program: user specifies exposure, camera selects all other variables
                     automatically
-            action: camera selects all variables while attempting to maximize 
+            action: camera selects all variables while attempting to maximize
                     shutter speed
-            portrait: camera selects all variables while attempting to minimize 
+            portrait: camera selects all variables while attempting to minimize
                     aperture
 
-        A more general approach might allow the user to provide more explicit 
-        constraints on each variable (for example: I want a shutter speed of 1/30 or 
-        slower, an ISO no greater than 400, an exposure between -1 and 1, and the 
-        smallest aperture possible given all other constraints) and have the camera 
+        A more general approach might allow the user to provide more explicit
+        constraints on each variable (for example: I want a shutter speed of 1/30 or
+        slower, an ISO no greater than 400, an exposure between -1 and 1, and the
+        smallest aperture possible given all other constraints) and have the camera
         solve the system of equations, with a warning if no solution is found. This
         is exactly what we will implement in this example class.
         """
@@ -301,24 +301,24 @@ if __name__ == '__main__':
         defaultState = OrderedDict([
             # Field stop aperture
             ('aperture', [None, float, None, 'nf']),
-            # Duration that shutter is held open. 
+            # Duration that shutter is held open.
             ('shutter', [None, float, None, 'nf']),
-            # ISO (sensitivity) value. 100, 200, 400, 800, 1600.. 
+            # ISO (sensitivity) value. 100, 200, 400, 800, 1600..
             ('iso', [None, int, None, 'nf']),
-            
+
             # Flash is a value indicating the brightness of the flash. A table
             # is used to decide on "balanced" settings for each flash level:
             #   0: no flash
             #   1: s=1/60,  a=2.0, iso=100
             #   2: s=1/60,  a=4.0, iso=100   ..and so on..
             ('flash', [None, float, None, 'nf']),
-            
+
             # exposure is a value indicating how many stops brighter (+1) or
             # darker (-1) the photographer would like the photo to appear from
             # the 'balanced' settings indicated by the light meter (see below).
             ('exposure', [None, float, None, 'f']),
-            
-            # Let's define this as an external light meter (not affected by 
+
+            # Let's define this as an external light meter (not affected by
             # aperture) with logarithmic output. We arbitrarily choose the
             # following settings as "well balanced" for each light meter value:
             #   -1: s=1/60,  a=2.0, iso=100
@@ -326,14 +326,14 @@ if __name__ == '__main__':
             #    1: s=1/120, a=4.0, iso=100    ..and so on..
             # Note that the only allowed constraint mode is (f)ixed, since the
             # camera never _computes_ the light meter value, it only reads it.
-            ('lightMeter', [None, float, None, 'f']),  
-            
-            # Indicates the camera's final decision on how it thinks the photo will 
+            ('lightMeter', [None, float, None, 'f']),
+
+            # Indicates the camera's final decision on how it thinks the photo will
             # look, given the chosen settings. This value is _only_ determined
             # automatically.
             ('balance', [None, float, None, 'n']),
             ])
-        
+
         def _aperture(self):
             """
             Determine aperture automatically under a variety of conditions.
@@ -341,7 +341,7 @@ if __name__ == '__main__':
             iso = self.iso
             exp = self.exposure
             light = self.lightMeter
-            
+
             try:
                 # shutter-priority mode
                 sh = self.shutter   # this raises RuntimeError if shutter has not
@@ -353,9 +353,9 @@ if __name__ == '__main__':
                 # value at the same time.
                 sh = (1./60.)
                 raise
-            
-            
-            
+
+
+
             return ap
 
         def _balance(self):
@@ -364,18 +364,17 @@ if __name__ == '__main__':
             sh = self.shutter
             ap = self.aperture
             fl = self.flash
-            
+
             bal = (4.0 / ap) * (sh / (1./60.)) * (iso / 100.) * (2 ** light)
             return np.log2(bal)
-    
+
     camera = Camera()
-    
+
     camera.iso = 100
     camera.exposure = 0
     camera.lightMeter = 2
     camera.shutter = 1./60.
     camera.flash = 0
-    
+
     camera.solve()
     print(camera.saveState())
-    

--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -13,11 +13,11 @@ from ..pgcollections import OrderedDict
 class WidgetParameterItem(ParameterItem):
     """
     ParameterTree item with:
-    
+
     * label in second column for displaying value
     * simple widget for editing value (displayed instead of label when item is selected)
     * button that resets value to default
-    
+
     ==========================  =============================================================
     **Registered Types:**
     int                         Displays a :class:`SpinBox <pyqtgraph.SpinBox>` in integer
@@ -28,34 +28,34 @@ class WidgetParameterItem(ParameterItem):
     color                       Displays a :class:`ColorButton <pyqtgraph.ColorButton>`
     colormap                    Displays a :class:`GradientWidget <pyqtgraph.GradientWidget>`
     ==========================  =============================================================
-    
+
     This class can be subclassed by overriding makeWidget() to provide a custom widget.
     """
     def __init__(self, param, depth):
         ParameterItem.__init__(self, param, depth)
-        
+
         self.hideWidget = True  ## hide edit widget, replace with label when not selected
                                 ## set this to False to keep the editor widget always visible
-        
-        
+
+
         ## build widget into column 1 with a display label and default button.
-        w = self.makeWidget()  
+        w = self.makeWidget()
         self.widget = w
         self.eventProxy = EventProxy(w, self.widgetEventFilter)
-        
+
         opts = self.param.opts
         if 'tip' in opts:
             w.setToolTip(opts['tip'])
-        
+
         self.defaultBtn = QtGui.QPushButton()
         self.defaultBtn.setFixedWidth(20)
         self.defaultBtn.setFixedHeight(20)
         modDir = os.path.dirname(__file__)
         self.defaultBtn.setIcon(QtGui.QIcon(pixmaps.getPixmap('default')))
         self.defaultBtn.clicked.connect(self.defaultClicked)
-        
+
         self.displayLabel = QtGui.QLabel()
-        
+
         layout = QtGui.QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(2)
@@ -64,14 +64,14 @@ class WidgetParameterItem(ParameterItem):
         layout.addWidget(self.defaultBtn)
         self.layoutWidget = QtGui.QWidget()
         self.layoutWidget.setLayout(layout)
-        
+
         if w.sigChanged is not None:
             w.sigChanged.connect(self.widgetValueChanged)
-            
+
         if hasattr(w, 'sigChanging'):
             w.sigChanging.connect(self.widgetValueChanging)
-            
-        ## update value shown in widget. 
+
+        ## update value shown in widget.
         if opts.get('value', None) is not None:
             self.valueChanged(self, opts['value'], force=True)
         else:
@@ -84,13 +84,13 @@ class WidgetParameterItem(ParameterItem):
         """
         Return a single widget that should be placed in the second tree column.
         The widget must be given three attributes:
-        
+
         ==========  ============================================================
         sigChanged  a signal that is emitted when the widget's value is changed
         value       a function that returns the value
         setValue    a function that sets the value
         ==========  ============================================================
-            
+
         This is a good function to override in subclasses.
         """
         opts = self.param.opts
@@ -98,7 +98,7 @@ class WidgetParameterItem(ParameterItem):
         if t in ('int', 'float'):
             defs = {
                 'value': 0, 'min': None, 'max': None,
-                'step': 1.0, 'dec': False, 
+                'step': 1.0, 'dec': False,
                 'siPrefix': False, 'suffix': '', 'decimals': 3,
             }
             if t == 'int':
@@ -134,7 +134,7 @@ class WidgetParameterItem(ParameterItem):
             w.setValue = w.setColor
             self.hideWidget = False
             w.setFlat(True)
-            w.setEnabled(not opts.get('readonly', False))            
+            w.setEnabled(not opts.get('readonly', False))
         elif t == 'colormap':
             from ..widgets.GradientWidget import GradientWidget ## need this here to avoid import loop
             w = GradientWidget(orientation='bottom')
@@ -146,7 +146,7 @@ class WidgetParameterItem(ParameterItem):
         else:
             raise Exception("Unknown type '%s'" % asUnicode(t))
         return w
-        
+
     def widgetEventFilter(self, obj, ev):
         ## filter widget's events
         ## catch TAB to change focus
@@ -158,17 +158,17 @@ class WidgetParameterItem(ParameterItem):
             elif ev.key() == QtCore.Qt.Key_Backtab:
                 self.focusNext(forward=False)
                 return True ## don't let anyone else see this event
-            
+
         #elif ev.type() == ev.FocusOut:
             #self.hideEditor()
         return False
-        
+
     def setFocus(self):
         self.showEditor()
-        
+
     def isFocusable(self):
-        return self.param.writable()        
-        
+        return self.param.writable()
+
     def valueChanged(self, param, val, force=False):
         ## called when the parameter's value has changed
         ParameterItem.valueChanged(self, param, val)
@@ -180,11 +180,11 @@ class WidgetParameterItem(ParameterItem):
         finally:
             self.widget.sigChanged.connect(self.widgetValueChanged)
         self.updateDefaultBtn()
-        
+
     def updateDefaultBtn(self):
-        ## enable/disable default btn 
-        self.defaultBtn.setEnabled(not self.param.valueIsDefault() and self.param.writable())        
-        
+        ## enable/disable default btn
+        self.defaultBtn.setEnabled(not self.param.valueIsDefault() and self.param.writable())
+
         # hide / show
         self.defaultBtn.setVisible(not self.param.readonly())
 
@@ -214,11 +214,11 @@ class WidgetParameterItem(ParameterItem):
         # This is a bit sketchy: assume the last argument of each signal is
         # the value..
         self.param.sigValueChanging.emit(self.param, args[-1])
-        
+
     def selected(self, sel):
         """Called when this item has been selected (sel=True) OR deselected (sel=False)"""
         ParameterItem.selected(self, sel)
-        
+
         if self.widget is None:
             return
         if sel and self.param.writable():
@@ -240,7 +240,7 @@ class WidgetParameterItem(ParameterItem):
     def limitsChanged(self, param, limits):
         """Called when the parameter's limits have changed"""
         ParameterItem.limitsChanged(self, param, limits)
-        
+
         t = self.param.opts['type']
         if t == 'int' or t == 'float':
             self.widget.setOpts(bounds=limits)
@@ -253,7 +253,7 @@ class WidgetParameterItem(ParameterItem):
     def treeWidgetChanged(self):
         """Called when this item is added or removed from a tree."""
         ParameterItem.treeWidgetChanged(self)
-        
+
         ## add all widgets for this item into the tree
         if self.widget is not None:
             tree = self.treeWidget()
@@ -261,7 +261,7 @@ class WidgetParameterItem(ParameterItem):
                 return
             tree.setItemWidget(self, 1, self.layoutWidget)
             self.displayLabel.hide()
-            self.selected(False)            
+            self.selected(False)
 
     def defaultClicked(self):
         self.param.setToDefault()
@@ -271,54 +271,54 @@ class WidgetParameterItem(ParameterItem):
         name, value, default, or limits"""
         #print "opts changed:", opts
         ParameterItem.optsChanged(self, param, opts)
-        
+
         if 'readonly' in opts:
             self.updateDefaultBtn()
             if isinstance(self.widget, (QtGui.QCheckBox,ColorButton)):
                 self.widget.setEnabled(not opts['readonly'])
-        
+
         ## If widget is a SpinBox, pass options straight through
         if isinstance(self.widget, SpinBox):
             if 'units' in opts and 'suffix' not in opts:
                 opts['suffix'] = opts['units']
             self.widget.setOpts(**opts)
             self.updateDisplayLabel()
-        
-        
-        
-            
+
+
+
+
 class EventProxy(QtCore.QObject):
     def __init__(self, qobj, callback):
         QtCore.QObject.__init__(self)
         self.callback = callback
         qobj.installEventFilter(self)
-        
+
     def eventFilter(self, obj, ev):
         return self.callback(obj, ev)
 
-        
+
 
 
 class SimpleParameter(Parameter):
     itemClass = WidgetParameterItem
-    
+
     def __init__(self, *args, **kargs):
         Parameter.__init__(self, *args, **kargs)
-        
+
         ## override a few methods for color parameters
         if self.opts['type'] == 'color':
             self.value = self.colorValue
             self.saveState = self.saveColorState
-    
+
     def colorValue(self):
         return fn.mkColor(Parameter.value(self))
-    
+
     def saveColorState(self, *args, **kwds):
         state = Parameter.saveState(self, *args, **kwds)
         state['value'] = fn.colorTuple(self.value())
         return state
-        
-    
+
+
 registerParameterType('int', SimpleParameter, override=True)
 registerParameterType('float', SimpleParameter, override=True)
 registerParameterType('bool', SimpleParameter, override=True)
@@ -337,8 +337,8 @@ class GroupParameterItem(ParameterItem):
     """
     def __init__(self, param, depth):
         ParameterItem.__init__(self, param, depth)
-        self.updateDepth(depth) 
-                
+        self.updateDepth(depth)
+
         self.addItem = None
         if 'addText' in param.opts:
             addText = param.opts['addText']
@@ -361,7 +361,7 @@ class GroupParameterItem(ParameterItem):
             self.addItem = QtGui.QTreeWidgetItem([])
             self.addItem.setFlags(QtCore.Qt.ItemIsEnabled)
             ParameterItem.addChild(self, self.addItem)
-            
+
     def updateDepth(self, depth):
         ## Change item's appearance based on its depth in the tree
         ## This allows highest-level groups to be displayed more prominently.
@@ -382,7 +382,7 @@ class GroupParameterItem(ParameterItem):
                 #font.setPointSize(font.pointSize()+1)
                 self.setFont(c, font)
                 self.setSizeHint(0, QtCore.QSize(0, 20))
-    
+
     def addClicked(self):
         """Called when "add new" button is clicked
         The parameter MUST have an 'addNew' method defined.
@@ -405,17 +405,17 @@ class GroupParameterItem(ParameterItem):
         if self.addItem is not None:
             self.treeWidget().setItemWidget(self.addItem, 0, self.addWidgetBox)
             self.treeWidget().setFirstItemColumnSpanned(self.addItem, True)
-        
+
     def addChild(self, child):  ## make sure added childs are actually inserted before add btn
         if self.addItem is not None:
             ParameterItem.insertChild(self, self.childCount()-1, child)
         else:
             ParameterItem.addChild(self, child)
-            
+
     def optsChanged(self, param, changed):
         if 'addList' in changed:
             self.updateAddList()
-                
+
     def updateAddList(self):
         self.addWidget.blockSignals(True)
         try:
@@ -425,14 +425,14 @@ class GroupParameterItem(ParameterItem):
                 self.addWidget.addItem(t)
         finally:
             self.addWidget.blockSignals(False)
-            
+
 class GroupParameter(Parameter):
     """
     Group parameters are used mainly as a generic parent item that holds (and groups!) a set
-    of child parameters. 
-    
+    of child parameters.
+
     It also provides a simple mechanism for displaying a button or combo
-    that can be used to add new parameters to the group. To enable this, the group 
+    that can be used to add new parameters to the group. To enable this, the group
     must be initialized with the 'addText' option (the text will be displayed on
     a button which, when clicked, will cause addNew() to be called). If the 'addList'
     option is specified as well, then a dropdown-list of addable items will be displayed
@@ -445,12 +445,12 @@ class GroupParameter(Parameter):
         This method is called when the user has requested to add a new item to the group.
         """
         raise Exception("Must override this function in subclass.")
-    
+
     def setAddList(self, vals):
         """Change the list of options available for the user to add to the group."""
         self.setOpts(addList=vals)
 
-    
+
 
 registerParameterType('group', GroupParameter, override=True)
 
@@ -461,13 +461,13 @@ registerParameterType('group', GroupParameter, override=True)
 class ListParameterItem(WidgetParameterItem):
     """
     WidgetParameterItem subclass providing comboBox that lets the user select from a list of options.
-    
+
     """
     def __init__(self, param, depth):
         self.targetValue = None
         WidgetParameterItem.__init__(self, param, depth)
-        
-        
+
+
     def makeWidget(self):
         opts = self.param.opts
         t = opts['type']
@@ -481,12 +481,12 @@ class ListParameterItem(WidgetParameterItem):
         if len(self.forward) > 0:
             self.setValue(self.param.value())
         return w
-        
+
     def value(self):
         key = asUnicode(self.widget.currentText())
-        
+
         return self.forward.get(key, None)
-            
+
     def setValue(self, val):
         self.targetValue = val
         if val not in self.reverse[0]:
@@ -498,15 +498,15 @@ class ListParameterItem(WidgetParameterItem):
 
     def limitsChanged(self, param, limits):
         # set up forward / reverse mappings for name:value
-        
+
         if len(limits) == 0:
             limits = ['']  ## Can never have an empty list--there is always at least a singhe blank item.
-        
+
         self.forward, self.reverse = ListParameter.mapping(limits)
         try:
             self.widget.blockSignals(True)
             val = self.targetValue  #asUnicode(self.widget.currentText())
-            
+
             self.widget.clear()
             for k in self.forward:
                 self.widget.addItem(k)
@@ -515,7 +515,7 @@ class ListParameterItem(WidgetParameterItem):
                     self.updateDisplayLabel()
         finally:
             self.widget.blockSignals(False)
-            
+
 
 
 class ListParameter(Parameter):
@@ -524,7 +524,7 @@ class ListParameter(Parameter):
     def __init__(self, **opts):
         self.forward = OrderedDict()  ## {name: value, ...}
         self.reverse = ([], [])       ## ([value, ...], [name, ...])
-        
+
         ## Parameter uses 'limits' option to define the set of allowed values
         if 'values' in opts:
             opts['limits'] = opts['values']
@@ -532,14 +532,14 @@ class ListParameter(Parameter):
             opts['limits'] = []
         Parameter.__init__(self, **opts)
         self.setLimits(opts['limits'])
-        
+
     def setLimits(self, limits):
         self.forward, self.reverse = self.mapping(limits)
-        
+
         Parameter.setLimits(self, limits)
         if len(self.reverse[0]) > 0 and self.value() not in self.reverse[0]:
             self.setValue(self.reverse[0][0])
-            
+
     #def addItem(self, name, value=None):
         #if name in self.forward:
             #raise Exception("Name '%s' is already in use for this parameter" % name)
@@ -554,7 +554,7 @@ class ListParameter(Parameter):
             #limits = limits[:]
             #limits.append(name)
         ## what if limits == None?
-            
+
     @staticmethod
     def mapping(limits):
         ## Return forward and reverse mapping objects given a limit specification
@@ -590,31 +590,31 @@ class ActionParameterItem(ParameterItem):
         self.button.clicked.connect(self.buttonClicked)
         param.sigNameChanged.connect(self.paramRenamed)
         self.setText(0, '')
-        
+
     def treeWidgetChanged(self):
         ParameterItem.treeWidgetChanged(self)
         tree = self.treeWidget()
         if tree is None:
             return
-        
+
         tree.setFirstItemColumnSpanned(self, True)
         tree.setItemWidget(self, 0, self.layoutWidget)
-        
+
     def paramRenamed(self, param, name):
         self.button.setText(name)
-        
+
     def buttonClicked(self):
         self.param.activate()
-        
+
 class ActionParameter(Parameter):
     """Used for displaying a button within the tree."""
     itemClass = ActionParameterItem
     sigActivated = QtCore.Signal(object)
-    
+
     def activate(self):
         self.sigActivated.emit(self)
         self.emitStateChanged('activated', None)
-        
+
 registerParameterType('action', ActionParameter, override=True)
 
 
@@ -632,11 +632,11 @@ class TextParameterItem(WidgetParameterItem):
         #WidgetParameterItem.treeWidgetChanged(self)
         self.treeWidget().setFirstItemColumnSpanned(self.subItem, True)
         self.treeWidget().setItemWidget(self.subItem, 0, self.textBox)
-        
+
         # for now, these are copied from ParameterItem.treeWidgetChanged
         self.setHidden(not self.param.opts.get('visible', True))
         self.setExpanded(self.param.opts.get('expanded', True))
-        
+
     def makeWidget(self):
         self.textBox = QtGui.QTextEdit()
         self.textBox.setMaximumHeight(100)
@@ -645,11 +645,11 @@ class TextParameterItem(WidgetParameterItem):
         self.textBox.setValue = self.textBox.setPlainText
         self.textBox.sigChanged = self.textBox.textChanged
         return self.textBox
-        
+
 class TextParameter(Parameter):
     """Editable string; displayed as large text box in the tree."""
     itemClass = TextParameterItem
 
-    
-    
+
+
 registerParameterType('text', TextParameter, override=True)

--- a/pyqtgraph/parametertree/tests/test_parametertypes.py
+++ b/pyqtgraph/parametertree/tests/test_parametertypes.py
@@ -14,5 +14,3 @@ def test_opts():
 
     assert list(param.param('bool').items.keys())[0].widget.isEnabled() is False
     assert list(param.param('color').items.keys())[0].widget.isEnabled() is False
-
-

--- a/pyqtgraph/pgcollections.py
+++ b/pyqtgraph/pgcollections.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-advancedTypes.py - Basic data structures not included with python 
+advancedTypes.py - Basic data structures not included with python
 Copyright 2010  Luke Campagnola
 Distributed under MIT/X11 license. See license.txt for more infomation.
 
@@ -18,7 +18,7 @@ try:
 except ImportError:
     # fallback: try to use the ordereddict backport when using python 2.6
     from ordereddict import OrderedDict
-        
+
 
 class ReverseDict(dict):
     """extends dict so that reverse lookups are possible by requesting the key as a list of length 1:
@@ -35,7 +35,7 @@ class ReverseDict(dict):
         for k in data:
             self.reverse[data[k]] = k
         dict.__init__(self, data)
-        
+
     def __getitem__(self, item):
         if type(item) is list:
             return self.reverse[item[0]]
@@ -48,8 +48,8 @@ class ReverseDict(dict):
 
     def __deepcopy__(self, memo):
         raise Exception("deepcopy not implemented")
-        
-        
+
+
 class BiDict(dict):
     """extends dict so that reverse lookups are possible by adding each reverse combination to the dict.
     This only works if all values and keys are unique."""
@@ -59,11 +59,11 @@ class BiDict(dict):
         dict.__init__(self)
         for k in data:
             self[data[k]] = k
-        
+
     def __setitem__(self, item, value):
         dict.__setitem__(self, item, value)
         dict.__setitem__(self, value, item)
-    
+
     def __deepcopy__(self, memo):
         raise Exception("deepcopy not implemented")
 
@@ -72,7 +72,7 @@ class ThreadsafeDict(dict):
     Also adds lock/unlock functions for extended exclusive operations
     Converts all sub-dicts and lists to threadsafe as well.
     """
-    
+
     def __init__(self, *args, **kwargs):
         self.mutex = threading.RLock()
         dict.__init__(self, *args, **kwargs)
@@ -96,7 +96,7 @@ class ThreadsafeDict(dict):
             dict.__setitem__(self, attr, val)
         finally:
             self.unlock()
-        
+
     def __contains__(self, attr):
         self.lock()
         try:
@@ -122,19 +122,19 @@ class ThreadsafeDict(dict):
 
     def lock(self):
         self.mutex.acquire()
-        
+
     def unlock(self):
         self.mutex.release()
 
     def __deepcopy__(self, memo):
         raise Exception("deepcopy not implemented")
-        
+
 class ThreadsafeList(list):
     """Extends list so that getitem, setitem, and contains are all thread-safe.
     Also adds lock/unlock functions for extended exclusive operations
     Converts all sub-lists and dicts to threadsafe as well.
     """
-    
+
     def __init__(self, *args, **kwargs):
         self.mutex = threading.RLock()
         list.__init__(self, *args, **kwargs)
@@ -156,7 +156,7 @@ class ThreadsafeList(list):
             list.__setitem__(self, attr, val)
         finally:
             self.unlock()
-        
+
     def __contains__(self, attr):
         self.lock()
         try:
@@ -172,17 +172,17 @@ class ThreadsafeList(list):
         finally:
             self.unlock()
         return val
-    
+
     def lock(self):
         self.mutex.acquire()
-        
+
     def unlock(self):
         self.mutex.release()
 
     def __deepcopy__(self, memo):
         raise Exception("deepcopy not implemented")
-        
-        
+
+
 def makeThreadsafe(obj):
     if type(obj) is dict:
         return ThreadsafeDict(obj)
@@ -192,8 +192,8 @@ def makeThreadsafe(obj):
         return obj
     else:
         raise Exception("Not sure how to make object of type %s thread-safe" % str(type(obj)))
-        
-        
+
+
 class Locker(object):
     def __init__(self, lock):
         self.lock = lock
@@ -217,10 +217,10 @@ class CaselessDict(OrderedDict):
                 self[k] = args[0][k]
         else:
             raise Exception("CaselessDict may only be instantiated with a single dict.")
-        
+
     #def keys(self):
         #return self.keyMap.values()
-    
+
     def __setitem__(self, key, val):
         kl = key.lower()
         if kl in self.keyMap:
@@ -228,30 +228,30 @@ class CaselessDict(OrderedDict):
         else:
             OrderedDict.__setitem__(self, key, val)
             self.keyMap[kl] = key
-            
+
     def __getitem__(self, key):
         kl = key.lower()
         if kl not in self.keyMap:
             raise KeyError(key)
         return OrderedDict.__getitem__(self, self.keyMap[kl])
-        
+
     def __contains__(self, key):
         return key.lower() in self.keyMap
-    
+
     def update(self, d):
         for k, v in d.iteritems():
             self[k] = v
-            
+
     def copy(self):
         return CaselessDict(OrderedDict.copy(self))
-        
+
     def __delitem__(self, key):
         kl = key.lower()
         if kl not in self.keyMap:
             raise KeyError(key)
         OrderedDict.__delitem__(self, self.keyMap[kl])
         del self.keyMap[kl]
-            
+
     def __deepcopy__(self, memo):
         raise Exception("deepcopy not implemented")
 
@@ -263,34 +263,34 @@ class CaselessDict(OrderedDict):
 
 class ProtectedDict(dict):
     """
-    A class allowing read-only 'view' of a dict. 
+    A class allowing read-only 'view' of a dict.
     The object can be treated like a normal dict, but will never modify the original dict it points to.
     Any values accessed from the dict will also be read-only.
     """
     def __init__(self, data):
         self._data_ = data
-    
+
     ## List of methods to directly wrap from _data_
     wrapMethods = ['_cmp_', '__contains__', '__eq__', '__format__', '__ge__', '__gt__', '__le__', '__len__', '__lt__', '__ne__', '__reduce__', '__reduce_ex__', '__repr__', '__str__', 'count', 'has_key', 'iterkeys', 'keys', ]
-    
+
     ## List of methods which wrap from _data_ but return protected results
     protectMethods = ['__getitem__', '__iter__', 'get', 'items', 'values']
-    
+
     ## List of methods to disable
     disableMethods = ['__delitem__', '__setitem__', 'clear', 'pop', 'popitem', 'setdefault', 'update']
-    
-    
-    ## Template methods 
+
+
+    ## Template methods
     def wrapMethod(methodName):
         return lambda self, *a, **k: getattr(self._data_, methodName)(*a, **k)
-        
+
     def protectMethod(methodName):
         return lambda self, *a, **k: protect(getattr(self._data_, methodName)(*a, **k))
-    
+
     def error(self, *args, **kargs):
         raise Exception("Can not modify read-only list.")
-    
-    
+
+
     ## Directly (and explicitly) wrap some methods from _data_
     ## Many of these methods can not be intercepted using __getattribute__, so they
     ## must be implemented explicitly
@@ -305,33 +305,33 @@ class ProtectedDict(dict):
     for methodName in disableMethods:
         locals()[methodName] = error
 
-    
+
     ## Add a few extra methods.
     def copy(self):
         raise Exception("It is not safe to copy protected dicts! (instead try deepcopy, but be careful.)")
-    
+
     def itervalues(self):
         for v in self._data_.itervalues():
             yield protect(v)
-        
+
     def iteritems(self):
         for k, v in self._data_.iteritems():
             yield (k, protect(v))
-        
+
     def deepcopy(self):
         return copy.deepcopy(self._data_)
-    
+
     def __deepcopy__(self, memo):
         return copy.deepcopy(self._data_, memo)
 
 
-            
+
 class ProtectedList(collections.Sequence):
     """
-    A class allowing read-only 'view' of a list or dict. 
+    A class allowing read-only 'view' of a list or dict.
     The object can be treated like a normal list, but will never modify the original list it points to.
     Any values accessed from the list will also be read-only.
-    
+
     Note: It would be nice if we could inherit from list or tuple so that isinstance checks would work.
           However, doing this causes tuple(obj) to return unprotected results (importantly, this means
           unpacking into function arguments will also fail)
@@ -339,28 +339,28 @@ class ProtectedList(collections.Sequence):
     def __init__(self, data):
         self._data_ = data
         #self.__mro__ = (ProtectedList, object)
-        
+
     ## List of methods to directly wrap from _data_
     wrapMethods = ['__contains__', '__eq__', '__format__', '__ge__', '__gt__', '__le__', '__len__', '__lt__', '__ne__', '__reduce__', '__reduce_ex__', '__repr__', '__str__', 'count', 'index']
-    
+
     ## List of methods which wrap from _data_ but return protected results
     protectMethods = ['__getitem__', '__getslice__', '__mul__', '__reversed__', '__rmul__']
-    
+
     ## List of methods to disable
     disableMethods = ['__delitem__', '__delslice__', '__iadd__', '__imul__', '__setitem__', '__setslice__', 'append', 'extend', 'insert', 'pop', 'remove', 'reverse', 'sort']
-    
-    
-    ## Template methods 
+
+
+    ## Template methods
     def wrapMethod(methodName):
         return lambda self, *a, **k: getattr(self._data_, methodName)(*a, **k)
-        
+
     def protectMethod(methodName):
         return lambda self, *a, **k: protect(getattr(self._data_, methodName)(*a, **k))
-    
+
     def error(self, *args, **kargs):
         raise Exception("Can not modify read-only list.")
-    
-    
+
+
     ## Directly (and explicitly) wrap some methods from _data_
     ## Many of these methods can not be intercepted using __getattribute__, so they
     ## must be implemented explicitly
@@ -375,13 +375,13 @@ class ProtectedList(collections.Sequence):
     for methodName in disableMethods:
         locals()[methodName] = error
 
-    
+
     ## Add a few extra methods.
     def __iter__(self):
         for item in self._data_:
             yield protect(item)
-    
-    
+
+
     def __add__(self, op):
         if isinstance(op, ProtectedList):
             return protect(self._data_.__add__(op._data_))
@@ -389,7 +389,7 @@ class ProtectedList(collections.Sequence):
             return protect(self._data_.__add__(op))
         else:
             raise TypeError("Argument must be a list.")
-    
+
     def __radd__(self, op):
         if isinstance(op, ProtectedList):
             return protect(op._data_.__add__(self._data_))
@@ -397,13 +397,13 @@ class ProtectedList(collections.Sequence):
             return protect(op.__add__(self._data_))
         else:
             raise TypeError("Argument must be a list.")
-        
+
     def deepcopy(self):
         return copy.deepcopy(self._data_)
-    
+
     def __deepcopy__(self, memo):
         return copy.deepcopy(self._data_, memo)
-    
+
     def poop(self):
         raise Exception("This is a list. It does not poop.")
 
@@ -412,29 +412,29 @@ class ProtectedTuple(collections.Sequence):
     """
     A class allowing read-only 'view' of a tuple.
     The object can be treated like a normal tuple, but its contents will be returned as protected objects.
-    
+
     Note: It would be nice if we could inherit from list or tuple so that isinstance checks would work.
           However, doing this causes tuple(obj) to return unprotected results (importantly, this means
           unpacking into function arguments will also fail)
     """
     def __init__(self, data):
         self._data_ = data
-    
+
     ## List of methods to directly wrap from _data_
     wrapMethods = ['__contains__', '__eq__', '__format__', '__ge__', '__getnewargs__', '__gt__', '__hash__', '__le__', '__len__', '__lt__', '__ne__', '__reduce__', '__reduce_ex__', '__repr__', '__str__', 'count', 'index']
-    
+
     ## List of methods which wrap from _data_ but return protected results
     protectMethods = ['__getitem__', '__getslice__', '__iter__', '__add__', '__mul__', '__reversed__', '__rmul__']
-    
-    
-    ## Template methods 
+
+
+    ## Template methods
     def wrapMethod(methodName):
         return lambda self, *a, **k: getattr(self._data_, methodName)(*a, **k)
-        
+
     def protectMethod(methodName):
         return lambda self, *a, **k: protect(getattr(self._data_, methodName)(*a, **k))
-    
-    
+
+
     ## Directly (and explicitly) wrap some methods from _data_
     ## Many of these methods can not be intercepted using __getattribute__, so they
     ## must be implemented explicitly
@@ -445,14 +445,14 @@ class ProtectedTuple(collections.Sequence):
     for methodName in protectMethods:
         locals()[methodName] = protectMethod(methodName)
 
-    
+
     ## Add a few extra methods.
     def deepcopy(self):
         return copy.deepcopy(self._data_)
-    
+
     def __deepcopy__(self, memo):
         return copy.deepcopy(self._data_, memo)
-    
+
 
 
 def protect(obj):
@@ -464,14 +464,14 @@ def protect(obj):
         return ProtectedTuple(obj)
     else:
         return obj
-    
-    
+
+
 if __name__ == '__main__':
     d = {'x': 1, 'y': [1,2], 'z': ({'a': 2, 'b': [3,4], 'c': (5,6)}, 1, 2)}
     dp = protect(d)
-    
+
     l = [1, 'x', ['a', 'b'], ('c', 'd'), {'x': 1, 'y': 2}]
     lp = protect(l)
-    
+
     t = (1, 'x', ['a', 'b'], ('c', 'd'), {'x': 1, 'y': 2})
     tp = protect(t)

--- a/pyqtgraph/pixmaps/__init__.py
+++ b/pyqtgraph/pixmaps/__init__.py
@@ -1,5 +1,5 @@
 """
-Allows easy loading of pixmaps used in UI elements. 
+Allows easy loading of pixmaps used in UI elements.
 Provides support for frozen environments as well.
 """
 
@@ -24,4 +24,3 @@ def getPixmap(name):
         pixmapData.pixmapData[key] = pickle.loads(data)
     arr = pixmapData.pixmapData[key]
     return QtGui.QPixmap(makeQImage(arr, alpha=True))
-    

--- a/pyqtgraph/pixmaps/compile.py
+++ b/pyqtgraph/pixmaps/compile.py
@@ -16,4 +16,3 @@ for f in os.listdir(path):
 ver = sys.version_info[0]
 fh = open(os.path.join(path, 'pixmapData_%d.py' %ver), 'w')
 fh.write("import numpy as np; pixmapData=%s" % repr(pixmaps))
-    

--- a/pyqtgraph/ptime.py
+++ b/pyqtgraph/ptime.py
@@ -23,8 +23,7 @@ def unixTime():
 if sys.platform.startswith('win'):
     cstart = systime.clock()  ### Required to start the clock in windows
     START_TIME = systime.time() - cstart
-    
+
     time = winTime
 else:
     time = unixTime
-

--- a/pyqtgraph/python2_3.py
+++ b/pyqtgraph/python2_3.py
@@ -13,7 +13,7 @@ def asUnicode(x):
             return unicode(x)
     else:
         return str(x)
-        
+
 def cmpToKey(mycmp):
     'Convert a cmp= function into a key= function'
     class K(object):
@@ -54,5 +54,3 @@ else:
     basestring = __builtin__.basestring
     cmp = __builtin__.cmp
     xrange = __builtin__.xrange
-    
-    

--- a/pyqtgraph/tests/test_functions.py
+++ b/pyqtgraph/tests/test_functions.py
@@ -10,15 +10,15 @@ def testSolve3D():
                    [1,0,0,1],
                    [0,1,0,1],
                    [0,0,1,1]], dtype=float)
-    
+
     # transform points through random matrix
     tr = np.random.normal(size=(4, 4))
     tr[3] = (0,0,0,1)
     p2 = np.dot(tr, p1.T).T[:,:3]
-    
+
     # solve to see if we can recover the transformation matrix.
     tr2 = pg.solve3DTransform(p1, p2)
-    
+
     assert_array_almost_equal(tr[:3], tr2[:3])
 
 
@@ -27,11 +27,11 @@ def test_interpolateArray():
         result = pg.interpolateArray(data, x)
         assert result.shape == x.shape[:-1] + data.shape[x.shape[-1]:]
         return result
-    
+
     data = np.array([[ 1.,   2.,   4.  ],
                      [ 10.,  20.,  40. ],
                      [ 100., 200., 400.]])
-    
+
     # test various x shapes
     interpolateArray(data, np.ones((1,)))
     interpolateArray(data, np.ones((2,)))
@@ -47,21 +47,21 @@ def test_interpolateArray():
         interpolateArray(data, np.ones((1, 3,)))
     with pytest.raises(TypeError):
         interpolateArray(data, np.ones((5, 5, 3,)))
-    
-    
+
+
     x = np.array([[  0.3,   0.6],
                   [  1. ,   1. ],
                   [  0.5,   1. ],
                   [  0.5,   2.5],
                   [ 10. ,  10. ]])
-    
+
     result = interpolateArray(data, x)
     #import scipy.ndimage
     #spresult = scipy.ndimage.map_coordinates(data, x.T, order=1)
     spresult = np.array([  5.92,  20.  ,  11.  ,   0.  ,   0.  ])  # generated with the above line
-    
+
     assert_array_almost_equal(result, spresult)
-    
+
     # test mapping when x.shape[-1] < data.ndim
     x = np.array([[  0.3,   0],
                   [  0.3,   1],
@@ -69,39 +69,39 @@ def test_interpolateArray():
     r1 = interpolateArray(data, x)
     x = np.array([0.3])  # should broadcast across axis 1
     r2 = interpolateArray(data, x)
-    
+
     assert_array_almost_equal(r1, r2)
-    
-    
+
+
     # test mapping 2D array of locations
     x = np.array([[[0.5, 0.5], [0.5, 1.0], [0.5, 1.5]],
                   [[1.5, 0.5], [1.5, 1.0], [1.5, 1.5]]])
-    
+
     r1 = interpolateArray(data, x)
     #r2 = scipy.ndimage.map_coordinates(data, x.transpose(2,0,1), order=1)
     r2 = np.array([[   8.25,   11.  ,   16.5 ],  # generated with the above line
                    [  82.5 ,  110.  ,  165.  ]])
 
     assert_array_almost_equal(r1, r2)
-    
-    
+
+
     # test interpolate where data.ndim > x.shape[1]
-    
+
     data = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]) # 2x2x3
     x = np.array([[1, 1], [0, 0.5], [5, 5]])
-    
+
     r1 = interpolateArray(data, x)
     assert np.all(r1[0] == data[1, 1])
     assert np.all(r1[1] == 0.5 * (data[0, 0] + data[0, 1]))
     assert np.all(r1[2] == 0)
-    
-    
+
+
 def test_subArray():
     a = np.array([0, 0, 111, 112, 113, 0, 121, 122, 123, 0, 0, 0, 211, 212, 213, 0, 221, 222, 223, 0, 0, 0, 0])
     b = pg.subArray(a, offset=2, shape=(2,2,3), stride=(10,4,1))
     c = np.array([[[111,112,113], [121,122,123]], [[211,212,213], [221,222,223]]])
     assert np.all(b == c)
-    
+
     # operate over first axis; broadcast over the rest
     aa = np.vstack([a, a/100.]).T
     cc = np.empty(c.shape + (2,))
@@ -109,8 +109,8 @@ def test_subArray():
     cc[..., 1] = c / 100.
     bb = pg.subArray(aa, offset=2, shape=(2,2,3), stride=(10,4,1))
     assert np.all(bb == cc)
-    
-    
-    
+
+
+
 if __name__ == '__main__':
     test_interpolateArray()

--- a/pyqtgraph/tests/test_ref_cycles.py
+++ b/pyqtgraph/tests/test_ref_cycles.py
@@ -12,7 +12,7 @@ app = pg.mkQApp()
 skipreason = ('unclear why test is failing on python 3. skipping until someone '
               'has time to fix it. Or pyside is being used. This test is '
               'failing on pyside for an unknown reason too.')
-                 
+
 def assert_alldead(refs):
     for ref in refs:
         assert ref() is None
@@ -36,7 +36,7 @@ def mkrefs(*objs):
             obj = [obj]
         for o in obj:
             allObjs[id(o)] = o
-            
+
     return map(weakref.ref, allObjs.values())
 
 
@@ -47,26 +47,26 @@ def test_PlotWidget():
         data = pg.np.array([1,5,2,4,3])
         c = w.plot(data, name='stuff')
         w.addLegend()
-        
+
         # test that connections do not keep objects alive
         w.plotItem.vb.sigRangeChanged.connect(mkrefs)
         app.focusChanged.connect(w.plotItem.vb.invertY)
-        
+
         # return weakrefs to a bunch of objects that should die when the scope exits.
         return mkrefs(w, c, data, w.plotItem, w.plotItem.vb, w.plotItem.getMenu(), w.plotItem.getAxis('left'))
-    
+
     for i in range(5):
         assert_alldead(mkobjs())
-    
+
 @pytest.mark.skipif(six.PY3 or pg.Qt.USE_PYSIDE, reason=skipreason)
 def test_ImageView():
     def mkobjs():
         iv = pg.ImageView()
         data = np.zeros((10,10,5))
         iv.setImage(data)
-        
+
         return mkrefs(iv, iv.imageItem, iv.view, iv.ui.histogram, data)
-    
+
     for i in range(5):
         assert_alldead(mkobjs())
 
@@ -78,11 +78,11 @@ def test_GraphicsWindow():
         p1 = w.addPlot()
         v1 = w.addViewBox()
         return mkrefs(w, p1, v1)
-    
+
     for i in range(5):
         assert_alldead(mkobjs())
 
-    
-    
+
+
 if __name__ == '__main__':
     ot = test_PlotItem()

--- a/pyqtgraph/tests/test_srttransform3d.py
+++ b/pyqtgraph/tests/test_srttransform3d.py
@@ -26,7 +26,7 @@ def testMatrix():
 
     tr2 = pg.Transform3D(tr)
     assert np.all(tr.matrix() == tr2.matrix())
-    
+
     # This is the most important test:
     # The transition from Transform3D to SRTTransform3D is a tricky one.
     tr3 = pg.SRTTransform3D(tr2)
@@ -35,5 +35,3 @@ def testMatrix():
     assert_array_almost_equal(tr3.getRotation()[1], tr.getRotation()[1])
     assert_array_almost_equal(tr3.getScale(), tr.getScale())
     assert_array_almost_equal(tr3.getTranslation(), tr.getTranslation())
-
-

--- a/pyqtgraph/tests/test_stability.py
+++ b/pyqtgraph/tests/test_stability.py
@@ -2,7 +2,7 @@
 PyQt/PySide stress test:
 
 Create lots of random widgets and graphics items, connect them together randomly,
-the tear them down repeatedly. 
+the tear them down repeatedly.
 
 The purpose of this is to attempt to generate segmentation faults.
 """
@@ -16,18 +16,18 @@ app = pg.mkQApp()
 seed(12345)
 
 widgetTypes = [
-    pg.PlotWidget, 
-    pg.ImageView, 
-    pg.GraphicsView, 
+    pg.PlotWidget,
+    pg.ImageView,
+    pg.GraphicsView,
     pg.QtGui.QWidget,
-    pg.QtGui.QTreeWidget, 
+    pg.QtGui.QTreeWidget,
     pg.QtGui.QPushButton,
     ]
 
 itemTypes = [
-    pg.PlotCurveItem, 
-    pg.ImageItem, 
-    pg.PlotDataItem, 
+    pg.PlotCurveItem,
+    pg.ImageItem,
+    pg.PlotDataItem,
     pg.ViewBox,
     pg.QtGui.QGraphicsRectItem
     ]
@@ -82,7 +82,7 @@ class WorkThread(pg.QtCore.QThread):
             i += 1
             if (i % 1000000) == 0:
                 print('--worker--')
-            
+
 
 def randItem(items):
     return items[randint(0, len(items)-1)]
@@ -151,10 +151,10 @@ def addReference():
         return
     obj1 = randItem(widgets)
     obj2 = randItem(widgets)
-    p('    %s -> %s' % (obj1, obj2))    
+    p('    %s -> %s' % (obj1, obj2))
     obj1._testref = obj2
-    
 
-        
+
+
 if __name__ == '__main__':
     test_stability()

--- a/pyqtgraph/units.py
+++ b/pyqtgraph/units.py
@@ -4,7 +4,7 @@
 ##  - the value assigned to the variable corresponds to the scale prefix
 ##    (mV = 0.001)
 ##  - the actual units are purely cosmetic for making code clearer:
-##  
+##
 ##    x = 20*pA    is identical to    x = 20*1e-12
 
 ## No unicode variable names (μ,Ω) allowed until python 3
@@ -19,7 +19,7 @@ def addUnit(p, n):
     for u in UNITS:
         g[p+u] = v
         allUnits[p+u] = v
-    
+
 for p in SI_PREFIXES:
     if p ==  ' ':
         p = ''
@@ -46,19 +46,17 @@ def evalUnits(unitStr):
         A*s / V   =>  ([A, s], [V,])
     """
     pass
-    
+
 def formatUnits(units):
     """
     Format a unit specification ([numerators,...], [denominators,...])
     into a string (this is the inverse of evalUnits)
     """
     pass
-    
+
 def simplify(units):
     """
-    Cancel units that appear in both numerator and denominator, then attempt to replace 
+    Cancel units that appear in both numerator and denominator, then attempt to replace
     groups of units with single units where possible (ie, J/s => W)
     """
     pass
-    
-    

--- a/pyqtgraph/util/colorama/winterm.py
+++ b/pyqtgraph/util/colorama/winterm.py
@@ -73,7 +73,7 @@ class WinTerm(object):
         position.X += 1
         position.Y += 1
         return position
-    
+
     def set_cursor_position(self, position=None, on_stderr=False):
         if position is None:
             #I'm not currently tracking the position, so there is no default.

--- a/pyqtgraph/util/cprint.py
+++ b/pyqtgraph/util/cprint.py
@@ -98,5 +98,3 @@ def cout(*args):
 def cerr(*args):
     """Shorthand for cprint('stderr', ...)"""
     cprint('stderr', *args)
-
-

--- a/pyqtgraph/util/lru_cache.py
+++ b/pyqtgraph/util/lru_cache.py
@@ -19,10 +19,10 @@ class LRUCache(object):
         '''
         ============== =========================================================
         **Arguments:**
-        maxSize        (int) This is the maximum size of the cache. When some 
-                       item is added and the cache would become bigger than 
+        maxSize        (int) This is the maximum size of the cache. When some
+                       item is added and the cache would become bigger than
                        this, it's resized to the value passed on resizeTo.
-        resizeTo       (int) When a resize operation happens, this is the size 
+        resizeTo       (int) When a resize operation happens, this is the size
                        of the final cache.
         ============== =========================================================
         '''
@@ -49,37 +49,37 @@ class LRUCache(object):
         if item is None:
             if len(self._dict) + 1 > self.maxSize:
                 self._resizeTo()
-            
+
             item = [key, value, self._nextTime()]
             self._dict[key] = item
         else:
             item[1] = value
             item[2] = self._nextTime()
-            
+
     def __delitem__(self, key):
         del self._dict[key]
-        
+
     def get(self, key, default=None):
         try:
             return self[key]
         except KeyError:
             return default
-        
+
     def clear(self):
         self._dict.clear()
- 
+
     if _IS_PY3:
         def values(self):
             return [i[1] for i in self._dict.values()]
-        
+
         def keys(self):
             return [x[0] for x in self._dict.values()]
-        
+
         def _resizeTo(self):
             ordered = sorted(self._dict.values(), key=operator.itemgetter(2))[:self.resizeTo]
             for i in ordered:
                 del self._dict[i[0]]
-                
+
         def iteritems(self, accessTime=False):
             '''
             :param bool accessTime:
@@ -91,25 +91,25 @@ class LRUCache(object):
             else:
                 for x in self._dict.items():
                     yield x[0], x[1]
-                    
+
     else:
         def values(self):
             return [i[1] for i in self._dict.itervalues()]
-        
+
         def keys(self):
             return [x[0] for x in self._dict.itervalues()]
-            
-        
+
+
         def _resizeTo(self):
             ordered = sorted(self._dict.itervalues(), key=operator.itemgetter(2))[:self.resizeTo]
             for i in ordered:
                 del self._dict[i[0]]
-                
+
         def iteritems(self, accessTime=False):
             '''
             ============= ======================================================
             **Arguments**
-            accessTime    (bool) If True sorts the returned items by the 
+            accessTime    (bool) If True sorts the returned items by the
                           internal access time.
             ============= ======================================================
             '''

--- a/pyqtgraph/util/mutex.py
+++ b/pyqtgraph/util/mutex.py
@@ -5,12 +5,12 @@ import traceback
 class Mutex(QtCore.QMutex):
     """
     Subclass of QMutex that provides useful debugging information during
-    deadlocks--tracebacks are printed for both the code location that is 
+    deadlocks--tracebacks are printed for both the code location that is
     attempting to lock the mutex as well as the location that has already
     acquired the lock.
-    
+
     Also provides __enter__ and __exit__ methods for use in "with" statements.
-    """    
+    """
     def __init__(self, *args, **kargs):
         if kargs.get('recursive', False):
             args = (QtCore.QMutex.Recursive,)
@@ -36,7 +36,7 @@ class Mutex(QtCore.QMutex):
             finally:
                 self.l.unlock()
         return locked
-        
+
     def lock(self, id=None):
         c = 0
         waitTime = 5000  # in ms
@@ -47,7 +47,7 @@ class Mutex(QtCore.QMutex):
             if self.debug:
                 self.l.lock()
                 try:
-                    print("Waiting for mutex lock (%0.1f sec). Traceback follows:" 
+                    print("Waiting for mutex lock (%0.1f sec). Traceback follows:"
                           % (c*waitTime/1000.))
                     traceback.print_stack()
                     if len(self.tb) > 0:

--- a/pyqtgraph/util/pil_fix.py
+++ b/pyqtgraph/util/pil_fix.py
@@ -60,5 +60,5 @@ if Image.VERSION == '1.1.6':
             obj = obj.tostring()
 
         return frombuffer(mode, size, obj, "raw", mode, 0, 1)
-        
+
     Image.fromarray=fromarray

--- a/pyqtgraph/util/tests/test_lru_cache.py
+++ b/pyqtgraph/util/tests/test_lru_cache.py
@@ -17,7 +17,7 @@ def checkLru(lru):
 
     lru[2] = 2
     assert set([2, 3]) == set(lru.values())
-    
+
     lru[1] = 1
     set([2, 1]) == set(lru.values())
 

--- a/pyqtgraph/widgets/BusyCursor.py
+++ b/pyqtgraph/widgets/BusyCursor.py
@@ -21,4 +21,3 @@ class BusyCursor(object):
         BusyCursor.active.pop(-1)
         if len(BusyCursor.active) == 0:
             QtGui.QApplication.restoreOverrideCursor()
-        

--- a/pyqtgraph/widgets/CheckTable.py
+++ b/pyqtgraph/widgets/CheckTable.py
@@ -5,9 +5,9 @@ from . import VerticalLabel
 __all__ = ['CheckTable']
 
 class CheckTable(QtGui.QWidget):
-    
+
     sigStateChanged = QtCore.Signal(object, object, object) # (row, col, state)
-    
+
     def __init__(self, columns):
         QtGui.QWidget.__init__(self)
         self.layout = QtGui.QGridLayout()
@@ -21,11 +21,11 @@ class CheckTable(QtGui.QWidget):
             self.headers.append(label)
             self.layout.addWidget(label, 0, col)
             col += 1
-        
+
         self.rowNames = []
         self.rowWidgets = []
         self.oldRows = {}  ## remember settings from removed rows; reapply if they reappear.
-        
+
 
     def updateRows(self, rows):
         for r in self.rowNames[:]:
@@ -54,7 +54,7 @@ class CheckTable(QtGui.QWidget):
             check.stateChanged.connect(self.checkChanged)
         self.rowNames.append(name)
         self.rowWidgets.append([label] + checks)
-        
+
     def removeRow(self, name):
         row = self.rowNames.index(name)
         self.oldRows[name] = self.saveState()['rows'][row]  ## save for later
@@ -75,14 +75,14 @@ class CheckTable(QtGui.QWidget):
         check = QtCore.QObject.sender(self)
         #self.emit(QtCore.SIGNAL('stateChanged'), check.row, check.col, state)
         self.sigStateChanged.emit(check.row, check.col, state)
-        
+
     def saveState(self):
         rows = []
         for i in range(len(self.rowNames)):
             row = [self.rowNames[i]] + [c.isChecked() for c in self.rowWidgets[i][1:]]
             rows.append(row)
         return {'cols': self.columns, 'rows': rows}
-        
+
     def restoreState(self, state):
         rows = [r[0] for r in state['rows']]
         self.updateRows(rows)
@@ -90,4 +90,3 @@ class CheckTable(QtGui.QWidget):
             rowNum = self.rowNames.index(r[0])
             for i in range(1, len(r)):
                 self.rowWidgets[rowNum][i].setChecked(r[i])
-            

--- a/pyqtgraph/widgets/ColorButton.py
+++ b/pyqtgraph/widgets/ColorButton.py
@@ -7,9 +7,9 @@ __all__ = ['ColorButton']
 class ColorButton(QtGui.QPushButton):
     """
     **Bases:** QtGui.QPushButton
-    
+
     Button displaying a color and allowing the user to select a new color.
-    
+
     ====================== ============================================================
     **Signals:**
     sigColorChanging(self) emitted whenever a new color is picked in the color dialog
@@ -18,7 +18,7 @@ class ColorButton(QtGui.QPushButton):
     """
     sigColorChanging = QtCore.Signal(object)  ## emitted whenever a new color is picked in the color dialog
     sigColorChanged = QtCore.Signal(object)   ## emitted when the selected color is accepted (user clicks OK)
-    
+
     def __init__(self, parent=None, color=(128,128,128)):
         QtGui.QPushButton.__init__(self, parent)
         self.setColor(color)
@@ -33,7 +33,7 @@ class ColorButton(QtGui.QPushButton):
         self.clicked.connect(self.selectColor)
         self.setMinimumHeight(15)
         self.setMinimumWidth(15)
-        
+
     def paintEvent(self, ev):
         QtGui.QPushButton.paintEvent(self, ev)
         p = QtGui.QPainter(self)
@@ -46,7 +46,7 @@ class ColorButton(QtGui.QPushButton):
         p.setBrush(functions.mkBrush(self._color))
         p.drawRect(rect)
         p.end()
-    
+
     def setColor(self, color, finished=True):
         """Sets the button's color and emits both sigColorChanged and sigColorChanging."""
         self._color = functions.mkColor(color)
@@ -55,28 +55,28 @@ class ColorButton(QtGui.QPushButton):
         else:
             self.sigColorChanging.emit(self)
         self.update()
-        
+
     def selectColor(self):
         self.origColor = self.color()
         self.colorDialog.setCurrentColor(self.color())
         self.colorDialog.open()
-        
+
     def dialogColorChanged(self, color):
         if color.isValid():
             self.setColor(color, finished=False)
-            
+
     def colorRejected(self):
         self.setColor(self.origColor, finished=False)
-    
+
     def colorSelected(self, color):
         self.setColor(self._color, finished=True)
-    
+
     def saveState(self):
         return functions.colorTuple(self._color)
-        
+
     def restoreState(self, state):
         self.setColor(state)
-        
+
     def color(self, mode='qcolor'):
         color = functions.mkColor(self._color)
         if mode == 'qcolor':
@@ -88,4 +88,3 @@ class ColorButton(QtGui.QPushButton):
 
     def widgetGroupInterface(self):
         return (self.sigColorChanged, ColorButton.saveState, ColorButton.restoreState)
-    

--- a/pyqtgraph/widgets/ComboBox.py
+++ b/pyqtgraph/widgets/ComboBox.py
@@ -15,25 +15,25 @@ class ComboBox(QtGui.QComboBox):
     * setItems() replaces the items in the ComboBox and blocks signals if the
       value ultimately does not change.
     """
-    
-    
+
+
     def __init__(self, parent=None, items=None, default=None):
         QtGui.QComboBox.__init__(self, parent)
         self.currentIndexChanged.connect(self.indexChanged)
         self._ignoreIndexChange = False
-        
+
         #self.value = default
         if 'darwin' in sys.platform: ## because MacOSX can show names that are wider than the comboBox
             self.setSizeAdjustPolicy(QtGui.QComboBox.AdjustToMinimumContentsLength)
             #self.setMinimumContentsLength(10)
         self._chosenText = None
         self._items = OrderedDict()
-        
+
         if items is not None:
             self.setItems(items)
             if default is not None:
                 self.setValue(default)
-    
+
     def setValue(self, value):
         """Set the selected item to the first one having the given value."""
         text = None
@@ -43,7 +43,7 @@ class ComboBox(QtGui.QComboBox):
                 break
         if text is None:
             raise ValueError(value)
-            
+
         self.setText(text)
 
     def setText(self, text):
@@ -53,10 +53,10 @@ class ComboBox(QtGui.QComboBox):
             raise ValueError(text)
         #self.value = value
         self.setCurrentIndex(ind)
-       
+
     def value(self):
         """
-        If items were given as a list of strings, then return the currently 
+        If items were given as a list of strings, then return the currently
         selected text. If items were given as a dict, then return the value
         corresponding to the currently selected key. If the combo list is empty,
         return None.
@@ -65,7 +65,7 @@ class ComboBox(QtGui.QComboBox):
             return None
         text = asUnicode(self.currentText())
         return self._items[text]
-    
+
     def ignoreIndexChange(func):
         # Decorator that prevents updates to self._chosenText
         def fn(self, *args, **kwds):
@@ -77,7 +77,7 @@ class ComboBox(QtGui.QComboBox):
                 self._ignoreIndexChange = prev
             return ret
         return fn
-    
+
     def blockIfUnchanged(func):
         # decorator that blocks signal emission during complex operations
         # and emits currentIndexChanged only if the value has actually
@@ -90,38 +90,38 @@ class ComboBox(QtGui.QComboBox):
                 ret = func(self, *args, **kwds)
             finally:
                 self.blockSignals(blocked)
-                
+
             # only emit if the value has changed
             if self.value() != prevVal:
                 self.currentIndexChanged.emit(self.currentIndex())
-                
+
             return ret
         return fn
-    
+
     @ignoreIndexChange
     @blockIfUnchanged
     def setItems(self, items):
         """
-        *items* may be a list or a dict. 
+        *items* may be a list or a dict.
         If a dict is given, then the keys are used to populate the combo box
         and the values will be used for both value() and setValue().
         """
         prevVal = self.value()
-        
+
         self.blockSignals(True)
         try:
             self.clear()
             self.addItems(items)
         finally:
             self.blockSignals(False)
-            
+
         # only emit if we were not able to re-set the original value
         if self.value() != prevVal:
             self.currentIndexChanged.emit(self.currentIndex())
-        
+
     def items(self):
         return self.items.copy()
-        
+
     def updateList(self, items):
         # for backward compatibility
         return self.setItems(items)
@@ -131,10 +131,10 @@ class ComboBox(QtGui.QComboBox):
         if self._ignoreIndexChange:
             return
         self._chosenText = asUnicode(self.currentText())
-        
+
     def setCurrentIndex(self, index):
         QtGui.QComboBox.setCurrentIndex(self, index)
-        
+
     def itemsChanged(self):
         # try to set the value to the last one selected, if it is available.
         if self._chosenText is not None:
@@ -148,13 +148,13 @@ class ComboBox(QtGui.QComboBox):
         raise NotImplementedError()
         #QtGui.QComboBox.insertItem(self, *args)
         #self.itemsChanged()
-        
+
     @ignoreIndexChange
     def insertItems(self, *args):
         raise NotImplementedError()
         #QtGui.QComboBox.insertItems(self, *args)
         #self.itemsChanged()
-    
+
     @ignoreIndexChange
     def addItem(self, *args, **kwds):
         # Need to handle two different function signatures for QComboBox.addItem
@@ -171,23 +171,23 @@ class ComboBox(QtGui.QComboBox):
                     value = args[2]
                 else:
                     value = kwds.get('value', text)
-        
+
         except IndexError:
             raise TypeError("First or second argument of addItem must be a string.")
-            
+
         if text in self._items:
             raise Exception('ComboBox already has item named "%s".' % text)
-        
+
         self._items[text] = value
         QtGui.QComboBox.addItem(self, *args)
         self.itemsChanged()
-        
+
     def setItemValue(self, name, value):
         if name not in self._items:
             self.addItem(name, value)
         else:
             self._items[name] = value
-        
+
     @ignoreIndexChange
     @blockIfUnchanged
     def addItems(self, items):
@@ -198,21 +198,20 @@ class ComboBox(QtGui.QComboBox):
             texts = list(items.keys())
         else:
             raise TypeError("items argument must be list or dict (got %s)." % type(items))
-        
+
         for t in texts:
             if t in self._items:
                 raise Exception('ComboBox already has item named "%s".' % t)
-                
-        
+
+
         for k,v in items.items():
             self._items[k] = v
         QtGui.QComboBox.addItems(self, list(texts))
-        
+
         self.itemsChanged()
-        
+
     @ignoreIndexChange
     def clear(self):
         self._items = OrderedDict()
         QtGui.QComboBox.clear(self)
         self.itemsChanged()
-        

--- a/pyqtgraph/widgets/DataFilterWidget.py
+++ b/pyqtgraph/widgets/DataFilterWidget.py
@@ -11,60 +11,60 @@ class DataFilterWidget(ptree.ParameterTree):
     This class allows the user to filter multi-column data sets by specifying
     multiple criteria
     """
-    
+
     sigFilterChanged = QtCore.Signal(object)
-    
+
     def __init__(self):
         ptree.ParameterTree.__init__(self, showHeader=False)
         self.params = DataFilterParameter()
-        
+
         self.setParameters(self.params)
         self.params.sigTreeStateChanged.connect(self.filterChanged)
-        
+
         self.setFields = self.params.setFields
         self.filterData = self.params.filterData
         self.describe = self.params.describe
-        
+
     def filterChanged(self):
         self.sigFilterChanged.emit(self)
-        
+
     def parameters(self):
         return self.params
-        
-        
+
+
 class DataFilterParameter(ptree.types.GroupParameter):
-    
+
     sigFilterChanged = QtCore.Signal(object)
-    
+
     def __init__(self):
         self.fields = {}
         ptree.types.GroupParameter.__init__(self, name='Data Filter', addText='Add filter..', addList=[])
         self.sigTreeStateChanged.connect(self.filterChanged)
-    
+
     def filterChanged(self):
         self.sigFilterChanged.emit(self)
-        
+
     def addNew(self, name):
         mode = self.fields[name].get('mode', 'range')
         if mode == 'range':
             self.addChild(RangeFilterItem(name, self.fields[name]))
         elif mode == 'enum':
             self.addChild(EnumFilterItem(name, self.fields[name]))
-            
-            
+
+
     def fieldNames(self):
         return self.fields.keys()
-    
+
     def setFields(self, fields):
         self.fields = OrderedDict(fields)
         names = self.fieldNames()
         self.setAddList(names)
-    
+
     def filterData(self, data):
         if len(data) == 0:
             return data
         return data[self.generateMask(data)]
-    
+
     def generateMask(self, data):
         mask = np.ones(len(data), dtype=bool)
         if len(data) == 0:
@@ -74,12 +74,12 @@ class DataFilterParameter(ptree.types.GroupParameter):
                 continue
             mask &= fp.generateMask(data, mask.copy())
             #key, mn, mx = fp.fieldName, fp['Min'], fp['Max']
-            
+
             #vals = data[key]
             #mask &= (vals >= mn)
             #mask &= (vals < mx)  ## Use inclusive minimum and non-inclusive maximum. This makes it easier to create non-overlapping selections
         return mask
-    
+
     def describe(self):
         """Return a list of strings describing the currently enabled filters."""
         desc = []
@@ -94,22 +94,22 @@ class RangeFilterItem(ptree.types.SimpleParameter):
         self.fieldName = name
         units = opts.get('units', '')
         self.units = units
-        ptree.types.SimpleParameter.__init__(self, 
-            name=name, autoIncrementName=True, type='bool', value=True, removable=True, renamable=True, 
+        ptree.types.SimpleParameter.__init__(self,
+            name=name, autoIncrementName=True, type='bool', value=True, removable=True, renamable=True,
             children=[
                 #dict(name="Field", type='list', value=name, values=fields),
                 dict(name='Min', type='float', value=0.0, suffix=units, siPrefix=True),
                 dict(name='Max', type='float', value=1.0, suffix=units, siPrefix=True),
             ])
-            
+
     def generateMask(self, data, mask):
         vals = data[self.fieldName][mask]
         mask[mask] = (vals >= self['Min']) & (vals < self['Max'])  ## Use inclusive minimum and non-inclusive maximum. This makes it easier to create non-overlapping selections
         return mask
-    
+
     def describe(self):
         return "%s < %s < %s" % (fn.siFormat(self['Min'], suffix=self.units), self.fieldName, fn.siFormat(self['Max'], suffix=self.units))
-    
+
 class EnumFilterItem(ptree.types.SimpleParameter):
     def __init__(self, name, opts):
         self.fieldName = name
@@ -124,11 +124,11 @@ class EnumFilterItem(ptree.types.SimpleParameter):
         ch = ptree.Parameter.create(name='(other)', type='bool', value=True)
         ch.maskValue = '__other__'
         childs.append(ch)
-            
-        ptree.types.SimpleParameter.__init__(self, 
-            name=name, autoIncrementName=True, type='bool', value=True, removable=True, renamable=True, 
+
+        ptree.types.SimpleParameter.__init__(self,
+            name=name, autoIncrementName=True, type='bool', value=True, removable=True, renamable=True,
             children=childs)
-    
+
     def generateMask(self, data, startMask):
         vals = data[self.fieldName][startMask]
         mask = np.ones(len(vals), dtype=bool)

--- a/pyqtgraph/widgets/DataTreeWidget.py
+++ b/pyqtgraph/widgets/DataTreeWidget.py
@@ -17,15 +17,15 @@ class DataTreeWidget(QtGui.QTreeWidget):
     Widget for displaying hierarchical python data structures
     (eg, nested dicts, lists, and arrays)
     """
-    
-    
+
+
     def __init__(self, parent=None, data=None):
         QtGui.QTreeWidget.__init__(self, parent)
         self.setVerticalScrollMode(self.ScrollPerPixel)
         self.setData(data)
         self.setColumnCount(3)
         self.setHeaderLabels(['key / index', 'type', 'value'])
-        
+
     def setData(self, data, hideRoot=False):
         """data should be a dictionary."""
         self.clear()
@@ -37,7 +37,7 @@ class DataTreeWidget(QtGui.QTreeWidget):
             #self.invisibleRootItem().addChild(c)
         self.expandToDepth(3)
         self.resizeColumnToContents(0)
-        
+
     def buildTree(self, data, parent, name='', hideRoot=False):
         if hideRoot:
             node = parent
@@ -47,7 +47,7 @@ class DataTreeWidget(QtGui.QTreeWidget):
                 typeStr += ": " + data.__class__.__name__
             node = QtGui.QTreeWidgetItem([name, typeStr, ""])
             parent.addChild(node)
-        
+
         if isinstance(data, types.TracebackType):  ## convert traceback to a list of strings
             data = list(map(str.strip, traceback.format_list(traceback.extract_tb(data))))
         elif HAVE_METAARRAY and (hasattr(data, 'implements') and data.implements('MetaArray')):
@@ -55,7 +55,7 @@ class DataTreeWidget(QtGui.QTreeWidget):
                 'data': data.view(np.ndarray),
                 'meta': data.infoCopy()
             }
-            
+
         if isinstance(data, dict):
             for k in data.keys():
                 self.buildTree(data[k], node, str(k))
@@ -64,8 +64,8 @@ class DataTreeWidget(QtGui.QTreeWidget):
                 self.buildTree(data[i], node, str(i))
         else:
             node.setText(2, str(data))
-        
-        
+
+
     #def mkNode(self, name, v):
         #if type(v) is list and len(v) > 0 and isinstance(v[0], dict):
             #inds = map(unicode, range(len(v)))
@@ -80,4 +80,3 @@ class DataTreeWidget(QtGui.QTreeWidget):
             ##print "\nadd value", k, str(v)
             #node = QtGui.QTreeWidgetItem([unicode(name), unicode(v)])
         #return node
-        

--- a/pyqtgraph/widgets/FeedbackButton.py
+++ b/pyqtgraph/widgets/FeedbackButton.py
@@ -7,14 +7,14 @@ class FeedbackButton(QtGui.QPushButton):
     """
     QPushButton which flashes success/failure indication for slow or asynchronous procedures.
     """
-    
-    
+
+
     ### For thread-safetyness
     sigCallSuccess = QtCore.Signal(object, object, object)
     sigCallFailure = QtCore.Signal(object, object, object)
     sigCallProcess = QtCore.Signal(object, object, object)
     sigReset = QtCore.Signal()
-    
+
     def __init__(self, *args):
         QtGui.QPushButton.__init__(self, *args)
         self.origStyle = None
@@ -22,18 +22,18 @@ class FeedbackButton(QtGui.QPushButton):
         self.origStyle = self.styleSheet()
         self.origTip = self.toolTip()
         self.limitedTime = True
-        
-        
+
+
         #self.textTimer = QtCore.QTimer()
         #self.tipTimer = QtCore.QTimer()
         #self.textTimer.timeout.connect(self.setText)
         #self.tipTimer.timeout.connect(self.setToolTip)
-        
+
         self.sigCallSuccess.connect(self.success)
         self.sigCallFailure.connect(self.failure)
         self.sigCallProcess.connect(self.processing)
         self.sigReset.connect(self.reset)
-        
+
 
     def feedback(self, success, message=None, tip="", limitedTime=True):
         """Calls success() or failure(). If you want the message to be displayed until the user takes an action, set limitedTime to False. Then call self.reset() after the desired action.Threadsafe."""
@@ -41,7 +41,7 @@ class FeedbackButton(QtGui.QPushButton):
             self.success(message, tip, limitedTime=limitedTime)
         else:
             self.failure(message, tip, limitedTime=limitedTime)
-    
+
     def success(self, message=None, tip="", limitedTime=True):
         """Displays specified message on button and flashes button green to let user know action was successful. If you want the success to be displayed until the user takes an action, set limitedTime to False. Then call self.reset() after the desired action. Threadsafe."""
         isGuiThread = QtCore.QThread.currentThread() == QtCore.QCoreApplication.instance().thread()
@@ -51,7 +51,7 @@ class FeedbackButton(QtGui.QPushButton):
             self.startBlink("#0F0", message, tip, limitedTime=limitedTime)
         else:
             self.sigCallSuccess.emit(message, tip, limitedTime)
-            
+
     def failure(self, message=None, tip="", limitedTime=True):
         """Displays specified message on button and flashes button red to let user know there was an error. If you want the error to be displayed until the user takes an action, set limitedTime to False. Then call self.reset() after the desired action. Threadsafe. """
         isGuiThread = QtCore.QThread.currentThread() == QtCore.QCoreApplication.instance().thread()
@@ -73,8 +73,8 @@ class FeedbackButton(QtGui.QPushButton):
                 QtGui.QApplication.processEvents()
         else:
             self.sigCallProcess.emit(message, tip, processEvents)
-           
-                
+
+
     def reset(self):
         """Resets the button to its original text and style. Threadsafe."""
         isGuiThread = QtCore.QThread.currentThread() == QtCore.QCoreApplication.instance().thread()
@@ -85,13 +85,13 @@ class FeedbackButton(QtGui.QPushButton):
             self.setStyleSheet()
         else:
             self.sigReset.emit()
-        
+
     def startBlink(self, color, message=None, tip="", limitedTime=True):
         #if self.origStyle is None:
             #self.origStyle = self.styleSheet()
             #self.origText = self.text()
         self.setFixedHeight(self.height())
-        
+
         if message is not None:
             self.setText(message, temporary=True)
         self.setToolTip(tip, temporary=True)
@@ -108,8 +108,8 @@ class FeedbackButton(QtGui.QPushButton):
         self.setStyleSheet(self.indStyle, temporary=True)
         if self.limitedTime or self.count <=2:
             QtCore.QTimer.singleShot(100, self.borderOff)
-        
-            
+
+
     def borderOff(self):
         self.setStyleSheet()
         self.count += 1
@@ -117,8 +117,8 @@ class FeedbackButton(QtGui.QPushButton):
             if self.limitedTime:
                 return
         QtCore.QTimer.singleShot(30, self.borderOn)
-        
-            
+
+
     def setText(self, text=None, temporary=False):
         if text is None:
             text = self.origText
@@ -151,7 +151,7 @@ if __name__ == '__main__':
     def click():
         btn.processing("Hold on..")
         time.sleep(2.0)
-        
+
         global fail
         fail = not fail
         if fail:

--- a/pyqtgraph/widgets/FileDialog.py
+++ b/pyqtgraph/widgets/FileDialog.py
@@ -5,10 +5,10 @@ __all__ = ['FileDialog']
 
 class FileDialog(QtGui.QFileDialog):
     ## Compatibility fix for OSX:
-    ## For some reason the native dialog doesn't show up when you set AcceptMode to AcceptSave on OS X, so we don't use the native dialog    
-    
+    ## For some reason the native dialog doesn't show up when you set AcceptMode to AcceptSave on OS X, so we don't use the native dialog
+
     def __init__(self, *args):
         QtGui.QFileDialog.__init__(self, *args)
-        
-        if sys.platform == 'darwin': 
+
+        if sys.platform == 'darwin':
             self.setOption(QtGui.QFileDialog.DontUseNativeDialog)

--- a/pyqtgraph/widgets/GradientWidget.py
+++ b/pyqtgraph/widgets/GradientWidget.py
@@ -11,23 +11,23 @@ __all__ = ['GradientWidget']
 class GradientWidget(GraphicsView):
     """
     Widget displaying an editable color gradient. The user may add, move, recolor,
-    or remove colors from the gradient. Additionally, a context menu allows the 
+    or remove colors from the gradient. Additionally, a context menu allows the
     user to select from pre-defined gradients.
     """
     sigGradientChanged = QtCore.Signal(object)
     sigGradientChangeFinished = QtCore.Signal(object)
-    
+
     def __init__(self, parent=None, orientation='bottom',  *args, **kargs):
         """
-        The *orientation* argument may be 'bottom', 'top', 'left', or 'right' 
+        The *orientation* argument may be 'bottom', 'top', 'left', or 'right'
         indicating whether the gradient is displayed horizontally (top, bottom)
-        or vertically (left, right) and on what side of the gradient the editable 
+        or vertically (left, right) and on what side of the gradient the editable
         ticks will appear.
-        
-        All other arguments are passed to 
+
+        All other arguments are passed to
         :func:`GradientEditorItem.__init__ <pyqtgraph.GradientEditorItem.__init__>`.
-        
-        Note: For convenience, this class wraps methods from 
+
+        Note: For convenience, this class wraps methods from
         :class:`GradientEditorItem <pyqtgraph.GradientEditorItem>`.
         """
         GraphicsView.__init__(self, parent, useOpenGL=False, background=None)
@@ -48,27 +48,25 @@ class GradientWidget(GraphicsView):
         #self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent, True)
 
     def setOrientation(self, ort):
-        """Set the orientation of the widget. May be one of 'bottom', 'top', 
+        """Set the orientation of the widget. May be one of 'bottom', 'top',
         'left', or 'right'."""
         self.item.setOrientation(ort)
         self.orientation = ort
         self.setMaxDim()
-        
+
     def setMaxDim(self, mx=None):
         if mx is None:
             mx = self.maxDim
         else:
             self.maxDim = mx
-            
+
         if self.orientation in ['bottom', 'top']:
             self.setFixedHeight(mx)
             self.setMaximumWidth(16777215)
         else:
             self.setFixedWidth(mx)
             self.setMaximumHeight(16777215)
-        
+
     def __getattr__(self, attr):
         ### wrap methods from GradientEditorItem
         return getattr(self.item, attr)
-
-

--- a/pyqtgraph/widgets/GraphicsLayoutWidget.py
+++ b/pyqtgraph/widgets/GraphicsLayoutWidget.py
@@ -5,9 +5,9 @@ from .GraphicsView import GraphicsView
 __all__ = ['GraphicsLayoutWidget']
 class GraphicsLayoutWidget(GraphicsView):
     """
-    Convenience class consisting of a :class:`GraphicsView 
+    Convenience class consisting of a :class:`GraphicsView
     <pyqtgraph.GraphicsView>` with a single :class:`GraphicsLayout
-    <pyqtgraph.GraphicsLayout>` as its central item. 
+    <pyqtgraph.GraphicsLayout>` as its central item.
 
     This class wraps several methods from its internal GraphicsLayout:
     :func:`nextRow <pyqtgraph.GraphicsLayout.nextRow>`

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -25,21 +25,21 @@ from .. import getConfigOption
 __all__ = ['GraphicsView']
 
 class GraphicsView(QtGui.QGraphicsView):
-    """Re-implementation of QGraphicsView that removes scrollbars and allows unambiguous control of the 
+    """Re-implementation of QGraphicsView that removes scrollbars and allows unambiguous control of the
     viewed coordinate range. Also automatically creates a GraphicsScene and a central QGraphicsWidget
     that is automatically scaled to the full view geometry.
-    
-    This widget is the basis for :class:`PlotWidget <pyqtgraph.PlotWidget>`, 
+
+    This widget is the basis for :class:`PlotWidget <pyqtgraph.PlotWidget>`,
     :class:`GraphicsLayoutWidget <pyqtgraph.GraphicsLayoutWidget>`, and the view widget in
     :class:`ImageView <pyqtgraph.ImageView>`.
-    
-    By default, the view coordinate system matches the widget's pixel coordinates and 
-    automatically updates when the view is resized. This can be overridden by setting 
+
+    By default, the view coordinate system matches the widget's pixel coordinates and
+    automatically updates when the view is resized. This can be overridden by setting
     autoPixelRange=False. The exact visible range can be set with setRange().
-    
+
     The view can be panned using the middle mouse button and scaled using the right mouse button if
     enabled via enableMouse()  (but ordinarily, we use ViewBox for this functionality)."""
-    
+
     sigDeviceRangeChanged = QtCore.Signal(object, object)
     sigDeviceTransformChanged = QtCore.Signal(object)
     sigMouseReleased = QtCore.Signal(object)
@@ -47,7 +47,7 @@ class GraphicsView(QtGui.QGraphicsView):
     #sigRegionChanged = QtCore.Signal(object)
     sigScaleChanged = QtCore.Signal(object)
     lastFileDir = None
-    
+
     def __init__(self, parent=None, useOpenGL=None, background='default'):
         """
         ==============  ============================================================
@@ -55,42 +55,42 @@ class GraphicsView(QtGui.QGraphicsView):
         parent          Optional parent widget
         useOpenGL       If True, the GraphicsView will use OpenGL to do all of its
                         rendering. This can improve performance on some systems,
-                        but may also introduce bugs (the combination of 
-                        QGraphicsView and QGLWidget is still an 'experimental' 
+                        but may also introduce bugs (the combination of
+                        QGraphicsView and QGLWidget is still an 'experimental'
                         feature of Qt)
         background      Set the background color of the GraphicsView. Accepts any
-                        single argument accepted by 
-                        :func:`mkColor <pyqtgraph.mkColor>`. By 
+                        single argument accepted by
+                        :func:`mkColor <pyqtgraph.mkColor>`. By
                         default, the background color is determined using the
-                        'backgroundColor' configuration option (see 
+                        'backgroundColor' configuration option (see
                         :func:`setConfigOption <pyqtgraph.setConfigOption>`.
         ==============  ============================================================
         """
-        
+
         self.closed = False
-        
+
         QtGui.QGraphicsView.__init__(self, parent)
-        
+
         # This connects a cleanup function to QApplication.aboutToQuit. It is
         # called from here because we have no good way to react when the
         # QApplication is created by the user.
         # See pyqtgraph.__init__.py
         from .. import _connectCleanup
         _connectCleanup()
-        
+
         if useOpenGL is None:
             useOpenGL = getConfigOption('useOpenGL')
-        
+
         self.useOpenGL(useOpenGL)
-        
+
         self.setCacheMode(self.CacheBackground)
-        
+
         ## This might help, but it's probably dangerous in the general case..
         #self.setOptimizationFlag(self.DontSavePainterState, True)
-        
+
         self.setBackgroundRole(QtGui.QPalette.NoRole)
         self.setBackground(background)
-        
+
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
         self.setFrameShape(QtGui.QFrame.NoFrame)
         self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
@@ -98,8 +98,8 @@ class GraphicsView(QtGui.QGraphicsView):
         self.setTransformationAnchor(QtGui.QGraphicsView.NoAnchor)
         self.setResizeAnchor(QtGui.QGraphicsView.AnchorViewCenter)
         self.setViewportUpdateMode(QtGui.QGraphicsView.MinimalViewportUpdate)
-        
-        
+
+
         self.lockedViewports = []
         self.lastMousePos = None
         self.setMouseTracking(True)
@@ -112,23 +112,23 @@ class GraphicsView(QtGui.QGraphicsView):
         # GraphicsScene must have parent or expect crashes!
         self.sceneObj = GraphicsScene(parent=self)
         self.setScene(self.sceneObj)
-        
+
         ## Workaround for PySide crash
         ## This ensures that the scene will outlive the view.
         if USE_PYSIDE:
             self.sceneObj._view_ref_workaround = self
-        
+
         ## by default we set up a central widget with a grid layout.
         ## this can be replaced if needed.
         self.centralWidget = None
         self.setCentralItem(QtGui.QGraphicsWidget())
         self.centralLayout = QtGui.QGraphicsGridLayout()
         self.centralWidget.setLayout(self.centralLayout)
-        
+
         self.mouseEnabled = False
         self.scaleCenter = False  ## should scaling center around view center (True) or mouse click (False)
         self.clickAccepted = False
-        
+
     def setAntialiasing(self, aa):
         """Enable or disable default antialiasing.
         Note that this will only affect items that do not specify their own antialiasing options."""
@@ -136,7 +136,7 @@ class GraphicsView(QtGui.QGraphicsView):
             self.setRenderHints(self.renderHints() | QtGui.QPainter.Antialiasing)
         else:
             self.setRenderHints(self.renderHints() & ~QtGui.QPainter.Antialiasing)
-        
+
     def setBackground(self, background):
         """
         Set the background color of the GraphicsView.
@@ -148,16 +148,16 @@ class GraphicsView(QtGui.QGraphicsView):
             background = getConfigOption('background')
         brush = fn.mkBrush(background)
         self.setBackgroundBrush(brush)
-    
+
     def paintEvent(self, ev):
         self.scene().prepareForPaint()
         return QtGui.QGraphicsView.paintEvent(self, ev)
-    
+
     def render(self, *args, **kwds):
         self.scene().prepareForPaint()
         return QtGui.QGraphicsView.render(self, *args, **kwds)
-        
-    
+
+
     def close(self):
         self.centralWidget = None
         self.scene().clear()
@@ -165,7 +165,7 @@ class GraphicsView(QtGui.QGraphicsView):
         self.sceneObj = None
         self.closed = True
         self.setViewport(None)
-        
+
     def useOpenGL(self, b=True):
         if b:
             if not HAVE_OPENGL:
@@ -173,17 +173,17 @@ class GraphicsView(QtGui.QGraphicsView):
             v = QtOpenGL.QGLWidget()
         else:
             v = QtGui.QWidget()
-            
+
         self.setViewport(v)
-            
+
     def keyPressEvent(self, ev):
         self.scene().keyPressEvent(ev)  ## bypass view, hand event directly to scene
                                         ## (view likes to eat arrow key events)
-        
-        
+
+
     def setCentralItem(self, item):
         return self.setCentralWidget(item)
-        
+
     def setCentralWidget(self, item):
         """Sets a QGraphicsWidget to automatically fill the entire view (the item will be automatically
         resize whenever the GraphicsView is resized)."""
@@ -193,21 +193,21 @@ class GraphicsView(QtGui.QGraphicsView):
         if item is not None:
             self.sceneObj.addItem(item)
             self.resizeEvent(None)
-        
+
     def addItem(self, *args):
         return self.scene().addItem(*args)
-        
+
     def removeItem(self, *args):
         return self.scene().removeItem(*args)
-        
+
     def enableMouse(self, b=True):
         self.mouseEnabled = b
         self.autoPixelRange = (not b)
-        
+
     def clearMouse(self):
         self.mouseTrail = []
         self.lastButtonReleased = None
-    
+
     def resizeEvent(self, ev):
         if self.closed:
             return
@@ -215,7 +215,7 @@ class GraphicsView(QtGui.QGraphicsView):
             self.range = QtCore.QRectF(0, 0, self.size().width(), self.size().height())
         GraphicsView.setRange(self, self.range, padding=0, disableAutoPixel=False)  ## we do this because some subclasses like to redefine setRange in an incompatible way.
         self.updateMatrix()
-    
+
     def updateMatrix(self, propagate=True):
         self.setSceneRect(self.range)
         if self.autoPixelRange:
@@ -225,14 +225,14 @@ class GraphicsView(QtGui.QGraphicsView):
                 self.fitInView(self.range, QtCore.Qt.KeepAspectRatio)
             else:
                 self.fitInView(self.range, QtCore.Qt.IgnoreAspectRatio)
-            
+
         self.sigDeviceRangeChanged.emit(self, self.range)
         self.sigDeviceTransformChanged.emit(self)
-        
+
         if propagate:
             for v in self.lockedViewports:
                 v.setXRange(self.range, padding=0)
-        
+
     def viewRect(self):
         """Return the boundaries of the view in scene coordinates"""
         ## easier to just return self.range ?
@@ -246,22 +246,22 @@ class GraphicsView(QtGui.QGraphicsView):
     def translate(self, dx, dy):
         self.range.adjust(dx, dy, dx, dy)
         self.updateMatrix()
-    
+
     def scale(self, sx, sy, center=None):
         scale = [sx, sy]
         if self.aspectLocked:
             scale[0] = scale[1]
-        
+
         if self.scaleCenter:
             center = None
         if center is None:
             center = self.range.center()
-            
+
         w = self.range.width()  / scale[0]
         h = self.range.height() / scale[1]
         self.range = QtCore.QRectF(center.x() - (center.x()-self.range.left()) / scale[0], center.y() - (center.y()-self.range.top())  /scale[1], w, h)
-        
-        
+
+
         self.updateMatrix()
         self.sigScaleChanged.emit(self)
 
@@ -271,7 +271,7 @@ class GraphicsView(QtGui.QGraphicsView):
         if newRect is None:
             newRect = self.visibleRange()
             padding = 0
-        
+
         padding = Point(padding)
         newRect = QtCore.QRectF(newRect)
         pw = newRect.width() * padding[0]
@@ -302,25 +302,25 @@ class GraphicsView(QtGui.QGraphicsView):
         range = QtCore.QRectF(tl.x(), tl.y(), w, h)
         GraphicsView.setRange(self, range, padding=0)
         self.sigScaleChanged.connect(image.setScaledMode)
-        
-        
-        
+
+
+
     def lockXRange(self, v1):
         if not v1 in self.lockedViewports:
             self.lockedViewports.append(v1)
-        
+
     def setXRange(self, r, padding=0.05):
         r1 = QtCore.QRectF(self.range)
         r1.setLeft(r.left())
         r1.setRight(r.right())
         GraphicsView.setRange(self, r1, padding=[padding, 0], propagate=False)
-        
+
     def setYRange(self, r, padding=0.05):
         r1 = QtCore.QRectF(self.range)
         r1.setTop(r.top())
         r1.setBottom(r.bottom())
         GraphicsView.setRange(self, r1, padding=[0, padding], propagate=False)
-        
+
     def wheelEvent(self, ev):
         QtGui.QGraphicsView.wheelEvent(self, ev)
         if not self.mouseEnabled:
@@ -329,16 +329,16 @@ class GraphicsView(QtGui.QGraphicsView):
         #self.scale *= sc
         #self.updateMatrix()
         self.scale(sc, sc)
-        
+
     def setAspectLocked(self, s):
         self.aspectLocked = s
-        
+
     def leaveEvent(self, ev):
         self.scene().leaveEvent(ev)  ## inform scene when mouse leaves
-        
+
     def mousePressEvent(self, ev):
         QtGui.QGraphicsView.mousePressEvent(self, ev)
-        
+
 
         if not self.mouseEnabled:
             return
@@ -348,15 +348,15 @@ class GraphicsView(QtGui.QGraphicsView):
         if not self.clickAccepted:
             self.scene().clearSelection()
         return   ## Everything below disabled for now..
-        
+
     def mouseReleaseEvent(self, ev):
         QtGui.QGraphicsView.mouseReleaseEvent(self, ev)
         if not self.mouseEnabled:
-            return 
+            return
         self.sigMouseReleased.emit(ev)
         self.lastButtonReleased = ev.button()
         return   ## Everything below disabled for now..
-        
+
     def mouseMoveEvent(self, ev):
         if self.lastMousePos is None:
             self.lastMousePos = Point(ev.pos())
@@ -367,10 +367,10 @@ class GraphicsView(QtGui.QGraphicsView):
         if not self.mouseEnabled:
             return
         self.sigSceneMouseMoved.emit(self.mapToScene(ev.pos()))
-            
+
         if self.clickAccepted:  ## Ignore event if an item in the scene has already claimed it.
             return
-        
+
         if ev.buttons() == QtCore.Qt.RightButton:
             delta = Point(np.clip(delta[0], -50, 50), np.clip(-delta[1], -50, 50))
             scale = 1.01 ** delta
@@ -380,10 +380,10 @@ class GraphicsView(QtGui.QGraphicsView):
         elif ev.buttons() in [QtCore.Qt.MidButton, QtCore.Qt.LeftButton]:  ## Allow panning by left or mid button.
             px = self.pixelSize()
             tr = -delta * px
-            
+
             self.translate(tr[0], tr[1])
             self.sigDeviceRangeChanged.emit(self, self.range)
-        
+
     def pixelSize(self):
         """Return vector with the length and width of one view pixel in scene coordinates"""
         p0 = Point(0,0)
@@ -392,8 +392,6 @@ class GraphicsView(QtGui.QGraphicsView):
         p01 = tr.map(p0)
         p11 = tr.map(p1)
         return Point(p11 - p01)
-        
+
     def dragEnterEvent(self, ev):
         ev.ignore()  ## not sure why, but for some reason this class likes to consume drag events
-        
-

--- a/pyqtgraph/widgets/HistogramLUTWidget.py
+++ b/pyqtgraph/widgets/HistogramLUTWidget.py
@@ -11,7 +11,7 @@ __all__ = ['HistogramLUTWidget']
 
 
 class HistogramLUTWidget(GraphicsView):
-    
+
     def __init__(self, parent=None,  *args, **kargs):
         background = kargs.get('background', 'default')
         GraphicsView.__init__(self, parent, useOpenGL=False, background=background)
@@ -19,15 +19,12 @@ class HistogramLUTWidget(GraphicsView):
         self.setCentralItem(self.item)
         self.setSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Expanding)
         self.setMinimumWidth(95)
-        
+
 
     def sizeHint(self):
         return QtCore.QSize(115, 200)
-    
-    
+
+
 
     def __getattr__(self, attr):
         return getattr(self.item, attr)
-
-
-

--- a/pyqtgraph/widgets/JoystickButton.py
+++ b/pyqtgraph/widgets/JoystickButton.py
@@ -5,7 +5,7 @@ __all__ = ['JoystickButton']
 
 class JoystickButton(QtGui.QPushButton):
     sigStateChanged = QtCore.Signal(object, object)  ## self, state
-    
+
     def __init__(self, parent=None):
         QtGui.QPushButton.__init__(self, parent)
         self.radius = 200
@@ -14,31 +14,31 @@ class JoystickButton(QtGui.QPushButton):
         self.setState(0,0)
         self.setFixedWidth(50)
         self.setFixedHeight(50)
-        
-        
+
+
     def mousePressEvent(self, ev):
         self.setChecked(True)
         self.pressPos = ev.pos()
         ev.accept()
-        
+
     def mouseMoveEvent(self, ev):
         dif = ev.pos()-self.pressPos
         self.setState(dif.x(), -dif.y())
-        
+
     def mouseReleaseEvent(self, ev):
         self.setChecked(False)
         self.setState(0,0)
-        
+
     def wheelEvent(self, ev):
         ev.accept()
-        
-        
+
+
     def doubleClickEvent(self, ev):
         ev.accept()
-        
+
     def getState(self):
         return self.state
-        
+
     def setState(self, *xy):
         xy = list(xy)
         d = (xy[0]**2 + xy[1]**2)**0.5
@@ -48,12 +48,12 @@ class JoystickButton(QtGui.QPushButton):
                 nxy[i] = 0
             else:
                 nxy[i] = xy[i]/d
-        
+
         if d > self.radius:
             d = self.radius
         d = (d/self.radius)**2
         xy = [nxy[0]*d, nxy[1]*d]
-        
+
         w2 = self.width()/2.
         h2 = self.height()/2
         self.spotPos = QtCore.QPoint(w2*(1+xy[0]), h2*(1-xy[1]))
@@ -62,19 +62,19 @@ class JoystickButton(QtGui.QPushButton):
             return
         self.state = xy
         self.sigStateChanged.emit(self, self.state)
-        
+
     def paintEvent(self, ev):
         QtGui.QPushButton.paintEvent(self, ev)
         p = QtGui.QPainter(self)
         p.setBrush(QtGui.QBrush(QtGui.QColor(0,0,0)))
         p.drawEllipse(self.spotPos.x()-3,self.spotPos.y()-3,6,6)
-        
+
     def resizeEvent(self, ev):
         self.setState(*self.state)
         QtGui.QPushButton.resizeEvent(self, ev)
-        
-        
-        
+
+
+
 if __name__ == '__main__':
     app = QtGui.QApplication([])
     w = QtGui.QMainWindow()
@@ -82,14 +82,13 @@ if __name__ == '__main__':
     w.setCentralWidget(b)
     w.show()
     w.resize(100, 100)
-    
+
     def fn(b, s):
         print("state changed:", s)
-        
+
     b.sigStateChanged.connect(fn)
-        
+
     ## Start Qt event loop unless running in interactive mode.
     import sys
     if sys.flags.interactive != 1:
         app.exec_()
-        

--- a/pyqtgraph/widgets/LayoutWidget.py
+++ b/pyqtgraph/widgets/LayoutWidget.py
@@ -15,23 +15,23 @@ class LayoutWidget(QtGui.QWidget):
         self.rows = {}
         self.currentRow = 0
         self.currentCol = 0
-    
+
     def nextRow(self):
         """Advance to next row for automatic widget placement"""
         self.currentRow += 1
         self.currentCol = 0
-        
+
     def nextColumn(self, colspan=1):
-        """Advance to next column, while returning the current column number 
+        """Advance to next column, while returning the current column number
         (generally only for internal use--called by addWidget)"""
         self.currentCol += colspan
         return self.currentCol-colspan
-        
+
     def nextCol(self, *args, **kargs):
         """Alias of nextColumn"""
         return self.nextColumn(*args, **kargs)
-        
-        
+
+
     def addLabel(self, text=' ', row=None, col=None, rowspan=1, colspan=1, **kargs):
         """
         Create a QLabel with *text* and place it in the next available cell (or in the cell specified)
@@ -41,7 +41,7 @@ class LayoutWidget(QtGui.QWidget):
         text = QtGui.QLabel(text, **kargs)
         self.addItem(text, row, col, rowspan, colspan)
         return text
-        
+
     def addLayout(self, row=None, col=None, rowspan=1, colspan=1, **kargs):
         """
         Create an empty LayoutWidget and place it in the next available cell (or in the cell specified)
@@ -51,7 +51,7 @@ class LayoutWidget(QtGui.QWidget):
         layout = LayoutWidget(**kargs)
         self.addItem(layout, row, col, rowspan, colspan)
         return layout
-        
+
     def addWidget(self, item, row=None, col=None, rowspan=1, colspan=1):
         """
         Add a widget to the layout and place it in the next available cell (or in the cell specified).
@@ -61,16 +61,16 @@ class LayoutWidget(QtGui.QWidget):
             row = self.currentRow
         elif row is None:
             row = self.currentRow
-            
-        
+
+
         if col is None:
             col = self.nextCol(colspan)
-            
+
         if row not in self.rows:
             self.rows[row] = {}
         self.rows[row][col] = item
         self.items[item] = (row, col)
-        
+
         self.layout.addWidget(item, row, col, rowspan, colspan)
 
     def getWidget(self, row, col):
@@ -82,7 +82,7 @@ class LayoutWidget(QtGui.QWidget):
             #if self.layout.itemAt(i).graphicsItem() is item:
                 #return i
         #raise Exception("Could not determine index of item " + str(item))
-    
+
     #def removeItem(self, item):
         #"""Remove *item* from the layout."""
         #ind = self.itemIndex(item)
@@ -92,10 +92,8 @@ class LayoutWidget(QtGui.QWidget):
         #del self.items[item]
         #del self.rows[r][c]
         #self.update()
-    
+
     #def clear(self):
         #items = []
         #for i in list(self.items.keys()):
             #self.removeItem(i)
-
-

--- a/pyqtgraph/widgets/MatplotlibWidget.py
+++ b/pyqtgraph/widgets/MatplotlibWidget.py
@@ -17,30 +17,30 @@ class MatplotlibWidget(QtGui.QWidget):
     """
     Implements a Matplotlib figure inside a QWidget.
     Use getFigure() and redraw() to interact with matplotlib.
-    
+
     Example::
-    
+
         mw = MatplotlibWidget()
         subplot = mw.getFigure().add_subplot(111)
         subplot.plot(x,y)
         mw.draw()
     """
-    
+
     def __init__(self, size=(5.0, 4.0), dpi=100):
         QtGui.QWidget.__init__(self)
         self.fig = Figure(size, dpi=dpi)
         self.canvas = FigureCanvas(self.fig)
         self.canvas.setParent(self)
         self.toolbar = NavigationToolbar(self.canvas, self)
-        
+
         self.vbox = QtGui.QVBoxLayout()
         self.vbox.addWidget(self.toolbar)
         self.vbox.addWidget(self.canvas)
-        
+
         self.setLayout(self.vbox)
 
     def getFigure(self):
         return self.fig
-        
+
     def draw(self):
         self.canvas.draw()

--- a/pyqtgraph/widgets/MultiPlotWidget.py
+++ b/pyqtgraph/widgets/MultiPlotWidget.py
@@ -22,7 +22,7 @@ class MultiPlotWidget(GraphicsView):
             #setattr(self, m, getattr(self.mPlotItem, m))
         self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
         self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
-                
+
     def __getattr__(self, attr):  ## implicitly wrap methods from plotItem
         if hasattr(self.mPlotItem, attr):
             m = getattr(self.mPlotItem, attr)
@@ -31,12 +31,12 @@ class MultiPlotWidget(GraphicsView):
         raise AttributeError(attr)
 
     def setMinimumPlotHeight(self, min):
-        """Set the minimum height for each sub-plot displayed. 
-        
-        If the total height of all plots is greater than the height of the 
+        """Set the minimum height for each sub-plot displayed.
+
+        If the total height of all plots is greater than the height of the
         widget, then a scroll bar will appear to provide access to the entire
         set of plots.
-        
+
         Added in version 0.9.9
         """
         self.minPlotHeight = min
@@ -48,7 +48,7 @@ class MultiPlotWidget(GraphicsView):
     def saveState(self):
         return {}
         #return self.plotItem.saveState()
-        
+
     def restoreState(self, state):
         pass
         #return self.plotItem.restoreState(state)

--- a/pyqtgraph/widgets/PathButton.py
+++ b/pyqtgraph/widgets/PathButton.py
@@ -18,25 +18,25 @@ class PathButton(QtGui.QPushButton):
         if size is not None:
             self.setFixedWidth(size[0])
             self.setFixedHeight(size[1])
-            
-            
+
+
     def setBrush(self, brush):
         self.brush = fn.mkBrush(brush)
-        
+
     def setPen(self, *args, **kwargs):
         self.pen = fn.mkPen(*args, **kwargs)
-        
+
     def setPath(self, path):
         self.path = path
         self.update()
-        
+
     def paintEvent(self, ev):
         QtGui.QPushButton.paintEvent(self, ev)
         margin = 7
         geom = QtCore.QRectF(0, 0, self.width(), self.height()).adjusted(margin, margin, -margin, -margin)
         rect = self.path.boundingRect()
         scale = min(geom.width() / float(rect.width()), geom.height() / float(rect.height()))
-        
+
         p = QtGui.QPainter(self)
         p.setRenderHint(p.Antialiasing)
         p.translate(geom.center())
@@ -46,5 +46,3 @@ class PathButton(QtGui.QPushButton):
         p.setBrush(self.brush)
         p.drawPath(self.path)
         p.end()
-
-    

--- a/pyqtgraph/widgets/PlotWidget.py
+++ b/pyqtgraph/widgets/PlotWidget.py
@@ -11,19 +11,19 @@ from ..graphicsItems.PlotItem import *
 
 __all__ = ['PlotWidget']
 class PlotWidget(GraphicsView):
-    
+
     # signals wrapped from PlotItem / ViewBox
     sigRangeChanged = QtCore.Signal(object, object)
     sigTransformChanged = QtCore.Signal(object)
-    
+
     """
-    :class:`GraphicsView <pyqtgraph.GraphicsView>` widget with a single 
+    :class:`GraphicsView <pyqtgraph.GraphicsView>` widget with a single
     :class:`PlotItem <pyqtgraph.PlotItem>` inside.
-    
-    The following methods are wrapped directly from PlotItem: 
-    :func:`addItem <pyqtgraph.PlotItem.addItem>`, 
-    :func:`removeItem <pyqtgraph.PlotItem.removeItem>`, 
-    :func:`clear <pyqtgraph.PlotItem.clear>`, 
+
+    The following methods are wrapped directly from PlotItem:
+    :func:`addItem <pyqtgraph.PlotItem.addItem>`,
+    :func:`removeItem <pyqtgraph.PlotItem.removeItem>`,
+    :func:`clear <pyqtgraph.PlotItem.clear>`,
     :func:`setXRange <pyqtgraph.ViewBox.setXRange>`,
     :func:`setYRange <pyqtgraph.ViewBox.setYRange>`,
     :func:`setRange <pyqtgraph.ViewBox.setRange>`,
@@ -38,13 +38,13 @@ class PlotWidget(GraphicsView):
     :func:`setLimits <pyqtgraph.ViewBox.setLimits>`,
     :func:`register <pyqtgraph.ViewBox.register>`,
     :func:`unregister <pyqtgraph.ViewBox.unregister>`
-    
-    
-    For all 
+
+
+    For all
     other methods, use :func:`getPlotItem <pyqtgraph.PlotWidget.getPlotItem>`.
     """
     def __init__(self, parent=None, background='default', **kargs):
-        """When initializing PlotWidget, *parent* and *background* are passed to 
+        """When initializing PlotWidget, *parent* and *background* are passed to
         :func:`GraphicsWidget.__init__() <pyqtgraph.GraphicsWidget.__init__>`
         and all others are passed
         to :func:`PlotItem.__init__() <pyqtgraph.PlotItem.__init__>`."""
@@ -55,14 +55,14 @@ class PlotWidget(GraphicsView):
         self.setCentralItem(self.plotItem)
         ## Explicitly wrap methods from plotItem
         ## NOTE: If you change this list, update the documentation above as well.
-        for m in ['addItem', 'removeItem', 'autoRange', 'clear', 'setXRange', 
-                  'setYRange', 'setRange', 'setAspectLocked', 'setMouseEnabled', 
-                  'setXLink', 'setYLink', 'enableAutoRange', 'disableAutoRange', 
+        for m in ['addItem', 'removeItem', 'autoRange', 'clear', 'setXRange',
+                  'setYRange', 'setRange', 'setAspectLocked', 'setMouseEnabled',
+                  'setXLink', 'setYLink', 'enableAutoRange', 'disableAutoRange',
                   'setLimits', 'register', 'unregister', 'viewRect']:
             setattr(self, m, getattr(self.plotItem, m))
         #QtCore.QObject.connect(self.plotItem, QtCore.SIGNAL('viewChanged'), self.viewChanged)
         self.plotItem.sigRangeChanged.connect(self.viewRangeChanged)
-    
+
     def close(self):
         self.plotItem.close()
         self.plotItem = None
@@ -77,7 +77,7 @@ class PlotWidget(GraphicsView):
             if hasattr(m, '__call__'):
                 return m
         raise NameError(attr)
-    
+
     def viewRangeChanged(self, view, range):
         #self.emit(QtCore.SIGNAL('viewChanged'), *args)
         self.sigRangeChanged.emit(self, range)
@@ -87,13 +87,10 @@ class PlotWidget(GraphicsView):
 
     def saveState(self):
         return self.plotItem.saveState()
-        
+
     def restoreState(self, state):
         return self.plotItem.restoreState(state)
-        
+
     def getPlotItem(self):
         """Return the PlotItem contained within."""
         return self.plotItem
-        
-        
-        

--- a/pyqtgraph/widgets/ProgressDialog.py
+++ b/pyqtgraph/widgets/ProgressDialog.py
@@ -22,7 +22,7 @@ class ProgressDialog(QtGui.QProgressDialog):
         cancelText     Text to display on cancel button, or None to disable it.
         minimum
         maximum
-        parent       
+        parent
         wait           Length of time (im ms) to wait before displaying dialog
         busyCursor     If True, show busy cursor until dialog finishes
         disable        If True, the progress dialog will not be displayed
@@ -30,7 +30,7 @@ class ProgressDialog(QtGui.QProgressDialog):
                        If ProgressDialog is entered from a non-gui thread, it will
                        always be disabled.
         ============== ================================================================
-        """    
+        """
         isGuiThread = QtCore.QThread.currentThread() == QtCore.QCoreApplication.instance().thread()
         self.disabled = disable or (not isGuiThread)
         if self.disabled:
@@ -40,16 +40,16 @@ class ProgressDialog(QtGui.QProgressDialog):
         if cancelText is None:
             cancelText = ''
             noCancel = True
-            
+
         self.busyCursor = busyCursor
-            
+
         QtGui.QProgressDialog.__init__(self, labelText, cancelText, minimum, maximum, parent)
         self.setMinimumDuration(wait)
         self.setWindowModality(QtCore.Qt.WindowModal)
         self.setValue(self.minimum())
         if noCancel:
             self.setCancelButton(None)
-        
+
 
     def __enter__(self):
         if self.disabled:
@@ -64,7 +64,7 @@ class ProgressDialog(QtGui.QProgressDialog):
         if self.busyCursor:
             QtGui.QApplication.restoreOverrideCursor()
         self.setValue(self.maximum())
-        
+
     def __iadd__(self, val):
         """Use inplace-addition operator for easy incrementing."""
         if self.disabled:
@@ -74,17 +74,17 @@ class ProgressDialog(QtGui.QProgressDialog):
 
 
     ## wrap all other functions to make sure they aren't being called from non-gui threads
-    
+
     def setValue(self, val):
         if self.disabled:
             return
         QtGui.QProgressDialog.setValue(self, val)
-        
+
     def setLabelText(self, val):
         if self.disabled:
             return
         QtGui.QProgressDialog.setLabelText(self, val)
-    
+
     def setMaximum(self, val):
         if self.disabled:
             return
@@ -94,7 +94,7 @@ class ProgressDialog(QtGui.QProgressDialog):
         if self.disabled:
             return
         QtGui.QProgressDialog.setMinimum(self, val)
-        
+
     def wasCanceled(self):
         if self.disabled:
             return False
@@ -109,4 +109,3 @@ class ProgressDialog(QtGui.QProgressDialog):
         if self.disabled:
             return 0
         return QtGui.QProgressDialog.minimum(self)
-        

--- a/pyqtgraph/widgets/RawImageWidget.py
+++ b/pyqtgraph/widgets/RawImageWidget.py
@@ -11,7 +11,7 @@ import numpy as np
 
 class RawImageWidget(QtGui.QWidget):
     """
-    Widget optimized for very fast video display. 
+    Widget optimized for very fast video display.
     Generally using an ImageItem inside GraphicsView is fast enough.
     On some systems this may provide faster video. See the VideoSpeedTest example for benchmarking.
     """
@@ -24,7 +24,7 @@ class RawImageWidget(QtGui.QWidget):
         self.scaled = scaled
         self.opts = None
         self.image = None
-    
+
     def setImage(self, img, *args, **kargs):
         """
         img must be ndarray of shape (x,y), (x,y,3), or (x,y,4).
@@ -52,7 +52,7 @@ class RawImageWidget(QtGui.QWidget):
                 rect.setWidth(int(rect.width() * imar/ar))
             else:
                 rect.setHeight(int(rect.height() * ar/imar))
-                
+
             p.drawImage(rect, self.image)
         else:
             p.drawImage(QtCore.QPointF(), self.image)
@@ -85,7 +85,7 @@ if HAVE_OPENGL:
 
         def initializeGL(self):
             self.texture = glGenTextures(1)
-            
+
         def uploadTexture(self):
             glEnable(GL_TEXTURE_2D)
             glBindTexture(GL_TEXTURE_2D, self.texture)
@@ -99,15 +99,15 @@ if HAVE_OPENGL:
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER)
             #glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_BORDER)
             shape = self.image.shape
-            
+
             ### Test texture dimensions first
             #glTexImage2D(GL_PROXY_TEXTURE_2D, 0, GL_RGBA, shape[0], shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, None)
             #if glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_WIDTH) == 0:
                 #raise Exception("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % shape[:2])
-            
+
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, shape[0], shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, self.image.transpose((1,0,2)))
             glDisable(GL_TEXTURE_2D)
-            
+
         def paintGL(self):
             if self.image is None:
                 if self.opts is None:
@@ -115,10 +115,10 @@ if HAVE_OPENGL:
                 img, args, kwds = self.opts
                 kwds['useRGBA'] = True
                 self.image, alpha = fn.makeARGB(img, *args, **kwds)
-            
+
             if not self.uploaded:
                 self.uploadTexture()
-            
+
             glViewport(0, 0, self.width(), self.height())
             glEnable(GL_TEXTURE_2D)
             glBindTexture(GL_TEXTURE_2D, self.texture)
@@ -135,6 +135,3 @@ if HAVE_OPENGL:
             glVertex3f(-1, 1, 0)
             glEnd()
             glDisable(GL_TEXTURE_3D)
-            
-
-

--- a/pyqtgraph/widgets/ScatterPlotWidget.py
+++ b/pyqtgraph/widgets/ScatterPlotWidget.py
@@ -14,20 +14,20 @@ __all__ = ['ScatterPlotWidget']
 class ScatterPlotWidget(QtGui.QSplitter):
     """
     This is a high-level widget for exploring relationships in tabular data.
-        
+
     Given a multi-column record array, the widget displays a scatter plot of a
     specific subset of the data. Includes controls for selecting the columns to
     plot, filtering data, and determining symbol color and shape.
-    
+
     The widget consists of four components:
-    
+
     1) A list of column names from which the user may select 1 or 2 columns
        to plot. If one column is selected, the data for that column will be
        plotted in a histogram-like manner by using :func:`pseudoScatter()
        <pyqtgraph.pseudoScatter>`. If two columns are selected, then the
        scatter plot will be generated with x determined by the first column
        that was selected and y by the second.
-    2) A DataFilter that allows the user to select a subset of the data by 
+    2) A DataFilter that allows the user to select a subset of the data by
        specifying multiple selection criteria.
     3) A ColorMap that allows the user to determine how points are colored by
        specifying multiple criteria.
@@ -44,32 +44,32 @@ class ScatterPlotWidget(QtGui.QSplitter):
         self.colorMap = ColorMapParameter()
         self.params = ptree.Parameter.create(name='params', type='group', children=[self.filter, self.colorMap])
         self.ptree.setParameters(self.params, showTop=False)
-        
+
         self.plot = PlotWidget()
         self.ctrlPanel.addWidget(self.fieldList)
         self.ctrlPanel.addWidget(self.ptree)
         self.addWidget(self.plot)
-        
+
         bg = fn.mkColor(getConfigOption('background'))
         bg.setAlpha(150)
         self.filterText = TextItem(border=getConfigOption('foreground'), color=bg)
         self.filterText.setPos(60,20)
         self.filterText.setParentItem(self.plot.plotItem)
-        
+
         self.data = None
         self.mouseOverField = None
         self.scatterPlot = None
         self.style = dict(pen=None, symbol='o')
-        
+
         self.fieldList.itemSelectionChanged.connect(self.fieldSelectionChanged)
         self.filter.sigFilterChanged.connect(self.filterChanged)
         self.colorMap.sigColorMapChanged.connect(self.updatePlot)
-    
+
     def setFields(self, fields, mouseOverField=None):
         """
         Set the list of field names/units to be processed.
-        
-        The format of *fields* is the same as used by 
+
+        The format of *fields* is the same as used by
         :func:`ColorMapWidget.setFields <pyqtgraph.widgets.ColorMapWidget.ColorMapParameter.setFields>`
         """
         self.fields = OrderedDict(fields)
@@ -81,16 +81,16 @@ class ScatterPlotWidget(QtGui.QSplitter):
             item = self.fieldList.addItem(item)
         self.filter.setFields(fields)
         self.colorMap.setFields(fields)
-        
+
     def setData(self, data):
         """
-        Set the data to be processed and displayed. 
+        Set the data to be processed and displayed.
         Argument must be a numpy record array.
         """
         self.data = data
         self.filtered = None
         self.updatePlot()
-        
+
     def fieldSelectionChanged(self):
         sel = self.fieldList.selectedItems()
         if len(sel) > 2:
@@ -100,9 +100,9 @@ class ScatterPlotWidget(QtGui.QSplitter):
                     item.setSelected(False)
             finally:
                 self.fieldList.blockSignals(False)
-                
+
         self.updatePlot()
-        
+
     def filterChanged(self, f):
         self.filtered = None
         self.updatePlot()
@@ -112,30 +112,30 @@ class ScatterPlotWidget(QtGui.QSplitter):
         else:
             self.filterText.setText('\n'.join(desc))
             self.filterText.setVisible(True)
-            
-        
+
+
     def updatePlot(self):
         self.plot.clear()
         if self.data is None:
             return
-        
+
         if self.filtered is None:
             self.filtered = self.filter.filterData(self.data)
         data = self.filtered
         if len(data) == 0:
             return
-        
+
         colors = np.array([fn.mkBrush(*x) for x in self.colorMap.map(data)])
-        
+
         style = self.style.copy()
-        
+
         ## Look up selected columns and units
         sel = list([str(item.text()) for item in self.fieldList.selectedItems()])
         units = list([item.opts.get('units', '') for item in self.fieldList.selectedItems()])
         if len(sel) == 0:
             self.plot.setTitle('')
             return
-        
+
 
         if len(sel) == 1:
             self.plot.setLabels(left=('N', ''), bottom=(sel[0], units[0]), title='')
@@ -148,7 +148,7 @@ class ScatterPlotWidget(QtGui.QSplitter):
             self.plot.setLabels(left=(sel[1],units[1]), bottom=(sel[0],units[0]))
             if len(data) == 0:
                 return
-            
+
             xy = [data[sel[0]], data[sel[1]]]
             #xydata = []
             #for ax in [0,1]:
@@ -156,7 +156,7 @@ class ScatterPlotWidget(QtGui.QSplitter):
                 ### scatter catecorical values just a bit so they show up better in the scatter plot.
                 ##if sel[ax] in ['MorphologyBSMean', 'MorphologyTDMean', 'FIType']:
                     ##d += np.random.normal(size=len(cells), scale=0.1)
-                    
+
                 #xydata.append(d)
             #x,y = xydata
 
@@ -171,14 +171,14 @@ class ScatterPlotWidget(QtGui.QSplitter):
                 enum[i] = True
             else:
                 axis.setTicks(None)  # reset to automatic ticking
-        
+
         ## mask out any nan values
         mask = np.ones(len(xy[0]), dtype=bool)
         if xy[0].dtype.kind == 'f':
             mask &= ~np.isnan(xy[0])
         if xy[1] is not None and xy[1].dtype.kind == 'f':
             mask &= ~np.isnan(xy[1])
-        
+
         xy[0] = xy[0][mask]
         style['symbolBrush'] = colors[mask]
 
@@ -202,7 +202,7 @@ class ScatterPlotWidget(QtGui.QSplitter):
                     if smax != 0:
                         scatter *= 0.2 / smax
                     xy[ax][keymask] += scatter
-        
+
         if self.scatterPlot is not None:
             try:
                 self.scatterPlot.sigPointsClicked.disconnect(self.plotClicked)
@@ -210,9 +210,7 @@ class ScatterPlotWidget(QtGui.QSplitter):
                 pass
         self.scatterPlot = self.plot.plot(xy[0], xy[1], data=data[mask], **style)
         self.scatterPlot.sigPointsClicked.connect(self.plotClicked)
-        
-        
+
+
     def plotClicked(self, plot, points):
         pass
-
-

--- a/pyqtgraph/widgets/TableWidget.py
+++ b/pyqtgraph/widgets/TableWidget.py
@@ -22,7 +22,7 @@ def _defersort(fn):
             if setSorting:
                 self.setSortingEnabled(self._sorting)
                 self._sorting = None
-                
+
     return defersort
 
 
@@ -32,11 +32,11 @@ class TableWidget(QtGui.QTableWidget):
     of data types (see :func:`setData() <pyqtgraph.TableWidget.setData>` for more
     information.
     """
-    
+
     def __init__(self, *args, **kwds):
         """
         All positional arguments are passed to QTableWidget.__init__().
-        
+
         ===================== =================================================
         **Keyword Arguments**
         editable              (bool) If True, cells in the table can be edited
@@ -48,37 +48,37 @@ class TableWidget(QtGui.QTableWidget):
                               *(added in version 0.9.9)*
         ===================== =================================================
         """
-        
+
         QtGui.QTableWidget.__init__(self, *args)
-        
+
         self.itemClass = TableWidgetItem
-        
+
         self.setVerticalScrollMode(self.ScrollPerPixel)
         self.setSelectionMode(QtGui.QAbstractItemView.ContiguousSelection)
         self.setSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Preferred)
         self.clear()
-        
+
         kwds.setdefault('sortable', True)
         kwds.setdefault('editable', False)
         self.setEditable(kwds.pop('editable'))
         self.setSortingEnabled(kwds.pop('sortable'))
-        
+
         if len(kwds) > 0:
             raise TypeError("Invalid keyword arguments '%s'" % kwds.keys())
-        
+
         self._sorting = None  # used when temporarily disabling sorting
-        
+
         self._formats = {None: None} # stores per-column formats and entire table format
         self.sortModes = {} # stores per-column sort mode
-        
+
         self.itemChanged.connect(self.handleItemChanged)
-        
+
         self.contextMenu = QtGui.QMenu()
         self.contextMenu.addAction('Copy Selection').triggered.connect(self.copySel)
         self.contextMenu.addAction('Copy All').triggered.connect(self.copyAll)
         self.contextMenu.addAction('Save Selection').triggered.connect(self.saveSel)
         self.contextMenu.addAction('Save All').triggered.connect(self.saveAll)
-        
+
     def clear(self):
         """Clear all contents from the table."""
         QtGui.QTableWidget.clear(self)
@@ -88,13 +88,13 @@ class TableWidget(QtGui.QTableWidget):
         self.setRowCount(0)
         self.setColumnCount(0)
         self.sortModes = {}
-        
+
     def setData(self, data):
         """Set the data displayed in the table.
         Allowed formats are:
-        
+
         * numpy arrays
-        * numpy record arrays 
+        * numpy record arrays
         * metaarrays
         * list-of-lists  [[1,2,3], [4,5,6]]
         * dict-of-lists  {'x': [1,2,3], 'y': [4,5,6]}
@@ -103,17 +103,17 @@ class TableWidget(QtGui.QTableWidget):
         self.clear()
         self.appendData(data)
         self.resizeColumnsToContents()
-        
+
     @_defersort
     def appendData(self, data):
         """
         Add new rows to the table.
-        
+
         See :func:`setData() <pyqtgraph.TableWidget.setData>` for accepted
         data types.
         """
         startRow = self.rowCount()
-        
+
         fn0, header0 = self.iteratorFn(data)
         if fn0 is None:
             self.clear()
@@ -127,10 +127,10 @@ class TableWidget(QtGui.QTableWidget):
         if fn1 is None:
             self.clear()
             return
-        
+
         firstVals = [x for x in fn1(first)]
         self.setColumnCount(len(firstVals))
-        
+
         if not self.verticalHeadersSet and header0 is not None:
             labels = [self.verticalHeaderItem(i).text() for i in range(self.rowCount())]
             self.setRowCount(startRow + len(header0))
@@ -139,43 +139,43 @@ class TableWidget(QtGui.QTableWidget):
         if not self.horizontalHeadersSet and header1 is not None:
             self.setHorizontalHeaderLabels(header1)
             self.horizontalHeadersSet = True
-        
+
         i = startRow
         self.setRow(i, firstVals)
         for row in it0:
             i += 1
             self.setRow(i, [x for x in fn1(row)])
-            
+
         if self._sorting and self.horizontalHeader().sortIndicatorSection() >= self.columnCount():
             self.sortByColumn(0, QtCore.Qt.AscendingOrder)
-    
+
     def setEditable(self, editable=True):
         self.editable = editable
         for item in self.items:
             item.setEditable(editable)
-    
+
     def setFormat(self, format, column=None):
         """
         Specify the default text formatting for the entire table, or for a
         single column if *column* is specified.
-        
+
         If a string is specified, it is used as a format string for converting
-        float values (and all other types are converted using str). If a 
+        float values (and all other types are converted using str). If a
         function is specified, it will be called with the item as its only
-        argument and must return a string. Setting format = None causes the 
+        argument and must return a string. Setting format = None causes the
         default formatter to be used instead.
-        
+
         Added in version 0.9.9.
-        
+
         """
         if format is not None and not isinstance(format, basestring) and not callable(format):
             raise ValueError("Format argument must string, callable, or None. (got %s)" % format)
-        
+
         self._formats[column] = format
-        
-        
+
+
         if column is None:
-            # update format of all items that do not have a column format 
+            # update format of all items that do not have a column format
             # specified
             for c in range(self.columnCount()):
                 if self._formats.get(c, None) is None:
@@ -185,7 +185,7 @@ class TableWidget(QtGui.QTableWidget):
                             continue
                         item.setFormat(format)
         else:
-            # set all items in the column to use this format, or the default 
+            # set all items in the column to use this format, or the default
             # table format if None was specified.
             if format is None:
                 format = self._formats[None]
@@ -194,8 +194,8 @@ class TableWidget(QtGui.QTableWidget):
                 if item is None:
                     continue
                 item.setFormat(format)
-        
-    
+
+
     def iteratorFn(self, data):
         ## Return 1) a function that will provide an iterator for data and 2) a list of header strings
         if isinstance(data, list) or isinstance(data, tuple):
@@ -219,26 +219,26 @@ class TableWidget(QtGui.QTableWidget):
         else:
             msg = "Don't know how to iterate over data type: {!s}".format(type(data))
             raise TypeError(msg)
-        
+
     def iterFirstAxis(self, data):
         for i in range(data.shape[0]):
             yield data[i]
-            
+
     def iterate(self, data):
-        # for numpy.void, which can be iterated but mysteriously 
+        # for numpy.void, which can be iterated but mysteriously
         # has no __iter__ (??)
         for x in data:
             yield x
-        
+
     def appendRow(self, data):
         self.appendData([data])
-        
+
     @_defersort
     def addRow(self, vals):
         row = self.rowCount()
         self.setRowCount(row + 1)
         self.setRow(row, vals)
-        
+
     @_defersort
     def setRow(self, row, vals):
         if row > self.rowCount() - 1:
@@ -260,7 +260,7 @@ class TableWidget(QtGui.QTableWidget):
     def setSortMode(self, column, mode):
         """
         Set the mode used to sort *column*.
-        
+
         ============== ========================================================
         **Sort Modes**
         value          Compares item.value if available; falls back to text
@@ -268,7 +268,7 @@ class TableWidget(QtGui.QTableWidget):
         text           Compares item.text()
         index          Compares by the order in which items were inserted.
         ============== ========================================================
-        
+
         Added in version 0.9.9
         """
         for r in range(self.rowCount()):
@@ -276,7 +276,7 @@ class TableWidget(QtGui.QTableWidget):
             if hasattr(item, 'setSortMode'):
                 item.setSortMode(mode)
         self.sortModes[column] = mode
-        
+
     def sizeHint(self):
         # based on http://stackoverflow.com/a/7195443/54056
         width = sum(self.columnWidth(i) for i in range(self.columnCount()))
@@ -287,7 +287,7 @@ class TableWidget(QtGui.QTableWidget):
         height += self.verticalHeader().sizeHint().height()
         height += self.horizontalScrollBar().sizeHint().height()
         return QtCore.QSize(width, height)
-         
+
     def serialize(self, useSelection=False):
         """Convert entire table (or just selected area) into tab-separated text values"""
         if useSelection:
@@ -295,7 +295,7 @@ class TableWidget(QtGui.QTableWidget):
             rows = list(range(selection.topRow(),
                               selection.bottomRow() + 1))
             columns = list(range(selection.leftColumn(),
-                                 selection.rightColumn() + 1))        
+                                 selection.rightColumn() + 1))
         else:
             rows = list(range(self.rowCount()))
             columns = list(range(self.columnCount()))
@@ -305,11 +305,11 @@ class TableWidget(QtGui.QTableWidget):
             row = []
             if self.verticalHeadersSet:
                 row.append(asUnicode(''))
-            
+
             for c in columns:
                 row.append(asUnicode(self.horizontalHeaderItem(c).text()))
             data.append(row)
-        
+
         for r in rows:
             row = []
             if self.verticalHeadersSet:
@@ -321,7 +321,7 @@ class TableWidget(QtGui.QTableWidget):
                 else:
                     row.append(asUnicode(''))
             data.append(row)
-            
+
         s = ''
         for row in data:
             s += ('\t'.join(row) + '\n')
@@ -351,7 +351,7 @@ class TableWidget(QtGui.QTableWidget):
 
     def contextMenuEvent(self, ev):
         self.contextMenu.popup(ev.globalPos())
-        
+
     def keyPressEvent(self, ev):
         if ev.text() == 'c' and ev.modifiers() == QtCore.Qt.ControlModifier:
             ev.accept()
@@ -375,7 +375,7 @@ class TableWidgetItem(QtGui.QTableWidgetItem):
         self.setFlags(flags)
         self.setValue(val)
         self.setFormat(format)
-        
+
     def setEditable(self, editable):
         """
         Set whether this item is user-editable.
@@ -384,11 +384,11 @@ class TableWidgetItem(QtGui.QTableWidgetItem):
             self.setFlags(self.flags() | QtCore.Qt.ItemIsEditable)
         else:
             self.setFlags(self.flags() & ~QtCore.Qt.ItemIsEditable)
-            
+
     def setSortMode(self, mode):
         """
         Set the mode used to sort this item against others in its column.
-        
+
         ============== ========================================================
         **Sort Modes**
         value          Compares item.value if available; falls back to text
@@ -401,22 +401,22 @@ class TableWidgetItem(QtGui.QTableWidgetItem):
         if mode not in modes:
             raise ValueError('Sort mode must be one of %s' % str(modes))
         self.sortMode = mode
-        
+
     def setFormat(self, fmt):
-        """Define the conversion from item value to displayed text. 
-        
+        """Define the conversion from item value to displayed text.
+
         If a string is specified, it is used as a format string for converting
-        float values (and all other types are converted using str). If a 
+        float values (and all other types are converted using str). If a
         function is specified, it will be called with the item as its only
         argument and must return a string.
-        
+
         Added in version 0.9.9.
         """
         if fmt is not None and not isinstance(fmt, basestring) and not callable(fmt):
             raise ValueError("Format argument must string, callable, or None. (got %s)" % fmt)
         self._format = fmt
         self._updateText()
-        
+
     def _updateText(self):
         self._blockValueChange = True
         try:
@@ -442,7 +442,7 @@ class TableWidgetItem(QtGui.QTableWidgetItem):
             # text change was result of value or format change; do not
             # propagate.
             return
-        
+
         try:
 
             self.value = type(self.value)(self.text())
@@ -476,18 +476,18 @@ if __name__ == '__main__':
     win.setCentralWidget(t)
     win.resize(800,600)
     win.show()
-    
+
     ll = [[1,2,3,4,5]] * 20
     ld = [{'x': 1, 'y': 2, 'z': 3}] * 20
     dl = {'x': list(range(20)), 'y': list(range(20)), 'z': list(range(20))}
-    
+
     a = np.ones((20, 5))
     ra = np.ones((20,), dtype=[('x', int), ('y', int), ('z', int)])
-    
+
     t.setData(ll)
-    
+
     ma = metaarray.MetaArray(np.ones((20, 3)), info=[
-        {'values': np.linspace(1, 5, 20)}, 
+        {'values': np.linspace(1, 5, 20)},
         {'cols': [
             {'name': 'x'},
             {'name': 'y'},
@@ -495,4 +495,3 @@ if __name__ == '__main__':
         ]}
     ])
     t.setData(ma)
-    

--- a/pyqtgraph/widgets/TreeWidget.py
+++ b/pyqtgraph/widgets/TreeWidget.py
@@ -11,9 +11,9 @@ class TreeWidget(QtGui.QTreeWidget):
     """Extends QTreeWidget to allow internal drag/drop with widgets in the tree.
     Also maintains the expanded state of subtrees as they are moved.
     This class demonstrates the absurd lengths one must go to to make drag/drop work."""
-    
+
     sigItemMoved = QtCore.Signal(object, object, object) # (item, parent, index)
-    
+
     def __init__(self, parent=None):
         QtGui.QTreeWidget.__init__(self, parent)
         #self.itemWidgets = WeakKeyDictionary()
@@ -57,26 +57,26 @@ class TreeWidget(QtGui.QTreeWidget):
                 return False
                 #raise Exception("Can not move item into itself.")
             p = p.parent()
-        
+
         if not self.itemMoving(item, parent, index):
             return False
-        
+
         currentParent = item.parent()
         if currentParent is None:
             currentParent = self.invisibleRootItem()
         if parent is None:
             parent = self.invisibleRootItem()
-            
+
         if currentParent is parent and index > parent.indexOfChild(item):
             index -= 1
-            
+
         self.prepareMove(item)
-            
+
         currentParent.removeChild(item)
         #print "  insert child to index", index
         parent.insertChild(index, item)  ## index will not be correct
         self.setCurrentItem(item)
-        
+
         self.recoverMove(item)
         #self.emit(QtCore.SIGNAL('itemMoved'), item, parent, index)
         self.sigItemMoved.emit(item, parent, index)
@@ -86,7 +86,7 @@ class TreeWidget(QtGui.QTreeWidget):
         """Called when item has been dropped elsewhere in the tree.
         Return True to accept the move, False to reject."""
         return True
-        
+
     def prepareMove(self, item):
         item.__widgets = []
         item.__expanded = item.isExpanded()
@@ -98,7 +98,7 @@ class TreeWidget(QtGui.QTreeWidget):
             w.setParent(None)
         for i in range(item.childCount()):
             self.prepareMove(item.child(i))
-        
+
     def recoverMove(self, item):
         for i in range(self.columnCount()):
             w = item.__widgets[i]
@@ -107,45 +107,45 @@ class TreeWidget(QtGui.QTreeWidget):
             self.setItemWidget(item, i, w)
         for i in range(item.childCount()):
             self.recoverMove(item.child(i))
-        
+
         item.setExpanded(False)  ## Items do not re-expand correctly unless they are collapsed first.
         QtGui.QApplication.instance().processEvents()
         item.setExpanded(item.__expanded)
-        
+
     def collapseTree(self, item):
         item.setExpanded(False)
         for i in range(item.childCount()):
             self.collapseTree(item.child(i))
-            
+
     def removeTopLevelItem(self, item):
         for i in range(self.topLevelItemCount()):
             if self.topLevelItem(i) is item:
                 self.takeTopLevelItem(i)
                 return
         raise Exception("Item '%s' not in top-level items." % str(item))
-    
+
     def listAllItems(self, item=None):
         items = []
         if item != None:
             items.append(item)
         else:
             item = self.invisibleRootItem()
-        
+
         for cindex in range(item.childCount()):
             foundItems = self.listAllItems(item=item.child(cindex))
             for f in foundItems:
                 items.append(f)
         return items
-            
+
     def dropEvent(self, ev):
         QtGui.QTreeWidget.dropEvent(self, ev)
         self.updateDropFlags()
 
-    
+
     def updateDropFlags(self):
         ### intended to put a limit on how deep nests of children can go.
         ### self.childNestingLimit is upheld when moving items without children, but if the item being moved has children/grandchildren, the children/grandchildren
-        ### can end up over the childNestingLimit. 
+        ### can end up over the childNestingLimit.
         if self.childNestingLimit == None:
             pass # enable drops in all items (but only if there are drops that aren't enabled? for performance...)
         else:
@@ -168,8 +168,8 @@ class TreeWidget(QtGui.QTreeWidget):
         else:
             for i in xrange(item.childCount()):
                 TreeWidget.informTreeWidgetChange(item.child(i))
-        
-        
+
+
     def addTopLevelItem(self, item):
         QtGui.QTreeWidget.addTopLevelItem(self, item)
         self.informTreeWidgetChange(item)
@@ -178,7 +178,7 @@ class TreeWidget(QtGui.QTreeWidget):
         QtGui.QTreeWidget.addTopLevelItems(self, items)
         for item in items:
             self.informTreeWidgetChange(item)
-            
+
     def insertTopLevelItem(self, index, item):
         QtGui.QTreeWidget.insertTopLevelItem(self, index, item)
         self.informTreeWidgetChange(item)
@@ -187,7 +187,7 @@ class TreeWidget(QtGui.QTreeWidget):
         QtGui.QTreeWidget.insertTopLevelItems(self, index, items)
         for item in items:
             self.informTreeWidgetChange(item)
-            
+
     def takeTopLevelItem(self, index):
         item = self.topLevelItem(index)
         if item is not None:
@@ -199,18 +199,18 @@ class TreeWidget(QtGui.QTreeWidget):
 
     def topLevelItems(self):
         return map(self.topLevelItem, xrange(self.topLevelItemCount()))
-        
+
     def clear(self):
         items = self.topLevelItems()
         for item in items:
             self.prepareMove(item)
         QtGui.QTreeWidget.clear(self)
-        
-        ## Why do we want to do this? It causes RuntimeErrors. 
+
+        ## Why do we want to do this? It causes RuntimeErrors.
         #for item in items:
             #self.informTreeWidgetChange(item)
-        
-            
+
+
 class TreeWidgetItem(QtGui.QTreeWidgetItem):
     """
     TreeWidgetItem that keeps track of its own widgets.
@@ -220,11 +220,11 @@ class TreeWidgetItem(QtGui.QTreeWidgetItem):
         QtGui.QTreeWidgetItem.__init__(self, *args)
         self._widgets = {}  # col: widget
         self._tree = None
-        
-        
+
+
     def setChecked(self, column, checked):
         self.setCheckState(column, QtCore.Qt.Checked if checked else QtCore.Qt.Unchecked)
-        
+
     def setWidget(self, column, widget):
         if column in self._widgets:
             self.removeWidget(column)
@@ -234,14 +234,14 @@ class TreeWidgetItem(QtGui.QTreeWidgetItem):
             return
         else:
             tree.setItemWidget(self, column, widget)
-            
+
     def removeWidget(self, column):
         del self._widgets[column]
         tree = self.treeWidget()
         if tree is None:
             return
         tree.removeItemWidget(self, column)
-            
+
     def treeWidgetChanged(self):
         tree = self.treeWidget()
         if self._tree is tree:
@@ -251,11 +251,11 @@ class TreeWidgetItem(QtGui.QTreeWidgetItem):
             return
         for col, widget in self._widgets.items():
             tree.setItemWidget(self, col, widget)
-            
+
     def addChild(self, child):
         QtGui.QTreeWidgetItem.addChild(self, child)
         TreeWidget.informTreeWidgetChange(child)
-            
+
     def addChildren(self, childs):
         QtGui.QTreeWidgetItem.addChildren(self, childs)
         for child in childs:
@@ -264,25 +264,23 @@ class TreeWidgetItem(QtGui.QTreeWidgetItem):
     def insertChild(self, index, child):
         QtGui.QTreeWidgetItem.insertChild(self, index, child)
         TreeWidget.informTreeWidgetChange(child)
-    
+
     def insertChildren(self, index, childs):
         QtGui.QTreeWidgetItem.addChildren(self, index, childs)
         for child in childs:
             TreeWidget.informTreeWidgetChange(child)
-    
+
     def removeChild(self, child):
         QtGui.QTreeWidgetItem.removeChild(self, child)
         TreeWidget.informTreeWidgetChange(child)
-            
+
     def takeChild(self, index):
         child = QtGui.QTreeWidgetItem.takeChild(self, index)
         TreeWidget.informTreeWidgetChange(child)
         return child
-    
+
     def takeChildren(self):
         childs = QtGui.QTreeWidgetItem.takeChildren(self)
         for child in childs:
             TreeWidget.informTreeWidgetChange(child)
         return childs
-        
-        

--- a/pyqtgraph/widgets/ValueLabel.py
+++ b/pyqtgraph/widgets/ValueLabel.py
@@ -11,9 +11,9 @@ class ValueLabel(QtGui.QLabel):
     Extends QLabel adding some extra functionality:
 
     - displaying units with si prefix
-    - built-in exponential averaging 
+    - built-in exponential averaging
     """
-    
+
     def __init__(self, parent=None, suffix='', siPrefix=False, averageTime=0, formatStr=None):
         """
         ==============      ==================================================================================
@@ -37,7 +37,7 @@ class ValueLabel(QtGui.QLabel):
         if formatStr is None:
             formatStr = '{avgValue:0.2g} {suffix}'
         self.formatStr = formatStr
-    
+
     def setValue(self, value):
         now = time()
         self.values.append((now, value))
@@ -45,22 +45,22 @@ class ValueLabel(QtGui.QLabel):
         while len(self.values) > 0 and self.values[0][0] < cutoff:
             self.values.pop(0)
         self.update()
-        
+
     def setFormatStr(self, text):
         self.formatStr = text
         self.update()
-        
+
     def setAverageTime(self, t):
         self.averageTime = t
-        
+
     def averageValue(self):
         return reduce(lambda a,b: a+b, [v[1] for v in self.values]) / float(len(self.values))
-        
-        
+
+
     def paintEvent(self, ev):
         self.setText(self.generateText())
         return QtGui.QLabel.paintEvent(self, ev)
-        
+
     def generateText(self):
         if len(self.values) == 0:
             return ''
@@ -70,4 +70,3 @@ class ValueLabel(QtGui.QLabel):
             return fn.siFormat(avg, suffix=self.suffix)
         else:
             return self.formatStr.format(value=val, avgValue=avg, suffix=self.suffix)
-            

--- a/pyqtgraph/widgets/VerticalLabel.py
+++ b/pyqtgraph/widgets/VerticalLabel.py
@@ -23,22 +23,22 @@ class VerticalLabel(QtGui.QLabel):
         self.forceWidth = forceWidth
         self.orientation = None
         self.setOrientation(orientation)
-        
+
     def setOrientation(self, o):
         if self.orientation == o:
             return
         self.orientation = o
         self.update()
         self.updateGeometry()
-        
+
     def paintEvent(self, ev):
         p = QtGui.QPainter(self)
         #p.setBrush(QtGui.QBrush(QtGui.QColor(100, 100, 200)))
         #p.setPen(QtGui.QPen(QtGui.QColor(50, 50, 100)))
         #p.drawRect(self.rect().adjusted(0, 0, -1, -1))
-        
+
         #p.setPen(QtGui.QPen(QtGui.QColor(255, 255, 255)))
-        
+
         if self.orientation == 'vertical':
             p.rotate(-90)
             rgn = QtCore.QRect(-self.height(), 0, self.height(), self.width())
@@ -46,10 +46,10 @@ class VerticalLabel(QtGui.QLabel):
             rgn = self.contentsRect()
         align = self.alignment()
         #align  = QtCore.Qt.AlignTop|QtCore.Qt.AlignHCenter
-            
+
         self.hint = p.drawText(rgn, align, self.text())
         p.end()
-        
+
         if self.orientation == 'vertical':
             self.setMaximumWidth(self.hint.height())
             self.setMinimumWidth(0)
@@ -86,7 +86,7 @@ if __name__ == '__main__':
     w = QtGui.QWidget()
     l = QtGui.QGridLayout()
     w.setLayout(l)
-    
+
     l1 = VerticalLabel("text 1", orientation='horizontal')
     l2 = VerticalLabel("text 2")
     l3 = VerticalLabel("text 3")

--- a/pyqtgraph/widgets/__init__.py
+++ b/pyqtgraph/widgets/__init__.py
@@ -9,7 +9,7 @@
         #files.append(f)
     #elif f[-3:] == '.py' and f != '__init__.py':
         #files.append(f[:-3])
-    
+
 #for modName in files:
     #mod = __import__(modName, globals(), locals(), fromlist=['*'])
     #if hasattr(mod, '__all__'):

--- a/pyqtgraph/widgets/tests/test_combobox.py
+++ b/pyqtgraph/widgets/tests/test_combobox.py
@@ -8,33 +8,33 @@ def test_combobox():
     cb.setValue(2)
     assert str(cb.currentText()) == 'b'
     assert cb.value() == 2
-    
+
     # Clear item list; value should be None
     cb.clear()
     assert cb.value() == None
-    
+
     # Reset item list; value should be set automatically
     cb.setItems(items)
     assert cb.value() == 2
-    
+
     # Clear item list; repopulate with same names and new values
     items = {'a': 4, 'b': 5, 'c': 6}
     cb.clear()
     cb.setItems(items)
     assert cb.value() == 5
-    
+
     # Set list instead of dict
     cb.setItems(list(items.keys()))
     assert str(cb.currentText()) == 'b'
-    
+
     cb.setValue('c')
     assert cb.value() == str(cb.currentText())
     assert cb.value() == 'c'
-    
+
     cb.setItemValue('c', 7)
     assert cb.value() == 7
-    
-    
+
+
 if __name__ == '__main__':
     cb = pg.ComboBox()
     cb.show()

--- a/pyqtgraph/widgets/tests/test_tablewidget.py
+++ b/pyqtgraph/widgets/tests/test_tablewidget.py
@@ -8,8 +8,8 @@ app = pg.mkQApp()
 listOfTuples = [('text_%d' % i, i, i/9.) for i in range(12)]
 listOfLists = [list(row) for row in listOfTuples]
 plainArray = np.array(listOfLists, dtype=object)
-recordArray = np.array(listOfTuples, dtype=[('string', object), 
-                                            ('integer', int), 
+recordArray = np.array(listOfTuples, dtype=[('string', object),
+                                            ('integer', int),
                                             ('floating', float)])
 dictOfLists = OrderedDict([(name, list(recordArray[name])) for name in recordArray.dtype.names])
 listOfDicts = [OrderedDict([(name, rec[name]) for name in recordArray.dtype.names]) for rec in recordArray]
@@ -29,33 +29,33 @@ def assertTableData(table, data):
             else:
                 row.append(None)
         assert row == list(data[r])
-    
+
 
 def test_TableWidget():
     w = pg.TableWidget(sortable=False)
-    
+
     # Test all input data types
     w.setData(listOfTuples)
     assertTableData(w, listOfTuples)
-    
+
     w.setData(listOfLists)
     assertTableData(w, listOfTuples)
-    
+
     w.setData(plainArray)
     assertTableData(w, listOfTuples)
-    
+
     w.setData(recordArray)
     assertTableData(w, listOfTuples)
-    
+
     w.setData(dictOfLists)
     assertTableData(w, transposed)
-    
+
     w.appendData(dictOfLists)
     assertTableData(w, transposed * 2)
-        
+
     w.setData(listOfDicts)
     assertTableData(w, listOfTuples)
-    
+
     w.appendData(listOfDicts)
     assertTableData(w, listOfTuples * 2)
 
@@ -63,13 +63,13 @@ def test_TableWidget():
     w.setData(listOfTuples)
     w.sortByColumn(0, pg.QtCore.Qt.AscendingOrder)
     assertTableData(w, sorted(listOfTuples, key=lambda a: a[0]))
-    
+
     w.sortByColumn(1, pg.QtCore.Qt.AscendingOrder)
     assertTableData(w, sorted(listOfTuples, key=lambda a: a[1]))
-    
+
     w.sortByColumn(2, pg.QtCore.Qt.AscendingOrder)
     assertTableData(w, sorted(listOfTuples, key=lambda a: a[2]))
-    
+
     w.setSortMode(1, 'text')
     w.sortByColumn(1, pg.QtCore.Qt.AscendingOrder)
     assertTableData(w, sorted(listOfTuples, key=lambda a: str(a[1])))
@@ -81,32 +81,32 @@ def test_TableWidget():
     # Test formatting
     item = w.item(0, 2)
     assert item.text() == ('%0.3g' % item.value)
-    
+
     w.setFormat('%0.6f')
     assert item.text() == ('%0.6f' % item.value)
-    
+
     w.setFormat('X%0.7f', column=2)
     assert isinstance(item.value, float)
     assert item.text() == ('X%0.7f' % item.value)
-    
+
     # test setting items that do not exist yet
     w.setFormat('X%0.7f', column=3)
-    
+
     # test append uses correct formatting
     w.appendRow(('x', 10, 7.3))
     item = w.item(w.rowCount()-1, 2)
     assert isinstance(item.value, float)
     assert item.text() == ('X%0.7f' % item.value)
-    
+
     # test reset back to defaults
     w.setFormat(None, column=2)
     assert isinstance(item.value, float)
     assert item.text() == ('%0.6f' % item.value)
-    
+
     w.setFormat(None)
     assert isinstance(item.value, float)
     assert item.text() == ('%0.3g' % item.value)
-    
+
     # test function formatter
     def fmt(item):
         if isinstance(item.value, float):
@@ -117,7 +117,7 @@ def test_TableWidget():
     assert isinstance(item.value, float)
     assert isinstance(item.index, int)
     assert item.text() == ("%d %f" % (item.index, item.value))
-    
+
 
 
 if __name__ == '__main__':
@@ -125,4 +125,3 @@ if __name__ == '__main__':
     w.setData(listOfTuples)
     w.resize(600, 600)
     w.show()
-

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 DESCRIPTION = """\
 PyQtGraph is a pure-python graphics and GUI library built on PyQt4/PySide and
-numpy. 
+numpy.
 
 It is intended for use in mathematics / scientific / engineering applications.
 Despite being written entirely in python, the library is very fast due to its
@@ -51,7 +51,7 @@ sys.path.insert(0, os.path.join(path, 'tools'))
 import setupHelpers as helpers
 
 ## generate list of all sub-packages
-allPackages = (helpers.listAllPackages(pkgroot='pyqtgraph') + 
+allPackages = (helpers.listAllPackages(pkgroot='pyqtgraph') +
                ['pyqtgraph.'+x for x in helpers.listAllPackages(pkgroot='examples')])
 
 ## Decide what version string to use in the build
@@ -72,14 +72,14 @@ class Build(build.build):
         buildPath = os.path.join(path, self.build_lib)
         if os.path.isdir(buildPath):
             distutils.dir_util.remove_tree(buildPath)
-    
+
         ret = build.build.run(self)
-        
+
         # If the version in __init__ is different from the automatically-generated
         # version string, then we will update __init__ in the build directory
         if initVersion == version:
             return ret
-        
+
         try:
             initfile = os.path.join(buildPath, 'pyqtgraph', '__init__.py')
             data = open(initfile, 'r').read()
@@ -95,7 +95,7 @@ class Build(build.build):
                              )
             sys.excepthook(*sys.exc_info())
         return ret
-        
+
 
 class Install(install.install):
     """
@@ -106,17 +106,17 @@ class Install(install.install):
         path = self.install_libbase
         if os.path.exists(path) and name in os.listdir(path):
             raise Exception("It appears another version of %s is already "
-                            "installed at %s; remove this before installing." 
+                            "installed at %s; remove this before installing."
                             % (name, path))
         print("Installing to %s" % path)
         return install.install.run(self)
 
-        
+
 setup(
     version=version,
-    cmdclass={'build': Build, 
+    cmdclass={'build': Build,
               'install': Install,
-              'deb': helpers.DebCommand, 
+              'deb': helpers.DebCommand,
               'test': helpers.TestCommand,
               'debug': helpers.DebugCommand,
               'mergetest': helpers.MergeTestCommand,
@@ -129,4 +129,3 @@ setup(
         ],
     **setupOpts
 )
-

--- a/tools/generateChangelog.py
+++ b/tools/generateChangelog.py
@@ -16,8 +16,8 @@ def generateDebianChangelog(package, logFile, version, maintainer):
     * Initial release.
 
     -- Luke <luke.campagnola@gmail.com>  Sat, 29 Dec 2012 01:07:23 -0500
-    
-    
+
+
     *package* is the name of the python package.
     *logFile* is the CHANGELOG file to read; must have the format described above.
     *version* will be used to check that the most recent log entry corresponds
@@ -42,11 +42,11 @@ def generateDebianChangelog(package, logFile, version, maintainer):
 
     if releases[0][0] != version:
         raise Exception("Latest release in changelog (%s) does not match current release (%s)\n" % (releases[0][0],  version))
-    
+
     output = []
     for release, changes, date in releases:
         date = time.strptime(date, '%Y-%m-%d')
-        changeset = [ 
+        changeset = [
             "python-%s (%s-1) UNRELEASED; urgency=low\n" % (package, release),
             "\n"] + changes + [
             " -- %s  %s -0%d00\n"  % (maintainer, time.strftime('%a, %d %b %Y %H:%M:%S', date), time.timezone/3600),
@@ -65,7 +65,7 @@ def generateDebianChangelog(package, logFile, version, maintainer):
             else:
                 clean += line
                 lastBlank = False
-                
+
         output.append(clean)
         output.append("")
     return "\n".join(output) + "\n"
@@ -75,6 +75,5 @@ if __name__ == '__main__':
     if len(sys.argv) < 5:
         sys.stderr.write('Usage: generateChangelog.py package_name log_file version "Maintainer <maint@email.com>"\n')
         sys.exit(-1)
-    
-    print(generateDebianChangelog(*sys.argv[1:]))
 
+    print(generateDebianChangelog(*sys.argv[1:]))

--- a/tools/py2exeSetupWindows.py
+++ b/tools/py2exeSetupWindows.py
@@ -1,5 +1,5 @@
 """
-Example distutils setup script for packaging a program with 
+Example distutils setup script for packaging a program with
 pyqtgraph and py2exe. See the packaging tutorial at
 http://luke.campagnola.me/code/pyqtgraph for more information.
 """

--- a/tools/rebuildUi.py
+++ b/tools/rebuildUi.py
@@ -27,4 +27,3 @@ for path, sd, files in os.walk('.'):
         if not os.path.exists(py) or os.stat(ui).st_mtime > os.stat(py).st_mtime:
             os.system('%s %s > %s' % (pyqt5uic, ui, py))
             print(py)
-

--- a/tools/setVersion.py
+++ b/tools/setVersion.py
@@ -19,8 +19,5 @@ for filename, search, sub in replace:
         print('Error: Search expression "%s" not found in file %s.' % (search, filename))
         os._exit(1)
     open(filename, 'w').write(re.sub(search, sub, data))
-    
+
 print("Updated version strings to %s" % version)
-
-
-

--- a/tools/setupHelpers.py
+++ b/tools/setupHelpers.py
@@ -17,7 +17,7 @@ except ImportError:
         return output
 
 # Maximum allowed repository size difference (in kB) following merge.
-# This is used to prevent large files from being inappropriately added to 
+# This is used to prevent large files from being inappropriately added to
 # the repository history.
 MERGE_SIZE_LIMIT = 100
 
@@ -42,19 +42,19 @@ FLAKE_MANDATORY = set([
 
     'E901',  #  SyntaxError or IndentationError
     'E902',  #  IOError
-        
+
     'W191',  #  indentation contains tabs
-        
+
     'W601',  #  .has_key() is deprecated, use ‘in’
     'W602',  #  deprecated form of raising exception
     'W603',  #  ‘<>’ is deprecated, use ‘!=’
-    'W604',  #  backticks are deprecated, use ‘repr()’    
+    'W604',  #  backticks are deprecated, use ‘repr()’
     ])
 
 FLAKE_RECOMMENDED = set([
     'E124',  #  closing bracket does not match visual indentation
     'E231',  #  missing whitespace after ‘,’
-    
+
     'E211',  #  whitespace before ‘(‘
     'E261',  #  at least two spaces before inline comment
     'E271',  #  multiple spaces after keyword
@@ -65,10 +65,10 @@ FLAKE_RECOMMENDED = set([
     'F402',  #  import module from line N shadowed by loop variable
     'F403',  #  ‘from module import *’ used; unable to detect undefined names
     'F404',  #  future import(s) name after other statements
-        
+
     'E501',  #  line too long (82 > 79 characters)
     'E502',  #  the backslash is redundant between brackets
-    
+
     'E702',  #  multiple statements on one line (semicolon)
     'E703',  #  statement ends with a semicolon
     'E711',  #  comparison to None should be ‘if cond is None:’
@@ -82,7 +82,7 @@ FLAKE_RECOMMENDED = set([
     'F823',  #  local variable name ... referenced before assignment
     'F831',  #  duplicate argument name in function definition
     'F841',  #  local variable name is assigned to but never used
-    
+
     'W292',  #  no newline at end of file
 
     ])
@@ -93,7 +93,7 @@ FLAKE_OPTIONAL = set([
     'E126',  #  continuation line over-indented for hanging indent
     'E127',  #  continuation line over-indented for visual indent
     'E128',  #  continuation line under-indented for visual indent
-        
+
     'E201',  #  whitespace after ‘(‘
     'E202',  #  whitespace before ‘)’
     'E203',  #  whitespace before ‘:’
@@ -105,19 +105,19 @@ FLAKE_OPTIONAL = set([
     'E228',  #  missing whitespace around modulo operator
     'E241',  #  multiple spaces after ‘,’
     'E251',  #  unexpected spaces around keyword / parameter equals
-    'E262',  #  inline comment should start with ‘# ‘     
-        
+    'E262',  #  inline comment should start with ‘# ‘
+
     'E301',  #  expected 1 blank line, found 0
     'E302',  #  expected 2 blank lines, found 0
     'E303',  #  too many blank lines (3)
-        
+
     'E401',  #  multiple imports on one line
 
     'E701',  #  multiple statements on one line (colon)
-        
+
     'W291',  #  trailing whitespace
     'W293',  #  blank line contains whitespace
-        
+
     'W391',  #  blank line at end of file
     ])
 
@@ -144,7 +144,7 @@ def checkStyle():
     """ Run flake8, checking only lines that are modified since the last
     git commit. """
     test = [ 1,2,3 ]
-    
+
     # First check _all_ code against mandatory error codes
     print('flake8: check all code against mandatory error set...')
     errors = ','.join(FLAKE_MANDATORY)
@@ -154,7 +154,7 @@ def checkStyle():
     output = proc.stdout.read().decode('utf-8')
     ret = proc.wait()
     printFlakeOutput(output)
-    
+
     # Check for DOS newlines
     print('check line endings in all files...')
     count = 0
@@ -173,20 +173,20 @@ def checkStyle():
                 ret = ret | 2
             count += 1
     print('checked line endings in %d files' % count)
-            
-    
+
+
     # Next check new code with optional error codes
     print('flake8: check new code against recommended error set...')
     diff = subprocess.check_output(['git', 'diff'])
     proc = subprocess.Popen(['flake8', '--diff', #'--show-source',
                                 '--ignore=' + errors],
-                            stdin=subprocess.PIPE, 
+                            stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE)
     proc.stdin.write(diff)
     proc.stdin.close()
     output = proc.stdout.read().decode('utf-8')
     ret |= printFlakeOutput(output)
-    
+
     if ret == 0:
         print('style test passed.')
     else:
@@ -251,7 +251,7 @@ def checkMergeSize(sourceBranch=None, targetBranch=None, sourceRepo=None, target
     if sourceBranch is None:
         sourceBranch = getGitBranch()
         sourceRepo = '..'
-        
+
     if targetBranch is None:
         if sourceBranch == 'develop':
             targetBranch = 'develop'
@@ -259,38 +259,38 @@ def checkMergeSize(sourceBranch=None, targetBranch=None, sourceRepo=None, target
         else:
             targetBranch = 'develop'
             targetRepo = '..'
-    
+
     workingDir = '__merge-test-clone'
-    env = dict(TARGET_BRANCH=targetBranch, 
-               SOURCE_BRANCH=sourceBranch, 
-               TARGET_REPO=targetRepo, 
+    env = dict(TARGET_BRANCH=targetBranch,
+               SOURCE_BRANCH=sourceBranch,
+               TARGET_REPO=targetRepo,
                SOURCE_REPO=sourceRepo,
                WORKING_DIR=workingDir,
                )
-    
+
     print("Testing merge size difference:\n"
           "  SOURCE: {SOURCE_REPO} {SOURCE_BRANCH}\n"
           "  TARGET: {TARGET_BRANCH} {TARGET_REPO}".format(**env))
-    
+
     setup = """
         mkdir {WORKING_DIR} && cd {WORKING_DIR} &&
         git init && git remote add -t {TARGET_BRANCH} target {TARGET_REPO} &&
-        git fetch target {TARGET_BRANCH} && 
-        git checkout -qf target/{TARGET_BRANCH} && 
+        git fetch target {TARGET_BRANCH} &&
+        git checkout -qf target/{TARGET_BRANCH} &&
         git gc -q --aggressive
         """.format(**env)
-        
+
     checkSize = """
-        cd {WORKING_DIR} && 
+        cd {WORKING_DIR} &&
         du -s . | sed -e "s/\t.*//"
         """.format(**env)
-    
+
     merge = """
         cd {WORKING_DIR} &&
-        git pull -q {SOURCE_REPO} {SOURCE_BRANCH} && 
+        git pull -q {SOURCE_REPO} {SOURCE_BRANCH} &&
         git gc -q --aggressive
         """.format(**env)
-    
+
     try:
         print("Check out target branch:\n" + setup)
         check_call(setup, shell=True)
@@ -300,7 +300,7 @@ def checkMergeSize(sourceBranch=None, targetBranch=None, sourceRepo=None, target
         check_call(merge, shell=True)
         mergeSize = int(check_output(checkSize, shell=True))
         print("MERGE SIZE: %d kB" % mergeSize)
-        
+
         diff = mergeSize - targetSize
         if diff <= MERGE_SIZE_LIMIT:
             print("DIFFERENCE: %d kB  [OK]" % diff)
@@ -357,17 +357,17 @@ def getGitVersion(tagPrefix):
     path = os.getcwd()
     if not os.path.isdir(os.path.join(path, '.git')):
         return None
-        
+
     gitVersion = check_output(['git', 'describe', '--tags']).strip().decode('utf-8')
-    
+
     # any uncommitted modifications?
     modified = False
     status = check_output(['git', 'status', '--porcelain'], universal_newlines=True).strip().split('\n')
     for line in status:
         if line != '' and line[:2] != '??':
             modified = True
-            break        
-                
+            break
+
     if modified:
         gitVersion = gitVersion + '+'
 
@@ -382,16 +382,16 @@ def getGitBranch():
 
 def getVersionStrings(pkg):
     """
-    Returns 4 version strings: 
-    
+    Returns 4 version strings:
+
     * the version string to use for this build,
     * version string requested with --force-version (or None)
     * version string that describes the current git checkout (or None).
-    * version string in the pkg/__init__.py, 
-    
+    * version string in the pkg/__init__.py,
+
     The first return value is (forceVersion or gitVersion or initVersion).
     """
-    
+
     ## Determine current version string from __init__.py
     initVersion = getInitVersion(pkgroot='pyqtgraph')
 
@@ -416,8 +416,8 @@ def getVersionStrings(pkg):
             elif arg.startswith('--force-version='):
                 forcedVersion = sys.argv[i].replace('--force-version=', '')
                 sys.argv.pop(i)
-                
-                
+
+
     ## Finally decide on a version string to use:
     if forcedVersion is not None:
         version = forcedVersion
@@ -439,29 +439,29 @@ class DebCommand(Command):
     maintainer = "Luke Campagnola <luke.campagnola@gmail.com>"
     debTemplate = "debian"
     debDir = "deb_build"
-    
+
     user_options = []
-    
+
     def initialize_options(self):
         self.cwd = None
-        
+
     def finalize_options(self):
         self.cwd = os.getcwd()
-        
+
     def run(self):
         version = self.distribution.get_version()
         pkgName = self.distribution.get_name()
         debName = "python-" + pkgName
         debDir = self.debDir
-        
+
         assert os.getcwd() == self.cwd, 'Must be in package root: %s' % self.cwd
-        
+
         if os.path.isdir(debDir):
             raise Exception('DEB build dir already exists: "%s"' % debDir)
         sdist = "dist/%s-%s.tar.gz" % (pkgName, version)
         if not os.path.isfile(sdist):
             raise Exception("No source distribution; run `setup.py sdist` first.")
-        
+
         # copy sdist to build directory and extract
         os.mkdir(debDir)
         renamedSdist = '%s_%s.orig.tar.gz' % (debName, version)
@@ -471,16 +471,16 @@ class DebCommand(Command):
         if os.system("cd %s; tar -xzf %s" % (debDir, renamedSdist)) != 0:
             raise Exception("Error extracting source distribution.")
         buildDir = '%s/%s-%s' % (debDir, pkgName, version)
-        
+
         # copy debian control structure
         print("copytree %s => %s" % (self.debTemplate, buildDir+'/debian'))
         shutil.copytree(self.debTemplate, buildDir+'/debian')
-        
+
         # Write new changelog
         chlog = generateDebianChangelog(pkgName, 'CHANGELOG', version, self.maintainer)
         print("write changelog %s" % buildDir+'/debian/changelog')
         open(buildDir+'/debian/changelog', 'w').write(chlog)
-        
+
         # build package
         print('cd %s; debuild -us -uc' % buildDir)
         if os.system('cd %s; debuild -us -uc' % buildDir) != 0:
@@ -505,41 +505,40 @@ class DebugCommand(Command):
 class TestCommand(Command):
     description = "Run all package tests and exit immediately with informative return code."
     user_options = []
-    
+
     def run(self):
         sys.exit(unitTests())
-        
+
     def initialize_options(self):
         pass
-    
+
     def finalize_options(self):
         pass
-    
+
 
 class StyleCommand(Command):
     description = "Check all code for style, exit immediately with informative return code."
     user_options = []
-    
+
     def run(self):
         sys.exit(checkStyle())
-        
+
     def initialize_options(self):
         pass
-    
+
     def finalize_options(self):
         pass
 
-    
+
 class MergeTestCommand(Command):
     description = "Run all tests needed to determine whether the current code is suitable for merge."
     user_options = []
-    
+
     def run(self):
         sys.exit(mergeTests())
-        
+
     def initialize_options(self):
         pass
-    
+
     def finalize_options(self):
         pass
-


### PR DESCRIPTION
Hello Luke,

I'm currently working on improving the docking system in PyQtGraph. My editor is setup to automatically strip trailing spaces, as they are mostly diff garbage. I can see why you left some of them (to ease indentation on the next line), but many of them have no particular reason to be there.
So before creating pull requests for the rest, here's a PR with all trailing spaces removed from all *.py file.
Feel free to apply or not ! :)

Anyway, thanks for your great work. I'm eagerly looking into vispy too, but it's not yet as mature as PyQtGraph.

Alexis :)