### PR TITLE
fix repetitive update() of nodes with multiple input

### DIFF
--- a/pyqtgraph/flowchart/Flowchart.py
+++ b/pyqtgraph/flowchart/Flowchart.py
@@ -381,22 +381,22 @@ class Flowchart(Node):
             terms = set(startNode.outputs().values())
             
             #print "======= Updating", startNode
-            #print "Order:", order
+            # print("Order:", order)
             for node in order[1:]:
-                #print "Processing node", node
+                # print("Processing node", node)
+                update = False
                 for term in list(node.inputs().values()):
-                    #print "  checking terminal", term
+                    # print("  checking terminal", term)
                     deps = list(term.connections().keys())
-                    update = False
                     for d in deps:
                         if d in terms:
-                            #print "    ..input", d, "changed"
-                            update = True
+                            # print("    ..input", d, "changed")
+                            update |= True
                             term.inputChanged(d, process=False)
-                    if update:
-                        #print "  processing.."
-                        node.update()
-                        terms |= set(node.outputs().values())
+                if update:
+                    # print("  processing..")
+                    node.update()
+                    terms |= set(node.outputs().values())
                     
         finally:
             self.processing = False


### PR DESCRIPTION
This commit fixes the issue below:
For a flowchart with connections between nodes like
node A -> node B -> node D
node A -> node C -> node D
The update() method of node D would be called twice if node A is changed and propagate the change through two different paths. This should not be the behavior expected. The update of D should only be called once after processing node B and node C.