### PR TITLE
Axis fixes

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -910,6 +910,7 @@ class AxisItem(GraphicsWidget):
             #textHeight = self.style['tickTextHeight'] ## space allocated for horizontal text
             
         textSize2 = 0
+        last_textSize2 = 0
         textRects = []
         textSpecs = []  ## list of draw
         
@@ -971,7 +972,9 @@ class AxisItem(GraphicsWidget):
                         break
                 if finished:
                     break
-            
+
+            last_textSize2 = textSize2
+
             #spacing, values = tickLevels[best]
             #strings = self.tickStrings(values, self.scale, spacing)
             # Determine exactly where tick text should be drawn
@@ -1006,7 +1009,7 @@ class AxisItem(GraphicsWidget):
         profiler('compute text')
             
         ## update max text size if needed.
-        self._updateMaxTextSize(textSize2)
+        self._updateMaxTextSize(last_textSize2)
         
         return (axisSpec, tickSpecs, textSpecs)
     

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -292,16 +292,14 @@ class AxisItem(GraphicsWidget):
         ## changed; we use this to decide whether the item needs to be resized
         ## to accomodate.
         if self.orientation in ['left', 'right']:
-            mx = max(self.textWidth, x)
-            if mx > self.textWidth or mx < self.textWidth-10:
-                self.textWidth = mx
+            if x > self.textWidth or x < self.textWidth - 10:
+                self.textWidth = x
                 if self.style['autoExpandTextSpace'] is True:
                     self._updateWidth()
                     #return True  ## size has changed
         else:
-            mx = max(self.textHeight, x)
-            if mx > self.textHeight or mx < self.textHeight-10:
-                self.textHeight = mx
+            if x > self.textHeight or x < self.textHeight - 10:
+                self.textHeight = x
                 if self.style['autoExpandTextSpace'] is True:
                     self._updateHeight()
                     #return True  ## size has changed


### PR DESCRIPTION
These changes correct two problems the AxisItem has:
- It never shrinks when the space for the tick labels is not needed any more: ![example](https://www.dropbox.com/s/mdiodhlo4oap0tn/axis1.png)
- Depending on the zoom, sometimes a wrong value is used to calculate the distance between the axis label and the tick labels: ![example](https://www.dropbox.com/s/fnovmzngx55zv1f/axis2.png)
