### PR TITLE
Fixing numpy bug in functions.py

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -826,7 +826,7 @@ def rescaleData(data, scale, offset, dtype=None):
         #p = np.poly1d([scale, -offset*scale])
         #data = p(data).astype(dtype)
         d2 = data-offset
-        d2 *= scale
+        d2 = d2 * scale
         data = d2.astype(dtype)
     return data
     


### PR DESCRIPTION
Fixing an error which is caused by a new numpy version: 
d2 *= scale 
gave:
"TypeError: Cannot cast ufunc multiply output from dtype('float64') to dtype('int16') with casting rule 'same_kind'"
however, d2 = d2 * scale does seem to work without problems