### PR TITLE
Fixing order of positions in colormap

### DIFF
--- a/pyqtgraph/colormap.py
+++ b/pyqtgraph/colormap.py
@@ -66,7 +66,9 @@ class ColorMap(object):
         ===============     ==============================================================
         """
         self.pos = np.array(pos)
-        self.color = np.array(color)
+        order = np.argsort(self.pos)
+        self.pos = self.pos[order]
+        self.color = np.array(color)[order]
         if mode is None:
             mode = np.ones(len(pos))
         self.mode = mode


### PR DESCRIPTION
numpy.interp (called in ColorMap.map) forces pos to be in increasing order. Not following this requirement does not raise any Error but provide unexpected behavior.