### PR TITLE
slight changes in TextItem

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,11 +11,16 @@ pyqtgraph-0.9.11  [unreleased]
     - Remove all modifications to builtins
     - Fix SpinBox decimals
 
+  API / behavior changes:
+    - Change the defaut color kwarg to None in TextItem.setText() to avoid changing
+      the color everytime the text is changed.
+
   New Features:
     - Preliminary PyQt5 support
     - DockArea:
 	- Dock titles can be changed after creation
         - Added Dock.sigClosed
+    - Added TextItem.setColor()
 
   Maintenance:
     - Add examples to unit tests

--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -124,7 +124,6 @@ class TextItem(GraphicsObject):
         """
         self.color = fn.mkColor(color)
         self.textItem.setDefaultTextColor(self.color)
-        self.updateTextPos()
         
     def updateTextPos(self):
         # update text position to obey anchor

--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -50,8 +50,8 @@ class TextItem(GraphicsObject):
         self._lastTransform = None
         self._bounds = QtCore.QRectF()
         if html is None:
-            self.color = color
-            self.setText(text, color)
+            self.setColor(color)
+            self.setText(text)
         else:
             self.setHtml(html)
         self.fill = fn.mkBrush(fill)
@@ -64,10 +64,6 @@ class TextItem(GraphicsObject):
         
         This method sets the plain text of the item; see also setHtml().
         """
-        if color != self.color:
-            color = self.color
-        color = fn.mkColor(color)
-        self.textItem.setDefaultTextColor(color)
         self.textItem.setPlainText(text)
         self.updateTextPos()
         
@@ -116,6 +112,16 @@ class TextItem(GraphicsObject):
         
     def setAnchor(self, anchor):
         self.anchor = Point(anchor)
+        self.updateTextPos()
+
+    def setColor(self, color):
+        """
+        Set the color for this text.
+        
+        See QtGui.QGraphicsItem.setDefaultTextColor().
+        """
+        self.color = fn.mkColor(color)
+        self.textItem.setDefaultTextColor(self.color)
         self.updateTextPos()
         
     def updateTextPos(self):

--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -60,7 +60,9 @@ class TextItem(GraphicsObject):
 
     def setText(self, text, color=(200,200,200)):
         """
-        Set the text and color of this item. 
+        Set the text of this item. 
+        
+        The color entry is deprecated and kept to avoid an API change.
         
         This method sets the plain text of the item; see also setHtml().
         """

--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -50,6 +50,7 @@ class TextItem(GraphicsObject):
         self._lastTransform = None
         self._bounds = QtCore.QRectF()
         if html is None:
+            self.color = color
             self.setText(text, color)
         else:
             self.setHtml(html)
@@ -63,6 +64,8 @@ class TextItem(GraphicsObject):
         
         This method sets the plain text of the item; see also setHtml().
         """
+        if color != self.color:
+            color = self.color
         color = fn.mkColor(color)
         self.textItem.setDefaultTextColor(color)
         self.textItem.setPlainText(text)

--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -58,14 +58,14 @@ class TextItem(GraphicsObject):
         self.border = fn.mkPen(border)
         self.setAngle(angle)
 
-    def setText(self, text, color=(200,200,200)):
+    def setText(self, text, color=None):
         """
         Set the text of this item. 
         
-        The color entry is deprecated and kept to avoid an API change.
-        
         This method sets the plain text of the item; see also setHtml().
         """
+        if color is not None:
+            self.setColor(color)
         self.textItem.setPlainText(text)
         self.updateTextPos()
         


### PR DESCRIPTION
The default text color of any TextItem objects is reinitialized everytime the setText method is called. As a consequence, the color argument of labelOpts in the new InfiniteLine class can not be taken into account. This PR changes this behaviour.