### PR TITLE
TST/CI/DOC: Use `coverage` as it is intended to be used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,8 +136,10 @@ script:
 
     # Run unit tests
     - start_test "unit tests";
+      pushd /home/travis/build/pyqtgraph/pyqtgraph;
       coverage run run_tests.py;
       check_output "unit tests";
+      popd;
     - echo "test script finished. Current directory:"
     - pwd
 
@@ -184,8 +186,8 @@ script:
       check_output "import test";
 
 after_success:
-  - coverage report -m
   - cd /home/travis/build/pyqtgraph/pyqtgraph
+  - coverage report -m
   - pip install codecov --upgrade  # add coverage integration service
   - codecov
   - pip install coveralls --upgrade  # add another coverage integration service

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ install:
     - if [ "${QT}" == "pyside" ]; then
           conda install pyside --yes;
       fi;
-    - pip install pytest-xdist # multi-thread py.test
     - pip install pytest-cov # add coverage stats
 
     # required for example testing on python 2.6
@@ -137,7 +136,7 @@ script:
 
     # Run unit tests
     - start_test "unit tests";
-      PYTHONPATH=. py.test --cov pyqtgraph -sv;
+      coverage run run_tests.py
       check_output "unit tests";
     - echo "test script finished. Current directory:"
     - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ script:
 
     # Run unit tests
     - start_test "unit tests";
-      coverage run run_tests.py
+      coverage run run_tests.py;
       check_output "unit tests";
     - echo "test script finished. Current directory:"
     - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -184,6 +184,7 @@ script:
       check_output "import test";
 
 after_success:
+  - coverage report -m
   - cd /home/travis/build/pyqtgraph/pyqtgraph
   - pip install codecov --upgrade  # add coverage integration service
   - codecov

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -55,6 +55,8 @@ Please use the following guidelines when preparing changes:
     Tests for a module should ideally cover all code in that module,
     i.e., statement coverage should be at 100%.
 
-    To measure the test coverage, install py.test, pytest-cov and pytest-xdist.
-    Then run 'py.test --cov -n 4' to run the test suite with coverage on 4 cores.
-
+    To measure the test coverage, install py.test and coverage.
+    Then run 'coverage run run_tests.py' to run the test suite with coverage
+    stats.  Then view the coverage stats with `coverage report` for a summary
+    and `coverage report -m` for a breakdown of the lines that are missed by
+    the test suite.

--- a/run_tests.py
+++ b/run_tests.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
     args.append('-rxs')
     if len(sys.argv) > 1:
         args.extend(sys.argv[1:])
-    print('pytest arguments: {}'.format(args))
+    print('pytest arguments:', args)
     # call pytest and exit with the return code from pytest so that
     # travis will fail correctly if tests fail
     sys.exit(pytest.main(args))

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import sys
 import pytest
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import sys
+import pytest
+
+if __name__ == '__main__':
+    # show output results from every test function
+    args = ['-v']
+    # show the message output for skipped and expected failure tests
+    args.append('-rxs')
+    if len(sys.argv) > 1:
+        args.extend(sys.argv[1:])
+    print('pytest arguments: {}'.format(args))
+    # call pytest and exit with the return code from pytest so that
+    # travis will fail correctly if tests fail
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
On the Python Test Podcast, @nedbat recommended using the coverage package as
the execuable with the `run` subcommand, e.g., `coverage run run_tests.py`.
This guarantees that all code executed goes through the `coverage` pipeline and
code reporting stats are accurate.  This PR makes those changes by adding a
test script that provides the same results (or better) as running `py.test
-vrxs --cov pyqtgraph`.  Additionally, @nedbat recommends using coverage
directly instead of the coverage plugins for the various testing frameworks
(nose coverage, pytest-cov, etc...) because those plugins can lag behind
development of coverage.
