### PR TITLE
Encode QPropertyAnimation property name if not passed as bytes.

### DIFF
--- a/pyqtgraph/graphicsItems/CurvePoint.py
+++ b/pyqtgraph/graphicsItems/CurvePoint.py
@@ -91,7 +91,9 @@ class CurvePoint(GraphicsObject):
         pass
     
     def makeAnimation(self, prop='position', start=0.0, end=1.0, duration=10000, loop=1):
-        # automatic encoding when QByteString expected was removed in PyQt v5.5
+        # In Python 3, a bytes object needs to be used as a property name in
+        # QPropertyAnimation. PyQt stopped automatically encoding a str when a
+        # QByteArray was expected in v5.5 (see qbytearray.sip).
         if not isinstance(prop, bytes):
             prop = prop.encode('latin-1')
         anim = QtCore.QPropertyAnimation(self, prop)

--- a/pyqtgraph/graphicsItems/CurvePoint.py
+++ b/pyqtgraph/graphicsItems/CurvePoint.py
@@ -91,6 +91,9 @@ class CurvePoint(GraphicsObject):
         pass
     
     def makeAnimation(self, prop='position', start=0.0, end=1.0, duration=10000, loop=1):
+        # automatic encoding when QByteString expected was removed in PyQt v5.5
+        if not isinstance(prop, bytes):
+            prop = prop.encode('latin-1')
         anim = QtCore.QPropertyAnimation(self, prop)
         anim.setDuration(duration)
         anim.setStartValue(start)


### PR DESCRIPTION
Fixes #257 

Note: someone should check compatibility with PySide

As mentioned in the comment I added, this is needed because PyQt stopped automatically converting as of v5.5 [(ref)](http://pyqt.sourceforge.net/Docs/PyQt5/incompatibilities.html). This was *probably* disabled because it's not a smart way to handle things, but I can't think of a better way to do it.