### PR TITLE
Correction of a bug in the removeHandle method of PolyLineROI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ pyqtgraph-0.9.11  [unreleased]
     - Properly remove select box when export dialog is closed using window decorations
     - Remove all modifications to builtins
     - Fix SpinBox decimals
+    - Fixed removeHandle method of the PolyLineROI class
 
   API / behavior changes:
     - Change the defaut color kwarg to None in TextItem.setText() to avoid changing

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -1897,7 +1897,9 @@ class PolyLineROI(ROI):
             return
         segments = handle.rois[:]
         
-        if len(segments) == 1:
+        if len(segments) == 0:
+            return
+        elif len(segments) == 1:
             self.removeSegment(segments[0])
         else:
             handles = [h['item'] for h in segments[1].handles]


### PR DESCRIPTION
I had some troubles trying to restore the state of PolyLineROI objects using the setState method. This simple modification fixed the problem. 

Here is the error message I got (if it helps):

  `File "/home/lesaux/Documents/Belenos/belenos/plottingwidgets/ImageWidgetFull.py", line 305, in addPolyLineROI`
    `polyLine.setState(params)`

  `File "/home/lesaux/Documents/Belenos/belenos/pyqtgraph/graphicsItems/ROI.py", line 1854, in setState`
    `self.clearPoints()`

  `File "/home/lesaux/Documents/Belenos/belenos/pyqtgraph/graphicsItems/ROI.py", line 1844, in clearPoints`
    `self.removeHandle(self.handles[0]['item'])`

  `File "/home/lesaux/Documents/Belenos/belenos/pyqtgraph/graphicsItems/ROI.py", line 1907, in removeHandle`
    `handles = [h['item'] for h in segments[1].handles]`
`IndexError: list index out of range`
