### PR TITLE
Addition of the _name attribute to ROI

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -110,7 +110,9 @@ class ROI(GraphicsObject):
     sigClicked = QtCore.Signal(object, object)
     sigRemoveRequested = QtCore.Signal(object)
     
-    def __init__(self, pos, size=Point(1, 1), angle=0.0, invertible=False, maxBounds=None, snapSize=1.0, scaleSnap=False, translateSnap=False, rotateSnap=False, parent=None, pen=None, movable=True, removable=False):
+    def __init__(self, pos, size=Point(1, 1), angle=0.0, invertible=False, maxBounds=None,
+                 snapSize=1.0, scaleSnap=False, translateSnap=False, rotateSnap=False,
+                 parent=None, pen=None, movable=True, removable=False, name=None):
         #QObjectWorkaround.__init__(self)
         GraphicsObject.__init__(self, parent)
         self.setAcceptedMouseButtons(QtCore.Qt.NoButton)
@@ -147,6 +149,8 @@ class ROI(GraphicsObject):
         self.rotateSnap = rotateSnap
         self.scaleSnap = scaleSnap
         #self.setFlag(self.ItemIsSelectable, True)
+        
+        self._name = name
     
     def getState(self):
         return self.stateCopy()
@@ -1163,6 +1167,12 @@ class ROI(GraphicsObject):
         st = (st * tr).saveState()
         st['size'] = st['scale']
         self.setState(st)
+        
+    def setName(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
 
 
 class Handle(UIGraphicsItem):


### PR DESCRIPTION
Small PR to add a _name attribute as well as a getter and a setter.

I'm developing a widget that list all the elements that are present in a plotItem and I'm taking advantage of the _name attribute to feed this widget with the items name. I'll propose it as PR when it will be ready... Currently, only PlotDataItem and InfiniteLine objects have this feature.
