### PR TITLE
Added  "self.moving = False" in  InfLineLabel class

### DIFF
--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -325,6 +325,7 @@ class InfLineLabel(TextItem):
     def __init__(self, line, text="", movable=False, position=0.5, anchors=None, **kwds):
         self.line = line
         self.movable = movable
+        self.moving = False
         self.orthoPos = position  # text will always be placed on the line at a position relative to view bounds
         self.format = text
         self.line.sigPositionChanged.connect(self.valueChanged)


### PR DESCRIPTION
Added  "self.moving = False" in  InfLineLabel class to solve the error message when clicking on the label.

error message:

 |==============================>>
    |    File "D:/VenableInstruments/w_s/venable6/main.py", line 3, in <module>
    |      main()
    |    File "D:\VenableInstruments\w_s\venable6\Venable\venable6\controller.py", line 338, in main
    |      app.exec_()  # and execute the app
    |    File "D:\Python\Python34\lib\site-packages\pyqtgraph\widgets\GraphicsView.py", line 354, in mouseReleaseEvent
    |      QtGui.QGraphicsView.mouseReleaseEvent(self, ev)
    |    File "D:\Python\Python34\lib\site-packages\pyqtgraph\GraphicsScene\GraphicsScene.py", line 200, in mouseReleaseEvent
    |      if self.sendClickEvent(cev[0]):
    |    File "D:\Python\Python34\lib\site-packages\pyqtgraph\GraphicsScene\GraphicsScene.py", line 348, in sendClickEvent
    |      debug.printExc("Error sending click event:")
    |    ---- exception caught ---->
    |    File "D:\Python\Python34\lib\site-packages\pyqtgraph\GraphicsScene\GraphicsScene.py", line 346, in sendClickEvent
    |      item.mouseClickEvent(ev)
    |    File "D:\Python\Python34\lib\site-packages\pyqtgraph\graphicsItems\InfiniteLine.py", line 449, in mouseClickEvent
    |      if self.moving and ev.button() == QtCore.Qt.RightButton:
    |  AttributeError: 'InfLineLabel' object has no attribute 'moving'
    |==============================<<
