### PR TITLE
Fix Parameter.show for float, int, and group types

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -414,6 +414,8 @@ class GroupParameterItem(ParameterItem):
             ParameterItem.addChild(self, child)
             
     def optsChanged(self, param, changed):
+        ParameterItem.optsChanged(self, param, changed)
+
         if 'addList' in changed:
             self.updateAddList()
                 

--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -277,11 +277,12 @@ class WidgetParameterItem(ParameterItem):
             if isinstance(self.widget, (QtGui.QCheckBox,ColorButton)):
                 self.widget.setEnabled(not opts['readonly'])
         
-        ## If widget is a SpinBox, pass options straight through
         if isinstance(self.widget, SpinBox):
+            spinOpts = opts.copy()
+            spinOpts.pop('visible', None)
             if 'units' in opts and 'suffix' not in opts:
-                opts['suffix'] = opts['units']
-            self.widget.setOpts(**opts)
+                spinOpts['suffix'] = opts['units']
+            self.widget.setOpts(**spinOpts)
             self.updateDisplayLabel()
         
         


### PR DESCRIPTION
Fixes issue #263.  Here's a script for demonstrating the bugs/fixes:

```
from pyqtgraph.Qt import QtGui
from pyqtgraph.parametertree import ParameterTree, Parameter

app = QtGui.QApplication([])
tree = ParameterTree()
param = Parameter.create(name='param', type='group', children=[
    {'name': 'int', 'type': 'int'},
    {'name': 'float', 'type': 'float'},
    {'name': 'group', 'type': 'group'}
])
tree.setParameters(param)
tree.show()
for child in param.children():
    child.show(False)

app.exec_()
```
