### PR TITLE
Fix bug where int and float parameter limits are not always set

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -108,7 +108,7 @@ class WidgetParameterItem(ParameterItem):
                 if k in opts:
                     defs[k] = opts[k]
             if 'limits' in opts:
-                defs['bounds'] = opts['limits']
+                defs['min'], defs['max'] = opts['limits']
             w = SpinBox()
             w.setOpts(**defs)
             w.sigChanged = w.sigValueChanged


### PR DESCRIPTION
Here's a script to demonstrate:

```
from pyqtgraph.Qt import QtGui
from pyqtgraph.parametertree import ParameterTree, Parameter

app = QtGui.QApplication([])
tree = ParameterTree()
param = Parameter.create(name='param', type='int', limits=[0, 1])
tree.setParameters(param)
tree.show()
app.exec_()
```

Note that the bug is non-deterministic; while SpinBox.setOpts loops through the defs dict, sometimes the default min and max keys are hit before the bounds key, in which case the bug won't be triggered.
