### PR TITLE
Set parameter's default button autoDefault value to False

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -48,6 +48,7 @@ class WidgetParameterItem(ParameterItem):
             w.setToolTip(opts['tip'])
         
         self.defaultBtn = QtGui.QPushButton()
+        self.defaultBtn.setAutoDefault(False)
         self.defaultBtn.setFixedWidth(20)
         self.defaultBtn.setFixedHeight(20)
         modDir = os.path.dirname(__file__)


### PR DESCRIPTION
When a parameter tree is included in a dialog, currently when the user presses Enter, the first parameter's default button is clicked.  This seems unexpected.
