### PR TITLE
Allow Parameter to have no default value.

### DIFF
--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -174,15 +174,14 @@ class Parameter(QtCore.QObject):
         
         if 'value' not in self.opts:
             self.opts['value'] = None
+        elif 'default' not in self.opts:
+            self.opts['default'] = self.opts['value']
         
         if 'name' not in self.opts or not isinstance(self.opts['name'], basestring):
             raise Exception("Parameter must have a string name specified in opts.")
         self.setName(opts['name'])
         
         self.addChildren(self.opts.get('children', []))
-            
-        if 'value' in self.opts and 'default' not in self.opts:
-            self.opts['default'] = self.opts['value']
     
         ## Connect all state changed signals to the general sigStateChanged
         self.sigValueChanged.connect(lambda param, data: self.emitStateChanged('value', data))
@@ -401,7 +400,8 @@ class Parameter(QtCore.QObject):
         
     def valueIsDefault(self):
         """Returns True if this parameter's value is equal to the default value."""
-        return self.value() == self.defaultValue()
+        if self.hasDefault():
+            return self.value() == self.defaultValue()
         
     def setLimits(self, limits):
         """Set limits on the acceptable values for this parameter. 

--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -183,10 +183,10 @@ class WidgetParameterItem(ParameterItem):
         
     def updateDefaultBtn(self):
         ## enable/disable default btn 
-        self.defaultBtn.setEnabled(not self.param.valueIsDefault() and self.param.writable())        
-        
+        self.defaultBtn.setEnabled(not self.param.valueIsDefault() and self.param.writable())
+
         # hide / show
-        self.defaultBtn.setVisible(not self.param.readonly())
+        self.defaultBtn.setVisible(self.param.hasDefault() and self.param.writable())
 
     def updateDisplayLabel(self, value=None):
         """Update the display label to reflect the value of the parameter."""


### PR DESCRIPTION
Currently the default is always set to None, while it's clear from the rest of the code that a missing 'default' key in Parameter.opts is meant to represent the case of a missing default.

Edit: To be more clear, the default is set to None if neither 'value' nor 'default' are explicitly set.
