### PR TITLE
Fix incorrect tick text boundaries calculation on axis by setting the font

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -771,6 +771,10 @@ class AxisItem(GraphicsWidget):
         """
         profiler = debug.Profiler()
 
+        # painter should have the same font as tickFont, otherwise it calculates tick text boundaries incorreclty
+        if self.tickFont is not None:
+            p.setFont(self.tickFont)
+
         #bounds = self.boundingRect()
         bounds = self.mapRectFromParent(self.geometry())
         


### PR DESCRIPTION
In AxisItem.generateDrawSpecs painter should have the same font as tickFont, otherwise it calculates tick text boundaries incorreclty. Without this fix we have tickLabels overflowing each other and everything else on the screen when we change their font. This quick fix solved the issue for us.
