### PR TITLE
Fix error in siEval for exponential notation with plus sign

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -115,7 +115,7 @@ def siEval(s):
     """
     
     s = asUnicode(s)
-    m = re.match(r'(-?((\d+(\.\d*)?)|(\.\d+))([eE]-?\d+)?)\s*([u' + SI_PREFIXES + r']?).*$', s)
+    m = re.match(r'(-?((\d+(\.\d*)?)|(\.\d+))([eE][+-]?\d+)?)\s*([u' + SI_PREFIXES + r']?).*$', s)
     if m is None:
         raise Exception("Can't convert string '%s' to number." % s)
     v = float(m.groups()[0])


### PR DESCRIPTION
if number has  a plus sign in exponent, the conversion failed and e.g.
2.0e+03 returned 2.0 instead of 2000 in a SpinBox
