### PR TITLE
PlotItem.addItem checks item's existence

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -505,6 +505,9 @@ class PlotItem(GraphicsWidget):
         If the item has plot data (PlotDataItem, PlotCurveItem, ScatterPlotItem), it may
         be included in analysis performed by the PlotItem.
         """
+        if item in self.items:
+            return
+
         self.items.append(item)
         vbargs = {}
         if 'ignoreBounds' in kargs:


### PR DESCRIPTION
It should avoid adding an item twice.
