### PR TITLE
performance improvement of GLImageItem

### DIFF
--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -73,6 +73,7 @@ class GLImageItem(GLGraphicsItem):
     def paint(self):
         if self._needUpdate:
             self._updateTexture()
+            self._needUpdate = False
         glEnable(GL_TEXTURE_2D)
         glBindTexture(GL_TEXTURE_2D, self.texture)
         


### PR DESCRIPTION
The paint method didn't clear the _needUpdate flag, resulting in redundant re-uploads of textures at each redraw. This commit clears the flag, improving rendering performance significantly.
(solution to this issue: https://github.com/pyqtgraph/pyqtgraph/issues/344 )
