### PR TITLE
Update MatplotlibWidget.py

### DIFF
--- a/pyqtgraph/widgets/MatplotlibWidget.py
+++ b/pyqtgraph/widgets/MatplotlibWidget.py
@@ -6,7 +6,11 @@ if not USE_PYQT5:
         matplotlib.rcParams['backend.qt4']='PySide'
 
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+    # NavigationToolbar2QTAgg doesn't exist in matplotlib >= 1.4.0. Import NavigationToolbar2QT instead
+    try:
+        from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+    except:
+        from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
 else:
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
     from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar


### PR DESCRIPTION
NavigationToolbar2QTAgg doesn't exist in matplotlib >= 1.4.0 anymore, and has been replaced with import NavigationToolbar2QT. This is detailed [here](http://matplotlib.org/api/api_changes.html). 
In this pull request, it is proposed that if there is an error importing NavigationToolbar2QTAgg, then NavigationToolbar2QT is imported instead. This is both backwards and forwards compatible.
