### PR TITLE
Python 3 fixes

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -1,6 +1,5 @@
 import weakref
 from ..Qt import QtCore, QtGui
-from ..python2_3 import sortList, cmp
 from ..Point import Point
 from .. import functions as fn
 from .. import ptime as ptime
@@ -439,7 +438,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 return 0
             return item.zValue() + absZValue(item.parentItem())
         
-        sortList(items2, lambda a,b: cmp(absZValue(b), absZValue(a)))
+        items2.sort(key=absZValue, reverse=True)
         
         return items2
         

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -83,7 +83,8 @@ def systemInfo():
     if __version__ is None:  ## this code was probably checked out from bzr; look up the last-revision file
         lastRevFile = os.path.join(os.path.dirname(__file__), '..', '.bzr', 'branch', 'last-revision')
         if os.path.exists(lastRevFile):
-            rev = open(lastRevFile, 'r').read().strip()
+            with open(lastRevFile, 'r') as fd:
+                rev = fd.read().strip()
     
     print("pyqtgraph: %s; %s" % (__version__, rev))
     print("config:")

--- a/pyqtgraph/canvas/Canvas.py
+++ b/pyqtgraph/canvas/Canvas.py
@@ -1,8 +1,4 @@
 # -*- coding: utf-8 -*-
-if __name__ == '__main__':
-    import sys, os
-    md = os.path.dirname(os.path.abspath(__file__))
-    sys.path = [os.path.dirname(md), os.path.join(md, '..', '..', '..')] + sys.path
 
 from ..Qt import QtGui, QtCore, USE_PYSIDE
 from ..graphicsItems.ROI import ROI

--- a/pyqtgraph/configfile.py
+++ b/pyqtgraph/configfile.py
@@ -40,10 +40,10 @@ class ParseError(Exception):
 
 def writeConfigFile(data, fname):
     s = genString(data)
-    fd = open(fname, 'w')
-    fd.write(s)
-    fd.close()
-    
+    with open(fname, 'w') as fd:
+        fd.write(s)
+
+
 def readConfigFile(fname):
     #cwd = os.getcwd()
     global GLOBAL_PATH
@@ -56,9 +56,8 @@ def readConfigFile(fname):
         
     try:
         #os.chdir(newDir)  ## bad.
-        fd = open(fname)
-        s = asUnicode(fd.read())
-        fd.close()
+        with open(fname) as fd:
+            s = asUnicode(fd.read())
         s = s.replace("\r\n", "\n")
         s = s.replace("\r", "\n")
         data = parseString(s)[1]
@@ -74,9 +73,8 @@ def readConfigFile(fname):
 
 def appendConfigFile(data, fname):
     s = genString(data)
-    fd = open(fname, 'a')
-    fd.write(s)
-    fd.close()
+    with open(fname, 'a') as fd:
+        fd.write(s)
 
 
 def genString(data, indent=''):
@@ -193,8 +191,6 @@ def measureIndent(s):
     
 if __name__ == '__main__':
     import tempfile
-    fn = tempfile.mktemp()
-    tf = open(fn, 'w')
     cf = """
 key: 'value'
 key2:              ##comment
@@ -204,8 +200,9 @@ key2:              ##comment
     key22: [1,2,3]
     key23: 234  #comment
     """
-    tf.write(cf)
-    tf.close()
+    fn = tempfile.mktemp()
+    with open(fn, 'w') as tf:
+        tf.write(cf)
     print("=== Test:===")
     num = 1
     for line in cf.split('\n'):

--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -89,12 +89,14 @@ class ConsoleWidget(QtGui.QWidget):
     def loadHistory(self):
         """Return the list of previously-invoked command strings (or None)."""
         if self.historyFile is not None:
-            return pickle.load(open(self.historyFile, 'rb'))
+            with open(self.historyFile, 'rb') as pf:
+                return pickle.load(pf)
         
     def saveHistory(self, history):
         """Store the list of previously-invoked command strings."""
         if self.historyFile is not None:
-            pickle.dump(open(self.historyFile, 'wb'), history)
+            with open(self.historyFile, 'wb') as pf:
+                pickle.dump(pf, history)
         
     def runCmd(self, cmd):
         #cmd = str(self.input.lastCmd)

--- a/pyqtgraph/debug.py
+++ b/pyqtgraph/debug.py
@@ -1074,7 +1074,8 @@ def pretty(data, indent=''):
     ind2 = indent + "    "
     if isinstance(data, dict):
         ret = indent+"{\n"
-        for k, v in data.iteritems():
+        items = getattr(data, 'iteritems', data.items)
+        for k, v in items():
             ret += ind2 + repr(k) + ":  " + pretty(v, ind2).strip() + "\n"
         ret += indent+"}\n"
     elif isinstance(data, list) or isinstance(data, tuple):

--- a/pyqtgraph/exporters/CSVExporter.py
+++ b/pyqtgraph/exporters/CSVExporter.py
@@ -29,7 +29,6 @@ class CSVExporter(Exporter):
             self.fileSaveDialog(filter=["*.csv", "*.tsv"])
             return
 
-        fd = open(fileName, 'w')
         data = []
         header = []
 
@@ -55,28 +54,29 @@ class CSVExporter(Exporter):
             sep = ','
         else:
             sep = '\t'
-            
-        fd.write(sep.join(header) + '\n')
-        i = 0
-        numFormat = '%%0.%dg' % self.params['precision']
-        numRows = max([len(d[0]) for d in data])
-        for i in range(numRows):
-            for j, d in enumerate(data):
-                # write x value if this is the first column, or if we want x 
-                # for all rows
-                if appendAllX or j == 0:
-                    if d is not None and i < len(d[0]):
-                        fd.write(numFormat % d[0][i] + sep)
+
+        with open(fileName, 'w') as fd:
+            fd.write(sep.join(header) + '\n')
+            i = 0
+            numFormat = '%%0.%dg' % self.params['precision']
+            numRows = max([len(d[0]) for d in data])
+            for i in range(numRows):
+                for j, d in enumerate(data):
+                    # write x value if this is the first column, or if we want
+                    # x for all rows
+                    if appendAllX or j == 0:
+                        if d is not None and i < len(d[0]):
+                            fd.write(numFormat % d[0][i] + sep)
+                        else:
+                            fd.write(' %s' % sep)
+
+                    # write y value
+                    if d is not None and i < len(d[1]):
+                        fd.write(numFormat % d[1][i] + sep)
                     else:
                         fd.write(' %s' % sep)
-                
-                # write y value 
-                if d is not None and i < len(d[1]):
-                    fd.write(numFormat % d[1][i] + sep)
-                else:
-                    fd.write(' %s' % sep)
-            fd.write('\n')
-        fd.close()
+                fd.write('\n')
+
 
 CSVExporter.register()        
                 

--- a/pyqtgraph/exporters/Matplotlib.py
+++ b/pyqtgraph/exporters/Matplotlib.py
@@ -43,7 +43,7 @@ class MatplotlibExporter(Exporter):
         for ax in axl:
             if ax is None:
                 continue
-            for loc, spine in ax.spines.iteritems():
+            for loc, spine in ax.spines.items():
                 if loc in ['left', 'bottom']:
                     pass
                 elif loc in ['right', 'top']:

--- a/pyqtgraph/exporters/tests/test_csv.py
+++ b/pyqtgraph/exporters/tests/test_csv.py
@@ -33,8 +33,9 @@ def test_CSVExporter():
     ex = pg.exporters.CSVExporter(plt.plotItem)
     ex.export(fileName=tempfilename)
 
-    r = csv.reader(open(tempfilename, 'r'))
-    lines = [line for line in r]
+    with open(tempfilename, 'r') as fd:
+        r = csv.reader(fd)
+        lines = [line for line in r]
     header = lines.pop(0)
     assert header == ['myPlot_x', 'myPlot_y', 'x0001', 'y0001', 'x0002', 'y0002']
     

--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -1,14 +1,13 @@
+import operator
 import weakref
 import numpy as np
 from ..Qt import QtGui, QtCore
-from ..python2_3 import sortList
 from .. import functions as fn
 from .GraphicsObject import GraphicsObject
 from .GraphicsWidget import GraphicsWidget
 from ..widgets.SpinBox import SpinBox
 from ..pgcollections import OrderedDict
 from ..colormap import ColorMap
-from ..python2_3 import cmp
 
 
 __all__ = ['TickSliderItem', 'GradientEditorItem']
@@ -346,8 +345,7 @@ class TickSliderItem(GraphicsWidget):
     def listTicks(self):
         """Return a sorted list of all the Tick objects on the slider."""
         ## public
-        ticks = list(self.ticks.items())
-        sortList(ticks, lambda a,b: cmp(a[1], b[1]))  ## see pyqtgraph.python2_3.sortList
+        ticks = sorted(self.ticks.items(), key=operator.itemgetter(1))
         return ticks
 
 

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -714,7 +714,6 @@ class PlotItem(GraphicsWidget):
         xRange = rect.left(), rect.right() 
         
         svg = ""
-        fh = open(fileName, 'w')
 
         dx = max(rect.right(),0) - min(rect.left(),0)
         ymn = min(rect.top(), rect.bottom())
@@ -728,57 +727,68 @@ class PlotItem(GraphicsWidget):
             sy *= 1000
         sy *= -1
 
-        #fh.write('<svg viewBox="%f %f %f %f">\n' % (rect.left()*sx, rect.top()*sx, rect.width()*sy, rect.height()*sy))
-        fh.write('<svg>\n')
-        fh.write('<path fill="none" stroke="#000000" stroke-opacity="0.5" stroke-width="1" d="M%f,0 L%f,0"/>\n' % (rect.left()*sx, rect.right()*sx))
-        fh.write('<path fill="none" stroke="#000000" stroke-opacity="0.5" stroke-width="1" d="M0,%f L0,%f"/>\n' % (rect.top()*sy, rect.bottom()*sy))
+        with open(fileName, 'w') as fh:
+            # fh.write('<svg viewBox="%f %f %f %f">\n' % (rect.left() * sx,
+            #                                             rect.top() * sx,
+            #                                             rect.width() * sy,
+            #                                             rect.height()*sy))
+            fh.write('<svg>\n')
+            fh.write('<path fill="none" stroke="#000000" stroke-opacity="0.5" '
+                     'stroke-width="1" d="M%f,0 L%f,0"/>\n' % (
+                        rect.left() * sx, rect.right() * sx))
+            fh.write('<path fill="none" stroke="#000000" stroke-opacity="0.5" '
+                     'stroke-width="1" d="M0,%f L0,%f"/>\n' % (
+                        rect.top() * sy, rect.bottom() * sy))
 
-
-        for item in self.curves:
-            if isinstance(item, PlotCurveItem):
-                color = fn.colorStr(item.pen.color())
-                opacity = item.pen.color().alpha() / 255.
-                color = color[:6]
-                x, y = item.getData()
-                mask = (x > xRange[0]) * (x < xRange[1])
-                mask[:-1] += mask[1:]
-                m2 = mask.copy()
-                mask[1:] += m2[:-1]
-                x = x[mask]
-                y = y[mask]
-                
-                x *= sx
-                y *= sy
-                
-                #fh.write('<g fill="none" stroke="#%s" stroke-opacity="1" stroke-width="1">\n' % color)
-                fh.write('<path fill="none" stroke="#%s" stroke-opacity="%f" stroke-width="1" d="M%f,%f ' % (color, opacity, x[0], y[0]))
-                for i in range(1, len(x)):
-                    fh.write('L%f,%f ' % (x[i], y[i]))
-                
-                fh.write('"/>')
-                #fh.write("</g>")
-        for item in self.dataItems:
-            if isinstance(item, ScatterPlotItem):
-                
-                pRect = item.boundingRect()
-                vRect = pRect.intersected(rect)
-                
-                for point in item.points():
-                    pos = point.pos()
-                    if not rect.contains(pos):
-                        continue
-                    color = fn.colorStr(point.brush.color())
-                    opacity = point.brush.color().alpha() / 255.
+            for item in self.curves:
+                if isinstance(item, PlotCurveItem):
+                    color = fn.colorStr(item.pen.color())
+                    opacity = item.pen.color().alpha() / 255.
                     color = color[:6]
-                    x = pos.x() * sx
-                    y = pos.y() * sy
-                    
-                    fh.write('<circle cx="%f" cy="%f" r="1" fill="#%s" stroke="none" fill-opacity="%f"/>\n' % (x, y, color, opacity))
-        
-        fh.write("</svg>\n")
-        
-        
-    
+                    x, y = item.getData()
+                    mask = (x > xRange[0]) * (x < xRange[1])
+                    mask[:-1] += mask[1:]
+                    m2 = mask.copy()
+                    mask[1:] += m2[:-1]
+                    x = x[mask]
+                    y = y[mask]
+
+                    x *= sx
+                    y *= sy
+
+                    # fh.write('<g fill="none" stroke="#%s" '
+                    #          'stroke-opacity="1" stroke-width="1">\n' % (
+                    #           color, ))
+                    fh.write('<path fill="none" stroke="#%s" '
+                             'stroke-opacity="%f" stroke-width="1" '
+                             'd="M%f,%f ' % (color, opacity, x[0], y[0]))
+                    for i in range(1, len(x)):
+                        fh.write('L%f,%f ' % (x[i], y[i]))
+
+                    fh.write('"/>')
+                    # fh.write("</g>")
+
+            for item in self.dataItems:
+                if isinstance(item, ScatterPlotItem):
+                    pRect = item.boundingRect()
+                    vRect = pRect.intersected(rect)
+
+                    for point in item.points():
+                        pos = point.pos()
+                        if not rect.contains(pos):
+                            continue
+                        color = fn.colorStr(point.brush.color())
+                        opacity = point.brush.color().alpha() / 255.
+                        color = color[:6]
+                        x = pos.x() * sx
+                        y = pos.y() * sy
+
+                        fh.write('<circle cx="%f" cy="%f" r="1" fill="#%s" '
+                                 'stroke="none" fill-opacity="%f"/>\n' % (
+                                    x, y, color, opacity))
+
+            fh.write("</svg>\n")
+
     def writeSvg(self, fileName=None):
         if fileName is None:
             fileName = QtGui.QFileDialog.getSaveFileName()
@@ -827,22 +837,21 @@ class PlotItem(GraphicsWidget):
         fileName = str(fileName)
         PlotItem.lastFileDir = os.path.dirname(fileName)
         
-        fd = open(fileName, 'w')
         data = [c.getData() for c in self.curves]
-        i = 0
-        while True:
-            done = True
-            for d in data:
-                if i < len(d[0]):
-                    fd.write('%g,%g,'%(d[0][i], d[1][i]))
-                    done = False
-                else:
-                    fd.write(' , ,')
-            fd.write('\n')
-            if done:
-                break
-            i += 1
-        fd.close()
+        with open(fileName, 'w') as fd:
+            i = 0
+            while True:
+                done = True
+                for d in data:
+                    if i < len(d[0]):
+                        fd.write('%g,%g,' % (d[0][i], d[1][i]))
+                        done = False
+                    else:
+                        fd.write(' , ,')
+                fd.write('\n')
+                if done:
+                    break
+                i += 1
 
 
     def saveState(self):

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -3,7 +3,7 @@ import sys
 from copy import deepcopy
 import numpy as np
 from ...Qt import QtGui, QtCore
-from ...python2_3 import sortList, basestring, cmp
+from ...python2_3 import basestring
 from ...Point import Point
 from ... import functions as fn
 from .. ItemGroup import ItemGroup
@@ -1660,15 +1660,11 @@ class ViewBox(GraphicsWidget):
         except RuntimeError:  ## this view has already been deleted; it will probably be collected shortly.
             return
             
-        def cmpViews(a, b):
-            wins = 100 * cmp(a.window() is self.window(), b.window() is self.window())
-            alpha = cmp(a.name, b.name)
-            return wins + alpha
+        def view_key(view):
+            return (view.window() is self.window(), view.name)
             
         ## make a sorted list of all named views
-        nv = list(ViewBox.NamedViews.values())
-        #print "new view list:", nv
-        sortList(nv, cmpViews) ## see pyqtgraph.python2_3.sortList
+        nv = sorted(ViewBox.NamedViews.values(), key=view_key)
         
         if self in nv:
             nv.remove(self)

--- a/pyqtgraph/metaarray/MetaArray.py
+++ b/pyqtgraph/metaarray/MetaArray.py
@@ -741,7 +741,7 @@ class MetaArray(object):
         ## decide which read function to use
         with open(filename, 'rb') as fd:
             magic = fd.read(8)
-            if magic == '\x89HDF\r\n\x1a\n':
+            if magic == b'\x89HDF\r\n\x1a\n':
                 fd.close()
                 self._readHDF5(filename, **kwargs)
                 self._isHDF = True
@@ -767,11 +767,11 @@ class MetaArray(object):
         """Read meta array from the top of a file. Read lines until a blank line is reached.
         This function should ideally work for ALL versions of MetaArray.
         """
-        meta = ''
+        meta = b''
         ## Read meta information until the first blank line
         while True:
             line = fd.readline().strip()
-            if line == '':
+            if line == b'':
                 break
             meta += line
         ret = eval(meta)
@@ -1224,7 +1224,7 @@ class MetaArray(object):
 
         with open(fileName, mode) as fd:
             if appendAxis is None or newFile:
-                fd.write(str(meta) + '\n\n')
+                fd.write(str(meta).encode('utf-8') + b'\n\n')
                 for ax in axstrs:
                     fd.write(ax)
 
@@ -1233,7 +1233,7 @@ class MetaArray(object):
                              'numFrames': self.shape[appendAxis]}
                 if dynXVals is not None:
                     frameInfo['xVals'] = list(dynXVals)
-                fd.write('\n' + str(frameInfo) + '\n')
+                fd.write(b'\n' + str(frameInfo).encode('utf-8') + b'\n')
 
             fd.write(dataStr)
 

--- a/pyqtgraph/metaarray/MetaArray.py
+++ b/pyqtgraph/metaarray/MetaArray.py
@@ -12,7 +12,6 @@ More info at http://www.scipy.org/Cookbook/MetaArray
 
 import types, copy, threading, os, re
 import pickle
-from functools import reduce
 import numpy as np
 from ..python2_3 import basestring
 #import traceback
@@ -845,7 +844,7 @@ class MetaArray(object):
             frames = []
             frameShape = list(meta['shape'])
             frameShape[dynAxis] = 1
-            frameSize = reduce(lambda a,b: a*b, frameShape)
+            frameSize = np.prod(frameShape)
             n = 0
             while True:
                 ## Extract one non-blank line
@@ -1294,7 +1293,7 @@ class MetaArray(object):
             #frames = []
             #frameShape = list(meta['shape'])
             #frameShape[dynAxis] = 1
-            #frameSize = reduce(lambda a,b: a*b, frameShape)
+            #frameSize = np.prod(frameShape)
             #n = 0
             #while True:
                 ### Extract one non-blank line

--- a/pyqtgraph/multiprocess/parallelizer.py
+++ b/pyqtgraph/multiprocess/parallelizer.py
@@ -240,7 +240,7 @@ class Tasker(object):
         self.proc = process
         self.par = parallelizer
         self.tasks = tasks
-        for k, v in kwds.iteritems():
+        for k, v in kwds.items():
             setattr(self, k, v)
         
     def __iter__(self):

--- a/pyqtgraph/multiprocess/parallelizer.py
+++ b/pyqtgraph/multiprocess/parallelizer.py
@@ -208,14 +208,14 @@ class Parallelize(object):
             try:
                 cores = {}
                 pid = None
-                
-                for line in open('/proc/cpuinfo'):
-                    m = re.match(r'physical id\s+:\s+(\d+)', line)
-                    if m is not None:
-                        pid = m.groups()[0]
-                    m = re.match(r'cpu cores\s+:\s+(\d+)', line)
-                    if m is not None:
-                        cores[pid] = int(m.groups()[0])
+                with open('/proc/cpuinfo') as fd:
+                    for line in fd:
+                        m = re.match(r'physical id\s+:\s+(\d+)', line)
+                        if m is not None:
+                            pid = m.groups()[0]
+                        m = re.match(r'cpu cores\s+:\s+(\d+)', line)
+                        if m is not None:
+                            cores[pid] = int(m.groups()[0])
                 return sum(cores.values())
             except:
                 return multiprocessing.cpu_count()

--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -238,7 +238,7 @@ class ForkedProcess(RemoteEventHandler):
         
         proxyIDs = {}
         if preProxy is not None:
-            for k, v in preProxy.iteritems():
+            for k, v in preProxy.items():
                 proxyId = LocalObjectProxy.registerObject(v)
                 proxyIDs[k] = proxyId
         
@@ -287,7 +287,7 @@ class ForkedProcess(RemoteEventHandler):
             RemoteEventHandler.__init__(self, remoteConn, name+'_child', pid=ppid)
             
             self.forkedProxies = {}
-            for name, proxyId in proxyIDs.iteritems():
+            for name, proxyId in proxyIDs.items():
                 self.forkedProxies[name] = ObjectProxy(ppid, proxyId=proxyId, typeStr=repr(preProxy[name]))
             
             if target is not None:

--- a/pyqtgraph/multiprocess/remoteproxy.py
+++ b/pyqtgraph/multiprocess/remoteproxy.py
@@ -548,7 +548,7 @@ class RemoteEventHandler(object):
         
         if autoProxy is True:
             args = [self.autoProxy(v, noProxyTypes) for v in args]
-            for k, v in kwds.iteritems():
+            for k, v in kwds.items():
                 opts[k] = self.autoProxy(v, noProxyTypes)
         
         byteMsgs = []

--- a/pyqtgraph/opengl/items/GLBarGraphItem.py
+++ b/pyqtgraph/opengl/items/GLBarGraphItem.py
@@ -8,7 +8,7 @@ class GLBarGraphItem(GLMeshItem):
         pos is (...,3) array of the bar positions (the corner of each bar)
         size is (...,3) array of the sizes of each bar
         """
-        nCubes = reduce(lambda a,b: a*b, pos.shape[:-1])
+        nCubes = np.prod(pos.shape[:-1])
         cubeVerts = np.mgrid[0:2,0:2,0:2].reshape(3,8).transpose().reshape(1,8,3)
         cubeFaces = np.array([
             [0,1,2], [3,2,1],
@@ -22,8 +22,5 @@ class GLBarGraphItem(GLMeshItem):
         verts = cubeVerts * size + pos
         faces = cubeFaces + (np.arange(nCubes) * 8).reshape(nCubes,1,1)
         md = MeshData(verts.reshape(nCubes*8,3), faces.reshape(nCubes*12,3))
-        
-        GLMeshItem.__init__(self, meshdata=md, shader='shaded', smooth=False)
 
-        
-        
+        GLMeshItem.__init__(self, meshdata=md, shader='shaded', smooth=False)

--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -120,7 +120,7 @@ class GLScatterPlotItem(GLGraphicsItem):
             try:
                 pos = self.pos
                 #if pos.ndim > 2:
-                    #pos = pos.reshape((reduce(lambda a,b: a*b, pos.shape[:-1]), pos.shape[-1]))
+                    #pos = pos.reshape((-1, pos.shape[-1]))
                 glVertexPointerf(pos)
             
                 if isinstance(self.color, np.ndarray):

--- a/pyqtgraph/pgcollections.py
+++ b/pyqtgraph/pgcollections.py
@@ -239,7 +239,8 @@ class CaselessDict(OrderedDict):
         return key.lower() in self.keyMap
     
     def update(self, d):
-        for k, v in d.iteritems():
+        items = getattr(d, 'iteritems', d.items)
+        for k, v in items():
             self[k] = v
             
     def copy(self):
@@ -311,11 +312,13 @@ class ProtectedDict(dict):
         raise Exception("It is not safe to copy protected dicts! (instead try deepcopy, but be careful.)")
     
     def itervalues(self):
-        for v in self._data_.itervalues():
+        items = getattr(self._data_, 'itervalues', self._data_.values)
+        for v in values():
             yield protect(v)
         
     def iteritems(self):
-        for k, v in self._data_.iteritems():
+        items = getattr(self._data_, 'iteritems', self._data_.items)
+        for k, v in items():
             yield (k, protect(v))
         
     def deepcopy(self):

--- a/pyqtgraph/pixmaps/compile.py
+++ b/pyqtgraph/pixmaps/compile.py
@@ -14,6 +14,5 @@ for f in os.listdir(path):
     arr = np.asarray(ptr).reshape(img.height(), img.width(), 4).transpose(1,0,2)
     pixmaps[f] = pickle.dumps(arr)
 ver = sys.version_info[0]
-fh = open(os.path.join(path, 'pixmapData_%d.py' %ver), 'w')
-fh.write("import numpy as np; pixmapData=%s" % repr(pixmaps))
-    
+with open(os.path.join(path, 'pixmapData_%d.py' % (ver, )), 'w') as fh:
+    fh.write("import numpy as np; pixmapData=%s" % (repr(pixmaps), ))

--- a/pyqtgraph/python2_3.py
+++ b/pyqtgraph/python2_3.py
@@ -13,46 +13,12 @@ def asUnicode(x):
             return unicode(x)
     else:
         return str(x)
-        
-def cmpToKey(mycmp):
-    'Convert a cmp= function into a key= function'
-    class K(object):
-        def __init__(self, obj, *args):
-            self.obj = obj
-        def __lt__(self, other):
-            return mycmp(self.obj, other.obj) < 0
-        def __gt__(self, other):
-            return mycmp(self.obj, other.obj) > 0
-        def __eq__(self, other):
-            return mycmp(self.obj, other.obj) == 0
-        def __le__(self, other):
-            return mycmp(self.obj, other.obj) <= 0
-        def __ge__(self, other):
-            return mycmp(self.obj, other.obj) >= 0
-        def __ne__(self, other):
-            return mycmp(self.obj, other.obj) != 0
-    return K
 
-def sortList(l, cmpFunc):
-    if sys.version_info[0] == 2:
-        l.sort(cmpFunc)
-    else:
-        l.sort(key=cmpToKey(cmpFunc))
 
 if sys.version_info[0] == 3:
     basestring = str
-    def cmp(a,b):
-        if a>b:
-            return 1
-        elif b > a:
-            return -1
-        else:
-            return 0
     xrange = range
 else:
     import __builtin__
     basestring = __builtin__.basestring
-    cmp = __builtin__.cmp
     xrange = __builtin__.xrange
-    
-    

--- a/pyqtgraph/reload.py
+++ b/pyqtgraph/reload.py
@@ -258,7 +258,8 @@ if __name__ == '__main__':
     import os
     if not os.path.isdir('test1'):
         os.mkdir('test1')
-    open('test1/__init__.py', 'w')
+    with open('test1/__init__.py', 'w'):
+        pass
     modFile1 = "test1/test1.py"
     modCode1 = """
 import sys
@@ -297,8 +298,10 @@ def fn():
     print("fn: %s")
 """ 
 
-    open(modFile1, 'w').write(modCode1%(1,1))
-    open(modFile2, 'w').write(modCode2%"message 1")
+    with open(modFile1, 'w') as f:
+        f.write(modCode1 % (1, 1))
+    with open(modFile2, 'w') as f:
+        f.write(modCode2 % ("message 1", ))
     import test1.test1 as test1
     import test2
     print("Test 1 originals:")
@@ -334,7 +337,8 @@ def fn():
     c1.fn()
     
     os.remove(modFile1+'c')
-    open(modFile1, 'w').write(modCode1%(2,2))
+    with open(modFile1, 'w') as f:
+        f.write(modCode1 %(2, 2))
     print("\n----RELOAD test1-----\n")
     reloadAll(os.path.abspath(__file__)[:10], debug=True)
     
@@ -345,7 +349,8 @@ def fn():
     
     
     os.remove(modFile2+'c')
-    open(modFile2, 'w').write(modCode2%"message 2")
+    with open(modFile2, 'w') as f:
+        f.write(modCode2 % ("message 2", ))
     print("\n----RELOAD test2-----\n")
     reloadAll(os.path.abspath(__file__)[:10], debug=True)
 
@@ -381,8 +386,10 @@ def fn():
 
     os.remove(modFile1+'c')
     os.remove(modFile2+'c')
-    open(modFile1, 'w').write(modCode1%(3,3))
-    open(modFile2, 'w').write(modCode2%"message 3")
+    with open(modFile1, 'w') as f:
+        f.write(modCode1 % (3, 3))
+    with open(modFile2, 'w') as f:
+        f.write(modCode2 % ("message 3", ))
     
     print("\n----RELOAD-----\n")
     reloadAll(os.path.abspath(__file__)[:10], debug=True)

--- a/pyqtgraph/tests/test_exit_crash.py
+++ b/pyqtgraph/tests/test_exit_crash.py
@@ -35,7 +35,8 @@ def test_exit_crash():
 
         print(name)
         argstr = initArgs.get(name, "")
-        open(tmp, 'w').write(code.format(path=path, classname=name, args=argstr))
+        with open(tmp, 'w') as f:
+            f.write(code.format(path=path, classname=name, args=argstr))
         proc = subprocess.Popen([sys.executable, tmp])
         assert proc.wait() == 0
 

--- a/pyqtgraph/widgets/TableWidget.py
+++ b/pyqtgraph/widgets/TableWidget.py
@@ -347,7 +347,8 @@ class TableWidget(QtGui.QTableWidget):
         fileName = QtGui.QFileDialog.getSaveFileName(self, "Save As..", "", "Tab-separated values (*.tsv)")
         if fileName == '':
             return
-        open(fileName, 'w').write(data)
+        with open(fileName, 'w') as fd:
+            fd.write(data)
 
     def contextMenuEvent(self, ev):
         self.contextMenu.popup(ev.globalPos())

--- a/pyqtgraph/widgets/ValueLabel.py
+++ b/pyqtgraph/widgets/ValueLabel.py
@@ -1,7 +1,6 @@
 from ..Qt import QtCore, QtGui
 from ..ptime import time
 from .. import functions as fn
-from functools import reduce
 
 __all__ = ['ValueLabel']
 
@@ -54,7 +53,7 @@ class ValueLabel(QtGui.QLabel):
         self.averageTime = t
         
     def averageValue(self):
-        return reduce(lambda a,b: a+b, [v[1] for v in self.values]) / float(len(self.values))
+        return sum(v[1] for v in self.values) / float(len(self.values))
         
         
     def paintEvent(self, ev):


### PR DESCRIPTION
This fixes various issues on Python 3:
- Broken multiprocessing/remote examples due to `iteritems` calls.
- Drop `sortList` compat function; key-based sorting is available on all supported Python versions, and is simpler.
- Use a context manager for file I/O in as many places as possible; could cause a `ResourceWarning` on Python 3, though it's not enabled by default.
- Fix some encoding issues with `MetaArray`. I'm not sure why the tests are hidden away in the file and not run on Travis, but they would have pointed out this problem.
