### PR TITLE
Allow MetaArray.__array__ to accept an optional dtype arg

### DIFF
--- a/pyqtgraph/metaarray/MetaArray.py
+++ b/pyqtgraph/metaarray/MetaArray.py
@@ -358,7 +358,7 @@ class MetaArray(object):
         else:
             return np.array(self._data)
             
-    def __array__(self):
+    def __array__(self, dtype=None):
         ## supports np.array(metaarray_instance) 
         return self.asarray()
             


### PR DESCRIPTION
Fixes #359
