### PR TITLE
Fix canceling GraphicsScene context menu.

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -197,10 +197,11 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 self.dragButtons.remove(ev.button())
             else:
                 cev = [e for e in self.clickEvents if int(e.button()) == int(ev.button())]
-                if self.sendClickEvent(cev[0]):
-                    #print "sent click event"
-                    ev.accept()
-                self.clickEvents.remove(cev[0])
+                if cev:
+                    if self.sendClickEvent(cev[0]):
+                        #print "sent click event"
+                        ev.accept()
+                    self.clickEvents.remove(cev[0])
                 
         if int(ev.buttons()) == 0:
             self.dragItem = None


### PR DESCRIPTION
When the `GraphicsItem` context menu is cancelled (by left-clicking outside the menu), an `IndexError` is being raised. The `cev` event list is empty. This simple pull request fixes this.

Catching this exception will become more important in Qt5 because [in PyQt 5.5 Qt exceptions are no longer swallowed](http://pyqt.sourceforge.net/Docs/PyQt5/incompatibilities.html#pyqt-v5-5).

Steps to reproduce:
1.     Start the `ImageItem.py` example.
2.     Right click on the image to get the context menu.
3.     Left click outside the menu to cancel it (i.e. close the menu without selecting an option).

The following exception occurs:

```
    Traceback (most recent call last):
      File "/Users/kenter/prog/py/pyqtgraph/pyqtgraph/GraphicsScene/GraphicsScene.py", line 200, in mouseReleaseEvent
        if self.sendClickEvent(cev[0]):
    IndexError: list index out of range
```
