### PR TITLE
Use console's namespace as both local and global context for exec/eval.

### DIFF
--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -48,6 +48,7 @@ class ConsoleWidget(QtGui.QWidget):
         QtGui.QWidget.__init__(self, parent)
         if namespace is None:
             namespace = {}
+        namespace['__console__'] = self
         self.localNamespace = namespace
         self.editor = editor
         self.multiline = None
@@ -134,7 +135,7 @@ class ConsoleWidget(QtGui.QWidget):
         if frame is not None and self.ui.runSelectedFrameCheck.isChecked():
             return self.currentFrame().tb_frame.f_globals
         else:
-            return globals()
+            return self.localNamespace
         
     def locals(self):
         frame = self.currentFrame()


### PR DESCRIPTION
This allows functions defined in the console to access global variables.
Also expose the console itself via special __console__ variable.