### PR TITLE
Suppress VisibleDeprecationWarning when using numpy 1.11.1

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -454,7 +454,7 @@ class ImageItem(GraphicsObject):
                     int(np.ceil(self.image.shape[1] / targetImageSize)))
         if np.isscalar(step):
             step = (step, step)
-        stepData = self.image[::step[0], ::step[1]]
+        stepData = self.image[::int(step[0]), ::int(step[1])]
         
         if bins == 'auto':
             if stepData.dtype.kind in "ui":


### PR DESCRIPTION
np.ceil returns a float
however, slicing with a float step results in the following warning:

VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future