### PR TITLE
Revert "ignore wheel events in GraphicsView if mouse disabled"

### DIFF
--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -325,7 +325,6 @@ class GraphicsView(QtGui.QGraphicsView):
     def wheelEvent(self, ev):
         QtGui.QGraphicsView.wheelEvent(self, ev)
         if not self.mouseEnabled:
-            ev.ignore()
             return
         sc = 1.001 ** ev.delta()
         #self.scale *= sc


### PR DESCRIPTION
This reverts commit f49c179275e86786af70b38b8c5085e38d4e6cce.

On Qt 5.7 ignoring the initial `wheelEvent` when `phase() ==
Qt.ScrollBegin` suppresses all intermediate events (`Qt.ScrollUpdate`)
from being delivered to the view. This makes ViewBox zooming
unresponsive.