### PR TITLE
NEW parameter 'empty' and 'menu' + TextParameterItem debugged

### DIFF
--- a/examples/parametertree.py
+++ b/examples/parametertree.py
@@ -59,8 +59,6 @@ class ScalableGroup(pTypes.GroupParameter):
         self.addChild(dict(name="ScalableParam %d" % (len(self.childs)+1), type=typ, value=val, removable=True, renamable=True))
 
 
-
-
 params = [
     {'name': 'Basic parameter data types', 'type': 'group', 'children': [
         {'name': 'Integer', 'type': 'int', 'value': 10},
@@ -72,6 +70,7 @@ params = [
         {'name': 'Color', 'type': 'color', 'value': "FF0", 'tip': "This is a color button"},
         {'name': 'Gradient', 'type': 'colormap'},
         {'name': 'Slider', 'type': 'slider', 'value':1.75, 'limits':[1,2.5]},
+        {'name': 'Empty', 'type': 'empty'},        
         {'name': 'Subgroup', 'type': 'group', 'children': [
             {'name': 'Sub-param 1', 'type': 'int', 'value': 10},
             {'name': 'Sub-param 2', 'type': 'float', 'value': 1.2e6},

--- a/examples/parametertree.py
+++ b/examples/parametertree.py
@@ -71,6 +71,7 @@ params = [
         {'name': 'Boolean', 'type': 'bool', 'value': True, 'tip': "This is a checkbox"},
         {'name': 'Color', 'type': 'color', 'value': "FF0", 'tip': "This is a color button"},
         {'name': 'Gradient', 'type': 'colormap'},
+        {'name': 'Slider', 'type': 'slider', 'value':1.75, 'limits':[1,2.5]},
         {'name': 'Subgroup', 'type': 'group', 'children': [
             {'name': 'Sub-param 1', 'type': 'int', 'value': 10},
             {'name': 'Sub-param 2', 'type': 'float', 'value': 1.2e6},

--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -27,6 +27,7 @@ class WidgetParameterItem(ParameterItem):
     str                         Displays a QLineEdit
     color                       Displays a :class:`ColorButton <pyqtgraph.ColorButton>`
     colormap                    Displays a :class:`GradientWidget <pyqtgraph.GradientWidget>`
+    slider                      Displays a :class:`SliderWidget <pyqtgraph.SliderWidget>`.
     ==========================  =============================================================
     
     This class can be subclassed by overriding makeWidget() to provide a custom widget.
@@ -142,6 +143,18 @@ class WidgetParameterItem(ParameterItem):
             w.sigChanging = w.sigGradientChanged
             w.value = w.colorMap
             w.setValue = w.setColorMap
+            self.hideWidget = False
+        elif t == 'slider':
+            from ..widgets.SliderWidget import SliderWidget
+            w = SliderWidget()
+            w.sigChanged = w.sigValueChanged
+            w.sigChanging = w.sigValueChanged
+            l = opts.get('limits')
+            if l:
+                w.setRange(*l)
+            v = opts.get('value')
+            if l:
+                w.setValue(v)
             self.hideWidget = False
         else:
             raise Exception("Unknown type '%s'" % asUnicode(t))
@@ -321,7 +334,7 @@ registerParameterType('bool', SimpleParameter, override=True)
 registerParameterType('str', SimpleParameter, override=True)
 registerParameterType('color', SimpleParameter, override=True)
 registerParameterType('colormap', SimpleParameter, override=True)
-
+registerParameterType('slider', SimpleParameter, override=True)
 
 
 

--- a/pyqtgraph/widgets/SliderWidget.py
+++ b/pyqtgraph/widgets/SliderWidget.py
@@ -1,0 +1,92 @@
+from pyqtgraph.Qt import QtGui, QtCore
+import numpy as np
+
+__all__ = ['SliderWidget']
+
+class SliderWidget(QtGui.QWidget):
+    '''
+    shows a horizontal/vertical slider with a label showing its value
+    '''
+    sigValueChanged = QtCore.Signal(object)  ## value
+
+    def __init__(self, horizontal=True, parent=None):
+        '''
+        horizontal -> True/False
+        '''
+        QtGui.QWidget.__init__(self, parent)
+        self.mn, self.mx = None, None
+        self.precission = 0
+        self.step = 100
+        self.valueLen=2
+ 
+        self.label = QtGui.QLabel()
+        self.label.setFont(QtGui.QFont('Courier'))
+        self.slider = QtGui.QSlider(QtCore.Qt.Orientation(
+                        1 if horizontal else 0), self)#1...horizontal
+        self.slider.setTickPosition(
+                        QtGui.QSlider.TicksAbove if horizontal else QtGui.QSlider.TicksLeft)
+        #self.slider.setRange (0, 100)
+        self.slider.sliderMoved.connect(self._updateLabel)        
+        self._updateLabel(self.slider.value())
+        
+        layout = QtGui.QHBoxLayout() if horizontal else QtGui.QVBoxLayout()
+        self.setLayout(layout)
+        layout.addWidget(self.slider)
+        layout.addWidget(self.label)
+  
+    def value(self):
+        return self._value
+
+    def setValue(self, val):
+        if val == None:
+            val = self.mn
+        if self.mn != None:
+            val = (val-self.mn) / (self.mx-self.mn) 
+            val *= 99.0
+            val = int(round(val))
+        self.slider.setValue(val)
+        self._updateLabel(val)
+
+    def setRange(self, mn, mx):
+        '''
+        mn, mx -> arbitrary values that are not equal
+        '''
+        if mn == mx:
+            raise ValueError('limits must be different values')
+        self.mn = float(min(mn,mx))
+        self.mx = float(max(mn,mx))
+        self._calcPrecission()
+        self._updateLabel(self.slider.value())
+
+    def _calcPrecission(self):
+        #number of floating points:
+        self.precission = int(round( np.log10( (self.step / (self.mx-self.mn) )) ) )
+        if self.precission < 0: 
+            self.precission = 0
+        #length of the number in the label:
+        self.valueLen = max(len(str(int(self.mn))), len(str(int(self.mx))) ) + self.precission
+
+    def setOpts(self, bounds=None):
+        if bounds != None:
+            self.setRange(bounds)
+
+    def _updateLabel(self, val):
+        if self.mn != None:
+            val /= 99.0 #val->0...1
+            val = val *(self.mx-self.mn) + self.mn  
+        self._value = round(val, self.precission)
+        self.sigValueChanged.emit(self._value)
+        #to have a fixed width of the label: format the value to a given length:
+        self.label.setText(format(self._value, '%s.%sf' %(self.valueLen,self.precission)))
+
+
+
+if __name__ == '__main__':
+    import sys
+    app = QtGui.QApplication([])
+    s = SliderWidget()
+    s.setRange(2,7)
+    s.setValue(4.6)
+    s.show()
+    sys.exit(app.exec_())
+    


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/350050/20189243/3876b72c-a774-11e6-9be2-cf9ba610eb2b.png)

the update also gived the rudimentray option to add a QMenu into the parametertree
def fn(menu):
   menu.clear()
   menu.addction('.....)
   ...

m = param.addChild('type':'menu')
m.aboutToShow.connect(fn)