### PR TITLE
Join the fileforwarder threads in RemoteGraphicsView

### DIFF
--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -454,24 +454,26 @@ class FileForwarder(threading.Thread):
         self.lock = threading.Lock()
         self.daemon = True
         self.color = color
+        self.enabled = True
         self.start()
 
     def run(self):
         if self.output == 'stdout':
-            while True:
+            while self.enabled:
                 line = self.input.readline()
                 with self.lock:
                     cprint.cout(self.color, line, -1)
         elif self.output == 'stderr':
-            while True:
+            while self.enabled:
                 line = self.input.readline()
                 with self.lock:
                     cprint.cerr(self.color, line, -1)
         else:
-            while True:
+            while self.enabled:
                 line = self.input.readline()
                 with self.lock:
                     self.output.write(line)
+
 
 
 

--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -136,6 +136,13 @@ class RemoteGraphicsView(QtGui.QWidget):
     def close(self):
         """Close the remote process. After this call, the widget will no longer be updated."""
         self._proc.close()
+        self._proc.proxies = {}
+        self._proc._stderrForwarder.enabled = False
+        self._proc._stdoutForwarder.enabled = False
+
+        # Hold off until the fileforwarders have finished
+        self._proc._stderrForwarder.join()
+        self._proc._stdoutForwarder.join()
 
 
 class Renderer(GraphicsView):


### PR DESCRIPTION
Deals with the occasional exception thrown when RemoteGraphicsView closes but these threads aren't stopped.