### PR TITLE
makeRGBA/ImageItem: Applying alpha mask on numpy.nan data values

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -991,8 +991,9 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False):
         dtype = np.min_scalar_type(lut.shape[0]-1)
 
     # awkward, but fastest numpy native nan evaluation
+    # 
     nanMask = None
-    if np.isnan(data.min()):
+    if data.dtype.kind == 'f' and np.isnan(data.min()):
         nanMask = np.isnan(data)
     # Apply levels if given
     if levels is not None:


### PR DESCRIPTION
Alpha channel is pulled on all `numpy.nan` values encountered in `makeARGB()`.

For a cleaner slate `ImageItem` could have a switch turning this behaviour on or off. E.g.`showNans`.