### PR TITLE
DEBUGGED: Spinbox.setOpts

### DIFF
--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -154,6 +154,8 @@ class SpinBox(QtGui.QAbstractSpinBox):
                 self.opts[k] = D(asUnicode(opts[k]))
             elif k == 'value':
                 pass   ## don't set value until bounds have been set
+            elif k == 'visible':
+                self.show() if k else self.hide()
             elif k in self.opts:
                 self.opts[k] = opts[k]
             else:


### PR DESCRIPTION
to eval. this PR:
just modify parametertree example as follows:

before
'if __name__ == '__main__':'
add line:
'p.param('Basic parameter data types', 'Integer').show()'

In result the example will crush, because if a parameter is Spinbox-based all options are directly forwarded.
however, SpinBox.setOpts doesnt have k=='visible'
and therefore raises an error


