### PR TITLE
Fix `cleanup` when the running qt application is not a QApplication

### DIFF
--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -303,7 +303,10 @@ def cleanup():
     ## ALL QGraphicsItems must have a scene before they are deleted.
     ## This is potentially very expensive, but preferred over crashing.
     ## Note: this appears to be fixed in PySide as of 2012.12, but it should be left in for a while longer..
-    if QtGui.QApplication.instance() is None:
+    app = QtGui.QApplication.instance()
+    if app is None or not isinstance(app, QtGui.QApplication):
+        # app was never constructed is already deleted or is an
+        # QCoreApplication/QGuiApplication and not a full QApplication
         return
     import gc
     s = QtGui.QGraphicsScene()


### PR DESCRIPTION
Fix a segmentation fault in atexit registered cleanup function (in QGraphicsScene constructor) when the running qt application is not a fully fledged QApplication but a QCoreApplication (or possibly QGuiApplication on PyQt5).
