### PR TITLE
Spinbox formatting

### DIFF
--- a/examples/SpinBox.py
+++ b/examples/SpinBox.py
@@ -13,7 +13,7 @@ import initExample ## Add path to library (just for examples; you do not need th
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
 import numpy as np
-
+import ast
 
 app = QtGui.QApplication([])
 
@@ -31,6 +31,13 @@ spins = [
      pg.SpinBox(value=1.0, suffix='V', siPrefix=True, dec=True, step=0.5, minStep=0.01)),
     ("Float with SI-prefixed units,<br>dec step=1.0, minStep=0.001", 
      pg.SpinBox(value=1.0, suffix='V', siPrefix=True, dec=True, step=1.0, minStep=0.001)),
+    ("Float with custom formatting", 
+     pg.SpinBox(value=23.07, format='${value:0.02f}',
+                regex='\$?(?P<number>(-?\d+(\.\d+)?)|(-?\.\d+))$')),
+    ("Int with custom formatting", 
+     pg.SpinBox(value=4567, step=1, int=True, bounds=[0,None], format='0x{value:X}', 
+                regex='(0x)?(?P<number>[0-9a-fA-F]+)$',
+                evalFunc=lambda s: ast.literal_eval('0x'+s))),
 ]
 
 

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -37,8 +37,8 @@ SI_PREFIXES_ASCII = 'yzafpnum kMGTPEZY'
 SI_PREFIX_EXPONENTS = dict([(SI_PREFIXES[i], (i-8)*3) for i in range(len(SI_PREFIXES))])
 SI_PREFIX_EXPONENTS['u'] = -6
 
-FLOAT_REGEX = re.compile(r'(?P<number>[+-]?((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)\s*((?P<siprefix>[u' + SI_PREFIXES + r']?)(?P<suffix>\w.*))?$')
-INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siprefix>[u' + SI_PREFIXES + r']?)(?P<suffix>.*)$')
+FLOAT_REGEX = re.compile(r'(?P<number>[+-]?((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)\s*((?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>\w.*))?$')
+INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>.*)$')
 
     
 def siScale(x, minVal=1e-25, allowUnicode=True):
@@ -121,8 +121,16 @@ def siParse(s, regex=FLOAT_REGEX):
     m = regex.match(s)
     if m is None:
         raise ValueError('Cannot parse number "%s"' % s)
-    sip = m.group('siprefix')
-    suf = m.group('suffix')
+    try:
+        sip = m.group('siPrefix')
+    except IndexError:
+        sip = ''
+    
+    try:
+        suf = m.group('suffix')
+    except IndexError:
+        suf = ''
+    
     return m.group('number'), '' if sip is None else sip, '' if suf is None else suf 
 
 

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -36,8 +36,6 @@ SI_PREFIXES = asUnicode('yzafpnµm kMGTPEZY')
 SI_PREFIXES_ASCII = 'yzafpnum kMGTPEZY'
 
 
-
-
 def siScale(x, minVal=1e-25, allowUnicode=True):
     """
     Return the recommended scale factor and SI prefix string for x.
@@ -75,6 +73,7 @@ def siScale(x, minVal=1e-25, allowUnicode=True):
     p = .001**m
     
     return (p, pref)    
+
 
 def siFormat(x, precision=3, suffix='', space=True, error=None, minVal=1e-25, allowUnicode=True):
     """

--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -279,9 +279,14 @@ class WidgetParameterItem(ParameterItem):
         
         ## If widget is a SpinBox, pass options straight through
         if isinstance(self.widget, SpinBox):
+            # send only options supported by spinbox
+            sbOpts = {}
             if 'units' in opts and 'suffix' not in opts:
-                opts['suffix'] = opts['units']
-            self.widget.setOpts(**opts)
+                sbOpts['suffix'] = opts['units']
+            for k,v in opts.items():
+                if k in self.widget.opts:
+                    sbOpts[k] = v
+            self.widget.setOpts(**sbOpts)
             self.updateDisplayLabel()
         
             

--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -122,6 +122,7 @@ class WidgetParameterItem(ParameterItem):
             self.hideWidget = False
         elif t == 'str':
             w = QtGui.QLineEdit()
+            w.setStyleSheet('border: 0px')
             w.sigChanged = w.editingFinished
             w.value = lambda: asUnicode(w.text())
             w.setValue = lambda v: w.setText(asUnicode(v))

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -18,12 +18,14 @@ class SpinBox(QtGui.QAbstractSpinBox):
     """
     **Bases:** QtGui.QAbstractSpinBox
     
-    QSpinBox widget on steroids. Allows selection of numerical value, with extra features:
+    Extension of QSpinBox widget for selection of a numerical value.     
+    Adds many extra features:
     
-    - SI prefix notation (eg, automatically display "300 mV" instead of "0.003 V")
-    - Float values with linear and decimal stepping (1-9, 10-90, 100-900, etc.)
-    - Option for unbounded values
-    - Delayed signals (allows multiple rapid changes with only one change signal)
+    * SI prefix notation (eg, automatically display "300 mV" instead of "0.003 V")
+    * Float values with linear and decimal stepping (1-9, 10-90, 100-900, etc.)
+    * Option for unbounded values
+    * Delayed signals (allows multiple rapid changes with only one change signal)
+    * Customizable text formatting
     
     =============================  ==============================================
     **Signals:**

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -264,6 +264,10 @@ class SpinBox(QtGui.QAbstractSpinBox):
                 return
             le.setSelection(0, index)
 
+    def focusInEvent(self, ev):
+        super(SpinBox, self).focusInEvent(ev)
+        self.selectNumber()
+
     def value(self):
         """
         Return the value of this SpinBox.

--- a/pyqtgraph/widgets/tests/test_spinbox.py
+++ b/pyqtgraph/widgets/tests/test_spinbox.py
@@ -4,7 +4,7 @@ pg.mkQApp()
 
 def test_spinbox():
     sb = pg.SpinBox()
-    assert sb.opts['decimals'] == 3
+    assert sb.opts['decimals'] == 6
     assert sb.opts['int'] is False
     
     # table  of test conditions:
@@ -16,7 +16,7 @@ def test_spinbox():
         (1000, '1e+03', dict(decimals=2)),
         (1000000, '1e+06', dict(int=True, decimals=6)),
         (12345678955, '12345678955', dict(int=True, decimals=100)),
-        (1.45e-9, '1.45e-9 A', dict(int=False, decimals=6, suffix='A', siPrefix=False)),
+        (1.45e-9, '1.45e-09 A', dict(int=False, decimals=6, suffix='A', siPrefix=False)),
         (1.45e-9, '1.45 nA', dict(int=False, decimals=6, suffix='A', siPrefix=True)),
     ]
     

--- a/pyqtgraph/widgets/tests/test_spinbox.py
+++ b/pyqtgraph/widgets/tests/test_spinbox.py
@@ -2,7 +2,7 @@ import pyqtgraph as pg
 pg.mkQApp()
 
 
-def test_spinbox():
+def test_spinbox_formatting():
     sb = pg.SpinBox()
     assert sb.opts['decimals'] == 6
     assert sb.opts['int'] is False
@@ -18,6 +18,7 @@ def test_spinbox():
         (12345678955, '12345678955', dict(int=True, decimals=100)),
         (1.45e-9, '1.45e-09 A', dict(int=False, decimals=6, suffix='A', siPrefix=False)),
         (1.45e-9, '1.45 nA', dict(int=False, decimals=6, suffix='A', siPrefix=True)),
+        (-2500.3427, '$-2500.34', dict(int=False, format='${value:0.02f}')),
     ]
     
     for (value, text, opts) in conds:

--- a/pyqtgraph/widgets/tests/test_spinbox.py
+++ b/pyqtgraph/widgets/tests/test_spinbox.py
@@ -1,6 +1,7 @@
 import pyqtgraph as pg
 pg.mkQApp()
 
+
 def test_spinbox():
     sb = pg.SpinBox()
     assert sb.opts['decimals'] == 3
@@ -13,8 +14,10 @@ def test_spinbox():
         (100, '100', dict()),
         (1000000, '1e+06', dict()),
         (1000, '1e+03', dict(decimals=2)),
-        (1000000, '1000000', dict(int=True)),
-        (12345678955, '12345678955', dict(int=True)),
+        (1000000, '1e+06', dict(int=True, decimals=6)),
+        (12345678955, '12345678955', dict(int=True, decimals=100)),
+        (1.45e-9, '1.45e-9 A', dict(int=False, decimals=6, suffix='A', siPrefix=False)),
+        (1.45e-9, '1.45 nA', dict(int=False, decimals=6, suffix='A', siPrefix=True)),
     ]
     
     for (value, text, opts) in conds:

--- a/pyqtgraph/widgets/tests/test_spinbox.py
+++ b/pyqtgraph/widgets/tests/test_spinbox.py
@@ -1,0 +1,24 @@
+import pyqtgraph as pg
+pg.mkQApp()
+
+def test_spinbox():
+    sb = pg.SpinBox()
+    assert sb.opts['decimals'] == 3
+    assert sb.opts['int'] is False
+    
+    # table  of test conditions:
+    # value, text, options
+    conds = [
+        (0, '0', dict(suffix='', siPrefix=False, dec=False, int=False)),
+        (100, '100', dict()),
+        (1000000, '1e+06', dict()),
+        (1000, '1e+03', dict(decimals=2)),
+        (1000000, '1000000', dict(int=True)),
+        (12345678955, '12345678955', dict(int=True)),
+    ]
+    
+    for (value, text, opts) in conds:
+        sb.setOpts(**opts)
+        sb.setValue(value)
+        assert sb.value() == value
+        assert pg.asUnicode(sb.text()) == text


### PR DESCRIPTION
Multiple bugfixes for SpinBox:
     - fixed bug with exponents disappearing after edit
     - fixed parsing of values with junk after suffix
     - fixed red border
     - reverted default decimals to 6
     - make suffix editable (but show red border if it's wrong)
     - revert invalid text on focus lost
     - siPrefix without suffix is no longer allowed
     - fixed parametree sending invalid options to spinbox
     - fix spinbox wrapping (merged #159 from @lidstrom83)
     - fixed parametertree ignoring spinbox bounds (merged #329 from @lidstrom83)
     - fixed spinbox height too small for font size

..and a few enhancements:
     - select only numerical portion of text on focus-in
     - let user set arbitrary format string

fixes #340, closes #407, fixes #210, fixes #263, fixes #256