### PR TITLE
Scatterplot bugfixes

### DIFF
--- a/pyqtgraph/exporters/ImageExporter.py
+++ b/pyqtgraph/exporters/ImageExporter.py
@@ -34,12 +34,12 @@ class ImageExporter(Exporter):
     def widthChanged(self):
         sr = self.getSourceRect()
         ar = float(sr.height()) / sr.width()
-        self.params.param('height').setValue(self.params['width'] * ar, blockSignal=self.heightChanged)
+        self.params.param('height').setValue(int(self.params['width'] * ar), blockSignal=self.heightChanged)
         
     def heightChanged(self):
         sr = self.getSourceRect()
         ar = float(sr.width()) / sr.height()
-        self.params.param('width').setValue(self.params['height'] * ar, blockSignal=self.widthChanged)
+        self.params.param('width').setValue(int(self.params['height'] * ar), blockSignal=self.widthChanged)
         
     def parameters(self):
         return self.params
@@ -61,9 +61,6 @@ class ImageExporter(Exporter):
         targetRect = QtCore.QRect(0, 0, self.params['width'], self.params['height'])
         sourceRect = self.getSourceRect()
         
-        
-        #self.png = QtGui.QImage(targetRect.size(), QtGui.QImage.Format_ARGB32)
-        #self.png.fill(pyqtgraph.mkColor(self.params['background']))
         w, h = self.params['width'], self.params['height']
         if w == 0 or h == 0:
             raise Exception("Cannot export image with size=0 (requested export size is %dx%d)" % (w,h))
@@ -78,11 +75,8 @@ class ImageExporter(Exporter):
         ## set resolution of image:
         origTargetRect = self.getTargetRect()
         resolutionScale = targetRect.width() / origTargetRect.width()
-        #self.png.setDotsPerMeterX(self.png.dotsPerMeterX() * resolutionScale)
-        #self.png.setDotsPerMeterY(self.png.dotsPerMeterY() * resolutionScale)
         
         painter = QtGui.QPainter(self.png)
-        #dtr = painter.deviceTransform()
         try:
             self.setExportMode(True, {'antialias': self.params['antialias'], 'background': self.params['background'], 'painter': painter, 'resolutionScale': resolutionScale})
             painter.setRenderHint(QtGui.QPainter.Antialiasing, self.params['antialias'])
@@ -97,6 +91,6 @@ class ImageExporter(Exporter):
             return self.png
         else:
             self.png.save(fileName)
+
         
 ImageExporter.register()        
-        

--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -131,8 +131,6 @@ class GraphicsItem(object):
             return self.sceneTransform()
             #return self.deviceTransform(view.viewportTransform())
 
-
-
     def getBoundingParents(self):
         """Return a list of parents to this item that have child clipping enabled."""
         p = self
@@ -161,8 +159,6 @@ class GraphicsItem(object):
             #bounds &= self.mapRectFromScene(p.sceneBoundingRect())
             
         return bounds
-        
-        
         
     def pixelVectors(self, direction=None):
         """Return vectors in local coordinates representing the width and height of a view pixel.
@@ -255,7 +251,6 @@ class GraphicsItem(object):
         self._pixelVectorCache[0] = dt
         self._pixelVectorGlobalCache[key] = pv
         return self._pixelVectorCache[1]
-    
         
     def pixelLength(self, direction, ortho=False):
         """Return the length of one pixel in the direction indicated (in local coordinates)
@@ -269,7 +264,6 @@ class GraphicsItem(object):
         if ortho:
             return orthoV.length()
         return normV.length()
-        
 
     def pixelSize(self):
         ## deprecated
@@ -293,8 +287,6 @@ class GraphicsItem(object):
             return 0
         vt = fn.invertQTransform(vt)
         return vt.map(QtCore.QLineF(0, 0, 0, 1)).length()
-        #return Point(vt.map(QtCore.QPointF(0, 1))-vt.map(QtCore.QPointF(0, 0))).length()
-        
         
     def mapToDevice(self, obj):
         """
@@ -388,7 +380,6 @@ class GraphicsItem(object):
         ## PyQt bug -- some child items are returned incorrectly.
         return list(map(GraphicsScene.translateGraphicsItem, self._qtBaseClass.childItems(self)))
 
-
     def sceneTransform(self):
         ## Qt bug: do no allow access to sceneTransform() until 
         ## the item has a scene.
@@ -397,7 +388,6 @@ class GraphicsItem(object):
             return self.transform()
         else:
             return self._qtBaseClass.sceneTransform(self)
-
 
     def transformAngle(self, relativeItem=None):
         """Return the rotation produced by this item's transform (this assumes there is no shear in the transform)
@@ -438,7 +428,6 @@ class GraphicsItem(object):
         to make sure viewRangeChanged works properly. It should generally be 
         extended, not overridden."""
         self._updateView()
-        
 
     def _updateView(self):
         ## called to see whether this item has a new view to connect to
@@ -513,8 +502,6 @@ class GraphicsItem(object):
             else:
                 self._replaceView(oldView, child)
         
-        
-
     def viewRangeChanged(self):
         """
         Called whenever the view coordinates of the ViewBox containing this item have changed.
@@ -528,10 +515,6 @@ class GraphicsItem(object):
         """
         pass
     
-    #def prepareGeometryChange(self):
-        #self._qtBaseClass.prepareGeometryChange(self)
-        #self.informViewBoundsChanged()
-        
     def informViewBoundsChanged(self):
         """
         Inform this item's container ViewBox that the bounds of this item have changed.
@@ -557,7 +540,6 @@ class GraphicsItem(object):
             tree.extend(self.allChildItems(ch))
         return tree
     
-    
     def setExportMode(self, export, opts=None):
         """
         This method is called by exporters to inform items that they are being drawn for export
@@ -568,14 +550,8 @@ class GraphicsItem(object):
             opts = {}
         if export:
             self._exportOpts = opts
-            #if 'antialias' not in opts:
-                #self._exportOpts['antialias'] = True
         else:
             self._exportOpts = False
     
-    #def update(self):
-        #self._qtBaseClass.update(self)
-        #print "Update:", self
-
     def getContextMenus(self, event):
         return [self.getMenu()] if hasattr(self, "getMenu") else []

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -713,10 +713,10 @@ class ScatterPlotItem(GraphicsObject):
             return None
         viewBounds = tr.mapRect(vb.mapRectToItem(self, vb.boundingRect()))
         w = self.data['width']
-        mask = ((pts[0] + w > viewBounds.left()) &
-                (pts[0] - w < viewBounds.right()) &
-                (pts[1] + w > viewBounds.top()) &
-                (pts[1] - w < viewBounds.bottom())) ## remove out of view points
+        mask = ((pts[0] > viewBounds.left() - 2*w) &
+                (pts[0] < viewBounds.right()) &
+                (pts[1] > viewBounds.top() - 2*w) &
+                (pts[1] < viewBounds.bottom())) ## remove out of view points
         return mask
 
     @debug.warnOnException  ## raising an exception here causes crash


### PR DESCRIPTION
- Corrects a long-standing issue with exporting ScatterPlotItem to image when the resolution does not match that of the original graphics view.
- Fixes scatter plot symbols being incorrectly culled when they come close to the edge of the view box.

fixes #16, fixes #105