### PR TITLE
Add print wrapper to work around interrupted system calls on travis

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -3,13 +3,17 @@ from pyqtgraph import Qt
 from . import utils
 import itertools
 import pytest
-import os
-import __builtin__
+import os, sys
 
 
 # printing on travis ci frequently leads to "interrupted system call" errors.
 # as a workaround, we overwrite the built-in print function (bleh)
 if os.getenv('TRAVIS') is not None:
+    if sys.version_info[0] < 3:
+        import __builtin__ as builtins
+    else:
+        import builtins
+
     def flaky_print(*args):
         """Wrapper for print that retries in case of IOError.
         """
@@ -24,7 +28,7 @@ if os.getenv('TRAVIS') is not None:
                     raise
                 pass
     orig_print = __builtin__.print
-    __builtin__.print = flaky_print
+    builtins.print = flaky_print
     print("Installed wrapper for flaky print.")
 
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -27,7 +27,7 @@ if os.getenv('TRAVIS') is not None:
                 if count >= 5:
                     raise
                 pass
-    orig_print = __builtin__.print
+    orig_print = builtins.print
     builtins.print = flaky_print
     print("Installed wrapper for flaky print.")
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -3,6 +3,30 @@ from pyqtgraph import Qt
 from . import utils
 import itertools
 import pytest
+import os
+import __builtin__
+
+
+# printing on travis ci frequently leads to "interrupted system call" errors.
+# as a workaround, we overwrite the built-in print function (bleh)
+if os.getenv('TRAVIS') is not None:
+    def flaky_print(*args):
+        """Wrapper for print that retries in case of IOError.
+        """
+        count = 0
+        while count < 5:
+            count += 1
+            try:
+                orig_print(*args)
+                break
+            except IOError:
+                if count >= 5:
+                    raise
+                pass
+    orig_print = __builtin__.print
+    __builtin__.print = flaky_print
+    print("Installed wrapper for flaky print.")
+
 
 # apparently importlib does not exist in python 2.6...
 try:


### PR DESCRIPTION
Printing on travis occasionally fail with `IOError: Interrupted system call`. Usually just restarting the job on travis fixes the problem, but this is a pain.

Example: https://travis-ci.org/pyqtgraph/pyqtgraph/jobs/183496470#L1066

This PR is an attempt to work around the issue..