### PR TITLE
Adding color support for GLGridItem

### DIFF
--- a/pyqtgraph/opengl/items/GLGridItem.py
+++ b/pyqtgraph/opengl/items/GLGridItem.py
@@ -9,32 +9,31 @@ __all__ = ['GLGridItem']
 class GLGridItem(GLGraphicsItem):
     """
     **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
-    
-    Displays a wire-grame grid. 
+    Displays a wire-grame grid.
     """
-    
-    def __init__(self, size=None, color=(0, 0, 0, .0), antialias=True, glOptions='translucent'):
+
+    def __init__(self, size=None, color=(0, 0, 0, .3), antialias=True, glOptions='translucent'):
         GLGraphicsItem.__init__(self)
         self.setGLOptions(glOptions)
         self.antialias = antialias
         if size is None:
-            size = QtGui.QVector3D(20,20,1)
+            size = QtGui.QVector3D(20, 20, 1)
         self.setSize(size=size)
         self.setSpacing(1, 1, 1)
         self.color = color
-    
+
     def setSize(self, x=None, y=None, z=None, size=None):
         """
-        Set the size of the axes (in its local coordinate system; this does not affect the transform)
-        Arguments can be x,y,z or size=QVector3D().
+        Set the size of the axes (in its local coordinate system; this does not affect
+        the transform) Arguments can be x,y,z or size=QVector3D().
         """
         if size is not None:
             x = size.x()
             y = size.y()
             z = size.z()
-        self.__size = [x,y,z]
+        self.__size = [x, y, z]
         self.update()
-        
+
     def size(self):
         return self.__size[:]
 
@@ -47,36 +46,40 @@ class GLGridItem(GLGraphicsItem):
             x = spacing.x()
             y = spacing.y()
             z = spacing.z()
-        self.__spacing = [x,y,z]
-        self.update() 
-        
+        self.__spacing = [x, y, z]
+        self.update()
+
     def spacing(self):
         return self.__spacing[:]
-        
+
     def setColor(self, color):
+        """
+        Set the color of the grid line. Recieves a 4-tuple with (r, g, b, a) such
+        as glColor
+        """
         self.color = color
 
     def paint(self):
         self.setupGLState()
-        
+
         if self.antialias:
             glEnable(GL_LINE_SMOOTH)
             glEnable(GL_BLEND)
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
             glHint(GL_LINE_SMOOTH_HINT, GL_NICEST)
-            
-        glBegin( GL_LINES )
-        
-        x,y,z = self.size()
-        xs,ys,zs = self.spacing()
-        xvals = np.arange(-x/2., x/2. + xs*0.001, xs) 
-        yvals = np.arange(-y/2., y/2. + ys*0.001, ys) 
+
+        glBegin(GL_LINES)
+
+        x, y, z = self.size()
+        xs, ys, zs = self.spacing()
+        xvals = np.arange(-x/2., x/2. + xs*0.001, xs)
+        yvals = np.arange(-y/2., y/2. + ys*0.001, ys)
         glColor4f(*self.color)
         for x in xvals:
             glVertex3f(x, yvals[0], 0)
-            glVertex3f(x,  yvals[-1], 0)
+            glVertex3f(x, yvals[-1], 0)
         for y in yvals:
             glVertex3f(xvals[0], y, 0)
             glVertex3f(xvals[-1], y, 0)
-        
+
         glEnd()

--- a/pyqtgraph/opengl/items/GLGridItem.py
+++ b/pyqtgraph/opengl/items/GLGridItem.py
@@ -21,7 +21,7 @@ class GLGridItem(GLGraphicsItem):
             size = QtGui.QVector3D(20,20,1)
         self.setSize(size=size)
         self.setSpacing(1, 1, 1)
-        self.color = color if color is not None else (1, 1, 1, .3)
+        self.color = color if color is not None else (0, 0, 0, .0)
     
     def setSize(self, x=None, y=None, z=None, size=None):
         """

--- a/pyqtgraph/opengl/items/GLGridItem.py
+++ b/pyqtgraph/opengl/items/GLGridItem.py
@@ -13,7 +13,7 @@ class GLGridItem(GLGraphicsItem):
     Displays a wire-grame grid. 
     """
     
-    def __init__(self, size=None, color=None, antialias=True, glOptions='translucent'):
+    def __init__(self, size=None, color=(0, 0, 0, .0), antialias=True, glOptions='translucent'):
         GLGraphicsItem.__init__(self)
         self.setGLOptions(glOptions)
         self.antialias = antialias
@@ -21,7 +21,7 @@ class GLGridItem(GLGraphicsItem):
             size = QtGui.QVector3D(20,20,1)
         self.setSize(size=size)
         self.setSpacing(1, 1, 1)
-        self.color = color if color is not None else (0, 0, 0, .0)
+        self.color = color
     
     def setSize(self, x=None, y=None, z=None, size=None):
         """

--- a/pyqtgraph/opengl/items/GLGridItem.py
+++ b/pyqtgraph/opengl/items/GLGridItem.py
@@ -53,6 +53,9 @@ class GLGridItem(GLGraphicsItem):
     def spacing(self):
         return self.__spacing[:]
         
+    def setColor(self, color):
+        self.color = color
+
     def paint(self):
         self.setupGLState()
         

--- a/pyqtgraph/opengl/items/GLGridItem.py
+++ b/pyqtgraph/opengl/items/GLGridItem.py
@@ -21,6 +21,7 @@ class GLGridItem(GLGraphicsItem):
             size = QtGui.QVector3D(20,20,1)
         self.setSize(size=size)
         self.setSpacing(1, 1, 1)
+        self.color = color if color is not None else (1, 1, 1, .3)
     
     def setSize(self, x=None, y=None, z=None, size=None):
         """
@@ -67,7 +68,7 @@ class GLGridItem(GLGraphicsItem):
         xs,ys,zs = self.spacing()
         xvals = np.arange(-x/2., x/2. + xs*0.001, xs) 
         yvals = np.arange(-y/2., y/2. + ys*0.001, ys) 
-        glColor4f(1, 1, 1, .3)
+        glColor4f(*self.color)
         for x in xvals:
             glVertex3f(x, yvals[0], 0)
             glVertex3f(x,  yvals[-1], 0)


### PR DESCRIPTION
GLGridItem init has attribute color which is ignored. Currently the grid is hardcoded to draw in white. This minor modification takes into consideration a 4-element tuple (r,g,b,a) such as glColor passed by the user at the method's init to draw the grid at the desired color. The Standard grid color is still white.