### PR TITLE
Removed unnecessary 'curve1' from 'global'

### DIFF
--- a/examples/scrollingPlots.py
+++ b/examples/scrollingPlots.py
@@ -21,7 +21,7 @@ curve1 = p1.plot(data1)
 curve2 = p2.plot(data1)
 ptr1 = 0
 def update1():
-    global data1, curve1, ptr1
+    global data1, ptr1
     data1[:-1] = data1[1:]  # shift data in the array one sample left
                             # (see also: np.roll)
     data1[-1] = np.random.normal()


### PR DESCRIPTION
It works without "curve1" being global, so I figured we should take it out to avoid confusing newcomers (like me).

(Note: This is the first time I've contributed to someone else's githib repo, so let me know if minor changes like this are silly.)