### PR TITLE
fix fft premature slicing away of 0 freq bin

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -679,8 +679,10 @@ class PlotDataItem(GraphicsObject):
             x2 = np.linspace(x[0], x[-1], len(x))
             y = np.interp(x2, x, y)
             x = x2
-        f = np.fft.rfft(y) / y.size
-        x = np.fft.rfftfreq(y.size)
+        n = y.size
+        f = np.fft.rfft(y) / n
+        d = (x[-1] - x[0]) / (n - 1)
+        x = np.fft.rfftfreq(n, d)
         y = np.abs(f)
         return x, y
     

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -681,7 +681,7 @@ class PlotDataItem(GraphicsObject):
             x = x2
         n = y.size
         f = np.fft.rfft(y) / n
-        d = (x[-1] - x[0]) / (n - 1)
+        d = float(x[-1]-x[0]) / (len(x)-1)
         x = np.fft.rfftfreq(n, d)
         y = np.abs(f)
         return x, y

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -679,10 +679,9 @@ class PlotDataItem(GraphicsObject):
             x2 = np.linspace(x[0], x[-1], len(x))
             y = np.interp(x2, x, y)
             x = x2
-        f = np.fft.fft(y) / len(y)
-        y = abs(f[1:len(f)/2])
-        dt = x[-1] - x[0]
-        x = np.linspace(0, 0.5*len(x)/dt, len(y))
+        f = np.fft.rfft(y) / y.size
+        x = np.fft.rfftfreq(y.size)
+        y = np.abs(f)
         return x, y
     
 def dataType(obj):


### PR DESCRIPTION
#179 already slices away the first element when doing X log scale.
the old implementation slices away the first frequency value but still computes the freq coord as starting from 0.

also fixes:
- use rfft for better efficiency
- use rfftfreq to compute coords correctly
  - works for both odd/even lengths
- python3: integer division needed for numpy indexing