### PR TITLE
add warnings for remote exceptions

### DIFF
--- a/pyqtgraph/multiprocess/remoteproxy.py
+++ b/pyqtgraph/multiprocess/remoteproxy.py
@@ -1,6 +1,7 @@
 import os, time, sys, traceback, weakref
 import numpy as np
 import threading
+import warnings
 try:
     import __builtin__ as builtins
     import cPickle as pickle
@@ -21,6 +22,9 @@ class NoResultError(Exception):
     because the call has not yet returned."""
     pass
 
+class RemoteExceptionWarning(UserWarning):
+    """Emitted when a request to a remote object results in an Exception """
+    pass
     
 class RemoteEventHandler(object):
     """
@@ -502,9 +506,9 @@ class RemoteEventHandler(object):
             #print ''.join(result)
             exc, excStr = result
             if exc is not None:
-                print("===== Remote process raised exception on request: =====")
-                print(''.join(excStr))
-                print("===== Local Traceback to request follows: =====")
+                warnings.warn("===== Remote process raised exception on request: =====", RemoteExceptionWarning)
+                warnings.warn(''.join(excStr), RemoteExceptionWarning)
+                warnings.warn("===== Local Traceback to request follows: =====", RemoteExceptionWarning)
                 raise exc
             else:
                 print(''.join(excStr))


### PR DESCRIPTION
For remote objects that generate an exception the exception is printed to screen. This is inconvenient of the software using the remote object wants to generate an exception (ipython does this to test some capabilities of objects). This PR solves this issue by replacing the `print` statement with a `warning.warn` This solves #442 by allowing the user to filter output on a `RemoteExceptionWarning`. 

An alternative to warnings would be to use the Python logging framework, or add an option to the `pyqtgraph` to not print exceptions at all.
