### PR TITLE
Fix color alpha limits in LinearRegionItem hover.

### DIFF
--- a/pyqtgraph/graphicsItems/LinearRegionItem.py
+++ b/pyqtgraph/graphicsItems/LinearRegionItem.py
@@ -1,4 +1,5 @@
 from ..Qt import QtGui, QtCore
+import numpy as np
 from .UIGraphicsItem import UIGraphicsItem
 from .InfiniteLine import InfiniteLine
 from .. import functions as fn
@@ -256,7 +257,8 @@ class LinearRegionItem(UIGraphicsItem):
         self.mouseHovering = hover
         if hover:
             c = self.brush.color()
-            c.setAlpha(c.alpha() * 2)
+            hover_alpha = np.clip(c.alpha() * 2, 0, 255 )
+            c.setAlpha(hover_alpha)
             self.currentBrush = fn.mkBrush(c)
         else:
             self.currentBrush = self.brush


### PR DESCRIPTION
Clip hover color alpha to limits (0, 255) for LinearRegionItem, to
remove QT warnings about calling the function QColor::setAlpha with a
invalid value.