### PR TITLE
Fixed incorrect height in VTickGroup.

### DIFF
--- a/pyqtgraph/graphicsItems/VTickGroup.py
+++ b/pyqtgraph/graphicsItems/VTickGroup.py
@@ -90,7 +90,7 @@ class VTickGroup(UIGraphicsItem):
         br = self.boundingRect()
         h = br.height()
         br.setY(br.y() + self.yrange[0] * h)
-        br.setHeight(h - (1.0-self.yrange[1]) * h)
+        br.setHeight((self.yrange[1] - self.yrange[0]) * h)
         p.translate(0, br.y())
         p.scale(1.0, br.height())
         p.setPen(self.pen)


### PR DESCRIPTION
Tick heights are incorrect if they start at anything other than the bottom of the view.

Here is some test code:

```Python
from pyqtgraph.Qt import QtGui, QtCore
import numpy as np
import pyqtgraph as pg

app = QtGui.QApplication([])
win = pg.GraphicsWindow(title="VTickGroup example")
win.resize(1000,600)
win.setWindowTitle('pyqtgraph example: VTickGroup')
p1 = win.addPlot(title="Basic plot with ticks", y=np.random.normal(size=100))

for start_ix in range(0, 90, 10):
    xvals = range(start_ix, start_ix+10)
    yrange = [start_ix/100, (start_ix+10)/100]
    penColor = QtGui.QColor(*np.random.randint(0, 255+1, 3).tolist())
    new_tick_group = pg.VTickGroup(xvals=xvals, yrange=yrange, pen=penColor)
    p1.addItem(new_tick_group)

if __name__ == '__main__':
    import sys
    if sys.flags.interactive != 1 or not hasattr(QtCore, 'PYQT_VERSION'):
        pg.QtGui.QApplication.exec_()

```

Before the fix:
<img width="999" alt="screen shot 2017-05-17 at 9 21 40 am" src="https://cloud.githubusercontent.com/assets/303797/26155930/ca986568-3ae2-11e7-9a39-75ab0d3edf3f.png">

After the fix:
<img width="999" alt="screen shot 2017-05-17 at 9 22 46 am" src="https://cloud.githubusercontent.com/assets/303797/26155946/d117387e-3ae2-11e7-8097-6024ddefc425.png">
