### PR TITLE
debugged: RGB images cause exception if GradientEditorItem is not 'grey'

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -399,7 +399,11 @@ class ImageItem(GraphicsObject):
         
         if self.axisOrder == 'col-major':
             image = image.transpose((1, 0, 2)[:image.ndim])
-        
+
+        if image.ndim > 2:
+            #no lookup table form color images
+            lut = None
+
         argb, alpha = fn.makeARGB(image, lut=lut, levels=levels)
         self.qimage = fn.makeQImage(argb, alpha, transpose=False)
 


### PR DESCRIPTION
to reproduce error:
- load RGB image into imageView
- change gradient to anything, but 'grey'
--> you will see the error:

```
    argb, alpha = fn.makeARGB(image, lut=lut, levels=levels)
  File "/home/karl/git/pyqtgraph_karl/pyqtgraph_karl/functions.py", line 1110, in makeARGB
    imgData[..., i] = data[..., order[i]] 
ValueError: could not broadcast input array from shape (512,512,3) into shape (512,512)
```

no gradient can still be changed but no error is generated