### PR TITLE
Expose the `clickable` property of `PlotDataItem`.

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -174,7 +174,7 @@ class PlotDataItem(GraphicsObject):
             
             'data': None,
         }
-        self.setClickable(kargs.get('clickable', False))
+        self.setCurvesClickable(kargs.get('clickable', False))
         self.setData(*args, **kargs)
     
     def implements(self, interface=None):
@@ -186,17 +186,12 @@ class PlotDataItem(GraphicsObject):
     def name(self):
         return self.opts.get('name', None)
 
-    def setClickable(self, s, width=None):
+    def setCurvesClickable(self, s, width=None):
         self.curve.setClickable(s, width)
 
-    @property
-    def clickable(self):
+    def curvesClickable(self):
         return self.curve.clickable
 
-    @clickable.setter
-    def clickable(self, s):
-        self.setClickable(s)
-    
     def boundingRect(self):
         return QtCore.QRectF()  ## let child items handle this
 

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -174,6 +174,7 @@ class PlotDataItem(GraphicsObject):
             
             'data': None,
         }
+        self.setClickable(kargs.get('clickable', False))
         self.setData(*args, **kargs)
     
     def implements(self, interface=None):
@@ -184,6 +185,17 @@ class PlotDataItem(GraphicsObject):
     
     def name(self):
         return self.opts.get('name', None)
+
+    def setClickable(self, s, width=None):
+        self.curve.setClickable(s, width)
+
+    @property
+    def clickable(self):
+        return self.curve.clickable
+
+    @clickable.setter
+    def clickable(self, s):
+        self.setClickable(s)
     
     def boundingRect(self):
         return QtCore.QRectF()  ## let child items handle this

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -174,7 +174,7 @@ class PlotDataItem(GraphicsObject):
             
             'data': None,
         }
-        self.setCurvesClickable(kargs.get('clickable', False))
+        self.setCurveClickable(kargs.get('clickable', False))
         self.setData(*args, **kargs)
     
     def implements(self, interface=None):
@@ -186,10 +186,10 @@ class PlotDataItem(GraphicsObject):
     def name(self):
         return self.opts.get('name', None)
 
-    def setCurvesClickable(self, s, width=None):
+    def setCurveClickable(self, s, width=None):
         self.curve.setClickable(s, width)
 
-    def curvesClickable(self):
+    def curveClickable(self):
         return self.curve.clickable
 
     def boundingRect(self):


### PR DESCRIPTION
Currently if you attempt to set the `clickable` property of a PlotDataItem,
this property is silently ignored. The expected behavior is to set the
`clickable` property of the underlying PlotCurveItem, and to return the 
property from the PlotCurveItem.

This commit allows us to set the `clickable` property in these ways:
```
pdi = pq.PlotDataItem(...,clickable=True)
pdi.setClickable(True)
pdi.clickable = True
```
and "get" the property in this way:
```
print(pdi.clickable)
```
without referencing `pdi.curve`.