### PR TITLE
Added essential if.

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -648,6 +648,9 @@ class ScatterPlotItem(GraphicsObject):
             d = d[mask]
             d2 = d2[mask]
 
+            if d.size == 0:
+                return (None, None)
+
         if frac >= 1.0:
             self.bounds[ax] = (np.nanmin(d) - self._maxSpotWidth*0.7072, np.nanmax(d) + self._maxSpotWidth*0.7072)
             return self.bounds[ax]


### PR DESCRIPTION
When autorange is enabled and there is no dots of `ScatterPlotItem` on current scene, `np.nanmin` (line 655) throws exception as `d` is empty.