### PR TITLE
Fixed downsample inf image issue

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -368,6 +368,10 @@ class ImageItem(GraphicsObject):
             image = fn.downsample(self.image, xds, axis=axes[0])
             image = fn.downsample(image, yds, axis=axes[1])
             self._lastDownsample = (xds, yds)
+            
+            # Check if downsampling reduced the image size to zero due to inf values.
+            if image.size == 0:
+                return
         else:
             image = self.image
 
@@ -401,8 +405,7 @@ class ImageItem(GraphicsObject):
             image = image.transpose((1, 0, 2)[:image.ndim])
         
         argb, alpha = fn.makeARGB(image, lut=lut, levels=levels)
-        if argb.size > 0:
-            self.qimage = fn.makeQImage(argb, alpha, transpose=False)
+        self.qimage = fn.makeQImage(argb, alpha, transpose=False)
 
     def paint(self, p, *args):
         profile = debug.Profiler()

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -401,7 +401,8 @@ class ImageItem(GraphicsObject):
             image = image.transpose((1, 0, 2)[:image.ndim])
         
         argb, alpha = fn.makeARGB(image, lut=lut, levels=levels)
-        self.qimage = fn.makeQImage(argb, alpha, transpose=False)
+        if argb.size > 0:
+            self.qimage = fn.makeQImage(argb, alpha, transpose=False)
 
     def paint(self, p, *args):
         profile = debug.Profiler()

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -132,11 +132,7 @@ class PlotCurveItem(GraphicsObject):
             if any(np.isinf(b)):
                 mask = np.isfinite(d)
                 d = d[mask]
-                try:
-                    b = (d.min(), d.max())
-                except ValueError:
-                    # d has no size, because all of d is inf.
-                    b = (-1, 1)  # Some default bounds
+                b = (d.min(), d.max())
                 
         elif frac <= 0.0:
             raise Exception("Value for parameter 'frac' must be > 0. (got %s)" % str(frac))

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -132,7 +132,11 @@ class PlotCurveItem(GraphicsObject):
             if any(np.isinf(b)):
                 mask = np.isfinite(d)
                 d = d[mask]
-                b = (d.min(), d.max())
+                try:
+                    b = (d.min(), d.max())
+                except ValueError:
+                    # d has no size, because all of d is inf.
+                    b = (-1, 1)  # Some default bounds
                 
         elif frac <= 0.0:
             raise Exception("Value for parameter 'frac' must be > 0. (got %s)" % str(frac))


### PR DESCRIPTION
The fn.downsample function can cause an image array size to go to 0. This will cause an error in makeQImage.