### PR TITLE
Fixed legend size after remove item

### DIFF
--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -110,7 +110,8 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         #print("-------")
         for sample, label in self.items:
             height += max(sample.height(), label.height()) + 3
-            width = max(width, sample.width()+label.width())
+            width = max(width, (sample.sizeHint(QtCore.Qt.MinimumSize, sample.size()).width() +
+                                label.sizeHint(QtCore.Qt.MinimumSize, label.size()).width()))
             #print(width, height)
         #print width, height
         self.setGeometry(0, 0, width+25, height)


### PR DESCRIPTION
When the legend removed an item with a large label name the legend would not shrink in width. This fix uses the sample and label minimum width to allow the legend to shrink when an item is removed.