### PR TITLE
Prevent viewbox auto-scaling to items that are not in the same scene.

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1280,7 +1280,7 @@ class ViewBox(GraphicsWidget):
         ## First collect all boundary information
         itemBounds = []
         for item in items:
-            if not item.isVisible():
+            if not item.isVisible() or not item.scene() is self.scene():
                 continue
         
             useX = True


### PR DESCRIPTION
This can happen when an item that was previously added to the viewbox
is then removed using scene.removeItem().