### PR TITLE
Allow console exception label to wrap text

### DIFF
--- a/pyqtgraph/console/template.ui
+++ b/pyqtgraph/console/template.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>694</width>
+    <width>739</width>
     <height>497</height>
    </rect>
   </property>
@@ -153,6 +153,9 @@
         <widget class="QLabel" name="exceptionInfoLabel">
          <property name="text">
           <string>Stack Trace</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/pyqtgraph/console/template_pyqt.py
+++ b/pyqtgraph/console/template_pyqt.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'template.ui'
+# Form implementation generated from reading ui file 'pyqtgraph/console/template.ui'
 #
-# Created: Wed Apr 08 16:28:53 2015
-#      by: PyQt4 UI code generator 4.10.4
+# Created by: PyQt4 UI code generator 4.11.4
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -26,7 +25,7 @@ except AttributeError:
 class Ui_Form(object):
     def setupUi(self, Form):
         Form.setObjectName(_fromUtf8("Form"))
-        Form.resize(694, 497)
+        Form.resize(739, 497)
         self.gridLayout = QtGui.QGridLayout(Form)
         self.gridLayout.setMargin(0)
         self.gridLayout.setSpacing(0)
@@ -37,7 +36,6 @@ class Ui_Form(object):
         self.layoutWidget = QtGui.QWidget(self.splitter)
         self.layoutWidget.setObjectName(_fromUtf8("layoutWidget"))
         self.verticalLayout = QtGui.QVBoxLayout(self.layoutWidget)
-        self.verticalLayout.setMargin(0)
         self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
         self.output = QtGui.QPlainTextEdit(self.layoutWidget)
         font = QtGui.QFont()
@@ -97,6 +95,7 @@ class Ui_Form(object):
         self.runSelectedFrameCheck.setObjectName(_fromUtf8("runSelectedFrameCheck"))
         self.gridLayout_2.addWidget(self.runSelectedFrameCheck, 3, 0, 1, 7)
         self.exceptionInfoLabel = QtGui.QLabel(self.exceptionGroup)
+        self.exceptionInfoLabel.setWordWrap(True)
         self.exceptionInfoLabel.setObjectName(_fromUtf8("exceptionInfoLabel"))
         self.gridLayout_2.addWidget(self.exceptionInfoLabel, 1, 0, 1, 7)
         spacerItem = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)

--- a/pyqtgraph/console/template_pyqt5.py
+++ b/pyqtgraph/console/template_pyqt5.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file './pyqtgraph/console/template.ui'
+# Form implementation generated from reading ui file 'pyqtgraph/console/template.ui'
 #
-# Created: Wed Mar 26 15:09:29 2014
-#      by: PyQt5 UI code generator 5.0.1
+# Created by: PyQt5 UI code generator 5.5.1
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -12,7 +11,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 class Ui_Form(object):
     def setupUi(self, Form):
         Form.setObjectName("Form")
-        Form.resize(710, 497)
+        Form.resize(739, 497)
         self.gridLayout = QtWidgets.QGridLayout(Form)
         self.gridLayout.setContentsMargins(0, 0, 0, 0)
         self.gridLayout.setSpacing(0)
@@ -23,7 +22,6 @@ class Ui_Form(object):
         self.layoutWidget = QtWidgets.QWidget(self.splitter)
         self.layoutWidget.setObjectName("layoutWidget")
         self.verticalLayout = QtWidgets.QVBoxLayout(self.layoutWidget)
-        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout.setObjectName("verticalLayout")
         self.output = QtWidgets.QPlainTextEdit(self.layoutWidget)
         font = QtGui.QFont()
@@ -54,9 +52,14 @@ class Ui_Form(object):
         self.exceptionGroup = QtWidgets.QGroupBox(self.splitter)
         self.exceptionGroup.setObjectName("exceptionGroup")
         self.gridLayout_2 = QtWidgets.QGridLayout(self.exceptionGroup)
-        self.gridLayout_2.setSpacing(0)
         self.gridLayout_2.setContentsMargins(-1, 0, -1, 0)
+        self.gridLayout_2.setHorizontalSpacing(2)
+        self.gridLayout_2.setVerticalSpacing(0)
         self.gridLayout_2.setObjectName("gridLayout_2")
+        self.clearExceptionBtn = QtWidgets.QPushButton(self.exceptionGroup)
+        self.clearExceptionBtn.setEnabled(False)
+        self.clearExceptionBtn.setObjectName("clearExceptionBtn")
+        self.gridLayout_2.addWidget(self.clearExceptionBtn, 0, 6, 1, 1)
         self.catchAllExceptionsBtn = QtWidgets.QPushButton(self.exceptionGroup)
         self.catchAllExceptionsBtn.setCheckable(True)
         self.catchAllExceptionsBtn.setObjectName("catchAllExceptionsBtn")
@@ -68,24 +71,27 @@ class Ui_Form(object):
         self.onlyUncaughtCheck = QtWidgets.QCheckBox(self.exceptionGroup)
         self.onlyUncaughtCheck.setChecked(True)
         self.onlyUncaughtCheck.setObjectName("onlyUncaughtCheck")
-        self.gridLayout_2.addWidget(self.onlyUncaughtCheck, 0, 2, 1, 1)
+        self.gridLayout_2.addWidget(self.onlyUncaughtCheck, 0, 4, 1, 1)
         self.exceptionStackList = QtWidgets.QListWidget(self.exceptionGroup)
         self.exceptionStackList.setAlternatingRowColors(True)
         self.exceptionStackList.setObjectName("exceptionStackList")
-        self.gridLayout_2.addWidget(self.exceptionStackList, 2, 0, 1, 5)
+        self.gridLayout_2.addWidget(self.exceptionStackList, 2, 0, 1, 7)
         self.runSelectedFrameCheck = QtWidgets.QCheckBox(self.exceptionGroup)
         self.runSelectedFrameCheck.setChecked(True)
         self.runSelectedFrameCheck.setObjectName("runSelectedFrameCheck")
-        self.gridLayout_2.addWidget(self.runSelectedFrameCheck, 3, 0, 1, 5)
+        self.gridLayout_2.addWidget(self.runSelectedFrameCheck, 3, 0, 1, 7)
         self.exceptionInfoLabel = QtWidgets.QLabel(self.exceptionGroup)
+        self.exceptionInfoLabel.setWordWrap(True)
         self.exceptionInfoLabel.setObjectName("exceptionInfoLabel")
-        self.gridLayout_2.addWidget(self.exceptionInfoLabel, 1, 0, 1, 5)
-        self.clearExceptionBtn = QtWidgets.QPushButton(self.exceptionGroup)
-        self.clearExceptionBtn.setEnabled(False)
-        self.clearExceptionBtn.setObjectName("clearExceptionBtn")
-        self.gridLayout_2.addWidget(self.clearExceptionBtn, 0, 4, 1, 1)
+        self.gridLayout_2.addWidget(self.exceptionInfoLabel, 1, 0, 1, 7)
         spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-        self.gridLayout_2.addItem(spacerItem, 0, 3, 1, 1)
+        self.gridLayout_2.addItem(spacerItem, 0, 5, 1, 1)
+        self.label = QtWidgets.QLabel(self.exceptionGroup)
+        self.label.setObjectName("label")
+        self.gridLayout_2.addWidget(self.label, 0, 2, 1, 1)
+        self.filterText = QtWidgets.QLineEdit(self.exceptionGroup)
+        self.filterText.setObjectName("filterText")
+        self.gridLayout_2.addWidget(self.filterText, 0, 3, 1, 1)
         self.gridLayout.addWidget(self.splitter, 0, 0, 1, 1)
 
         self.retranslateUi(Form)
@@ -97,11 +103,12 @@ class Ui_Form(object):
         self.historyBtn.setText(_translate("Form", "History.."))
         self.exceptionBtn.setText(_translate("Form", "Exceptions.."))
         self.exceptionGroup.setTitle(_translate("Form", "Exception Handling"))
+        self.clearExceptionBtn.setText(_translate("Form", "Clear Stack"))
         self.catchAllExceptionsBtn.setText(_translate("Form", "Show All Exceptions"))
         self.catchNextExceptionBtn.setText(_translate("Form", "Show Next Exception"))
         self.onlyUncaughtCheck.setText(_translate("Form", "Only Uncaught Exceptions"))
         self.runSelectedFrameCheck.setText(_translate("Form", "Run commands in selected stack frame"))
-        self.exceptionInfoLabel.setText(_translate("Form", "Exception Info"))
-        self.clearExceptionBtn.setText(_translate("Form", "Clear Exception"))
+        self.exceptionInfoLabel.setText(_translate("Form", "Stack Trace"))
+        self.label.setText(_translate("Form", "Filter (regex):"))
 
 from .CmdInput import CmdInput

--- a/pyqtgraph/console/template_pyside.py
+++ b/pyqtgraph/console/template_pyside.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file './pyqtgraph/console/template.ui'
+# Form implementation generated from reading ui file 'pyqtgraph/console/template.ui'
 #
-# Created: Mon Dec 23 10:10:53 2013
-#      by: pyside-uic 0.2.14 running on PySide 1.1.2
+# Created: Tue Sep 19 09:45:18 2017
+#      by: pyside-uic 0.2.15 running on PySide 1.2.2
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -12,7 +12,7 @@ from PySide import QtCore, QtGui
 class Ui_Form(object):
     def setupUi(self, Form):
         Form.setObjectName("Form")
-        Form.resize(710, 497)
+        Form.resize(739, 497)
         self.gridLayout = QtGui.QGridLayout(Form)
         self.gridLayout.setContentsMargins(0, 0, 0, 0)
         self.gridLayout.setSpacing(0)
@@ -54,9 +54,14 @@ class Ui_Form(object):
         self.exceptionGroup = QtGui.QGroupBox(self.splitter)
         self.exceptionGroup.setObjectName("exceptionGroup")
         self.gridLayout_2 = QtGui.QGridLayout(self.exceptionGroup)
-        self.gridLayout_2.setSpacing(0)
         self.gridLayout_2.setContentsMargins(-1, 0, -1, 0)
+        self.gridLayout_2.setHorizontalSpacing(2)
+        self.gridLayout_2.setVerticalSpacing(0)
         self.gridLayout_2.setObjectName("gridLayout_2")
+        self.clearExceptionBtn = QtGui.QPushButton(self.exceptionGroup)
+        self.clearExceptionBtn.setEnabled(False)
+        self.clearExceptionBtn.setObjectName("clearExceptionBtn")
+        self.gridLayout_2.addWidget(self.clearExceptionBtn, 0, 6, 1, 1)
         self.catchAllExceptionsBtn = QtGui.QPushButton(self.exceptionGroup)
         self.catchAllExceptionsBtn.setCheckable(True)
         self.catchAllExceptionsBtn.setObjectName("catchAllExceptionsBtn")
@@ -68,24 +73,27 @@ class Ui_Form(object):
         self.onlyUncaughtCheck = QtGui.QCheckBox(self.exceptionGroup)
         self.onlyUncaughtCheck.setChecked(True)
         self.onlyUncaughtCheck.setObjectName("onlyUncaughtCheck")
-        self.gridLayout_2.addWidget(self.onlyUncaughtCheck, 0, 2, 1, 1)
+        self.gridLayout_2.addWidget(self.onlyUncaughtCheck, 0, 4, 1, 1)
         self.exceptionStackList = QtGui.QListWidget(self.exceptionGroup)
         self.exceptionStackList.setAlternatingRowColors(True)
         self.exceptionStackList.setObjectName("exceptionStackList")
-        self.gridLayout_2.addWidget(self.exceptionStackList, 2, 0, 1, 5)
+        self.gridLayout_2.addWidget(self.exceptionStackList, 2, 0, 1, 7)
         self.runSelectedFrameCheck = QtGui.QCheckBox(self.exceptionGroup)
         self.runSelectedFrameCheck.setChecked(True)
         self.runSelectedFrameCheck.setObjectName("runSelectedFrameCheck")
-        self.gridLayout_2.addWidget(self.runSelectedFrameCheck, 3, 0, 1, 5)
+        self.gridLayout_2.addWidget(self.runSelectedFrameCheck, 3, 0, 1, 7)
         self.exceptionInfoLabel = QtGui.QLabel(self.exceptionGroup)
+        self.exceptionInfoLabel.setWordWrap(True)
         self.exceptionInfoLabel.setObjectName("exceptionInfoLabel")
-        self.gridLayout_2.addWidget(self.exceptionInfoLabel, 1, 0, 1, 5)
-        self.clearExceptionBtn = QtGui.QPushButton(self.exceptionGroup)
-        self.clearExceptionBtn.setEnabled(False)
-        self.clearExceptionBtn.setObjectName("clearExceptionBtn")
-        self.gridLayout_2.addWidget(self.clearExceptionBtn, 0, 4, 1, 1)
+        self.gridLayout_2.addWidget(self.exceptionInfoLabel, 1, 0, 1, 7)
         spacerItem = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
-        self.gridLayout_2.addItem(spacerItem, 0, 3, 1, 1)
+        self.gridLayout_2.addItem(spacerItem, 0, 5, 1, 1)
+        self.label = QtGui.QLabel(self.exceptionGroup)
+        self.label.setObjectName("label")
+        self.gridLayout_2.addWidget(self.label, 0, 2, 1, 1)
+        self.filterText = QtGui.QLineEdit(self.exceptionGroup)
+        self.filterText.setObjectName("filterText")
+        self.gridLayout_2.addWidget(self.filterText, 0, 3, 1, 1)
         self.gridLayout.addWidget(self.splitter, 0, 0, 1, 1)
 
         self.retranslateUi(Form)
@@ -96,11 +104,12 @@ class Ui_Form(object):
         self.historyBtn.setText(QtGui.QApplication.translate("Form", "History..", None, QtGui.QApplication.UnicodeUTF8))
         self.exceptionBtn.setText(QtGui.QApplication.translate("Form", "Exceptions..", None, QtGui.QApplication.UnicodeUTF8))
         self.exceptionGroup.setTitle(QtGui.QApplication.translate("Form", "Exception Handling", None, QtGui.QApplication.UnicodeUTF8))
+        self.clearExceptionBtn.setText(QtGui.QApplication.translate("Form", "Clear Stack", None, QtGui.QApplication.UnicodeUTF8))
         self.catchAllExceptionsBtn.setText(QtGui.QApplication.translate("Form", "Show All Exceptions", None, QtGui.QApplication.UnicodeUTF8))
         self.catchNextExceptionBtn.setText(QtGui.QApplication.translate("Form", "Show Next Exception", None, QtGui.QApplication.UnicodeUTF8))
         self.onlyUncaughtCheck.setText(QtGui.QApplication.translate("Form", "Only Uncaught Exceptions", None, QtGui.QApplication.UnicodeUTF8))
         self.runSelectedFrameCheck.setText(QtGui.QApplication.translate("Form", "Run commands in selected stack frame", None, QtGui.QApplication.UnicodeUTF8))
         self.exceptionInfoLabel.setText(QtGui.QApplication.translate("Form", "Stack Trace", None, QtGui.QApplication.UnicodeUTF8))
-        self.clearExceptionBtn.setText(QtGui.QApplication.translate("Form", "Clear Stack", None, QtGui.QApplication.UnicodeUTF8))
+        self.label.setText(QtGui.QApplication.translate("Form", "Filter (regex):", None, QtGui.QApplication.UnicodeUTF8))
 
 from .CmdInput import CmdInput


### PR DESCRIPTION
This prevents the console window from growing if the exception message contains a very long line