### PR TITLE
Fixed AxisItem mouse drag issue

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1069,6 +1069,10 @@ class AxisItem(GraphicsWidget):
             ret = self.linkedView().mouseDragEvent(event, axis=1)
         else:
             ret = self.linkedView().mouseDragEvent(event, axis=0)
+        # Ignore event because if grid lines are enabled, we don't want the
+        # AxisItem to eat events meant for the ViewBox (see PR #565). A better
+        # solution here is to have grid lines drawn by a separate item inside the 
+        # viewbox.
         event.ignore()
         return ret
         

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1066,9 +1066,11 @@ class AxisItem(GraphicsWidget):
         if self.linkedView() is None: 
             return
         if self.orientation in ['left', 'right']:
-            return self.linkedView().mouseDragEvent(event, axis=1)
+            ret = self.linkedView().mouseDragEvent(event, axis=1)
         else:
-            return self.linkedView().mouseDragEvent(event, axis=0)
+            ret = self.linkedView().mouseDragEvent(event, axis=0)
+        event.ignore()
+        return ret
         
     def mouseClickEvent(self, event):
         if self.linkedView() is None: 


### PR DESCRIPTION
Issue where MouseDragEvent would only work for 1 AxisItem. I made it so the MouseDragEvent could propagate to other AxisItems. I had this issue by setting the ViewBox background color and changing the AxisItem ZValue to make the AxisItems visible. This made one of the AxisItems receive all of the MouseDragEvents and only one Axis would actually allow dragging. ViewBox.mouseDragEvent sets event.accept() preventing the mouse event to propagate to other AxisItems.