### PR TITLE
ArrowItem: rotate painterpath instead of the item

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+pyqtgraph-0.11.0 (in development)
+
+  API / behavior changes:
+    - ArrowItem's `angle` option now rotates the arrow without affecting its coordinate system.
+      The result is visually the same, but children of ArrowItem are no longer rotated
+      (this allows screen-aligned text to be attached more easily).
+      To mimic the old behavior, use ArrowItem.rotate() instead of the `angle` argument.
+        
+
+
 pyqtgraph-0.10.0
 
   New Features:

--- a/pyqtgraph/graphicsItems/ArrowItem.py
+++ b/pyqtgraph/graphicsItems/ArrowItem.py
@@ -39,7 +39,6 @@ class ArrowItem(QtGui.QGraphicsPathItem):
         
         self.setStyle(**defaultOpts)
         
-        self.rotate(self.opts['angle'])
         self.moveBy(*self.opts['pos'])
     
     def setStyle(self, **opts):
@@ -72,7 +71,10 @@ class ArrowItem(QtGui.QGraphicsPathItem):
         self.opts.update(opts)
         
         opt = dict([(k,self.opts[k]) for k in ['headLen', 'tipAngle', 'baseAngle', 'tailLen', 'tailWidth']])
-        self.path = fn.makeArrowPath(**opt)
+        tr = QtGui.QTransform()
+        tr.rotate(self.opts['angle'])
+        self.path = tr.map(fn.makeArrowPath(**opt))
+
         self.setPath(self.path)
         
         self.setPen(fn.mkPen(self.opts['pen']))
@@ -82,7 +84,8 @@ class ArrowItem(QtGui.QGraphicsPathItem):
             self.setFlags(self.flags() | self.ItemIgnoresTransformations)
         else:
             self.setFlags(self.flags() & ~self.ItemIgnoresTransformations)
-        
+
+
     def paint(self, p, *args):
         p.setRenderHint(QtGui.QPainter.Antialiasing)
         QtGui.QGraphicsPathItem.paint(self, p, *args)


### PR DESCRIPTION
This behavior change makes it easier to attach text to the arrow.
It does break backward compatibility a bit, but it's easy to work around by using arrow.rotate() instead.
