### PR TITLE
Fixed: items are not removed from legend

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -603,7 +603,7 @@ class PlotItem(GraphicsWidget):
             #item.sigPlotChanged.connect(self.plotChanged)
 
         if self.legend is not None:
-            self.legend.removeItem(item)
+            self.legend.removeItem(item.name())
 
     def clear(self):
         """


### PR DESCRIPTION
LegendItem.removeItem requires the name of the item to be removed as an input. However, here the entire GraphicsItem was passed instead.