### PR TITLE
Fix: InvisibleRootItem is no longer a subclass of QTreeWidgetItem

### DIFF
--- a/pyqtgraph/widgets/TreeWidget.py
+++ b/pyqtgraph/widgets/TreeWidget.py
@@ -350,7 +350,7 @@ class TreeWidgetItem(QtGui.QTreeWidgetItem):
         """
 
             
-class InvisibleRootItem(QtGui.QTreeWidgetItem):
+class InvisibleRootItem(object):
     """Wrapper around a TreeWidget's invisible root item that calls
     TreeWidget.informTreeWidgetChange when child items are added/removed.
     """


### PR DESCRIPTION
The __getattr__ method is supposed to wrap attributes from the internal TreeWidgetItem,
but this was broken because the superclass had already implemented these.