### PR TITLE
Override qAbort on slot exceptions for PyQt>=5.5

### DIFF
--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -151,6 +151,17 @@ elif QT_LIB == PYQT5:
     # We're using PyQt5 which has a different structure so we're going to use a shim to
     # recreate the Qt4 structure for Qt5
     from PyQt5 import QtGui, QtCore, QtWidgets, uic
+    
+    # PyQt5, starting in v5.5, calls qAbort when an exception is raised inside
+    # a slot. To maintain backward compatibility (and sanity for interactive
+    # users), we install a global exception hook to override this behavior.
+    ver = QtCore.PYQT_VERSION_STR.split('.')
+    if int(ver[1]) >= 5:
+        sys_excepthook = sys.excepthook
+        def pyqt5_qabort_override(*args, **kwds):
+            return sys_excepthook(*args, **kwds)
+        sys.excepthook = pyqt5_qabort_override
+    
     try:
         from PyQt5 import QtSvg
     except ImportError:


### PR DESCRIPTION
PyQt5, starting in v5.5, calls qAbort when an exception is raised inside a slot. To maintain backward compatibility (and sanity for interactive users), we install a global exception hook to override this behavior.

See: 
http://pyqt.sourceforge.net/Docs/PyQt5/incompatibilities.html#pyqt-v5-5
https://www.riverbankcomputing.com/pipermail/pyqt/2017-July/039411.html