### PR TITLE
fix: some unreadable items in dark themes

### DIFF
--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -115,7 +115,7 @@ class ConsoleWidget(QtGui.QWidget):
                 self.write("<br><b>%s</b>\n"%encCmd, html=True)
                 self.execMulti(cmd)
             else:
-                self.write("<br><div style='background-color: #CCF'><b>%s</b>\n"%encCmd, html=True)
+                self.write("<br><div style='background-color: #CCF; color: black'><b>%s</b>\n"%encCmd, html=True)
                 self.inCmd = True
                 self.execSingle(cmd)
             
@@ -209,7 +209,7 @@ class ConsoleWidget(QtGui.QWidget):
         else:
             if self.inCmd:
                 self.inCmd = False
-                self.output.textCursor().insertHtml("</div><br><div style='font-weight: normal; background-color: #FFF;'>")
+                self.output.textCursor().insertHtml("</div><br><div style='font-weight: normal; background-color: #FFF; color: black'>")
                 #self.stdout.write("</div><br><div style='font-weight: normal; background-color: #FFF;'>")
             self.output.insertPlainText(strn)
         #self.stdout.write(strn)
@@ -366,6 +366,7 @@ class ConsoleWidget(QtGui.QWidget):
         self.ui.exceptionStackList.addItem('-- exception caught here: --')
         item = self.ui.exceptionStackList.item(self.ui.exceptionStackList.count()-1)
         item.setBackground(QtGui.QBrush(QtGui.QColor(200, 200, 200)))
+        item.setForeground(QtGui.QBrush(QtGui.QColor(50, 50, 50)))
         self.frames.append(None)
 
         # And finish the rest of the stack up to the exception

--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -400,6 +400,7 @@ class GroupParameterItem(ParameterItem):
         else:
             for c in [0,1]:
                 self.setBackground(c, QtGui.QBrush(QtGui.QColor(220,220,220)))
+                self.setForeground(c, QtGui.QBrush(QtGui.QColor(100,100,100)))
                 font = self.font(c)
                 font.setBold(True)
                 #font.setPointSize(font.pointSize()+1)


### PR DESCRIPTION
The problem:
on KDE5 breeze dark theme few pyqtgraph items are not readable. I think the problem is not only on KDE5, but apparently could be seen on win10? It is caused by statically set background color, supposing that default font color is black, but that is not the case when OS uses dark theme/skins.
Two items were identified: 
1. subgroup items in parameter tree:
![parameter_tree1](https://user-images.githubusercontent.com/12324068/31823698-39433818-b5ad-11e7-993e-d487244c060a.png)
2. console output:
![console_foreground](https://user-images.githubusercontent.com/12324068/31823817-a23c5048-b5ad-11e7-9f1a-f8b16e905b22.png)

Fix:
The foreground color of these items is statically set.
