### PR TITLE
Update ImageItem.py

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -329,7 +329,7 @@ class ImageItem(GraphicsObject):
             sl = [slice(None)] * data.ndim
             sl[ax] = slice(None, None, 2)
             data = data[sl]
-        return nanmin(data), nanmax(data)
+        return np.nanmin(data), np.nanmax(data)
 
     def updateImage(self, *args, **kargs):
         ## used for re-rendering qimage from self.image.


### PR DESCRIPTION
Functions nanmin and nanmax are defined in the numpy module and cannot be accessed from the global namespace. An exception is raised each time the code in ImageItem:331 is executed.