### PR TITLE
Avoid raising a general Exception for Dock

### DIFF
--- a/pyqtgraph/dockarea/Container.py
+++ b/pyqtgraph/dockarea/Container.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from ..Qt import QtCore, QtGui
 import weakref
+from .DockError import DockError
 
 class Container(object):
     #sigStretchChanged = QtCore.Signal()  ## can't do this here; not a QObject.
@@ -233,7 +234,7 @@ class TContainer(Container, QtGui.QWidget):
 
     def _insertItem(self, item, index):
         if not isinstance(item, Dock.Dock):
-            raise Exception("Tab containers may hold only docks, not other containers.")
+            raise DockError("Tab containers may hold only docks, not other containers.")
         self.stack.insertWidget(index, item)
         self.hTabLayout.insertWidget(index, item.label)
         #QtCore.QObject.connect(item.label, QtCore.SIGNAL('clicked'), self.tabClicked)

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -1,8 +1,10 @@
 from ..Qt import QtCore, QtGui
 
 from .DockDrop import *
+from .DockError import DockError
 from ..widgets.VerticalLabel import VerticalLabel
 from ..python2_3 import asUnicode
+
 
 class Dock(QtGui.QWidget, DockDrop):
     

--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -4,8 +4,10 @@ from ..Qt import QtCore, QtGui
 from .Container import *
 from .DockDrop import *
 from .Dock import Dock
+from .DockError import DockError
 from .. import debug as debug
 from ..python2_3 import basestring
+from . import DockError
 
 
 class DockArea(Container, QtGui.QWidget, DockDrop):
@@ -62,7 +64,7 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
                 relativeTo = self.docks[relativeTo]
             container = self.getContainer(relativeTo)
             if container is None:
-                raise TypeError("Dock %s is not contained in a DockArea; cannot add another dock relative to it." % relativeTo)
+                raise DockError("Dock %s is not contained in a DockArea; cannot add another dock relative to it." % relativeTo)
             neighbor = relativeTo
         
         ## what container type do we need?
@@ -264,13 +266,13 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
                 del docks[contents]
             except KeyError:
                 if missing == 'error':
-                    raise Exception('Cannot restore dock state; no dock with name "%s"' % contents)
+                    raise DockError('Cannot restore dock state; no dock with name "%s"' % contents)
                 elif missing == 'create':
                     obj = Dock(name=contents)
                 elif missing == 'ignore':
                     return
                 else:
-                    raise ValueError('"missing" argument must be one of "error", "create", or "ignore".')
+                    raise DockError('"missing" argument must be one of "error", "create", or "ignore".')
 
         else:
             obj = self.makeContainer(typ)

--- a/pyqtgraph/dockarea/DockError.py
+++ b/pyqtgraph/dockarea/DockError.py
@@ -1,0 +1,2 @@
+class DockError(Exception):
+    pass

--- a/pyqtgraph/dockarea/__init__.py
+++ b/pyqtgraph/dockarea/__init__.py
@@ -1,2 +1,3 @@
 from .DockArea import DockArea
 from .Dock import Dock
+from .DockError import DockError


### PR DESCRIPTION
It is not very pythonic to raise just a general Exception whenever an error appears. Here, for Dock, we define a DockError class, which is always raised whenever there is an exception, which makes it much easier to catch.