### PR TITLE
Infrastructure Fixes: ParameterError where due, type safety for SimpleParameter

### DIFF
--- a/pyqtgraph/graphicsWindows.py
+++ b/pyqtgraph/graphicsWindows.py
@@ -31,7 +31,7 @@ class GraphicsWindow(GraphicsLayoutWidget):
         if title is not None:
             self.setWindowTitle(title)
         self.show()
-        
+
 
 class TabWindow(QtGui.QMainWindow):
     def __init__(self, title=None, size=(800,600)):
@@ -43,13 +43,13 @@ class TabWindow(QtGui.QMainWindow):
         if title is not None:
             self.setWindowTitle(title)
         self.show()
-        
+
     def __getattr__(self, attr):
         if hasattr(self.cw, attr):
             return getattr(self.cw, attr)
         else:
-            raise NameError(attr)
-    
+            raise AttributeError(attr)
+
 
 class PlotWindow(PlotWidget):
     def __init__(self, title=None, **kargs):

--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -297,7 +297,12 @@ class EventProxy(QtCore.QObject):
 
 class SimpleParameter(Parameter):
     itemClass = WidgetParameterItem
-    
+    _type_mapping = {
+        'int' : int,
+        'float' : float,
+        'bool' : bool,
+        'str' : str
+    }
     def __init__(self, *args, **kargs):
         Parameter.__init__(self, *args, **kargs)
         
@@ -305,6 +310,8 @@ class SimpleParameter(Parameter):
         if self.opts['type'] == 'color':
             self.value = self.colorValue
             self.saveState = self.saveColorState
+        elif self.opts['type'] in self._type_mapping.keys():
+            self.value = lambda: self._type_mapping[self.opts['type']](Parameter.value(self))
     
     def colorValue(self):
         return fn.mkColor(Parameter.value(self))
@@ -315,13 +322,10 @@ class SimpleParameter(Parameter):
         return state
         
     
-registerParameterType('int', SimpleParameter, override=True)
-registerParameterType('float', SimpleParameter, override=True)
-registerParameterType('bool', SimpleParameter, override=True)
-registerParameterType('str', SimpleParameter, override=True)
 registerParameterType('color', SimpleParameter, override=True)
 registerParameterType('colormap', SimpleParameter, override=True)
-
+for type_ in SimpleParameter._type_mapping.keys():
+    registerParameterType(type_, SimpleParameter, override=True)
 
 
 

--- a/pyqtgraph/widgets/PlotWidget.py
+++ b/pyqtgraph/widgets/PlotWidget.py
@@ -76,7 +76,7 @@ class PlotWidget(GraphicsView):
             m = getattr(self.plotItem, attr)
             if hasattr(m, '__call__'):
                 return m
-        raise NameError(attr)
+        raise AttributeError(attr)
     
     def viewRangeChanged(self, view, range):
         #self.emit(QtCore.SIGNAL('viewChanged'), *args)
@@ -94,6 +94,3 @@ class PlotWidget(GraphicsView):
     def getPlotItem(self):
         """Return the PlotItem contained within."""
         return self.plotItem
-        
-        
-        


### PR DESCRIPTION
The need for this patch (and the addition of the Qt import) arose during trying
to make Jupyter Notebooks work with pyqtgraph. Since these belong in the area
of infrastructure fixing rather than forward dev, PR'ing against master.

The PR containing rudimentary Notebook integration will be done separately
against develop.