### PR TITLE
fix an error type in the cleanup function

### DIFF
--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -320,7 +320,7 @@ def cleanup():
                         'are properly called before app shutdown (%s)\n' % (o,))
                 
                 s.addItem(o)
-        except RuntimeError:  ## occurs if a python wrapper no longer has its underlying C++ object
+        except ReferenceError:  ## occurs if a python wrapper no longer has its underlying C++ object
             continue
     _cleanupCalled = True
 


### PR DESCRIPTION
Fix the error type from RuntimeError to ReferenceError in the cleanup function.

A problem happened when try to use both pyqtgraph and tensorflow at a same time This was reported on [PyQtGraph tries to put TensorFlow stuff onto a QGraphicsScene() on cleanup](https://stackoverflow.com/questions/41542571/pyqtgraph-tries-to-put-tensorflow-stuff-onto-a-qgraphicsscene-on-cleanup)

Here is minimal code (from above post) that cause a following error message when closing the app.

----
```
from PyQt5 import QtGui
import tensorflow as tf
import pyqtgraph as pg


app = QtGui.QApplication([])
wnd = QtGui.QWidget()
wnd.show()
app.exec_()
```

_Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "~\anaconda3\lib\site-packages\pyqtgraph\__init__.py", line 312, in cleanup
    if isinstance(o, QtGui.QGraphicsItem) and isQObjectAlive(o) and o.scene() is None:
ReferenceError: weakly-referenced object no longer exists_
