### PR TITLE
Prevent ReferenceErrors on cleanup

### DIFF
--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -320,7 +320,7 @@ def cleanup():
                         'are properly called before app shutdown (%s)\n' % (o,))
                 
                 s.addItem(o)
-        except RuntimeError:  ## occurs if a python wrapper no longer has its underlying C++ object
+        except (RuntimeError, ReferenceError):  ## occurs if a python wrapper no longer has its underlying C++ object
             continue
     _cleanupCalled = True
 


### PR DESCRIPTION
Prevents a ReferenceError being thrown when PyQtGraph tries to put TensorFlow stuff onto a QGraphicsScene() on cleanup - see https://github.com/pyqtgraph/pyqtgraph/issues/603 and https://stackoverflow.com/questions/41542571/pyqtgraph-tries-to-put-tensorflow-stuff-onto-a-qgraphicsscene-on-cleanup