### PR TITLE
ROI.py, getArrayRegion: Fix return mapped coordinates

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -1631,16 +1631,25 @@ class EllipseROI(ROI):
         
         p.drawEllipse(r)
         
-    def getArrayRegion(self, arr, img=None, axes=(0, 1), **kwds):
+    def getArrayRegion(self, arr, img=None, axes=(0, 1),
+                       returnMappedCoords=False, **kwds):
         """
         Return the result of ROI.getArrayRegion() masked by the elliptical shape
         of the ROI. Regions outside the ellipse are set to 0.
         """
         # Note: we could use the same method as used by PolyLineROI, but this
         # implementation produces a nicer mask.
-        arr = ROI.getArrayRegion(self, arr, img, axes, **kwds)
+        if returnMappedCoords:
+           arr, mappedCoords = ROI.getArrayRegion(self, arr, img, axes,
+                                                  returnMappedCoords, **kwds)
+        else:
+           arr = ROI.getArrayRegion(self, arr, img, axes,
+                                    returnMappedCoords, **kwds)
         if arr is None or arr.shape[axes[0]] == 0 or arr.shape[axes[1]] == 0:
-            return arr
+            if returnMappedCoords:
+                return arr, mappedCoords
+            else:
+                return arr
         w = arr.shape[axes[0]]
         h = arr.shape[axes[1]]
 
@@ -1653,7 +1662,10 @@ class EllipseROI(ROI):
         shape = [(n if i in axes else 1) for i,n in enumerate(arr.shape)]
         mask = mask.reshape(shape)
         
-        return arr * mask
+        if returnMappedCoords:
+            return arr * mask, mappedCoords
+        else:
+            return arr * mask
     
     def shape(self):
         if self.path is None:

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -1926,7 +1926,8 @@ class PolyLineROI(ROI):
         p.lineTo(self.handles[0]['item'].pos())
         return p
 
-    def getArrayRegion(self, data, img, axes=(0,1), **kwds):
+    def getArrayRegion(self, data, img, axes=(0,1),
+                       returnMappedCoords=False, **kwds):
         """
         Return the result of ROI.getArrayRegion(), masked by the shape of the 
         ROI. Values outside the ROI shape are set to 0.
@@ -1934,7 +1935,15 @@ class PolyLineROI(ROI):
         br = self.boundingRect()
         if br.width() > 1000:
             raise Exception()
-        sliced = ROI.getArrayRegion(self, data, img, axes=axes, fromBoundingRect=True, **kwds)
+        if returnMappedCoords:
+            sliced, mappedCoords = ROI.getArrayRegion(self, data, img, axes,
+                                                      returnMappedCoords,
+                                                      fromBoundingRect=True,
+                                                      **kwds)
+        else:
+            sliced = ROI.getArrayRegion(self, data, img, axes,
+                                        returnMappedCoords,
+                                        fromBoundingRect=True, **kwds)
         
         if img.axisOrder == 'col-major':
             mask = self.renderShapeMask(sliced.shape[axes[0]], sliced.shape[axes[1]])
@@ -1948,7 +1957,10 @@ class PolyLineROI(ROI):
         shape[axes[1]] = sliced.shape[axes[1]]
         mask = mask.reshape(shape)
 
-        return sliced * mask
+        if returnMappedCoords:
+            return sliced * mask, mappedCoords
+        else:
+            return sliced * mask
 
     def setPen(self, *args, **kwds):
         ROI.setPen(self, *args, **kwds)


### PR DESCRIPTION
The *getArrayRegion* method is defined as returning a tuple of the points
in the selected region and the mapped coordinates if the
*returnMappedCoords* keyword argument is set to True in the parent class
*ROI*.

In the *EllipseROI* and *PolyLineROI* classes, *getArrayRegion* was overriden,
however it ignores the *returnMappedCoords* keyword argument, leading to
unintended bugs because of the change in interface between the parent class and
the subclass.

This patch fixes the above bug.
If *returnMappedCoords* is set to False, then only *arr* containing the
array region is returned. If *returnMappedCoords* is set to True, a
tuple of the array region and the mapped coordinates is returned.

EDIT: Fixed the same bug for PolyLineROI.

@campagnola Do you require unit tests? I wanted to write some but I gave up for now as I cannot get unit tests to succeed in my environment (maybe I missed something in the setup):

```
$ python --version
Python 3.6.3
$ pip --version
pip 9.0.1 from /home/malik/workspace/pyqtgraph/venv/lib/python3.6/site-packages (python 3.6)
$ pip freeze
apipkg==1.4
attrs==17.4.0
coverage==4.4.2
execnet==1.5.0
numpy==1.14.0
pkg-resources==0.0.0
pluggy==0.6.0
py==1.5.2
PyQt5==5.9.2
pytest==3.3.2
pytest-cov==2.5.1
pytest-forked==0.2
pytest-xdist==1.22.0
scipy==1.0.0
sip==4.19.6
six==1.11.0
$ py.test
7 failed, 24 passed, 129 skipped in 4.04 seconds
```