### PR TITLE
Fix spinbox units

### DIFF
--- a/examples/SpinBox.py
+++ b/examples/SpinBox.py
@@ -26,7 +26,7 @@ spins = [
     ("Float with SI-prefixed units<br>(n, u, m, k, M, etc)", 
      pg.SpinBox(value=0.9, suffix='V', siPrefix=True)),
     ("Float with SI-prefixed units,<br>dec step=0.1, minStep=0.1", 
-     pg.SpinBox(value=1.0, suffix='V', siPrefix=True, dec=True, step=0.1, minStep=0.1)),
+     pg.SpinBox(value=1.0, suffix='PSI', siPrefix=True, dec=True, step=0.1, minStep=0.1)),
     ("Float with SI-prefixed units,<br>dec step=0.5, minStep=0.01", 
      pg.SpinBox(value=1.0, suffix='V', siPrefix=True, dec=True, step=0.5, minStep=0.01)),
     ("Float with SI-prefixed units,<br>dec step=1.0, minStep=0.001", 

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -518,7 +518,7 @@ class SpinBox(QtGui.QAbstractSpinBox):
         
         # tokenize into numerical value, si prefix, and suffix
         try:
-            val, siprefix, suffix = fn.siParse(strn, self.opts['regex'])
+            val, siprefix, suffix = fn.siParse(strn, self.opts['regex'], suffix=self.opts['suffix'])
         except Exception:
             return False
             

--- a/pyqtgraph/widgets/tests/test_spinbox.py
+++ b/pyqtgraph/widgets/tests/test_spinbox.py
@@ -18,6 +18,8 @@ def test_spinbox_formatting():
         (12345678955, '12345678955', dict(int=True, decimals=100)),
         (1.45e-9, '1.45e-09 A', dict(int=False, decimals=6, suffix='A', siPrefix=False)),
         (1.45e-9, '1.45 nA', dict(int=False, decimals=6, suffix='A', siPrefix=True)),
+        (1.45, '1.45 PSI', dict(int=False, decimals=6, suffix='PSI', siPrefix=True)),
+        (1.45e-3, '1.45 mPSI', dict(int=False, decimals=6, suffix='PSI', siPrefix=True)),
         (-2500.3427, '$-2500.34', dict(int=False, format='${value:0.02f}')),
     ]
     
@@ -26,3 +28,14 @@ def test_spinbox_formatting():
         sb.setValue(value)
         assert sb.value() == value
         assert pg.asUnicode(sb.text()) == text
+
+        # test setting value
+        if not opts.get('int', False):
+            suf = sb.opts['suffix']
+            sb.lineEdit().setText('0.1' + suf)
+            sb.editingFinishedEvent()
+            assert sb.value() == 0.1
+            if suf != '':
+                sb.lineEdit().setText('0.1 m' + suf)
+                sb.editingFinishedEvent()
+                assert sb.value() == 0.1e-3


### PR DESCRIPTION
Fixes bug where spinbox value cannot be edited if the suffix begins with a letter that is also an SI prefix (for example, 'PSI')