### PR TITLE
Replace deprecate class in examples

### DIFF
--- a/examples/CustomGraphItem.py
+++ b/examples/CustomGraphItem.py
@@ -12,7 +12,7 @@ import numpy as np
 # Enable antialiasing for prettier plots
 pg.setConfigOptions(antialias=True)
 
-w = pg.GraphicsWindow()
+w = pg.GraphicsLayoutWidget(show=True)
 w.setWindowTitle('pyqtgraph example: CustomGraphItem')
 v = w.addViewBox()
 v.setAspectLocked()

--- a/examples/GraphItem.py
+++ b/examples/GraphItem.py
@@ -13,7 +13,7 @@ import numpy as np
 # Enable antialiasing for prettier plots
 pg.setConfigOptions(antialias=True)
 
-w = pg.GraphicsWindow()
+w = pg.GraphicsLayoutWidget(show=True)
 w.setWindowTitle('pyqtgraph example: GraphItem')
 v = w.addViewBox()
 v.setAspectLocked()

--- a/examples/InfiniteLine.py
+++ b/examples/InfiniteLine.py
@@ -10,7 +10,7 @@ import pyqtgraph as pg
 
 
 app = QtGui.QApplication([])
-win = pg.GraphicsWindow(title="Plotting items examples")
+win = pg.GraphicsLayoutWidget(show=True, title="Plotting items examples")
 win.resize(1000,600)
 
 # Enable antialiasing for prettier plots

--- a/examples/LogPlotTest.py
+++ b/examples/LogPlotTest.py
@@ -12,7 +12,7 @@ import pyqtgraph as pg
 
 app = QtGui.QApplication([])
 
-win = pg.GraphicsWindow(title="Basic plotting examples")
+win = pg.GraphicsLayoutWidget(show=True, title="Basic plotting examples")
 win.resize(1000,600)
 win.setWindowTitle('pyqtgraph example: LogPlotTest')
 

--- a/examples/PanningPlot.py
+++ b/examples/PanningPlot.py
@@ -9,7 +9,7 @@ import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
 import numpy as np
 
-win = pg.GraphicsWindow()
+win = pg.GraphicsLayoutWidget(show=True)
 win.setWindowTitle('pyqtgraph example: PanningPlot')
 
 plt = win.addPlot()

--- a/examples/PlotAutoRange.py
+++ b/examples/PlotAutoRange.py
@@ -16,7 +16,7 @@ app = QtGui.QApplication([])
 #mw = QtGui.QMainWindow()
 #mw.resize(800,800)
 
-win = pg.GraphicsWindow(title="Plot auto-range examples")
+win = pg.GraphicsLayoutWidget(show=True, title="Plot auto-range examples")
 win.resize(800,600)
 win.setWindowTitle('pyqtgraph example: PlotAutoRange')
 

--- a/examples/Plotting.py
+++ b/examples/Plotting.py
@@ -17,7 +17,7 @@ app = QtGui.QApplication([])
 #mw = QtGui.QMainWindow()
 #mw.resize(800,800)
 
-win = pg.GraphicsWindow(title="Basic plotting examples")
+win = pg.GraphicsLayoutWidget(show=True, title="Basic plotting examples")
 win.resize(1000,600)
 win.setWindowTitle('pyqtgraph example: Plotting')
 

--- a/examples/ROIExamples.py
+++ b/examples/ROIExamples.py
@@ -33,7 +33,7 @@ arr[8:13, 44:46] = 10
 
 ## create GUI
 app = QtGui.QApplication([])
-w = pg.GraphicsWindow(size=(1000,800), border=True)
+w = pg.GraphicsLayoutWidget(show=True, size=(1000,800), border=True)
 w.setWindowTitle('pyqtgraph example: ROI Examples')
 
 text = """Data Selection From Image.<br>\n

--- a/examples/ROItypes.py
+++ b/examples/ROItypes.py
@@ -13,7 +13,7 @@ pg.setConfigOptions(imageAxisOrder='row-major')
 ## create GUI
 app = QtGui.QApplication([])
 
-w = pg.GraphicsWindow(size=(800,800), border=True)
+w = pg.GraphicsLayoutWidget(show=True, size=(800,800), border=True)
 v = w.addViewBox(colspan=2)
 v.invertY(True)  ## Images usually have their Y-axis pointing downward
 v.setAspectLocked(True)

--- a/examples/ScaleBar.py
+++ b/examples/ScaleBar.py
@@ -9,7 +9,7 @@ from pyqtgraph.Qt import QtCore, QtGui
 import numpy as np
 
 pg.mkQApp()
-win = pg.GraphicsWindow()
+win = pg.GraphicsLayoutWidget(show=True)
 win.setWindowTitle('pyqtgraph example: ScaleBar')
 
 vb = win.addViewBox()

--- a/examples/Symbols.py
+++ b/examples/Symbols.py
@@ -11,7 +11,7 @@ from pyqtgraph.Qt import QtGui, QtCore
 import pyqtgraph as pg
 
 app = QtGui.QApplication([])
-win = pg.GraphicsWindow(title="Scatter Plot Symbols")
+win = pg.GraphicsLayoutWidget(show=True, title="Scatter Plot Symbols")
 win.resize(1000,600)
 
 pg.setConfigOptions(antialias=True)

--- a/examples/ViewBoxFeatures.py
+++ b/examples/ViewBoxFeatures.py
@@ -16,7 +16,7 @@ x = np.arange(1000, dtype=float)
 y = np.random.normal(size=1000)
 y += 5 * np.sin(x/100) 
 
-win = pg.GraphicsWindow()
+win = pg.GraphicsLayoutWidget(show=True)
 win.setWindowTitle('pyqtgraph example: ____')
 win.resize(1000, 800)
 win.ci.setBorder((50, 50, 100))

--- a/examples/contextMenu.py
+++ b/examples/contextMenu.py
@@ -14,7 +14,7 @@ import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
 import numpy as np
 
-win = pg.GraphicsWindow()
+win = pg.GraphicsLayoutWidget(show=True)
 win.setWindowTitle('pyqtgraph example: context menu')
 
 

--- a/examples/crosshair.py
+++ b/examples/crosshair.py
@@ -13,7 +13,7 @@ from pyqtgraph.Point import Point
 
 #generate layout
 app = QtGui.QApplication([])
-win = pg.GraphicsWindow()
+win = pg.GraphicsLayoutWidget(show=True)
 win.setWindowTitle('pyqtgraph example: crosshair')
 label = pg.LabelItem(justify='right')
 win.addItem(label)

--- a/examples/histogram.py
+++ b/examples/histogram.py
@@ -8,7 +8,7 @@ import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
 import numpy as np
 
-win = pg.GraphicsWindow()
+win = pg.GraphicsLayoutWidget(show=True)
 win.resize(800,350)
 win.setWindowTitle('pyqtgraph example: Histogram')
 plt1 = win.addPlot()

--- a/examples/isocurve.py
+++ b/examples/isocurve.py
@@ -20,7 +20,7 @@ data = np.concatenate([data, data], axis=0)
 data = pg.gaussianFilter(data, (10, 10, 10))[frames/2:frames + frames/2]
 data[:, 15:16, 15:17] += 1
 
-win = pg.GraphicsWindow()
+win = pg.GraphicsLayoutWidget(show=True)
 win.setWindowTitle('pyqtgraph example: Isocurve')
 vb = win.addViewBox()
 img = pg.ImageItem(data[0])

--- a/examples/linkedViews.py
+++ b/examples/linkedViews.py
@@ -20,7 +20,7 @@ app = QtGui.QApplication([])
 x = np.linspace(-50, 50, 1000)
 y = np.sin(x) / x
 
-win = pg.GraphicsWindow(title="pyqtgraph example: Linked Views")
+win = pg.GraphicsLayoutWidget(show=True, title="pyqtgraph example: Linked Views")
 win.resize(800,600)
 
 win.addLabel("Linked Views", colspan=2)

--- a/examples/logAxis.py
+++ b/examples/logAxis.py
@@ -11,7 +11,7 @@ import pyqtgraph as pg
 
 app = QtGui.QApplication([])
 
-w = pg.GraphicsWindow()
+w = pg.GraphicsLayoutWidget(show=True)
 w.setWindowTitle('pyqtgraph example: logAxis')
 p1 = w.addPlot(0,0, title="X Semilog")
 p2 = w.addPlot(1,0, title="Y Semilog")

--- a/examples/optics_demos.py
+++ b/examples/optics_demos.py
@@ -17,7 +17,7 @@ from pyqtgraph import Point
 
 app = pg.QtGui.QApplication([])
 
-w = pg.GraphicsWindow(border=0.5)
+w = pg.GraphicsLayoutWidget(show=True, border=0.5)
 w.resize(1000, 900)
 w.show()
 

--- a/examples/scrollingPlots.py
+++ b/examples/scrollingPlots.py
@@ -8,7 +8,7 @@ import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
 import numpy as np
 
-win = pg.GraphicsWindow()
+win = pg.GraphicsLayoutWidget(show=True)
 win.setWindowTitle('pyqtgraph example: Scrolling Plots')
 
 


### PR DESCRIPTION
Using class GraphicsLayoutWidget to replace the deprecated class GraphicsWindow, cc #631.