### PR TITLE
SVGExporter: fix axes position and scale

### DIFF
--- a/pyqtgraph/exporters/SVGExporter.py
+++ b/pyqtgraph/exporters/SVGExporter.py
@@ -169,7 +169,7 @@ def _generateItemSvg(item, nodes=None, root=None):
         buf = QtCore.QBuffer(arr)
         svg = QtSvg.QSvgGenerator()
         svg.setOutputDevice(buf)
-        dpi = QtGui.QDesktopWidget().physicalDpiX()
+        dpi = QtGui.QDesktopWidget().logicalDpiX()
         svg.setResolution(dpi)
 
         p = QtGui.QPainter()


### PR DESCRIPTION
Fixes problems with non-aligning axes on Qt5 svg exports.  In the output svg, the axes were (individually) scaled for physical/logical ration.

The export still works well in on Qt4. I suspect there were no problems there, because, at least on my machine (Ubuntu 14.04), logical and physical dpis return the same value.