### PR TITLE
SVG export: handle Qt.NoPen on Qt5

### DIFF
--- a/pyqtgraph/exporters/SVGExporter.py
+++ b/pyqtgraph/exporters/SVGExporter.py
@@ -372,7 +372,7 @@ def correctCoordinates(node, defs, item):
                     ch.setAttribute('font-family', ', '.join([f if ' ' not in f else '"%s"'%f for f in families]))
                 
             ## correct line widths if needed
-            if removeTransform and ch.getAttribute('vector-effect') != 'non-scaling-stroke':
+            if removeTransform and ch.getAttribute('vector-effect') != 'non-scaling-stroke' and grp.getAttribute('stroke-width'):
                 w = float(grp.getAttribute('stroke-width'))
                 s = fn.transformCoordinates(tr, np.array([[w,0], [0,0]]), transpose=True)
                 w = ((s[0]-s[1])**2).sum()**0.5


### PR DESCRIPTION
Example code that used to crash on Qt5:

```
from PyQt5.QtWidgets import QApplication
from PyQt5.QtGui import QPen
from PyQt5.QtCore import Qt

import pyqtgraph as pg
from pyqtgraph.exporters.SVGExporter import SVGExporter


if __name__ == '__main__':
    app = QApplication([])
    win = pg.GraphicsWindow()
    win.resize(300, 300)
    p1 = win.addPlot()
    p1.plot(x=[1, 10], y=[1, 10], pen=QPen(Qt.NoPen))
    exporter = SVGExporter(p1)
    exporter.export("test2.svg")
```