### PR TITLE
ScatterPlotItem: Fix a GC memory leak due to numpy issue 6581

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -857,10 +857,17 @@ class SpotItem(object):
     def __init__(self, data, plot):
         #GraphicsItem.__init__(self, register=False)
         self._data = data
-        self._plot = plot
+        # SpotItems are kept in plot.data["items"] numpy object array which
+        # does not support cyclic garbage collection (numpy issue 6581).
+        # Keeping a strong ref to plot here would leak the cycle
+        self.__plot_ref = weakref.ref(plot)
         #self.setParentItem(plot)
         #self.setPos(QtCore.QPointF(data['x'], data['y']))
         #self.updateItem()
+
+    @property
+    def _plot(self):
+        return self.__plot_ref()
 
     def data(self):
         """Return the user data associated with this spot."""


### PR DESCRIPTION
Accessing ``ScatterPlotItem.points` causes that instance to persist in memory indefinitely

```python
import gc

from PyQt5.QtWidgets import QApplication
from pyqtgraph import ScatterPlotItem

app = QApplication([])

sp = ScatterPlotItem(x=[1, 2], y=[1, 2], data=[42, 43])
sp.points()  # fill in data["items"]

del sp

gc.collect()

print([o for o in gc.get_objects() if isinstance(o, ScatterPlotItem)])
```

The cause is that `data` numpy array with object fields contains reference cycles back to itself (via a SpotItem._plot), but numpy does not support cyclic gc for object arrays ([numpy issue 6581](https://github.com/numpy/numpy/issues/6581)).

Fixed by taking a weak reference to `plot` in `SpotItem`
