### PR TITLE
When a floating Dock window is closed, the dock is now returned home

### DIFF
--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -46,6 +46,10 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
         """
         if dock is None:
             dock = Dock(**kwds)
+            
+        # store original area that the dock will return to when un-floated
+        if not self.temporary:
+            dock.orig_area = self
         
         
         ## Determine the container to insert this dock into.
@@ -371,5 +375,11 @@ class TempAreaWindow(QtGui.QWidget):
         self.layout.addWidget(area)
 
     def closeEvent(self, *args):
+        # restore docks to their original area
+        docks = self.dockarea.findAll()[1]
+        for dock in docks.values():
+            if hasattr(dock, 'orig_area'):
+                dock.orig_area.addDock(dock, )
+        # clear dock area, and close remaining docks
         self.dockarea.clear()
         QtGui.QWidget.closeEvent(self, *args)


### PR DESCRIPTION
When a Dock is floated by double clicking on the label, it pops into a new window. However when that window is closed the dock is closed rather than restored to its original DockArea. This can be a problem especially for Docks that are not supposed to be closed (and have the closable flag False).
This PR places the floated Dock back to its original area upon TempAreaWindow close.