### PR TITLE
examples: use integer division in indexing

### DIFF
--- a/examples/GLImageItem.py
+++ b/examples/GLImageItem.py
@@ -26,9 +26,9 @@ data += pg.gaussianFilter(np.random.normal(size=shape), (15,15,15))*15
 
 ## slice out three planes, convert to RGBA for OpenGL texture
 levels = (-0.08, 0.08)
-tex1 = pg.makeRGBA(data[shape[0]/2], levels=levels)[0]       # yz plane
-tex2 = pg.makeRGBA(data[:,shape[1]/2], levels=levels)[0]     # xz plane
-tex3 = pg.makeRGBA(data[:,:,shape[2]/2], levels=levels)[0]   # xy plane
+tex1 = pg.makeRGBA(data[shape[0]//2], levels=levels)[0]       # yz plane
+tex2 = pg.makeRGBA(data[:,shape[1]//2], levels=levels)[0]     # xz plane
+tex3 = pg.makeRGBA(data[:,:,shape[2]//2], levels=levels)[0]   # xy plane
 #tex1[:,:,3] = 128
 #tex2[:,:,3] = 128
 #tex3[:,:,3] = 128

--- a/examples/isocurve.py
+++ b/examples/isocurve.py
@@ -17,7 +17,7 @@ app = QtGui.QApplication([])
 frames = 200
 data = np.random.normal(size=(frames,30,30), loc=0, scale=100)
 data = np.concatenate([data, data], axis=0)
-data = pg.gaussianFilter(data, (10, 10, 10))[frames/2:frames + frames/2]
+data = pg.gaussianFilter(data, (10, 10, 10))[frames//2:frames + frames//2]
 data[:, 15:16, 15:17] += 1
 
 win = pg.GraphicsLayoutWidget(show=True)


### PR DESCRIPTION
This fixes an error that I saw in the examples while evalulating pyqtgraph.

In python3 `/` operator produces a float, which is not a valid index.
Replace with `//` integer division.

Here are the errors that this fixes under python3:
```
Traceback (most recent call last):
  File "/home/ilyak/work/pyvenv3.5/lib/python3.5/site-packages/pyqtgraph/examples/isocurve.py", line 20, in <module>
    data = pg.gaussianFilter(data, (10, 10, 10))[frames/2:frames + frames/2]
TypeError: slice indices must be integers or None or have an __index__ method

...

Traceback (most recent call last):
  File "/home/ilyak/work/pyvenv3.5/lib/python3.5/site-packages/pyqtgraph/examples/GLImageItem.py", line 29, in <module>
    tex1 = pg.makeRGBA(data[shape[0]/2], levels=levels)[0]       # yz plane
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```