### PR TITLE
Fix overflow in Point.length()

### DIFF
--- a/pyqtgraph/Point.py
+++ b/pyqtgraph/Point.py
@@ -105,7 +105,13 @@ class Point(QtCore.QPointF):
     
     def length(self):
         """Returns the vector length of this Point."""
-        return (self[0]**2 + self[1]**2) ** 0.5
+        try:
+            return (self[0]**2 + self[1]**2) ** 0.5
+        except OverflowError:
+            try:
+                return self[1] / np.sin(np.arctan2(self[1], self[0]))
+            except OverflowError:
+                return np.inf
     
     def norm(self):
         """Returns a vector in the same direction with unit length."""


### PR DESCRIPTION
Avoid overflow in Point.length by using trig functions or returning inf.
Fixes #678 