### PR TITLE
unable to set color on GLLinePlotItem

### DIFF
--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -3,6 +3,7 @@ from OpenGL.arrays import vbo
 from .. GLGraphicsItem import GLGraphicsItem
 from .. import shaders
 from ... import QtGui
+from ... import functions as fn
 import numpy as np
 
 __all__ = ['GLLinePlotItem']


### PR DESCRIPTION
currently setting a color results in:


    |==============================>>
    |  Traceback (most recent call last):
    |    File "lorenz system.py", line 80, in <module>
    |      v.animation()
    |    File "lorenz system.py", line 74, in animation
    |      self.start()
    |    File "lorenz system.py", line 46, in start
    |      QtGui.QApplication.instance().exec_()
    |    File "/home/kolt/.local/lib/python3.6/site-packages/pyqtgraph/opengl/GLViewWidget.py", line 179, in paintGL
    |      self.drawItemTree(useItemNames=useItemNames)
    |    File "/home/kolt/.local/lib/python3.6/site-packages/pyqtgraph/opengl/GLViewWidget.py", line 219, in drawItemTree
    |      self.drawItemTree(i, useItemNames=useItemNames)
    |    File "/home/kolt/.local/lib/python3.6/site-packages/pyqtgraph/opengl/GLViewWidget.py", line 200, in drawItemTree
    |      debug.printExc()
    |    --- exception caught here ---
    |    File "/home/kolt/.local/lib/python3.6/site-packages/pyqtgraph/opengl/GLViewWidget.py", line 197, in drawItemTree
    |      i.paint()
    |    File "/home/kolt/.local/lib/python3.6/site-packages/pyqtgraph/opengl/items/GLLinePlotItem.py", line 90, in paint
    |      glColor4f(*fn.glColor(self.color))
    |  NameError: name 'fn' is not defined
    |==============================<<
Error while drawing item <pyqtgraph.opengl.items.GLLinePlotItem.GLLinePlotItem object at 0x7fa86a2601f8>.
