### PR TITLE
Fix error when using PlotDataItem with both stepMode and symbol

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -490,6 +490,9 @@ class PlotDataItem(GraphicsObject):
             self.curve.hide()
         
         if scatterArgs['symbol'] is not None:
+            
+            if self.opts.get('stepMode', False) is True:
+                x = 0.5 * (x[:-1] + x[1:])                
             self.scatter.setData(x=x, y=y, **scatterArgs)
             self.scatter.show()
         else:


### PR DESCRIPTION
When a `PlotDataItem` uses `stepMode=True`, the expectation is that the length of `x` is one more than the length of `y`, but this is not allowed for ScatterPlotItem. Solution here is to modify x values in PlotDataItem, before they are passed to the scatter plot.

closes #684 