### PR TITLE
Don't store `children` key in Parameter.opts

### DIFF
--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -180,7 +180,7 @@ class Parameter(QtCore.QObject):
             raise Exception("Parameter must have a string name specified in opts.")
         self.setName(name)
         
-        self.addChildren(self.opts.get('children', []))
+        self.addChildren(self.opts.pop('children', []))
         
         self.opts['value'] = None
         if value is not None:


### PR DESCRIPTION
closes #494, fixes #493
#493 fixed this too once upon a time, but it is no longer mergeable (because I sat on it too long).