### PR TITLE
Console scrolling

### DIFF
--- a/pyqtgraph/console/CmdInput.py
+++ b/pyqtgraph/console/CmdInput.py
@@ -9,19 +9,18 @@ class CmdInput(QtGui.QLineEdit):
         QtGui.QLineEdit.__init__(self, parent)
         self.history = [""]
         self.ptr = 0
-        #self.lastCmd = None
-        #self.setMultiline(False)
     
     def keyPressEvent(self, ev):
-        #print "press:", ev.key(), QtCore.Qt.Key_Up, QtCore.Qt.Key_Down, QtCore.Qt.Key_Enter
-        if ev.key() == QtCore.Qt.Key_Up and self.ptr < len(self.history) - 1:
-            self.setHistory(self.ptr+1)
-            ev.accept()
-            return
-        elif ev.key() ==  QtCore.Qt.Key_Down and self.ptr > 0:
-            self.setHistory(self.ptr-1)
-            ev.accept()
-            return
+        if ev.key() == QtCore.Qt.Key_Up:
+            if self.ptr < len(self.history) - 1:
+                self.setHistory(self.ptr+1)
+                ev.accept()
+                return
+        elif ev.key() ==  QtCore.Qt.Key_Down:
+            if self.ptr > 0:
+                self.setHistory(self.ptr-1)
+                ev.accept()
+                return
         elif ev.key() == QtCore.Qt.Key_Return:
             self.execCmd()
         else:
@@ -32,7 +31,6 @@ class CmdInput(QtGui.QLineEdit):
         cmd = asUnicode(self.text())
         if len(self.history) == 1 or cmd != self.history[1]:
             self.history.insert(1, cmd)
-        #self.lastCmd = cmd
         self.history[0] = ""
         self.setHistory(0)
         self.sigExecuteCmd.emit(cmd)
@@ -40,23 +38,3 @@ class CmdInput(QtGui.QLineEdit):
     def setHistory(self, num):
         self.ptr = num
         self.setText(self.history[self.ptr])
-        
-    #def setMultiline(self, m):
-        #height = QtGui.QFontMetrics(self.font()).lineSpacing()
-        #if m:
-            #self.setFixedHeight(height*5)
-        #else:
-            #self.setFixedHeight(height+15)
-            #self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-            #self.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-            
-       
-    #def sizeHint(self):
-        #hint = QtGui.QPlainTextEdit.sizeHint(self)
-        #height = QtGui.QFontMetrics(self.font()).lineSpacing()
-        #hint.setHeight(height)
-        #return hint
-
-        
-        
-        


### PR DESCRIPTION
* Add `scrollToBottom` argument to ConsoleWidget.write(), allowing control over whether to automatically scroll down when new contents are added.
* Fixed a bug when using up/down arrows would sometimes prevent using down-arrow to get back to the original (usually blank) input state.