### PR TITLE
Fix exit error caused by callback invoked during Qt teardown

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -445,6 +445,10 @@ class GraphicsItem(object):
         ## called to see whether this item has a new view to connect to
         ## NOTE: This is called from GraphicsObject.itemChange or GraphicsWidget.itemChange.
 
+        if not hasattr(self, '_connectedView'):
+            # Happens when Python is shutting down.
+            return
+
         ## It is possible this item has moved to a different ViewBox or widget;
         ## clear out previously determined references to these.
         self.forgetViewBox()


### PR DESCRIPTION
Reference: https://groups.google.com/d/msgid/pyqtgraph/993a12ef-654c-406c-9d41-44812f74e61f%40googlegroups.com?utm_medium=email&utm_source=footer