### PR TITLE
Fix issue #481

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -236,6 +236,8 @@ class GLViewWidget(QtOpenGL.QGLWidget):
                     glPopMatrix()
             
     def setCameraPosition(self, pos=None, distance=None, elevation=None, azimuth=None):
+        if pos is not None:
+            self.opts['center'] = pos
         if distance is not None:
             self.opts['distance'] = distance
         if elevation is not None:


### PR DESCRIPTION
The method `setCameraPosition` of the `GLViewWidget` seems the ignore its first argument `pos` (see #481)
By adding the attached lines the position is set correctly.