### PR TITLE
Revert "Fixed AxisMouse drag issue"

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1066,15 +1066,9 @@ class AxisItem(GraphicsWidget):
         if self.linkedView() is None: 
             return
         if self.orientation in ['left', 'right']:
-            ret = self.linkedView().mouseDragEvent(event, axis=1)
+            return self.linkedView().mouseDragEvent(event, axis=1)
         else:
-            ret = self.linkedView().mouseDragEvent(event, axis=0)
-        # Ignore event because if grid lines are enabled, we don't want the
-        # AxisItem to eat events meant for the ViewBox (see PR #565). A better
-        # solution here is to have grid lines drawn by a separate item inside the 
-        # viewbox.
-        event.ignore()
-        return ret
+            return self.linkedView().mouseDragEvent(event, axis=0)
         
     def mouseClickEvent(self, event):
         if self.linkedView() is None: 


### PR DESCRIPTION
Reverts #565. The original change breaks mouse dragging directly on the axis - the axis moves one step but then does not receive any more drag events because the first was ignored. Since the original PR only applies to a relatively rare situation (when the user has manually changed the Z value of the AxisItem), I prefer the original behavior for now. 

A better fix for #565 would allow the axisitem+grid lines to be drawn above the viewbox background without changing its z value, but this is tricky wrt. item parenting in the current hierarchy. Another option is for the axisitem to check the location of its mouse events and ignore drags that started over the viewbox.