### PR TITLE
fix encoding error in checkOpenGLVersion

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -426,7 +426,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         ## Only to be called from within exception handler.
         ver = glGetString(GL_VERSION).split()[0]
         if int(ver.split(b'.')[0]) < 2:
-            from .. import debug
+            import pyqtgraph.debug
             pyqtgraph.debug.printExc()
             raise Exception(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)
         else:

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -425,7 +425,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
     def checkOpenGLVersion(self, msg):
         ## Only to be called from within exception handler.
         ver = glGetString(GL_VERSION).split()[0]
-        if int(ver.split('.')[0]) < 2:
+        if int(ver.split(b'.')[0]) < 2:
             from .. import debug
             pyqtgraph.debug.printExc()
             raise Exception(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -426,8 +426,8 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         ## Only to be called from within exception handler.
         ver = glGetString(GL_VERSION).split()[0]
         if int(ver.split(b'.')[0]) < 2:
-            import pyqtgraph.debug
-            pyqtgraph.debug.printExc()
+            from .. import debug
+            debug.printExc()
             raise Exception(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)
         else:
             raise


### PR DESCRIPTION
In the error handling of opengl errors, this error was thrown. I tried on Ubuntu 18.10 with python 3.6 and on Windows 10 with python 3.7. They both showed the same error, that this small change fixes. 

This also fixes #261 

I ran the tests and none of the errors were close to the change I made. 
