### PR TITLE
ensure QPoint.__sub__ doesn't get called

### DIFF
--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -362,7 +362,7 @@ class GraphicsView(QtGui.QGraphicsView):
     def mouseMoveEvent(self, ev):
         if self.lastMousePos is None:
             self.lastMousePos = Point(ev.pos())
-        delta = Point(ev.pos() - self.lastMousePos)
+        delta = Point(ev.pos()) - self.lastMousePos
         self.lastMousePos = Point(ev.pos())
 
         QtGui.QGraphicsView.mouseMoveEvent(self, ev)


### PR DESCRIPTION
In PySide2 5.12.0, the following code snippet: 
```python
import pyqtgraph
import PySide2
from PySide2.QtCore import QPoint

print(PySide2.__version__)

x = QPoint()
y = pyqtgraph.Point()
z = x - y
```
gives the following error output:
```text
5.12.0
Traceback (most recent call last):
  File "test_qpoint.py", line 9, in <module>
    z = x - y
TypeError: 'PySide2.QtCore.QPoint.__sub__' called with wrong argument types:
  PySide2.QtCore.QPoint.__sub__(Point)
Supported signatures:
  PySide2.QtCore.QPoint.__sub__(PySide2.QtCore.QPoint)
```

Previously, (tested on 5.11.2) Point.\_\_rsub\_\_ method was getting invoked.
This fix ensures that Point.\_\_sub\_\_ gets invoked rather than QPoint.\_\_sub\_\_ 