### PR TITLE
Remove use of GraphicsScene._addressCache in translateGraphicsItem

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import weakref
+import warnings
+
 from ..Qt import QtCore, QtGui
 from ..Point import Point
 from .. import functions as fn
@@ -88,15 +90,11 @@ class GraphicsScene(QtGui.QGraphicsScene):
     
     @classmethod
     def registerObject(cls, obj):
-        """
-        Workaround for PyQt bug in qgraphicsscene.items()
-        All subclasses of QGraphicsObject must register themselves with this function.
-        (otherwise, mouse interaction with those objects will likely fail)
-        """
-        if HAVE_SIP and isinstance(obj, sip.wrapper):
-            cls._addressCache[sip.unwrapinstance(sip.cast(obj, QtGui.QGraphicsItem))] = obj
-            
-            
+        warnings.warn(
+            "'registerObject' is deprecated and does nothing.",
+            DeprecationWarning, stacklevel=2
+        )
+
     def __init__(self, clickRadius=2, moveDistance=5, parent=None):
         QtGui.QGraphicsScene.__init__(self, parent)
         self.setClickRadius(clickRadius)
@@ -368,46 +366,15 @@ class GraphicsScene(QtGui.QGraphicsScene):
         return ev.isAccepted()
         
     def items(self, *args):
-        #print 'args:', args
         items = QtGui.QGraphicsScene.items(self, *args)
-        ## PyQt bug: items() returns a list of QGraphicsItem instances. If the item is subclassed from QGraphicsObject,
-        ## then the object returned will be different than the actual item that was originally added to the scene
-        items2 = list(map(self.translateGraphicsItem, items))
-        #if HAVE_SIP and isinstance(self, sip.wrapper):
-            #items2 = []
-            #for i in items:
-                #addr = sip.unwrapinstance(sip.cast(i, QtGui.QGraphicsItem))
-                #i2 = GraphicsScene._addressCache.get(addr, i)
-                ##print i, "==>", i2
-                #items2.append(i2)
-        #print 'items:', items
-        return items2
+        return self.translateGraphicsItems(items)
     
     def selectedItems(self, *args):
         items = QtGui.QGraphicsScene.selectedItems(self, *args)
-        ## PyQt bug: items() returns a list of QGraphicsItem instances. If the item is subclassed from QGraphicsObject,
-        ## then the object returned will be different than the actual item that was originally added to the scene
-        #if HAVE_SIP and isinstance(self, sip.wrapper):
-            #items2 = []
-            #for i in items:
-                #addr = sip.unwrapinstance(sip.cast(i, QtGui.QGraphicsItem))
-                #i2 = GraphicsScene._addressCache.get(addr, i)
-                ##print i, "==>", i2
-                #items2.append(i2)
-        items2 = list(map(self.translateGraphicsItem, items))
-
-        #print 'items:', items
-        return items2
+        return self.translateGraphicsItems(items)
 
     def itemAt(self, *args):
         item = QtGui.QGraphicsScene.itemAt(self, *args)
-        
-        ## PyQt bug: items() returns a list of QGraphicsItem instances. If the item is subclassed from QGraphicsObject,
-        ## then the object returned will be different than the actual item that was originally added to the scene
-        #if HAVE_SIP and isinstance(self, sip.wrapper):
-            #addr = sip.unwrapinstance(sip.cast(item, QtGui.QGraphicsItem))
-            #item = GraphicsScene._addressCache.get(addr, item)
-        #return item
         return self.translateGraphicsItem(item)
 
     def itemsNearEvent(self, event, selMode=QtCore.Qt.IntersectsItemShape, sortOrder=QtCore.Qt.DescendingOrder, hoverable=False):
@@ -554,10 +521,14 @@ class GraphicsScene(QtGui.QGraphicsScene):
 
     @staticmethod
     def translateGraphicsItem(item):
-        ## for fixing pyqt bugs where the wrong item is returned
+        # This function is intended as a workaround for a problem with older
+        # versions of PyQt (< 4.9?), where methods returning 'QGraphicsItem *'
+        # lose the type of the QGraphicsObject subclasses and instead return
+        # generic QGraphicsItem wrappers.
         if HAVE_SIP and isinstance(item, sip.wrapper):
-            addr = sip.unwrapinstance(sip.cast(item, QtGui.QGraphicsItem))
-            item = GraphicsScene._addressCache.get(addr, item)
+            obj = item.toGraphicsObject()
+            if obj is not None:
+                item = obj
         return item
 
     @staticmethod

--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -19,8 +19,8 @@ class GraphicsItem(object):
     The GraphicsView system places a lot of emphasis on the notion that the graphics within the scene should be device independent--you should be able to take the same graphics and display them on screens of different resolutions, printers, export to SVG, etc. This is nice in principle, but causes me a lot of headache in practice. It means that I have to circumvent all the device-independent expectations any time I want to operate in pixel coordinates rather than arbitrary scene coordinates. A lot of the code in GraphicsItem is devoted to this task--keeping track of view widgets and device transforms, computing the size and shape of a pixel in local item coordinates, etc. Note that in item coordinates, a pixel does not have to be square or even rectangular, so just asking how to increase a bounding rect by 2px can be a rather complex task.
     """
     _pixelVectorGlobalCache = LRUCache(100, 70)
-    
-    def __init__(self, register=True):
+
+    def __init__(self, register=None):
         if not hasattr(self, '_qtBaseClass'):
             for b in self.__class__.__bases__:
                 if issubclass(b, QtGui.QGraphicsItem):
@@ -28,15 +28,18 @@ class GraphicsItem(object):
                     break
         if not hasattr(self, '_qtBaseClass'):
             raise Exception('Could not determine Qt base class for GraphicsItem: %s' % str(self))
-        
+
         self._pixelVectorCache = [None, None]
         self._viewWidget = None
         self._viewBox = None
         self._connectedView = None
         self._exportOpts = False   ## If False, not currently exporting. Otherwise, contains dict of export options.
-        if register:
-            GraphicsScene.registerObject(self)  ## workaround for pyqt bug in graphicsscene.items()
-                    
+        if register is not None and register:
+            warnings.warn(
+                "'register' argument is deprecated and does nothing",
+                DeprecationWarning, stacklevel=2
+            )
+
     def getViewWidget(self):
         """
         Return the view widget for this item. 


### PR DESCRIPTION
Use `QGraphicsItem.toQGrapicsObject` on the item instead.

(This probably is not even needed since PyQt 4.9)

The problem with `_addressCache` is that it can map a plain QGraphicsItem that was not 'registered' with a `registerObject` to an invalid (already deleted on the C++ side) wrapper object. For instance:

1. An item registered with registerObject and added to a scene.
2. The item is deleted from the C++ side, but the PyQt wrapper remains live (its entry remains in `_addressCache`).
3. A plain QGraphicsItem that is not registered with `registerObject` is created that reuses the memory that the first item occupied (it is located at the same address) and is added to the scene.
Then calling `scene.items()` will replace the new item with a wrapper for the old invalid item in the output.

I have used `item.toQGraphicsObject()` in the past to workaround the same bug (I am pretty sure it is no longer needed since PyQt 4.9)