### PR TITLE
enforce enableMenu in ViewBox

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -35,21 +35,21 @@ class WeakList(object):
             i -= 1
 
 class ChildGroup(ItemGroup):
-    
+
     def __init__(self, parent):
         ItemGroup.__init__(self, parent)
-        
-        # Used as callback to inform ViewBox when items are added/removed from 
-        # the group. 
-        # Note 1: We would prefer to override itemChange directly on the 
+
+        # Used as callback to inform ViewBox when items are added/removed from
+        # the group.
+        # Note 1: We would prefer to override itemChange directly on the
         #         ViewBox, but this causes crashes on PySide.
         # Note 2: We might also like to use a signal rather than this callback
-        #         mechanism, but this causes a different PySide crash.        
+        #         mechanism, but this causes a different PySide crash.
         self.itemsChangedListeners = WeakList()
- 
+
         # excempt from telling view when transform changes
         self._GraphicsObject__inform_view_on_change = False
-    
+
     def itemChange(self, change, value):
         ret = ItemGroup.itemChange(self, change, value)
         if change == self.ItemChildAddedChange or change == self.ItemChildRemovedChange:
@@ -68,19 +68,19 @@ class ChildGroup(ItemGroup):
 class ViewBox(GraphicsWidget):
     """
     **Bases:** :class:`GraphicsWidget <pyqtgraph.GraphicsWidget>`
-    
-    Box that allows internal scaling/panning of children by mouse drag. 
+
+    Box that allows internal scaling/panning of children by mouse drag.
     This class is usually created automatically as part of a :class:`PlotItem <pyqtgraph.PlotItem>` or :class:`Canvas <pyqtgraph.canvas.Canvas>` or with :func:`GraphicsLayout.addViewBox() <pyqtgraph.GraphicsLayout.addViewBox>`.
-    
+
     Features:
-    
+
     * Scaling contents by mouse or auto-scale when contents change
     * View linking--multiple views display the same data ranges
     * Configurable by context menu
     * Item coordinate mapping methods
-    
+
     """
-    
+
     sigYRangeChanged = QtCore.Signal(object, object)
     sigXRangeChanged = QtCore.Signal(object, object)
     sigRangeChangedManually = QtCore.Signal(object)
@@ -88,20 +88,20 @@ class ViewBox(GraphicsWidget):
     sigStateChanged = QtCore.Signal(object)
     sigTransformChanged = QtCore.Signal(object)
     sigResized = QtCore.Signal(object)
-    
+
     ## mouse modes
     PanMode = 3
     RectMode = 1
-    
+
     ## axes
     XAxis = 0
     YAxis = 1
     XYAxes = 2
-    
+
     ## for linking views together
     NamedViews = weakref.WeakValueDictionary()   # name: ViewBox
     AllViews = weakref.WeakKeyDictionary()       # ViewBox: None
-    
+
     def __init__(self, parent=None, border=None, lockAspect=False, enableMouse=True, invertY=False, enableMenu=True, name=None, invertX=False):
         """
         ==============  =============================================================
@@ -114,15 +114,15 @@ class ViewBox(GraphicsWidget):
         *enableMouse*   (bool) Whether mouse can be used to scale/pan the view
         *invertY*       (bool) See :func:`invertY <pyqtgraph.ViewBox.invertY>`
         *invertX*       (bool) See :func:`invertX <pyqtgraph.ViewBox.invertX>`
-        *enableMenu*    (bool) Whether to display a context menu when 
+        *enableMenu*    (bool) Whether to display a context menu when
                         right-clicking on the ViewBox background.
         *name*          (str) Used to register this ViewBox so that it appears
                         in the "Link axis" dropdown inside other ViewBox
                         context menus. This allows the user to manually link
-                        the axes of any other view to this one. 
+                        the axes of any other view to this one.
         ==============  =============================================================
         """
-        
+
         GraphicsWidget.__init__(self, parent)
         self.name = None
         self.linksBlocked = False
@@ -131,60 +131,60 @@ class ViewBox(GraphicsWidget):
         self._autoRangeNeedsUpdate = True ## indicates auto-range needs to be recomputed.
 
         self._lastScene = None  ## stores reference to the last known scene this view was a part of.
-        
+
         self.state = {
-            
+
             ## separating targetRange and viewRange allows the view to be resized
             ## while keeping all previously viewed contents visible
             'targetRange': [[0,1], [0,1]],   ## child coord. range visible [[xmin, xmax], [ymin, ymax]]
             'viewRange': [[0,1], [0,1]],     ## actual range viewed
-        
+
             'yInverted': invertY,
             'xInverted': invertX,
             'aspectLocked': False,    ## False if aspect is unlocked, otherwise float specifies the locked ratio.
-            'autoRange': [True, True],  ## False if auto range is disabled, 
+            'autoRange': [True, True],  ## False if auto range is disabled,
                                           ## otherwise float gives the fraction of data that is visible
             'autoPan': [False, False],         ## whether to only pan (do not change scaling) when auto-range is enabled
-            'autoVisibleOnly': [False, False], ## whether to auto-range only to the visible portion of a plot 
+            'autoVisibleOnly': [False, False], ## whether to auto-range only to the visible portion of a plot
             'linkedViews': [None, None],  ## may be None, "viewName", or weakref.ref(view)
                                           ## a name string indicates that the view *should* link to another, but no view with that name exists yet.
-            
+
             'mouseEnabled': [enableMouse, enableMouse],
-            'mouseMode': ViewBox.PanMode if getConfigOption('leftButtonPan') else ViewBox.RectMode,  
+            'mouseMode': ViewBox.PanMode if getConfigOption('leftButtonPan') else ViewBox.RectMode,
             'enableMenu': enableMenu,
             'wheelScaleFactor': -1.0 / 8.0,
 
             'background': None,
-            
+
             # Limits
             'limits': {
-                'xLimits': [None, None],   # Maximum and minimum visible X values 
-                'yLimits': [None, None],   # Maximum and minimum visible Y values  
+                'xLimits': [None, None],   # Maximum and minimum visible X values
+                'yLimits': [None, None],   # Maximum and minimum visible Y values
                 'xRange': [None, None],   # Maximum and minimum X range
-                'yRange': [None, None],   # Maximum and minimum Y range 
+                'yRange': [None, None],   # Maximum and minimum Y range
                 }
-            
+
         }
         self._updatingRange = False  ## Used to break recursive loops. See updateAutoRange.
         self._itemBoundsCache = weakref.WeakKeyDictionary()
-        
+
         self.locateGroup = None  ## items displayed when using ViewBox.locate(item)
-        
+
         self.setFlag(self.ItemClipsChildrenToShape)
         self.setFlag(self.ItemIsFocusable, True)  ## so we can receive key presses
-        
+
         ## childGroup is required so that ViewBox has local coordinates similar to device coordinates.
         ## this is a workaround for a Qt + OpenGL bug that causes improper clipping
         ## https://bugreports.qt.nokia.com/browse/QTBUG-23723
         self.childGroup = ChildGroup(self)
         self.childGroup.itemsChangedListeners.append(self)
-        
+
         self.background = QtGui.QGraphicsRectItem(self.rect())
         self.background.setParentItem(self)
         self.background.setZValue(-1e6)
         self.background.setPen(fn.mkPen(None))
         self.updateBackground()
-        
+
         ## Make scale box that is shown when dragging on the view
         self.rbScaleBox = QtGui.QGraphicsRectItem(0, 0, 1, 1)
         self.rbScaleBox.setPen(fn.mkPen((255,255,100), width=1))
@@ -192,36 +192,39 @@ class ViewBox(GraphicsWidget):
         self.rbScaleBox.setZValue(1e9)
         self.rbScaleBox.hide()
         self.addItem(self.rbScaleBox, ignoreBounds=True)
-        
+
         ## show target rect for debugging
         self.target = QtGui.QGraphicsRectItem(0, 0, 1, 1)
         self.target.setPen(fn.mkPen('r'))
         self.target.setParentItem(self)
         self.target.hide()
-        
+
         self.axHistory = [] # maintain a history of zoom locations
         self.axHistoryPointer = -1 # pointer into the history. Allows forward/backward movement, not just "undo"
-        
+
         self.setZValue(-100)
         self.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding))
-        
+
         self.setAspectLocked(lockAspect)
-        
+
         self.border = fn.mkPen(border)
-        self.menu = ViewBoxMenu(self)
-        
+        if enableMenu:
+            self.menu = ViewBoxMenu(self)
+        else:
+            self.menu = None
+
         self.register(name)
         if name is None:
             self.updateViewLists()
-        
+
     def register(self, name):
         """
-        Add this ViewBox to the registered list of views. 
-        
+        Add this ViewBox to the registered list of views.
+
         This allows users to manually link the axes of any other ViewBox to
-        this one. The specified *name* will appear in the drop-down lists for 
+        this one. The specified *name* will appear in the drop-down lists for
         axis linking in the context menus of all other views.
-        
+
         The same can be accomplished by initializing the ViewBox with the *name* attribute.
         """
         ViewBox.AllViews[self] = None
@@ -248,7 +251,7 @@ class ViewBox(GraphicsWidget):
 
     def implements(self, interface):
         return interface == 'ViewBox'
-        
+
     # removed due to https://bugreports.qt-project.org/browse/PYSIDE-86
     #def itemChange(self, change, value):
         ## Note: Calling QWidget.itemChange causes segv in python 3 + PyQt
@@ -263,9 +266,9 @@ class ViewBox(GraphicsWidget):
             #if scene is not None and hasattr(scene, 'sigPrepareForPaint'):
                 #scene.sigPrepareForPaint.connect(self.prepareForPaint)
         #return ret
-        
+
     def checkSceneChange(self):
-        # ViewBox needs to receive sigPrepareForPaint from its scene before 
+        # ViewBox needs to receive sigPrepareForPaint from its scene before
         # being painted. However, we have no way of being informed when the
         # scene has changed in order to make this connection. The usual way
         # to do this is via itemChange(), but bugs prevent this approach
@@ -280,16 +283,16 @@ class ViewBox(GraphicsWidget):
             scene.sigPrepareForPaint.connect(self.prepareForPaint)
         self.prepareForPaint()
         self._lastScene = scene
-            
+
     def prepareForPaint(self):
         #autoRangeEnabled = (self.state['autoRange'][0] is not False) or (self.state['autoRange'][1] is not False)
         # don't check whether auto range is enabled here--only check when setting dirty flag.
-        if self._autoRangeNeedsUpdate: # and autoRangeEnabled: 
+        if self._autoRangeNeedsUpdate: # and autoRangeEnabled:
             self.updateAutoRange()
         self.updateMatrix()
-        
+
     def getState(self, copy=True):
-        """Return the current state of the ViewBox. 
+        """Return the current state of the ViewBox.
         Linked views are always converted to view names in the returned state."""
         state = self.state.copy()
         views = []
@@ -305,7 +308,7 @@ class ViewBox(GraphicsWidget):
             return deepcopy(state)
         else:
             return state
-        
+
     def setState(self, state):
         """Restore the state of this ViewBox.
         (see also getState)"""
@@ -313,17 +316,24 @@ class ViewBox(GraphicsWidget):
         self.setXLink(state['linkedViews'][0])
         self.setYLink(state['linkedViews'][1])
         del state['linkedViews']
-        
+
         self.state.update(state)
+
+        if self.state['enableMenu'] and self.menu is None:
+            self.menu = ViewBoxMenu(self)
+            self.updateViewLists()
+        else:
+            self.menu = None
+
         self.updateViewRange()
         self.sigStateChanged.emit(self)
 
     def setBackgroundColor(self, color):
         """
         Set the background color of the ViewBox.
-        
+
         If color is None, then no background will be drawn.
-        
+
         Added in version 0.9.9
         """
         self.background.setVisible(color is not None)
@@ -348,10 +358,10 @@ class ViewBox(GraphicsWidget):
             self.setMouseMode(ViewBox.PanMode)
         else:
             raise Exception('graphicsItems:ViewBox:setLeftButtonAction: unknown mode = %s (Options are "pan" and "rect")' % mode)
-            
+
     def innerSceneItem(self):
         return self.childGroup
-    
+
     def setMouseEnabled(self, x=None, y=None):
         """
         Set whether each axis is enabled for mouse interaction. *x*, *y* arguments must be True or False.
@@ -362,17 +372,24 @@ class ViewBox(GraphicsWidget):
         if y is not None:
             self.state['mouseEnabled'][1] = y
         self.sigStateChanged.emit(self)
-            
+
     def mouseEnabled(self):
         return self.state['mouseEnabled'][:]
-        
+
     def setMenuEnabled(self, enableMenu=True):
         self.state['enableMenu'] = enableMenu
+        if enableMenu:
+            if self.menu is None:
+                self.menu = ViewBoxMenu(self)
+                self.updateViewLists()
+        else:
+            self.menu.setParent(None)
+            self.menu = None
         self.sigStateChanged.emit(self)
 
     def menuEnabled(self):
-        return self.state.get('enableMenu', True)       
-    
+        return self.state.get('enableMenu', True)
+
     def addItem(self, item, ignoreBounds=False):
         """
         Add a QGraphicsItem to this view. The view will include this item when determining how to set its range
@@ -387,7 +404,7 @@ class ViewBox(GraphicsWidget):
         if not ignoreBounds:
             self.addedItems.append(item)
         self.updateAutoRange()
-        
+
     def removeItem(self, item):
         """Remove an item from this view."""
         try:
@@ -402,7 +419,7 @@ class ViewBox(GraphicsWidget):
             self.removeItem(i)
         for ch in self.childGroup.childItems():
             ch.setParentItem(None)
-        
+
     def resizeEvent(self, ev):
         self._matrixNeedsUpdate = True
         self.linkedXChanged()
@@ -413,7 +430,7 @@ class ViewBox(GraphicsWidget):
         self.sigStateChanged.emit(self)
         self.background.setRect(self.rect())
         self.sigResized.emit(self)
-        
+
     def viewRange(self):
         """Return a the view's visible range as a list: [[xmin, xmax], [ymin, ymax]]"""
         return [x[:] for x in self.state['viewRange']]  ## return copy
@@ -427,13 +444,13 @@ class ViewBox(GraphicsWidget):
         except:
             print("make qrectf failed:", self.state['viewRange'])
             raise
-    
+
     def targetRange(self):
         return [x[:] for x in self.state['targetRange']]  ## return copy
-    
-    def targetRect(self):  
+
+    def targetRect(self):
         """
-        Return the region which has been requested to be visible. 
+        Return the region which has been requested to be visible.
         (this is not necessarily the same as the region that is *actually* visible--
         resizing and aspect ratio constraints can cause targetRect() and viewRect() to differ)
         """
@@ -455,30 +472,30 @@ class ViewBox(GraphicsWidget):
     def setRange(self, rect=None, xRange=None, yRange=None, padding=None, update=True, disableAutoRange=True):
         """
         Set the visible range of the ViewBox.
-        Must specify at least one of *rect*, *xRange*, or *yRange*. 
-        
+        Must specify at least one of *rect*, *xRange*, or *yRange*.
+
         ================== =====================================================================
         **Arguments:**
         *rect*             (QRectF) The full range that should be visible in the view box.
         *xRange*           (min,max) The range that should be visible along the x-axis.
         *yRange*           (min,max) The range that should be visible along the y-axis.
-        *padding*          (float) Expand the view by a fraction of the requested range. 
+        *padding*          (float) Expand the view by a fraction of the requested range.
                            By default, this value is set between 0.02 and 0.1 depending on
                            the size of the ViewBox.
-        *update*           (bool) If True, update the range of the ViewBox immediately. 
+        *update*           (bool) If True, update the range of the ViewBox immediately.
                            Otherwise, the update is deferred until before the next render.
         *disableAutoRange* (bool) If True, auto-ranging is diabled. Otherwise, it is left
                            unchanged.
         ================== =====================================================================
-        
+
         """
         #print self.name, "ViewBox.setRange", rect, xRange, yRange, padding
         #import traceback
         #traceback.print_stack()
-        
+
         changes = {}   # axes
         setRequested = [False, False]
-        
+
         if rect is not None:
             changes = {0: [rect.left(), rect.right()], 1: [rect.top(), rect.bottom()]}
             setRequested = [True, True]
@@ -492,27 +509,27 @@ class ViewBox(GraphicsWidget):
         if len(changes) == 0:
             print(rect)
             raise Exception("Must specify at least one of rect, xRange, or yRange. (gave rect=%s)" % str(type(rect)))
-        
+
         # Update axes one at a time
         changed = [False, False]
         for ax, range in changes.items():
             mn = min(range)
             mx = max(range)
-            
-            # If we requested 0 range, try to preserve previous scale. 
+
+            # If we requested 0 range, try to preserve previous scale.
             # Otherwise just pick an arbitrary scale.
-            if mn == mx:   
+            if mn == mx:
                 dy = self.state['viewRange'][ax][1] - self.state['viewRange'][ax][0]
                 if dy == 0:
                     dy = 1
                 mn -= dy*0.5
                 mx += dy*0.5
                 xpad = 0.0
-                
+
             # Make sure no nan/inf get through
             if not all(np.isfinite([mn, mx])):
                 raise Exception("Cannot set range [%s, %s]" % (str(mn), str(mx)))
-            
+
             # Apply padding
             if padding is None:
                 xpad = self.suggestPadding(ax)
@@ -521,20 +538,20 @@ class ViewBox(GraphicsWidget):
             p = (mx-mn) * xpad
             mn -= p
             mx += p
-            
+
             # Set target range
             if self.state['targetRange'][ax] != [mn, mx]:
                 self.state['targetRange'][ax] = [mn, mx]
                 changed[ax] = True
-                
-        # Update viewRange to match targetRange as closely as possible while 
+
+        # Update viewRange to match targetRange as closely as possible while
         # accounting for aspect ratio constraint
         lockX, lockY = setRequested
         if lockX and lockY:
             lockX = False
             lockY = False
         self.updateViewRange(lockX, lockY)
-            
+
         # Disable auto-range for each axis that was requested to be set
         if disableAutoRange:
             xOff = False if setRequested[0] else None
@@ -545,11 +562,11 @@ class ViewBox(GraphicsWidget):
         # If nothing has changed, we are done.
         if any(changed):
             self.sigStateChanged.emit(self)
-            
+
             # Update target rect for debugging
             if self.target.isVisible():
                 self.target.setRect(self.mapRectFromItem(self.childGroup, self.targetRect()))
-                
+
         # If ortho axes have auto-visible-only, update them now
         # Note that aspect ratio constraints and auto-visible probably do not work together..
         if changed[0] and self.state['autoVisibleOnly'][1] and (self.state['autoRange'][0] is not False):
@@ -559,15 +576,15 @@ class ViewBox(GraphicsWidget):
 
     def setYRange(self, min, max, padding=None, update=True):
         """
-        Set the visible Y range of the view to [*min*, *max*]. 
+        Set the visible Y range of the view to [*min*, *max*].
         The *padding* argument causes the range to be set larger by the fraction specified.
         (by default, this value is between 0.02 and 0.1 depending on the size of the ViewBox)
         """
         self.setRange(yRange=[min, max], update=update, padding=padding)
-        
+
     def setXRange(self, min, max, padding=None, update=True):
         """
-        Set the visible X range of the view to [*min*, *max*]. 
+        Set the visible X range of the view to [*min*, *max*].
         The *padding* argument causes the range to be set larger by the fraction specified.
         (by default, this value is between 0.02 and 0.1 depending on the size of the ViewBox)
         """
@@ -576,9 +593,9 @@ class ViewBox(GraphicsWidget):
     def autoRange(self, padding=None, items=None, item=None):
         """
         Set the range of the view box to make all children visible.
-        Note that this is not the same as enableAutoRange, which causes the view to 
+        Note that this is not the same as enableAutoRange, which causes the view to
         automatically auto-range whenever its contents are changed.
-        
+
         ==============  ============================================================
         **Arguments:**
         padding         The fraction of the total data range to add on to the final
@@ -593,10 +610,10 @@ class ViewBox(GraphicsWidget):
         else:
             print("Warning: ViewBox.autoRange(item=__) is deprecated. Use 'items' argument instead.")
             bounds = self.mapFromItemToView(item, item.boundingRect()).boundingRect()
-            
+
         if bounds is not None:
             self.setRange(bounds, padding=padding)
-            
+
     def suggestPadding(self, axis):
         l = self.width() if axis==0 else self.height()
         if l > 0:
@@ -604,31 +621,31 @@ class ViewBox(GraphicsWidget):
         else:
             padding = 0.02
         return padding
-    
+
     def setLimits(self, **kwds):
         """
         Set limits that constrain the possible view ranges.
-        
-        **Panning limits**. The following arguments define the region within the 
+
+        **Panning limits**. The following arguments define the region within the
         viewbox coordinate system that may be accessed by panning the view.
-        
+
         =========== ============================================================
         xMin        Minimum allowed x-axis value
         xMax        Maximum allowed x-axis value
         yMin        Minimum allowed y-axis value
         yMax        Maximum allowed y-axis value
-        =========== ============================================================        
-        
+        =========== ============================================================
+
         **Scaling limits**. These arguments prevent the view being zoomed in or
         out too far.
-        
+
         =========== ============================================================
         minXRange   Minimum allowed left-to-right span across the view.
         maxXRange   Maximum allowed left-to-right span across the view.
         minYRange   Minimum allowed top-to-bottom span across the view.
         maxYRange   Maximum allowed top-to-bottom span across the view.
         =========== ============================================================
-        
+
         Added in version 0.9.9
         """
         update = False
@@ -648,28 +665,28 @@ class ViewBox(GraphicsWidget):
                 if kwd in kwds and self.state['limits'][lname][mnmx] != kwds[kwd]:
                     self.state['limits'][lname][mnmx] = kwds[kwd]
                     update = True
-                    
+
         if update:
             self.updateViewRange()
-            
+
     def scaleBy(self, s=None, center=None, x=None, y=None):
         """
         Scale by *s* around given center point (or center of view).
         *s* may be a Point or tuple (x, y).
-        
-        Optionally, x or y may be specified individually. This allows the other 
+
+        Optionally, x or y may be specified individually. This allows the other
         axis to be left unaffected (note that using a scale factor of 1.0 may
         cause slight changes due to floating-point error).
         """
         if s is not None:
             x, y = s[0], s[1]
-        
+
         affect = [x is not None, y is not None]
         if not any(affect):
             return
-        
+
         scale = Point([1.0 if x is None else x, 1.0 if y is None else y])
-            
+
         if self.state['aspectLocked'] is not False:
             scale[0] = scale[1]
 
@@ -678,21 +695,21 @@ class ViewBox(GraphicsWidget):
             center = Point(vr.center())
         else:
             center = Point(center)
-        
+
         tl = center + (vr.topLeft()-center) * scale
         br = center + (vr.bottomRight()-center) * scale
-        
+
         if not affect[0]:
             self.setYRange(tl.y(), br.y(), padding=0)
         elif not affect[1]:
             self.setXRange(tl.x(), br.x(), padding=0)
         else:
             self.setRange(QtCore.QRectF(tl, br), padding=0)
-        
+
     def translateBy(self, t=None, x=None, y=None):
         """
         Translate the view by *t*, which may be a Point or tuple (x, y).
-        
+
         Alternately, x or y may be specified independently, leaving the other
         axis unchanged (note that using a translation of 0 may still cause
         small changes due to floating-point error).
@@ -708,7 +725,7 @@ class ViewBox(GraphicsWidget):
                 y = vr.top()+y, vr.bottom()+y
             if x is not None or y is not None:
                 self.setRange(xRange=x, yRange=y, padding=0)
-        
+
     def enableAutoRange(self, axis=None, enable=True, x=None, y=None):
         """
         Enable (or disable) auto-range for *axis*, which may be ViewBox.XAxis, ViewBox.YAxis, or ViewBox.XYAxes for both
@@ -724,15 +741,15 @@ class ViewBox(GraphicsWidget):
             if y is not None:
                 self.enableAutoRange(ViewBox.YAxis, y)
             return
-        
+
         if enable is True:
             enable = 1.0
-        
+
         if axis is None:
             axis = ViewBox.XYAxes
-        
+
         needAutoRangeUpdate = False
-        
+
         if axis == ViewBox.XYAxes or axis == 'xy':
             axes = [0, 1]
         elif axis == ViewBox.XAxis or axis == 'x':
@@ -741,18 +758,18 @@ class ViewBox(GraphicsWidget):
             axes = [1]
         else:
             raise Exception('axis argument must be ViewBox.XAxis, ViewBox.YAxis, or ViewBox.XYAxes.')
-        
+
         for ax in axes:
             if self.state['autoRange'][ax] != enable:
                 # If we are disabling, do one last auto-range to make sure that
                 # previously scheduled auto-range changes are enacted
                 if enable is False and self._autoRangeNeedsUpdate:
                     self.updateAutoRange()
-                
+
                 self.state['autoRange'][ax] = enable
                 self._autoRangeNeedsUpdate |= (enable is not False)
                 self.update()
-        
+
         self.sigStateChanged.emit(self)
 
     def disableAutoRange(self, axis=None):
@@ -784,30 +801,30 @@ class ViewBox(GraphicsWidget):
             self.state['autoVisibleOnly'][1] = y
             if y is True:
                 self.state['autoVisibleOnly'][0] = False
-        
+
         if x is not None or y is not None:
             self.updateAutoRange()
 
     def updateAutoRange(self):
         ## Break recursive loops when auto-ranging.
-        ## This is needed because some items change their size in response 
+        ## This is needed because some items change their size in response
         ## to a view change.
         if self._updatingRange:
             return
-        
+
         self._updatingRange = True
         try:
             targetRect = self.viewRange()
             if not any(self.state['autoRange']):
                 return
-                
+
             fractionVisible = self.state['autoRange'][:]
             for i in [0,1]:
                 if type(fractionVisible[i]) is bool:
                     fractionVisible[i] = 1.0
 
             childRange = None
-            
+
             order = [0,1]
             if self.state['autoVisibleOnly'][0] is True:
                 order = [1,0]
@@ -820,11 +837,11 @@ class ViewBox(GraphicsWidget):
                     oRange = [None, None]
                     oRange[ax] = targetRect[1-ax]
                     childRange = self.childrenBounds(frac=fractionVisible, orthoRange=oRange)
-                    
+
                 else:
                     if childRange is None:
                         childRange = self.childrenBounds(frac=fractionVisible)
-                
+
                 ## Make corrections to range
                 xr = childRange[ax]
                 if xr is not None:
@@ -839,32 +856,32 @@ class ViewBox(GraphicsWidget):
                         childRange[ax][1] += wp
                     targetRect[ax] = childRange[ax]
                     args['xRange' if ax == 0 else 'yRange'] = targetRect[ax]
-            
+
              # check for and ignore bad ranges
             for k in ['xRange', 'yRange']:
                 if k in args:
                     if not np.all(np.isfinite(args[k])):
                         r = args.pop(k)
                         #print("Warning: %s is invalid: %s" % (k, str(r))
-            
+
             if len(args) == 0:
                 return
             args['padding'] = 0
             args['disableAutoRange'] = False
-                        
+
             self.setRange(**args)
         finally:
             self._autoRangeNeedsUpdate = False
             self._updatingRange = False
-        
+
     def setXLink(self, view):
         """Link this view's X axis to another view. (see LinkView)"""
         self.linkView(self.XAxis, view)
-        
+
     def setYLink(self, view):
         """Link this view's Y axis to another view. (see LinkView)"""
         self.linkView(self.YAxis, view)
-        
+
     def linkView(self, axis, view):
         """
         Link X or Y axes of two views and unlink any previously connected axes. *axis* must be ViewBox.XAxis or ViewBox.YAxis.
@@ -896,8 +913,8 @@ class ViewBox(GraphicsWidget):
             except (TypeError, RuntimeError):
                 ## This can occur if the view has been deleted already
                 pass
-            
-        
+
+
         if view is None or isinstance(view, basestring):
             self.state['linkedViews'][axis] = view
         else:
@@ -910,10 +927,10 @@ class ViewBox(GraphicsWidget):
             else:
                 if self.autoRangeEnabled()[axis] is False:
                     slot()
-        
-            
+
+
         self.sigStateChanged.emit(self)
-        
+
     def blockLink(self, b):
         self.linksBlocked = b  ## prevents recursive plot-change propagation
 
@@ -926,7 +943,7 @@ class ViewBox(GraphicsWidget):
         ## called when y range of linked view has changed
         view = self.linkedView(1)
         self.linkedViewChanged(view, ViewBox.YAxis)
-        
+
     def linkedView(self, ax):
         ## Return the linked view for axis *ax*.
         ## this method _always_ returns either a ViewBox or None.
@@ -939,19 +956,19 @@ class ViewBox(GraphicsWidget):
     def linkedViewChanged(self, view, axis):
         if self.linksBlocked or view is None:
             return
-        
+
         #print self.name, "ViewBox.linkedViewChanged", axis, view.viewRange()[axis]
         vr = view.viewRect()
         vg = view.screenGeometry()
         sg = self.screenGeometry()
         if vg is None or sg is None:
             return
-        
+
         view.blockLink(True)
         try:
             if axis == ViewBox.XAxis:
                 overlap = min(sg.right(), vg.right()) - max(sg.left(), vg.left())
-                if overlap < min(vg.width()/3, sg.width()/3):  ## if less than 1/3 of views overlap, 
+                if overlap < min(vg.width()/3, sg.width()/3):  ## if less than 1/3 of views overlap,
                                                                ## then just replicate the view
                     x1 = vr.left()
                     x2 = vr.right()
@@ -966,7 +983,7 @@ class ViewBox(GraphicsWidget):
                 self.setXRange(x1, x2, padding=0)
             else:
                 overlap = min(sg.bottom(), vg.bottom()) - max(sg.top(), vg.top())
-                if overlap < min(vg.height()/3, sg.height()/3):  ## if less than 1/3 of views overlap, 
+                if overlap < min(vg.height()/3, sg.height()/3):  ## if less than 1/3 of views overlap,
                                                                  ## then just replicate the view
                     y1 = vr.top()
                     y2 = vr.bottom()
@@ -981,7 +998,7 @@ class ViewBox(GraphicsWidget):
                 self.setYRange(y1, y2, padding=0)
         finally:
             view.blockLink(False)
-        
+
     def screenGeometry(self):
         """return the screen geometry of the viewbox"""
         v = self.getViewWidget()
@@ -996,7 +1013,7 @@ class ViewBox(GraphicsWidget):
     def itemsChanged(self):
         ## called when items are added/removed from self.childGroup
         self.updateAutoRange()
-        
+
     def itemBoundsChanged(self, item):
         self._itemBoundsCache.pop(item, None)
         if (self.state['autoRange'][0] is not False) or (self.state['autoRange'][1] is not False):
@@ -1008,7 +1025,7 @@ class ViewBox(GraphicsWidget):
         key = 'xy'[ax] + 'Inverted'
         if self.state[key] == inv:
             return
-        
+
         self.state[key] = inv
         self._matrixNeedsUpdate = True # updateViewRange won't detect this for us
         self.updateViewRange()
@@ -1024,7 +1041,7 @@ class ViewBox(GraphicsWidget):
 
     def yInverted(self):
         return self.state['yInverted']
-        
+
     def invertX(self, b=True):
         """
         By default, the positive x-axis points rightward on the screen. Use invertX(True) to reverse the x-axis.
@@ -1033,14 +1050,14 @@ class ViewBox(GraphicsWidget):
 
     def xInverted(self):
         return self.state['xInverted']
-        
+
     def setAspectLocked(self, lock=True, ratio=1):
         """
         If the aspect ratio is locked, view scaling must always preserve the aspect ratio.
         By default, the ratio is set to 1; x and y both have the same scaling.
         This ratio can be overridden (xScale/yScale), or use None to lock in the current ratio.
         """
-        
+
         if not lock:
             if self.state['aspectLocked'] == False:
                 return
@@ -1059,16 +1076,16 @@ class ViewBox(GraphicsWidget):
             self.state['aspectLocked'] = ratio
             if ratio != currentRatio:  ## If this would change the current range, do that now
                 self.updateViewRange()
-        
+
         self.updateAutoRange()
         self.updateViewRange()
         self.sigStateChanged.emit(self)
-        
+
     def childTransform(self):
         """
         Return the transform that maps from child(item in the childGroup) coordinates to local coordinates.
         (This maps from inside the viewbox to outside)
-        """ 
+        """
         self.updateMatrix()
         m = self.childGroup.transform()
         return m
@@ -1094,7 +1111,7 @@ class ViewBox(GraphicsWidget):
         """Maps from the coordinate system displayed inside the ViewBox to scene coordinates"""
         self.updateMatrix()
         return self.mapToScene(self.mapFromView(obj))
-    
+
     def mapFromItemToView(self, item, obj):
         """Maps *obj* from the local coordinate system of *item* to the view coordinates"""
         self.updateMatrix()
@@ -1109,17 +1126,17 @@ class ViewBox(GraphicsWidget):
     def mapViewToDevice(self, obj):
         self.updateMatrix()
         return self.mapToDevice(self.mapFromView(obj))
-        
+
     def mapDeviceToView(self, obj):
         self.updateMatrix()
         return self.mapToView(self.mapFromDevice(obj))
-        
+
     def viewPixelSize(self):
         """Return the (width, height) of a screen pixel in view coordinates."""
         o = self.mapToView(Point(0,0))
         px, py = [Point(self.mapToView(v) - o) for v in self.pixelVectors()]
         return (px.length(), py.length())
-        
+
     def itemBoundingRect(self, item):
         """Return the bounding rect of the item in view coordinates"""
         return self.mapSceneToView(item.sceneBoundingRect()).boundingRect()
@@ -1133,12 +1150,12 @@ class ViewBox(GraphicsWidget):
         s = 1.02 ** (ev.delta() * self.state['wheelScaleFactor']) # actual scaling factor
         s = [(None if m is False else s) for m in mask]
         center = Point(fn.invertQTransform(self.childGroup.transform()).map(ev.pos()))
-        
+
         self._resetTarget()
         self.scaleBy(s, center)
         self.sigRangeChangedManually.emit(mask)
         ev.accept()
-        
+
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.RightButton and self.menuEnabled():
             ev.accept()
@@ -1146,8 +1163,9 @@ class ViewBox(GraphicsWidget):
 
     def raiseContextMenu(self, ev):
         menu = self.getMenu(ev)
-        self.scene().addParentContextMenus(self, menu, ev)
-        menu.popup(ev.screenPos().toPoint())
+        if menu is not None:
+            self.scene().addParentContextMenus(self, menu, ev)
+            menu.popup(ev.screenPos().toPoint())
 
     def getMenu(self, ev):
         return self.menu
@@ -1158,7 +1176,7 @@ class ViewBox(GraphicsWidget):
     def mouseDragEvent(self, ev, axis=None):
         ## if axis is specified, event will only affect that axis.
         ev.accept()  ## we accept all buttons
-        
+
         pos = ev.pos()
         lastPos = ev.lastPos()
         dif = pos - lastPos
@@ -1189,7 +1207,7 @@ class ViewBox(GraphicsWidget):
                 tr = self.mapToView(tr) - self.mapToView(Point(0,0))
                 x = tr.x() if mask[0] == 1 else None
                 y = tr.y() if mask[1] == 1 else None
-                
+
                 self._resetTarget()
                 if x is not None or y is not None:
                     self.translateBy(x=x, y=y)
@@ -1198,18 +1216,18 @@ class ViewBox(GraphicsWidget):
             #print "vb.rightDrag"
             if self.state['aspectLocked'] is not False:
                 mask[0] = 0
-            
+
             dif = ev.screenPos() - ev.lastScreenPos()
             dif = np.array([dif.x(), dif.y()])
             dif[0] *= -1
             s = ((mask * 0.02) + 1) ** dif
-            
+
             tr = self.childGroup.transform()
             tr = fn.invertQTransform(tr)
-            
+
             x = s[0] if mouseEnabled[0] == 1 else None
             y = s[1] if mouseEnabled[1] == 1 else None
-            
+
             center = Point(tr.map(ev.buttonDownPos(QtCore.Qt.RightButton)))
             self._resetTarget()
             self.scaleBy(x=x, y=y, center=center)
@@ -1223,7 +1241,7 @@ class ViewBox(GraphicsWidget):
         ctrl-A : zooms out to the default "full" view of the plot
         ctrl-+ : moves forward in the zooming stack (if it exists)
         ctrl-- : moves backward in the zooming stack (if it exists)
-         
+
         """
         ev.accept()
         if ev.text() == '-':
@@ -1259,12 +1277,12 @@ class ViewBox(GraphicsWidget):
         """Return a list of all children and grandchildren of this ViewBox"""
         if item is None:
             item = self.childGroup
-        
+
         children = [item]
         for ch in item.childItems():
             children.extend(self.allChildren(ch))
         return children
-        
+
     def childrenBounds(self, frac=None, orthoRange=(None,None), items=None):
         """Return the bounding range of all children.
         [[xmin, xmax], [ymin, ymax]]
@@ -1273,19 +1291,19 @@ class ViewBox(GraphicsWidget):
         profiler = debug.Profiler()
         if items is None:
             items = self.addedItems
-        
+
         ## measure pixel dimensions in view box
         px, py = [v.length() if v is not None else 0 for v in self.childGroup.pixelVectors()]
-        
+
         ## First collect all boundary information
         itemBounds = []
         for item in items:
             if not item.isVisible() or not item.scene() is self.scene():
                 continue
-        
+
             useX = True
             useY = True
-            
+
             if hasattr(item, 'dataBounds'):
                 if frac is None:
                     frac = (1.0, 1.0)
@@ -1301,23 +1319,23 @@ class ViewBox(GraphicsWidget):
 
                 bounds = QtCore.QRectF(xr[0], yr[0], xr[1]-xr[0], yr[1]-yr[0])
                 bounds = self.mapFromItemToView(item, bounds).boundingRect()
-                
+
                 if not any([useX, useY]):
                     continue
-                
+
                 ## If we are ignoring only one axis, we need to check for rotations
                 if useX != useY:  ##   !=  means  xor
                     ang = round(item.transformAngle())
                     if ang == 0 or ang == 180:
                         pass
                     elif ang == 90 or ang == 270:
-                        useX, useY = useY, useX 
+                        useX, useY = useY, useX
                     else:
                         ## Item is rotated at non-orthogonal angle, ignore bounds entirely.
                         ## Not really sure what is the expected behavior in this case.
-                        continue  ## need to check for item rotations and decide how best to apply this boundary. 
-                
-                
+                        continue  ## need to check for item rotations and decide how best to apply this boundary.
+
+
                 itemBounds.append((bounds, useX, useY, pxPad))
             else:
                 if int(item.flags() & item.ItemHasNoContents) > 0:
@@ -1326,7 +1344,7 @@ class ViewBox(GraphicsWidget):
                     bounds = item.boundingRect()
                 bounds = self.mapFromItemToView(item, bounds).boundingRect()
                 itemBounds.append((bounds, True, True, 0))
-        
+
         ## determine tentative new range
         range = [None, None]
         for bounds, useX, useY, px in itemBounds:
@@ -1341,7 +1359,7 @@ class ViewBox(GraphicsWidget):
                 else:
                     range[0] = [bounds.left(), bounds.right()]
             profiler()
-        
+
         ## Now expand any bounds that have a pixel margin
         ## This must be done _after_ we have a good estimate of the new range
         ## to ensure that the pixel size is roughly accurate.
@@ -1363,7 +1381,7 @@ class ViewBox(GraphicsWidget):
                 range[1][1] = max(range[1][1], bounds.bottom() + px*pxSize)
 
         return range
-        
+
     def childrenBoundingRect(self, *args, **kwds):
         range = self.childrenBounds(*args, **kwds)
         tr = self.targetRange()
@@ -1371,31 +1389,31 @@ class ViewBox(GraphicsWidget):
             range[0] = tr[0]
         if range[1] is None:
             range[1] = tr[1]
-            
+
         bounds = QtCore.QRectF(range[0][0], range[1][0], range[0][1]-range[0][0], range[1][1]-range[1][0])
         return bounds
-            
+
     def updateViewRange(self, forceX=False, forceY=False):
-        ## Update viewRange to match targetRange as closely as possible, given 
-        ## aspect ratio constraints. The *force* arguments are used to indicate 
+        ## Update viewRange to match targetRange as closely as possible, given
+        ## aspect ratio constraints. The *force* arguments are used to indicate
         ## which axis (if any) should be unchanged when applying constraints.
         viewRange = [self.state['targetRange'][0][:], self.state['targetRange'][1][:]]
         changed = [False, False]
-        
+
         #-------- Make correction for aspect ratio constraint ----------
-        
+
         # aspect is (widget w/h) / (view range w/h)
         aspect = self.state['aspectLocked']  # size ratio / view ratio
         tr = self.targetRect()
         bounds = self.rect()
         if aspect is not False and 0 not in [aspect, tr.height(), bounds.height(), bounds.width()]:
-            
+
             ## This is the view range aspect ratio we have requested
             targetRatio = tr.width() / tr.height() if tr.height() != 0 else 1
             ## This is the view range aspect ratio we need to obey aspect constraint
             viewRatio = (bounds.width() / bounds.height() if bounds.height() != 0 else 1) / aspect
             viewRatio = 1 if viewRatio == 0 else viewRatio
-            
+
             # Decide which range to keep unchanged
             #print self.name, "aspect:", aspect, "changed:", changed, "auto:", self.state['autoRange']
             if forceX:
@@ -1403,11 +1421,11 @@ class ViewBox(GraphicsWidget):
             elif forceY:
                 ax = 1
             else:
-                # if we are not required to keep a particular axis unchanged, 
+                # if we are not required to keep a particular axis unchanged,
                 # then make the entire target range visible
                 ax = 0 if targetRatio > viewRatio else 1
-            
-            if ax == 0:  
+
+            if ax == 0:
                 ## view range needs to be taller than target
                 dy = 0.5 * (tr.width() / viewRatio - tr.height())
                 if dy != 0:
@@ -1420,27 +1438,27 @@ class ViewBox(GraphicsWidget):
                     changed[0] = True
                 viewRange[0] = [self.state['targetRange'][0][0] - dx, self.state['targetRange'][0][1] + dx]
 
-            
+
         # ----------- Make corrections for view limits -----------
-        
+
         limits = (self.state['limits']['xLimits'], self.state['limits']['yLimits'])
         minRng = [self.state['limits']['xRange'][0], self.state['limits']['yRange'][0]]
         maxRng = [self.state['limits']['xRange'][1], self.state['limits']['yRange'][1]]
-        
+
         for axis in [0, 1]:
             if limits[axis][0] is None and limits[axis][1] is None and minRng[axis] is None and maxRng[axis] is None:
                 continue
-            
+
             # max range cannot be larger than bounds, if they are given
             if limits[axis][0] is not None and limits[axis][1] is not None:
                 if maxRng[axis] is not None:
                     maxRng[axis] = min(maxRng[axis], limits[axis][1]-limits[axis][0])
                 else:
                     maxRng[axis] = limits[axis][1]-limits[axis][0]
-            
+
             #print "\nLimits for axis %d: range=%s min=%s max=%s" % (axis, limits[axis], minRng[axis], maxRng[axis])
             #print "Starting range:", viewRange[axis]
-            
+
             # Apply xRange, yRange
             diff = viewRange[axis][1] - viewRange[axis][0]
             if maxRng[axis] is not None and diff > maxRng[axis]:
@@ -1451,12 +1469,12 @@ class ViewBox(GraphicsWidget):
                 changed[axis] = True
             else:
                 delta = 0
-            
+
             viewRange[axis][0] -= delta/2.
             viewRange[axis][1] += delta/2.
-            
+
             #print "after applying min/max:", viewRange[axis]
-               
+
             # Apply xLimits, yLimits
             mn, mx = limits[axis]
             if mn is not None and viewRange[axis][0] < mn:
@@ -1469,23 +1487,23 @@ class ViewBox(GraphicsWidget):
                 viewRange[axis][0] += delta
                 viewRange[axis][1] += delta
                 changed[axis] = True
-            
+
             #print "after applying edge limits:", viewRange[axis]
 
         changed = [(viewRange[i][0] != self.state['viewRange'][i][0]) or (viewRange[i][1] != self.state['viewRange'][i][1]) for i in (0,1)]
         self.state['viewRange'] = viewRange
-        
+
         # emit range change signals
         if changed[0]:
             self.sigXRangeChanged.emit(self, tuple(self.state['viewRange'][0]))
         if changed[1]:
             self.sigYRangeChanged.emit(self, tuple(self.state['viewRange'][1]))
-        
+
         if any(changed):
             self._matrixNeedsUpdate = True
             self.sigRangeChanged.emit(self, self.state['viewRange'])
             self.update()
-        
+
             # Inform linked views that the range has changed
             for ax in [0, 1]:
                 if not changed[ax]:
@@ -1493,14 +1511,14 @@ class ViewBox(GraphicsWidget):
                 link = self.linkedView(ax)
                 if link is not None:
                     link.linkedViewChanged(self, ax)
-        
+
     def updateMatrix(self, changed=None):
         if not self._matrixNeedsUpdate:
             return
 
         ## Make the childGroup's transform match the requested viewRange.
         bounds = self.rect()
-        
+
         vr = self.viewRect()
         if vr.height() == 0 or vr.width() == 0:
             return
@@ -1510,30 +1528,30 @@ class ViewBox(GraphicsWidget):
         if self.state['xInverted']:
             scale = scale * Point(-1, 1)
         m = QtGui.QTransform()
-        
+
         ## First center the viewport at 0
         center = bounds.center()
         m.translate(center.x(), center.y())
-            
+
         ## Now scale and translate properly
         m.scale(scale[0], scale[1])
         st = Point(vr.center())
         m.translate(-st[0], -st[1])
-        
+
         self.childGroup.setTransform(m)
-        
+
         self.sigTransformChanged.emit(self)  ## segfaults here: 1
         self._matrixNeedsUpdate = False
 
     def paint(self, p, opt, widget):
         self.checkSceneChange()
-        
+
         if self.border is not None:
             bounds = self.shape()
             p.setPen(self.border)
             #p.fillRect(bounds, QtGui.QColor(0, 0, 0))
             p.drawPath(bounds)
-            
+
         #p.setPen(fn.mkPen('r'))
         #path = QtGui.QPainterPath()
         #path.addRect(self.targetRect())
@@ -1547,27 +1565,28 @@ class ViewBox(GraphicsWidget):
         else:
             self.background.show()
             self.background.setBrush(fn.mkBrush(bg))
-            
+
     def updateViewLists(self):
         try:
             self.window()
         except RuntimeError:  ## this view has already been deleted; it will probably be collected shortly.
             return
-            
+
         def cmpViews(a, b):
             wins = 100 * cmp(a.window() is self.window(), b.window() is self.window())
             alpha = cmp(a.name, b.name)
             return wins + alpha
-            
+
         ## make a sorted list of all named views
         nv = list(ViewBox.NamedViews.values())
         sortList(nv, cmpViews) ## see pyqtgraph.python2_3.sortList
-        
+
         if self in nv:
             nv.remove(self)
-            
-        self.menu.setViewList(nv)
-        
+
+        if self.menu is not None:
+            self.menu.setViewList(nv)
+
         for ax in [0,1]:
             link = self.state['linkedViews'][ax]
             if isinstance(link, basestring):     ## axis has not been linked yet; see if it's possible now
@@ -1601,7 +1620,7 @@ class ViewBox(GraphicsWidget):
         for k in ViewBox.AllViews:
             if isQObjectAlive(k) and getConfigOption('crashWarning'):
                 sys.stderr.write('Warning: ViewBox should be closed before application exit.\n')
-                
+
             try:
                 k.destroyed.disconnect()
             except RuntimeError:  ## signal is already disconnected.
@@ -1610,7 +1629,7 @@ class ViewBox(GraphicsWidget):
                 pass
             except AttributeError:  # PySide has deleted signal
                 pass
-            
+
     def locate(self, item, timeout=3.0, children=False):
         """
         Temporarily display the bounding rect of an item and lines connecting to the center of the view.
@@ -1618,16 +1637,16 @@ class ViewBox(GraphicsWidget):
         if allChildren is True, then the bounding rect of all item's children will be shown instead.
         """
         self.clearLocate()
-        
+
         if item.scene() is not self.scene():
             raise Exception("Item does not share a scene with this ViewBox.")
-        
+
         c = self.viewRect().center()
         if children:
             br = self.mapFromItemToView(item, item.childrenBoundingRect()).boundingRect()
         else:
             br = self.mapFromItemToView(item, item.boundingRect()).boundingRect()
-        
+
         g = ItemGroup()
         g.setParentItem(self.childGroup)
         self.locateGroup = g
@@ -1638,11 +1657,11 @@ class ViewBox(GraphicsWidget):
             line = QtGui.QGraphicsLineItem(c.x(), c.y(), p.x(), p.y())
             line.setParentItem(g)
             g.lines.append(line)
-            
+
         for item in g.childItems():
             item.setPen(fn.mkPen(color='y', width=3))
         g.setZValue(1000000)
-        
+
         if children:
             g.path = QtGui.QGraphicsPathItem(g.childrenShape())
         else:
@@ -1650,9 +1669,9 @@ class ViewBox(GraphicsWidget):
         g.path.setParentItem(g)
         g.path.setPen(fn.mkPen('g'))
         g.path.setZValue(100)
-        
+
         QtCore.QTimer.singleShot(timeout*1000, self.clearLocate)
-    
+
     def clearLocate(self):
         if self.locateGroup is None:
             return


### PR DESCRIPTION
enforce _enableMenu_ when False:
* set _menu_ attribute to None at __init__
* populate _menu_ as necessary is the state is changed

For example in case of 400 ViewBox objects, the time spent creating the _menu_ attributes was 1.2s. If no menu is needed then this can improve the performance. 