### PR TITLE
Fixed incorrect evaluation of Point in mouseMoveEvent.

### DIFF
--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -362,7 +362,7 @@ class GraphicsView(QtGui.QGraphicsView):
     def mouseMoveEvent(self, ev):
         if self.lastMousePos is None:
             self.lastMousePos = Point(ev.pos())
-        delta = Point(ev.pos() - self.lastMousePos)
+        delta = Point(ev.pos()) - self.lastMousePos
         self.lastMousePos = Point(ev.pos())
 
         QtGui.QGraphicsView.mouseMoveEvent(self, ev)


### PR DESCRIPTION
ev.pos() is a QT Point, but self.lastMousePos was converted to pyqtgraph Point.