### PR TITLE
Fix for PySide2; QtCore.QPoint.__sub__ no longer works with tuples

### DIFF
--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -362,7 +362,7 @@ class GraphicsView(QtGui.QGraphicsView):
     def mouseMoveEvent(self, ev):
         if self.lastMousePos is None:
             self.lastMousePos = Point(ev.pos())
-        delta = Point(ev.pos() - self.lastMousePos)
+        delta = Point(ev.pos() - QtCore.QPoint(*self.lastMousePos))
         self.lastMousePos = Point(ev.pos())
 
         QtGui.QGraphicsView.mouseMoveEvent(self, ev)


### PR DESCRIPTION
Otherwise, hovering over GraphicsViews produces error:
```
Traceback (most recent call last):
  File "C:\Users\rp\PycharmProjects\pyqtgraph\pyqtgraph\widgets\GraphicsView.py", line 365, in mouseMoveEvent
    delta = Point(ev.pos() - self.lastMousePos)
TypeError: 'PySide2.QtCore.QPoint.__sub__' called with wrong argument types:
  PySide2.QtCore.QPoint.__sub__(Point)
Supported signatures:
  PySide2.QtCore.QPoint.__sub__(PySide2.QtCore.QPoint)
```