### PR TITLE
Bug fix in test_csv.py

### DIFF
--- a/pyqtgraph/exporters/tests/test_csv.py
+++ b/pyqtgraph/exporters/tests/test_csv.py
@@ -1,5 +1,5 @@
 """
-SVG export test
+CSV export test
 """
 from __future__ import division, print_function, absolute_import
 import pyqtgraph as pg
@@ -33,8 +33,9 @@ def test_CSVExporter():
     ex = pg.exporters.CSVExporter(plt.plotItem)
     ex.export(fileName=tempfilename)
 
-    r = csv.reader(open(tempfilename, 'r'))
-    lines = [line for line in r]
+    with open(tempfilename, 'r') as csv_file:
+        r = csv.reader(csv_file)
+        lines = [line for line in r]
     header = lines.pop(0)
     assert header == ['myPlot_x', 'myPlot_y', 'x0001', 'y0001', 'x0002', 'y0002']
     


### PR DESCRIPTION
Fixed bug where the temp file ```test_CSVExporter``` generates remains open and ```os.unlink``` raises a ```PermissionError```. This commit closes the TextIO connection after the data is read. 