### PR TITLE
Set path attr in case ErrorBarItem initialized without data

### DIFF
--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -45,9 +45,11 @@ class ErrorBarItem(GraphicsObject):
         
         This method was added in version 0.9.9. For prior versions, use setOpts.
         """
-        if 'x' in opts and 'y' in opts:
-            self.setVisible(True)
         self.opts.update(opts)
+        if self.opts['x'] is not None and self.opts['y'] is not None:
+            self.setVisible(True)
+        else:
+            self.setVisible(False)
         self.path = None
         self.update()
         self.prepareGeometryChange()

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -46,10 +46,10 @@ class ErrorBarItem(GraphicsObject):
         This method was added in version 0.9.9. For prior versions, use setOpts.
         """
         self.opts.update(opts)
-        if self.opts['x'] is not None and self.opts['y'] is not None:
-            self.setVisible(True)
-        else:
+        if self.opts['x'] is None or self.opts['y'] is None:
             self.setVisible(False)
+        else:
+            self.setVisible(True)
         self.path = None
         self.update()
         self.prepareGeometryChange()

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -46,10 +46,7 @@ class ErrorBarItem(GraphicsObject):
         This method was added in version 0.9.9. For prior versions, use setOpts.
         """
         self.opts.update(opts)
-        if self.opts['x'] is None or self.opts['y'] is None:
-            self.setVisible(False)
-        else:
-            self.setVisible(True)
+        self.setVisible(all(self.opts[ax] is not None for ax in ['x', 'y']))
         self.path = None
         self.update()
         self.prepareGeometryChange()

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -23,6 +23,7 @@ class ErrorBarItem(GraphicsObject):
             beam=None,
             pen=None
         )
+        self.setVisible(False)
         self.setData(**opts)
 
     def setData(self, **opts):
@@ -44,6 +45,8 @@ class ErrorBarItem(GraphicsObject):
         
         This method was added in version 0.9.9. For prior versions, use setOpts.
         """
+        if 'x' in opts and 'y' in opts:
+            self.setVisible(True)
         self.opts.update(opts)
         self.path = None
         self.update()

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -59,6 +59,7 @@ class ErrorBarItem(GraphicsObject):
         
         x, y = self.opts['x'], self.opts['y']
         if x is None or y is None:
+            self.path = p
             return
         
         beam = self.opts['beam']

--- a/pyqtgraph/graphicsItems/tests/test_ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_ErrorBarItem.py
@@ -1,12 +1,10 @@
-import pytest
-from pyqtgraph.Qt import QtGui, QtCore
 import pyqtgraph as pg
 import numpy as np
 
 app = pg.mkQApp()
 
 
-def test_errorbaritem_defer_data():
+def test_ErrorBarItem_defer_data():
     plot = pg.PlotWidget()
     plot.show()
 

--- a/pyqtgraph/graphicsItems/tests/test_ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_ErrorBarItem.py
@@ -1,0 +1,39 @@
+import pytest
+from pyqtgraph.Qt import QtGui, QtCore
+import pyqtgraph as pg
+import numpy as np
+
+app = pg.mkQApp()
+
+
+def test_errorbaritem_defer_data():
+    plot = pg.PlotWidget()
+    plot.show()
+
+    # plot some data away from the origin to set the view rect
+    x = np.arange(5) + 10
+    curve = pg.PlotCurveItem(x=x, y=x)
+    plot.addItem(curve)
+    app.processEvents()
+    r_no_ebi = plot.viewRect()
+
+    # ErrorBarItem with no data shouldn't affect the view rect
+    err = pg.ErrorBarItem()
+    plot.addItem(err)
+    app.processEvents()
+    r_empty_ebi = plot.viewRect()
+
+    assert r_no_ebi == r_empty_ebi
+
+    err.setData(x=x, y=x, bottom=x, top=x)
+    app.processEvents()
+    r_ebi = plot.viewRect()
+
+    assert r_empty_ebi != r_ebi
+
+    # unset data, ErrorBarItem disappears and view rect goes back to original
+    err.setData(x=None, y=None)
+    app.processEvents()
+    r_clear_ebi = plot.viewRect()
+
+    assert r_clear_ebi == r_no_ebi


### PR DESCRIPTION
This aims to fix issue #860.

In case the user wants to defer setting `ErrorBarItem` data, we can set the `path` attribute to the plain `QPainterPath` which has a bounding rect with zero width/height. Example (borrowed from #860):

```python
import pyqtgraph as pg
import numpy as np

x = np.arange(5)
y = np.array([1, 2, 1, 3, 1])
e = np.array([1, 0.1, 0.5, 0.1, 3])

plt = pg.plot()
err = pg.ErrorBarItem()
cur = pg.PlotCurveItem(x=x, y=y)
plt.addItem(err)
plt.addItem(cur)

err.setData(x=x, y=y, top=e, bottom=e)

pg.mkQApp().exec_()
```

This avoids the error shown in the issue, but one potential shortcoming of this approach is the bounding rect is at the origin, so it could cause scaling/range issues until the `ErrorBarItem` data is set:

```python
import pyqtgraph as pg
import numpy as np

x = np.arange(5) + 100  # offset x data by 100 to demonstrate
y = np.array([1, 2, 1, 3, 1])
e = np.array([1, 0.1, 0.5, 0.1, 3])

plt = pg.plot()
err = pg.ErrorBarItem()
cur = pg.PlotCurveItem(x=x, y=y)
plt.addItem(err)
plt.addItem(cur)

pg.mkQApp().exec_()
```

![issue_860_2](https://user-images.githubusercontent.com/943602/57172471-51d6bd00-6dd5-11e9-8f70-b55651553162.png)