### PR TITLE
Fix pyside2 qt.py tests

### DIFF
--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -100,10 +100,13 @@ def _loadUiType(uiFile):
     how to make PyQt4 and pyside look the same...
         http://stackoverflow.com/a/8717832
     """
-    import pysideuic
+
+    if QT_LIB == "PYSIDE":
+        import pysideuic
+    else:
+        import pyside2uic as pysideuic
     import xml.etree.ElementTree as xml
-    #from io import StringIO
-    
+
     parsed = xml.parse(uiFile)
     widget_class = parsed.find('widget').get('class')
     form_class = parsed.find('class').text

--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -219,8 +219,12 @@ elif QT_LIB == PYSIDE2:
     except ImportError as err:
         QtTest = FailedImport(err)
 
-    isQObjectAlive = _isQObjectAlive
-    
+    try:
+        import shiboken2
+        isQObjectAlive = shiboken2.isValid
+    except ImportError:
+        # use approximate version
+        isQObjectAlive = _isQObjectAlive    
     import PySide2
     VERSION_INFO = 'PySide2 ' + PySide2.__version__ + ' Qt ' + QtCore.__version__
 

--- a/pyqtgraph/tests/test_qt.py
+++ b/pyqtgraph/tests/test_qt.py
@@ -10,7 +10,6 @@ def test_isQObjectAlive():
     o2 = pg.QtCore.QObject()
     o2.setParent(o1)
     del o1
-    gc.collect()
     assert not pg.Qt.isQObjectAlive(o2)
 
 @pytest.mark.skipif(pg.Qt.QT_LIB == 'PySide', reason='pysideuic does not appear to be '


### PR DESCRIPTION
This PR will address some of the errors with PySide2 tests, specifically fixes two errors, the `test_isQObjectAlive` test and `test_loadUiType`.  It also incorporates `shiboken2.isValid()`.

For `test_isQObjectAlive`, we remove the `gc.collect()` call.  After removing this call, we no longer get a segfault on pyside2.  The test passes on pyside2 and pyqt5 bindings, pyqt4/pyside1 were not tested.

We now no longer attempt to import `pysideuic` with `pyside2` bindings, and now import `import pyside2uic as pysideuic`.

Lastly, made reference to `shiboken2.isValid()`.  `shiboken2` is a dependency of pyside2.  There may be issues with this on conda-based pyside2 installations (that use Qt 5.6)
