### PR TITLE
FIX: Crash when closing Matplotlib exporter

### DIFF
--- a/pyqtgraph/exporters/Matplotlib.py
+++ b/pyqtgraph/exporters/Matplotlib.py
@@ -124,5 +124,4 @@ class MatplotlibWindow(QtGui.QMainWindow):
         
     def closeEvent(self, ev):
         MatplotlibExporter.windows.remove(self)
-
-
+        self.deleteLater()


### PR DESCRIPTION
Adds a call of `deleteLater` for the Matplotlib export QMainWindow when closing so although the local reference to that window might be deleted by the Python Garbage Collector, the QMainWindow object is not deleted too early, which otherwise leads to a segmentation fault. Note that since this is an effect of the Garbage Collector, this behavior seemingly occurs at random.

Closes #867