### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ sudo: false
 notifications:
   email: false
 
-virtualenv:
-    system_site_packages: true
-
-
 env:
     # Enable python 2 and python 3 builds
     # Note that the 2.6 build doesn't get flake8, and runs old versions of


### PR DESCRIPTION
Travis CI currently does not work because system_site_packages do not work with Conda installations. As system_site_packages are not needed, this pull request aims at removing them.

Note that now the build fails because of real bugs in the code, and not because of Travis.
Also note that some tests pass although there are errors in the Travis log that need attention.

Closes #869