### PR TITLE
Fix numpy deprecation warning by typecasting multi-dimension indices to tuples.

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1380,7 +1380,7 @@ def gaussianFilter(data, sigma):
         # clip off extra data
         sl = [slice(None)] * data.ndim
         sl[ax] = slice(filtered.shape[ax]-data.shape[ax],None,None)
-        filtered = filtered[sl]
+        filtered = filtered[tuple(sl)]
     return filtered + baseline
     
     

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -633,7 +633,7 @@ class ImageView(QtGui.QWidget):
             ax = np.argmax(data.shape)
             sl = [slice(None)] * data.ndim
             sl[ax] = slice(None, None, 2)
-            data = data[sl]
+            data = data[tuple(sl)]
             
         cax = self.axes['c']
         if cax is None:


### PR DESCRIPTION
I messed up my previous pull-request by doing something stupid. I hope, it's fixed now.