### PR TITLE
Typecast Levels to be float

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1057,6 +1057,7 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False):
             raise Exception('levels argument is required for float input types')
     if not isinstance(levels, np.ndarray):
         levels = np.array(levels)
+    levels = levels.astype(np.float)
     if levels.ndim == 1:
         if levels.shape[0] != 2:
             raise Exception('levels argument must have length 2')


### PR DESCRIPTION
This circumvents cases in which "levels" is a boolean array and therefore the substraction fails due to deprecation. It seems to be, that "levels" is only used for min/max calculation further down, so this change should not affect other code.