### PR TITLE
Add h5py dependency to Conda in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
     - conda update conda --yes
     - conda create -n test_env python=${PYTHON} --yes
     - source activate test_env
-    - conda install numpy scipy pyopengl pytest flake8 six coverage --yes
+    - conda install numpy scipy pyopengl pytest flake8 six coverage h5py --yes
     - echo ${QT}
     - echo ${TEST}
     - echo ${PYTHON}


### PR DESCRIPTION
test_examples.py needs h5py, which it hereby gets.