### PR TITLE
Fix flowchart save on Python 3

### DIFF
--- a/pyqtgraph/flowchart/Flowchart.py
+++ b/pyqtgraph/flowchart/Flowchart.py
@@ -526,11 +526,6 @@ class Flowchart(Node):
         self.viewBox.autoRange()
         self.sigFileLoaded.emit(fileName)
 
-    def saveFileSelected(self, fileName):
-        if not fileName.endswith('.fc'):
-            fileName += '.fc'
-        self.saveFile(fileName=fileName)
-
     def saveFile(self, fileName=None, startDir=None, suggestedFileName='flowchart.fc'):
         """Save this flowchart to a .fc file
         """
@@ -540,9 +535,10 @@ class Flowchart(Node):
             if startDir is None:
                 startDir = '.'
             self.fileDialog = FileDialog(None, "Save Flowchart..", startDir, "Flowchart (*.fc)")
+            self.fileDialog.setDefaultSuffix("fc")
             self.fileDialog.setAcceptMode(QtGui.QFileDialog.AcceptSave) 
             self.fileDialog.show()
-            self.fileDialog.fileSelected.connect(self.saveFileSelected)
+            self.fileDialog.fileSelected.connect(self.saveFile)
             return
         fileName = asUnicode(fileName)
         configfile.writeConfigFile(self.saveState(), fileName)

--- a/pyqtgraph/flowchart/Flowchart.py
+++ b/pyqtgraph/flowchart/Flowchart.py
@@ -525,7 +525,12 @@ class Flowchart(Node):
         self.restoreState(state, clear=True)
         self.viewBox.autoRange()
         self.sigFileLoaded.emit(fileName)
-        
+
+    def saveFileSelected(self, fileName):
+        if not fileName.endswith('.fc'):
+            fileName += '.fc'
+        self.saveFile(fileName=fileName)
+
     def saveFile(self, fileName=None, startDir=None, suggestedFileName='flowchart.fc'):
         """Save this flowchart to a .fc file
         """
@@ -537,11 +542,8 @@ class Flowchart(Node):
             self.fileDialog = FileDialog(None, "Save Flowchart..", startDir, "Flowchart (*.fc)")
             self.fileDialog.setAcceptMode(QtGui.QFileDialog.AcceptSave) 
             self.fileDialog.show()
-            self.fileDialog.fileSelected.connect(self.saveFile)
+            self.fileDialog.fileSelected.connect(self.saveFileSelected)
             return
-        fileName = unicode(fileName)
-        if not fileName.endswith('.fc'):
-            fileName += '.fc'
         fileName = asUnicode(fileName)
         configfile.writeConfigFile(self.saveState(), fileName)
         self.sigFileSaved.emit(fileName)

--- a/pyqtgraph/flowchart/Flowchart.py
+++ b/pyqtgraph/flowchart/Flowchart.py
@@ -27,6 +27,7 @@ from .. import configfile as configfile
 from .. import dockarea as dockarea
 from . import FlowchartGraphicsView
 from .. import functions as fn
+from ..python2_3 import asUnicode
 
 def strDict(d):
     return dict([(str(k), v) for k, v in d.items()])
@@ -519,7 +520,7 @@ class Flowchart(Node):
             self.fileDialog.fileSelected.connect(self.loadFile)
             return
             ## NOTE: was previously using a real widget for the file dialog's parent, but this caused weird mouse event bugs..
-        fileName = unicode(fileName)
+        fileName = asUnicode(fileName)
         state = configfile.readConfigFile(fileName)
         self.restoreState(state, clear=True)
         self.viewBox.autoRange()
@@ -539,6 +540,9 @@ class Flowchart(Node):
             self.fileDialog.fileSelected.connect(self.saveFile)
             return
         fileName = unicode(fileName)
+        if not fileName.endswith('.fc'):
+            fileName += '.fc'
+        fileName = asUnicode(fileName)
         configfile.writeConfigFile(self.saveState(), fileName)
         self.sigFileSaved.emit(fileName)
 
@@ -662,7 +666,7 @@ class FlowchartCtrlWidget(QtGui.QWidget):
         #self.setCurrentFile(newFile)
         
     def fileSaved(self, fileName):
-        self.setCurrentFile(unicode(fileName))
+        self.setCurrentFile(asUnicode(fileName))
         self.ui.saveBtn.success("Saved.")
         
     def saveClicked(self):
@@ -691,7 +695,7 @@ class FlowchartCtrlWidget(QtGui.QWidget):
         #self.setCurrentFile(newFile)
             
     def setCurrentFile(self, fileName):
-        self.currentFileName = unicode(fileName)
+        self.currentFileName = asUnicode(fileName)
         if fileName is None:
             self.ui.fileNameLabel.setText("<b>[ new ]</b>")
         else:

--- a/pyqtgraph/flowchart/Node.py
+++ b/pyqtgraph/flowchart/Node.py
@@ -373,7 +373,7 @@ class Node(QtCore.QObject):
         pos = self.graphicsItem().pos()
         state = {'pos': (pos.x(), pos.y()), 'bypass': self.isBypassed()}
         termsEditable = self._allowAddInput | self._allowAddOutput
-        for term in self._inputs.values() + self._outputs.values():
+        for term in list(self._inputs.values()) + list(self._outputs.values()):
             termsEditable |= term._renamable | term._removable | term._multiable
         if termsEditable:
             state['terminals'] = self.saveTerminals()


### PR DESCRIPTION
I took the work started in #231 and implemented the additional requested change to only append the `.fc` extension if the user didn't add it in the file dialog.

If this is merged, we can close duplicate pull requests #231, #423, #435, #441, #513.

Also fixes #512