### PR TITLE
TreeWidget.topLevelItems Python 3 fix

### DIFF
--- a/pyqtgraph/widgets/TreeWidget.py
+++ b/pyqtgraph/widgets/TreeWidget.py
@@ -201,7 +201,7 @@ class TreeWidget(QtGui.QTreeWidget):
         return item
 
     def topLevelItems(self):
-        return map(self.topLevelItem, xrange(self.topLevelItemCount()))
+        return [self.topLevelItem(i) for i in range(self.topLevelItemCount())]
         
     def clear(self):
         items = self.topLevelItems()


### PR DESCRIPTION
Fixes #726 

Opted to use the same pattern as in `TreeWidgetItem.childItems` rather than importing `xrange` from `python2_3`.