### PR TITLE
Show failing examples as "FAILED" in pytest

### DIFF
--- a/examples/utils.py
+++ b/examples/utils.py
@@ -168,8 +168,6 @@ except:
     res = (process.stdout.read(), process.stderr.read())
 
     if fail or 'exception' in res[1].decode().lower() or 'error' in res[1].decode().lower():
-        print('.' * (50-len(name)) + 'FAILED')
         print(res[0].decode())
         print(res[1].decode())
-    else:
-        print('.' * (50-len(name)) + 'passed')
+        assert False

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -170,4 +170,5 @@ except:
     if fail or 'exception' in res[1].decode().lower() or 'error' in res[1].decode().lower():
         print(res[0].decode())
         print(res[1].decode())
+        print()
         assert False


### PR DESCRIPTION
Catching everything and then just outputting the words "FAILED" does not help keeping track of errors. With this pull request, pytest is noticed via assert when an error occurred. This also replaces further additional text output of whether the test was failing.