### PR TITLE
Only execute hdf5 example if module h5py exists

### DIFF
--- a/examples/utils.py
+++ b/examples/utils.py
@@ -120,7 +120,7 @@ def testFile(name, f, exe, lib, graphicsSystem=None):
             try:
                 __import__(requirement)
             except ImportError:
-                print(" Requirement {} of this test not satified ".format(requirement))
+                print(" Requirement \"{}\" of this test not satified ".format(requirement))
                 pytest.skip()
 
     import1 = "import %s" % lib if lib != '' else ''

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -117,11 +117,7 @@ def testFile(name, f, exe, lib, graphicsSystem=None):
     
     if f in example_requirements:
         for requirement in example_requirements[f]:
-            try:
-                __import__(requirement)
-            except ImportError:
-                print(" Requirement \"{}\" of this test not satified ".format(requirement))
-                pytest.skip()
+            pytest.importorskip(requirement, reason="Requirement \"{}\" of this test not satified ".format(requirement))
 
     import1 = "import %s" % lib if lib != '' else ''
     import2 = os.path.splitext(os.path.split(fn)[1])[0]

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -4,6 +4,7 @@ import time
 import os
 import sys
 import errno
+import pytest
 from pyqtgraph.pgcollections import OrderedDict
 from pyqtgraph.python2_3 import basestring
 
@@ -90,6 +91,8 @@ examples = OrderedDict([
     ('Flowcharts', 'Flowchart.py'),
     ('Custom Flowchart Nodes', 'FlowchartCustomNode.py'),
 ])
+    
+example_requirements = {'hdf5.py' : ['h5py']}
 
 
 def buildFileList(examples, files=None):
@@ -105,12 +108,20 @@ def buildFileList(examples, files=None):
     return files
 
 def testFile(name, f, exe, lib, graphicsSystem=None):
-    global path
+    global path, example_requirements
     fn = os.path.join(path,f)
     #print "starting process: ", fn
     os.chdir(path)
     sys.stdout.write(name)
     sys.stdout.flush()
+    
+    if f in example_requirements:
+        for requirement in example_requirements[f]:
+            try:
+                __import__(requirement)
+            except ImportError:
+                print(" Requirement {} of this test not satified ".format(requirement))
+                pytest.skip()
 
     import1 = "import %s" % lib if lib != '' else ''
     import2 = os.path.splitext(os.path.split(fn)[1])[0]


### PR DESCRIPTION
Introduces a dictionary containing requirements of chosen examples. If a requirement is not met, the example will not be executed.

To test whether this really also works if h5py exists, I created a new branch with a similar commit but also let travis import h5py (not the identical, it contains one unnecessary import statement more - sorry):
branch: https://github.com/2xB/pyqtgraph/commits/hdf5_test
log: https://travis-ci.com/2xB/pyqtgraph/jobs/203002184

Closes #882 