### PR TITLE
PySide2 is also a Qt5 binding

### DIFF
--- a/pyqtgraph/tests/image_testing.py
+++ b/pyqtgraph/tests/image_testing.py
@@ -253,7 +253,7 @@ def assertImageMatch(im1, im2, minCorr=None, pxThreshold=50.,
     assert im1.dtype == im2.dtype
 
     if pxCount == -1:
-        if QT_LIB == 'PyQt5':
+        if QT_LIB in {'PyQt5', 'PySide2'}:
             # Qt5 generates slightly different results; relax the tolerance
             # until test images are updated.
             pxCount = int(im1.shape[0] * im1.shape[1] * 0.01)


### PR DESCRIPTION
This fixes some of the pyside2 tests for image checks; existing code checked for the presence of PyQt5 and had the following comment

```
            # Qt5 generates slightly different results; relax the tolerance
            # until test images are updated.
```

This PR merely checks if the bindings are either PyQt5 or PySide2.