### PR TITLE
Simpler way of extracting types from QByteArray

### DIFF
--- a/pyqtgraph/exporters/SVGExporter.py
+++ b/pyqtgraph/exporters/SVGExporter.py
@@ -190,12 +190,7 @@ def _generateItemSvg(item, nodes=None, root=None, options={}):
             ## this is taken care of in generateSvg instead.
             #if hasattr(item, 'setExportMode'):
                 #item.setExportMode(False)
-
-        if QT_LIB in ['PySide', 'PySide2']:
-            xmlStr = str(arr)
-        else:
-            xmlStr = bytes(arr).decode('utf-8')
-        doc = xml.parseString(xmlStr.encode('utf-8'))
+        doc = xml.parseString(arr.data())
         
     try:
         ## Get top-level group for this item


### PR DESCRIPTION
This pull request deals with one of the last test failures with unit-testing pyside2.  

After making this change, the following command generated this result:

command
```
tox -- pyqtgraph/exporters/tests/test_svg.py::test_plotscene
```

result
```
______________________________________________________________________________________ summary ______________________________________________________________________________________
  py27-pyside2-pip: commands succeeded
  py37-pyside2-pip: commands succeeded
  py35-pyqt5-pip: commands succeeded
  py37-pyqt5-pip: commands succeeded
  py27-pyqt5-conda: commands succeeded
  py37-pyqt5-conda: commands succeeded
  py35-pyqt5-conda: commands succeeded
  py27-pyside2-conda: commands succeeded
  py35-pyside2-conda: commands succeeded
  py37-pyside2-conda: commands succeeded
  py27-pyqt4-conda: commands succeeded
  py36-pyqt4-conda: commands succeeded
  py27-pyside-conda: commands succeeded
  py36-pyside-conda: commands succeeded
  congratulations :)
```