### PR TITLE
Add PyQt5 and PySide2 to test_example.py

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -42,7 +42,7 @@ except ImportError:
     pass
 
 files = utils.buildFileList(utils.examples)
-frontends = {Qt.PYQT4: False, Qt.PYSIDE: False}
+frontends = {Qt.PYQT4: False, Qt.PYQT5: False, Qt.PYSIDE: False}
 # sort out which of the front ends are available
 for frontend in frontends.keys():
     try:

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -42,7 +42,7 @@ except ImportError:
     pass
 
 files = utils.buildFileList(utils.examples)
-frontends = {Qt.PYQT4: False, Qt.PYQT5: False, Qt.PYSIDE: False}
+frontends = {Qt.PYQT4: False, Qt.PYQT5: False, Qt.PYSIDE: False, Qt.PYSIDE2: False}
 # sort out which of the front ends are available
 for frontend in frontends.keys():
     try:


### PR DESCRIPTION
Before, example tests were skipped for Python 3 on Travis because it used PyQt5, which was not used for testing examples.