### PR TITLE
Add condition for namespace packages

### DIFF
--- a/pyqtgraph/reload.py
+++ b/pyqtgraph/reload.py
@@ -47,7 +47,7 @@ def reloadAll(prefix=None, debug=False):
             continue
         
         ## Ignore if the file name does not start with prefix
-        if not hasattr(mod, '__file__') or os.path.splitext(mod.__file__)[1] not in ['.py', '.pyc']:
+        if not hasattr(mod, '__file__') or mod.__file__ is None or os.path.splitext(mod.__file__)[1] not in ['.py', '.pyc']:
             continue
         if prefix is not None and mod.__file__[:len(prefix)] != prefix:
             continue


### PR DESCRIPTION
Previously, on my local machine, `test_reload` would fail 
in environments with namspace packages (specifically, my
failure was `aspy` from `aspy.yaml`).

The namespace package has `__file__ = None`, so the splitext call
was failing.

I'm still a little confused as to why it was loaded for this test
in the first place, but this fixed the problem.