### PR TITLE
Take screenshots + Show Resolution

### DIFF
--- a/examples/__main__.py
+++ b/examples/__main__.py
@@ -135,6 +135,8 @@ if __name__ == '__main__':
             lib = 'PyQt4'
         elif '--pyqt5' in args:
             lib = 'PyQt5'
+        elif '--pyside2' in args:
+            lib = 'PySide2'
         else:
             lib = ''
             

--- a/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
@@ -31,8 +31,6 @@ def init_viewbox():
     
     g = pg.GridItem()
     vb.addItem(g)
-    desktop = app.desktop().screenGeometry()
-    print("\n\nDesktop Resolution: {} x {}\n\n".format(desktop.width(), desktop.height()))
     app.processEvents()
     
 def test_ViewBox():

--- a/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
@@ -31,7 +31,8 @@ def init_viewbox():
     
     g = pg.GridItem()
     vb.addItem(g)
-    
+    desktop = app.desktop().screenGeometry()
+    print("\n\nDesktop Resolution: {} x {}\n\n".format(desktop.width(), desktop.height()))
     app.processEvents()
     
 def test_ViewBox():

--- a/pyqtgraph/tests/image_testing.py
+++ b/pyqtgraph/tests/image_testing.py
@@ -289,9 +289,9 @@ def saveFailedTest(data, expect, filename, upload=False):
     """Upload failed test images to web server to allow CI test debugging.
     """
     commit = runSubprocess(['git', 'rev-parse',  'HEAD'])
-    name = filename.split('/')
+    name = filename.split(os.path.sep)
     name.insert(-1, commit.strip())
-    filename = '/'.join(name)
+    filename = os.path.sep.join(name)
 
     # concatenate data, expect, and diff into a single image
     ds = data.shape
@@ -309,7 +309,7 @@ def saveFailedTest(data, expect, filename, upload=False):
     img[2:2+diff.shape[0], -diff.shape[1]-2:-2] = diff
 
     png = makePng(img)
-    directory, _, _ = filename.rpartition("/")
+    directory = os.path.dirname(filename)
     if not os.path.isdir(directory):
         os.makedirs(directory)
     with open(filename + ".png", "wb") as png_file:
@@ -317,9 +317,9 @@ def saveFailedTest(data, expect, filename, upload=False):
     print("\nImage comparison failed. Test result: %s %s   Expected result: "
         "%s %s" % (data.shape, data.dtype, expect.shape, expect.dtype))
     if upload:
-        uploadFailedTest(filename)
+        uploadFailedTest(filename, png)
     
-def uploadFailedTest(filename):
+def uploadFailedTest(filename, png):
     host = 'data.pyqtgraph.org'
     conn = httplib.HTTPConnection(host)
     req = urllib.urlencode({'name': filename,

--- a/test.py
+++ b/test.py
@@ -15,10 +15,15 @@ elif '--pyqt4' in args:
 elif '--pyqt5' in args:
     args.remove('--pyqt5')
     import PyQt5
+elif '--pyside2' in args:
+    args.remove('--pyside2')
+    import PySide2
 
 import pyqtgraph as pg
 pg.systemInfo()
-
+qApp = pg.mkQApp()
+desktop = qApp.desktop().screenGeometry()
+print("\n\nDesktop Resolution: {} x {}\n\n".format(desktop.width(), desktop.height()))
 pytest.main(args)
     
     


### PR DESCRIPTION
This PR consists of a few changes.

1. Add `--pyside2` option to `examples/__main__.py
2. Take screenshots of failed tests, and optionally upload them to `data.pyqtgraph.org`
  * We will use this capability to extract failed images from CI systems via Artifact upload
3. Have `test_ViewBox.py` show us the available resolution of the desktop being tested on.
  * This may assist with troubleshooting the `assertMapping` failed tests on macOS Azure pipeline

Once this PR is merged, I will update the azure-pipeline templates to add the ability to capture the stored images from the failed tests and upload them as an artifact for further review.