### PR TITLE
Exclude selected examples from tests (such as HDF5)

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -41,7 +41,7 @@ except ImportError:
           "pypi\n\npip install importlib\n\n")
     pass
 
-files = utils.buildFileList(utils.examples)
+files = utils.buildFileList(utils.tested_examples)
 frontends = {Qt.PYQT4: False, Qt.PYQT5: False, Qt.PYSIDE: False, Qt.PYSIDE2: False}
 # sort out which of the front ends are available
 for frontend in frontends.keys():

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -4,6 +4,7 @@ import time
 import os
 import sys
 import errno
+import copy
 from pyqtgraph.pgcollections import OrderedDict
 from pyqtgraph.python2_3 import basestring
 
@@ -90,6 +91,11 @@ examples = OrderedDict([
     ('Flowcharts', 'Flowchart.py'),
     ('Custom Flowchart Nodes', 'FlowchartCustomNode.py'),
 ])
+
+not_tested = ['HDF5 big data']
+
+tested_examples = copy.deepcopy(examples)
+all(map(tested_examples.pop, not_tested))
 
 
 def buildFileList(examples, files=None):


### PR DESCRIPTION
This pull request is following from the discussions to PR #891 and #892 and issue #882.
It adds an array of examples that are excluded from testing.

Closes #882.