### PR TITLE
Fixed compatibility with Qt5

### DIFF
--- a/examples/ROIExamples.py
+++ b/examples/ROIExamples.py
@@ -8,7 +8,7 @@ function of the scale/rotate handles in very flexible ways.
 import initExample ## Add path to library (just for examples; you do not need this)
 
 import pyqtgraph as pg
-from pyqtgraph.Qt import QtCore, QtGui
+from pyqtgraph.Qt import QtCore, QtGui, QtWidgets
 import numpy as np
 
 pg.setConfigOptions(imageAxisOrder='row-major')
@@ -33,7 +33,15 @@ arr[8:13, 44:46] = 10
 
 ## create GUI
 app = QtGui.QApplication([])
-w = pg.GraphicsLayoutWidget(show=True, size=(1000,800), border=True)
+
+window = QtWidgets.QMainWindow()
+window.setGeometry(300, 300, 1000, 800)
+
+w = pg.GraphicsLayoutWidget(parent=window, border=True)
+
+window.setCentralWidget(w)
+window.show()
+
 w.setWindowTitle('pyqtgraph example: ROI Examples')
 
 text = """Data Selection From Image.<br>\n
@@ -138,7 +146,7 @@ label4 = w4.addLabel(text, row=0, col=0)
 v4 = w4.addViewBox(row=1, col=0, lockAspect=True)
 g = pg.GridItem()
 v4.addItem(g)
-r4 = pg.ROI([0,0], [100,100], resizable=False, removable=True)
+r4 = pg.ROI([0,0], [100,100], removable=True)
 r4.addRotateHandle([1,0], [0.5, 0.5])
 r4.addRotateHandle([0,1], [0.5, 0.5])
 img4 = pg.ImageItem(arr)


### PR DESCRIPTION
GraphicsLayoutWidget does not have a size keyword, nor a show keyword, removing these results in the display not showing, adding a QMainWindow() fixed the issue

ROI does not have a keyword resizable

Here are all of the tracebacks that I get when trying to run this demo:
```python
Traceback (most recent call last):
  File "/home/aaron/.PyCharmCE2019.1/config/scratches/emerson_pmd/new/scratch_8.py", line 35, in <module>
    w = pg.GraphicsLayoutWidget(show=True, size=(1000, 800), border=True)
  File "/home/aaron/anaconda3/envs/royale_backup/lib/python3.5/site-packages/pyqtgraph/widgets/GraphicsLayoutWidget.py", line 27, in __init__
    self.ci = GraphicsLayout(**kargs)
TypeError: __init__() got an unexpected keyword argument 'show'
```

Removing the `show=True` keyword results in:
```python
Traceback (most recent call last):
  File "/home/aaron/.PyCharmCE2019.1/config/scratches/emerson_pmd/new/scratch_8.py", line 35, in <module>
    w = pg.GraphicsLayoutWidget(size=(1000, 800), border=True)
  File "/home/aaron/anaconda3/envs/royale_backup/lib/python3.5/site-packages/pyqtgraph/widgets/GraphicsLayoutWidget.py", line 27, in __init__
    self.ci = GraphicsLayout(**kargs)
TypeError: __init__() got an unexpected keyword argument 'size'
```

Removing the `size=(1000, 800)` argument results in:
```python
Traceback (most recent call last):
  File "/home/aaron/.PyCharmCE2019.1/config/scratches/emerson_pmd/new/scratch_8.py", line 139, in <module>
    r4 = pg.ROI([0, 0], [100, 100], resizable=False, removable=True)
TypeError: __init__() got an unexpected keyword argument 'resizable'
```
After removing `resizable=False` the program is runnable, but no window pops up (since `show` was removed) and must be terminated with a kill command.

I have uploaded my conda environment export as well, find it at the link below:
[conda_list.txt](https://github.com/pyqtgraph/pyqtgraph/files/3248512/conda_list.txt)

