### PR TITLE
Fixed ViewBox.updateViewRange to apply transformation sooner

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1496,14 +1496,13 @@ class ViewBox(GraphicsWidget):
         changed = [(viewRange[i][0] != self.state['viewRange'][i][0]) or (viewRange[i][1] != self.state['viewRange'][i][1]) for i in (0,1)]
         self.state['viewRange'] = viewRange
 
-        # emit range change signals
-        if changed[0]:
-            self.sigXRangeChanged.emit(self, tuple(self.state['viewRange'][0]))
-        if changed[1]:
-            self.sigYRangeChanged.emit(self, tuple(self.state['viewRange'][1]))
-
         if any(changed):
             self._matrixNeedsUpdate = True
+            # emit range change signals
+            if changed[0]:
+                self.sigXRangeChanged.emit(self, tuple(self.state['viewRange'][0]))
+            if changed[1]:
+                self.sigYRangeChanged.emit(self, tuple(self.state['viewRange'][1]))
             self.sigRangeChanged.emit(self, self.state['viewRange'])
             self.update()
 


### PR DESCRIPTION
With PySide2, I traced updateViewRange triggering the sigXRangeChanged and sigYRangeChanged before _matrixNeedsUpdate was set to True.  This results in an incorrect mapViewToScene call in my application.  By assigning _matrixNeedsUpdate to True before these signals, the transform is correctly updated within the slot's code giving the correct mapViewToScene result. 