### PR TITLE
Add pytest config file specifying colordepth when using pytest-xvfb

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+
+xvfb_colordepth = 24


### PR DESCRIPTION
This PR is meant to address some of the failures on Linux, as @campagnola pointed out he was suspicious of the color depth setting.  I ran the tests on one of the head less servers I have access to and confirmed 6 tests that failed now pass.