### PR TITLE
Moved emits after all method state updates

### DIFF
--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -67,11 +67,11 @@ class SignalProxy(QtCore.QObject):
         """If there is a signal queued up, send it now."""
         if self.args is None or self.block:
             return False
-        #self.emit(self.signal, *self.args)
-        self.sigDelayed.emit(self.args)
-        self.args = None
+        args, self.args = self.args, None
         self.timer.stop()
         self.lastFlushTime = time()
+        #self.emit(self.signal, *self.args)
+        self.sigDelayed.emit(args)
         return True
         
     def disconnect(self):

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -346,9 +346,9 @@ class DockLabel(VerticalLabel):
         ev.accept()
             
     def mouseReleaseEvent(self, ev):
+        ev.accept()
         if not self.startedDrag:
             self.sigClicked.emit(self, ev)
-        ev.accept()
         
     def mouseDoubleClickEvent(self, ev):
         if ev.button() == QtCore.Qt.LeftButton:

--- a/pyqtgraph/flowchart/Flowchart.py
+++ b/pyqtgraph/flowchart/Flowchart.py
@@ -503,8 +503,8 @@ class Flowchart(Node):
         finally:
             self.blockSignals(False)
             
-        self.sigChartLoaded.emit()
         self.outputChanged()
+        self.sigChartLoaded.emit()
         self.sigStateChanged.emit()
             
     def loadFile(self, fileName=None, startDir=None):

--- a/pyqtgraph/graphicsItems/HistogramLUTItem.py
+++ b/pyqtgraph/graphicsItems/HistogramLUTItem.py
@@ -205,8 +205,8 @@ class HistogramLUTItem(GraphicsWidget):
     def regionChanging(self):
         if self.imageItem() is not None:
             self.imageItem().setLevels(self.getLevels())
-        self.sigLevelsChanged.emit(self)
         self.update()
+        self.sigLevelsChanged.emit(self)
 
     def imageChanged(self, autoLevel=False, autoRange=False):
         if self.imageItem() is None:

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -711,10 +711,10 @@ class ROI(GraphicsObject):
                 
         if hover:
             self.setMouseHover(True)
-            self.sigHoverEvent.emit(self)
             ev.acceptClicks(QtCore.Qt.LeftButton)  ## If the ROI is hilighted, we should accept all clicks to avoid confusion.
             ev.acceptClicks(QtCore.Qt.RightButton)
             ev.acceptClicks(QtCore.Qt.MidButton)
+            self.sigHoverEvent.emit(self)
         else:
             self.setMouseHover(False)
 

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -834,8 +834,8 @@ class ScatterPlotItem(GraphicsObject):
             pts = self.pointsAt(ev.pos())
             if len(pts) > 0:
                 self.ptsClicked = pts
-                self.sigClicked.emit(self, self.ptsClicked)
                 ev.accept()
+                self.sigClicked.emit(self, self.ptsClicked)
             else:
                 #print "no spots"
                 ev.ignore()

--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -559,8 +559,8 @@ class Parameter(QtCore.QObject):
             self.childs.insert(pos, child)
             
             child.parentChanged(self)
-            self.sigChildAdded.emit(self, child, pos)
             child.sigTreeStateChanged.connect(self.treeStateChanged)
+            self.sigChildAdded.emit(self, child, pos)
         return child
         
     def removeChild(self, child):
@@ -571,11 +571,11 @@ class Parameter(QtCore.QObject):
         del self.names[name]
         self.childs.pop(self.childs.index(child))
         child.parentChanged(None)
-        self.sigChildRemoved.emit(self, child)
         try:
             child.sigTreeStateChanged.disconnect(self.treeStateChanged)
         except (TypeError, RuntimeError):  ## already disconnected
             pass
+        self.sigChildRemoved.emit(self, child)
 
     def clearChildren(self):
         """Remove all child parameters."""

--- a/pyqtgraph/widgets/ColorButton.py
+++ b/pyqtgraph/widgets/ColorButton.py
@@ -50,11 +50,11 @@ class ColorButton(QtGui.QPushButton):
     def setColor(self, color, finished=True):
         """Sets the button's color and emits both sigColorChanged and sigColorChanging."""
         self._color = functions.mkColor(color)
+        self.update()
         if finished:
             self.sigColorChanged.emit(self)
         else:
             self.sigColorChanging.emit(self)
-        self.update()
         
     def selectColor(self):
         self.origColor = self.color()

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -227,12 +227,12 @@ class GraphicsView(QtGui.QGraphicsView):
             else:
                 self.fitInView(self.range, QtCore.Qt.IgnoreAspectRatio)
             
-        self.sigDeviceRangeChanged.emit(self, self.range)
-        self.sigDeviceTransformChanged.emit(self)
-        
         if propagate:
             for v in self.lockedViewports:
                 v.setXRange(self.range, padding=0)
+
+        self.sigDeviceRangeChanged.emit(self, self.range)
+        self.sigDeviceTransformChanged.emit(self)
         
     def viewRect(self):
         """Return the boundaries of the view in scene coordinates"""
@@ -261,7 +261,6 @@ class GraphicsView(QtGui.QGraphicsView):
         w = self.range.width()  / scale[0]
         h = self.range.height() / scale[1]
         self.range = QtCore.QRectF(center.x() - (center.x()-self.range.left()) / scale[0], center.y() - (center.y()-self.range.top())  /scale[1], w, h)
-        
         
         self.updateMatrix()
         self.sigScaleChanged.emit(self)


### PR DESCRIPTION
PySide2 immediately executes signals without passing through the Qt Event Queue. 

Pull request #907 addressed a specific case where a signal was emitted before a state update.
If an application's slot then calls back into the instance, the instance was in an inconsistent
state.  This pull request audits and fixes similar issues throughout the pyqtgraph library.  This
commit fixes several latent issues:

* SignalProxy: flush -> sigDelayed -> signalReceived would have incorrectly resulted in timer.stop().
* ViewBox: resizeEvent -> sigStateChange -> background state
* ViewBox: setRange -> sigStateChange -> autoranging not updated correctly
* ViewBox: updateMatrix -> sigTransformChanged -> any _matrixNeedsUpdate = True -> ignored
* Parameter: Child may have missed state tree messages on insert or received extra on remove
* GraphicsView: updateMatrix -> sigDeviceRangeChanged/sigDeviceTransformChange -> before propagated to locked viewports.