### PR TITLE
Prevent element-wise string comparison

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -488,7 +488,7 @@ class ImageItem(GraphicsObject):
             step = (step, step)
         stepData = self.image[::step[0], ::step[1]]
 
-        if bins == 'auto':
+        if 'auto' == bins:
             mn = np.nanmin(stepData)
             mx = np.nanmax(stepData)
             if mx == mn:


### PR DESCRIPTION
Issue #835 shows that comparing `bins`, which may be a numpy array, with a string `'auto'` leads to element-wise comparison. This is because the `==` operator for numpy arrays is used. With this Pull Request, potential array and string are switched, so the `==` operator for strings is used, which does no element-wise comparison.

Closes #835