### PR TITLE
Curve fill: draw line around patch 

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -644,9 +644,9 @@ class AxisItem(GraphicsWidget):
             if dif / intervals[minorIndex] <= maxTickCount:
                 levels.append((intervals[minorIndex], 0))
             return levels
-        
-        
-        
+
+
+
         ##### This does not work -- switching between 2/5 confuses the automatic text-level-selection
         ### Determine major/minor tick spacings which flank the optimal spacing.
         #intervals = np.array([1., 2., 5., 10., 20., 50., 100.]) * p10unit

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -507,7 +507,6 @@ class PlotCurveItem(GraphicsObject):
         else:
             p.drawPath(path)
         profiler('drawPath')
-        profiler('drawPath')
         
         #print "Render hints:", int(p.renderHints())
         #p.setPen(QtGui.QPen(QtGui.QColor(255,0,0)))


### PR DESCRIPTION
This is a matter of personal taste, but it sometimes looks a lot more refined when drawing a line around the fill-patch. For instance this example, created with pyqtgraph:

<img src="https://raw.githubusercontent.com/OE-FET/mercurygui/master/screenshots/MercuryGUI.png" alt="mercurygui screenshot"/>