### PR TITLE
Use Qt5 QWheelEvent functions if necessary

### DIFF
--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -326,7 +326,16 @@ class GraphicsView(QtGui.QGraphicsView):
         if not self.mouseEnabled:
             ev.ignore()
             return
-        sc = 1.001 ** ev.delta()
+        
+        delta = 0
+        if QT_LIB in ['PyQt4', 'PySide']:
+            delta = ev.delta()
+        else:
+            delta = ev.angleDelta().x()
+            if delta == 0:
+                delta = ev.angleDelta().y()
+                
+        sc = 1.001 ** delta
         #self.scale *= sc
         #self.updateMatrix()
         self.scale(sc, sc)

--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -144,17 +144,17 @@ class RemoteGraphicsView(QtGui.QWidget):
         p.end()
         
     def mousePressEvent(self, ev):
-        self._view.mousePressEvent(int(ev.type()), ev.pos(), ev.globalPos(), int(ev.button()), int(ev.buttons()), int(ev.modifiers()), _callSync='off')
+        self._view.mousePressEvent(int(ev.type()), ev.pos(), ev.pos(), int(ev.button()), int(ev.buttons()), int(ev.modifiers()), _callSync='off')
         ev.accept()
         return QtGui.QWidget.mousePressEvent(self, ev)
 
     def mouseReleaseEvent(self, ev):
-        self._view.mouseReleaseEvent(int(ev.type()), ev.pos(), ev.globalPos(), int(ev.button()), int(ev.buttons()), int(ev.modifiers()), _callSync='off')
+        self._view.mouseReleaseEvent(int(ev.type()), ev.pos(), ev.pos(), int(ev.button()), int(ev.buttons()), int(ev.modifiers()), _callSync='off')
         ev.accept()
         return QtGui.QWidget.mouseReleaseEvent(self, ev)
 
     def mouseMoveEvent(self, ev):
-        self._view.mouseMoveEvent(int(ev.type()), ev.pos(), ev.globalPos(), int(ev.button()), int(ev.buttons()), int(ev.modifiers()), _callSync='off')
+        self._view.mouseMoveEvent(int(ev.type()), ev.pos(), ev.pos(), int(ev.button()), int(ev.buttons()), int(ev.modifiers()), _callSync='off')
         ev.accept()
         return QtGui.QWidget.mouseMoveEvent(self, ev)
         

--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -33,14 +33,13 @@ class SerializableWheelEvent:
         return self._delta
     
     def orientation(self):
-        return (None, QtCore.Qt.Horizontal, QtCore.Qt.Vertical)[self._orientation]
+        return self._orientation
     
     def angleDelta(self):
-        if self._orientation == 1:
-            return QtCore.QPoint(self._delta, 0)
-        elif self._orientation == 2:
+        if self._orientation == QtCore.Qt.Vertical:
             return QtCore.QPoint(0, self._delta)
-        return QtCore.QPoint(0, 0)
+        else:
+            return QtCore.QPoint(self._delta, 0)
 
     def buttons(self):
         return QtCore.Qt.MouseButtons(self._buttons)
@@ -55,7 +54,7 @@ class SerializableWheelEvent:
         if QT_LIB in ['PyQt4', 'PySide']:
             return QtGui.QWheelEvent(self.pos(), self.globalPos(), self.delta(), self.buttons(), self.modifiers(), self.orientation())
         else:
-            return QtGui.QWheelEvent(self.pos(), self.globalPos(), QtCore.QPoint(0,0), self.angleDelta(), self.delta(), self.orientation(), self.buttons(), self.modifiers())
+            return QtGui.QWheelEvent(self.pos(), self.globalPos(), QtCore.QPoint(), self.angleDelta(), self.delta(), self.orientation(), self.buttons(), self.modifiers())
 
 class RemoteGraphicsView(QtGui.QWidget):
     """
@@ -161,17 +160,17 @@ class RemoteGraphicsView(QtGui.QWidget):
         
     def wheelEvent(self, ev):
         delta = 0
-        orientation = 1
+        orientation = QtCore.Qt.Horizontal
         if QT_LIB in ['PyQt4', 'PySide']:
             delta = ev.delta()
             orientation = int(ev.orientation())
         else:
             delta = ev.angleDelta().x()
             if delta == 0:
-                orientation = 2
+                orientation = QtCore.Qt.Vertical
                 delta = ev.angleDelta().y()
                 
-        serializableEvent = SerializableWheelEvent(ev.pos(), ev.globalPos(), delta, int(ev.buttons()), int(ev.modifiers()), orientation)
+        serializableEvent = SerializableWheelEvent(ev.pos(), ev.pos(), delta, int(ev.buttons()), int(ev.modifiers()), orientation)
         self._view.wheelEvent(serializableEvent, _callSync='off')
         ev.accept()
         return QtGui.QWidget.wheelEvent(self, ev)

--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -21,7 +21,7 @@ class SerializableWheelEvent:
         self._delta = _delta
         self._buttons = _buttons
         self._modifiers = _modifiers
-        self._orientation = _orientation
+        self._orientation_vertical = _orientation == QtCore.Qt.Vertical
         
     def pos(self):
         return self._pos
@@ -33,10 +33,13 @@ class SerializableWheelEvent:
         return self._delta
     
     def orientation(self):
-        return self._orientation
+        if self._orientation_vertical:
+            return QtCore.Qt.Vertical
+        else:
+            return QtCore.Qt.Horizontal
     
     def angleDelta(self):
-        if self._orientation == QtCore.Qt.Vertical:
+        if self._orientation_vertical:
             return QtCore.QPoint(0, self._delta)
         else:
             return QtCore.QPoint(self._delta, 0)
@@ -163,7 +166,7 @@ class RemoteGraphicsView(QtGui.QWidget):
         orientation = QtCore.Qt.Horizontal
         if QT_LIB in ['PyQt4', 'PySide']:
             delta = ev.delta()
-            orientation = int(ev.orientation())
+            orientation = ev.orientation()
         else:
             delta = ev.angleDelta().x()
             if delta == 0:

--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -10,6 +10,11 @@ import mmap, tempfile, ctypes, atexit, sys, random
 __all__ = ['RemoteGraphicsView']
         
 class SerializableWheelEvent:
+    """
+    Contains all information of a QWheelEvent, is serializable and can generate QWheelEvents.
+    
+    Methods have the functionality of their QWheelEvent equivalent.
+    """
     def __init__(self, _pos, _globalPos, _delta, _buttons, _modifiers, _orientation):
         self._pos = _pos
         self._globalPos = _globalPos
@@ -44,6 +49,9 @@ class SerializableWheelEvent:
         return QtCore.Qt.KeyboardModifiers(self._modifiers)
     
     def toQWheelEvent(self):
+        """
+        Generate QWheelEvent from SerializableWheelEvent.
+        """
         if QT_LIB in ['PyQt4', 'PySide']:
             return QtGui.QWheelEvent(self.pos(), self.globalPos(), self.delta(), self.buttons(), self.modifiers(), self.orientation())
         else:

--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -172,7 +172,7 @@ class RemoteGraphicsView(QtGui.QWidget):
                 delta = ev.angleDelta().y()
                 
         serializableEvent = SerializableWheelEvent(ev.pos(), ev.globalPos(), delta, int(ev.buttons()), int(ev.modifiers()), orientation)
-        self._view.wheelEvent(serializableEvent, _callSync='off') # TODO Serialize also QT5 wheelEvent
+        self._view.wheelEvent(serializableEvent, _callSync='off')
         ev.accept()
         return QtGui.QWidget.wheelEvent(self, ev)
     


### PR DESCRIPTION
As issue #426 shows, QWheelEvent has no longer the methods `.delta()` and `.orientation()` in Qt5. This pull request aims at fixing this in consistency with https://github.com/pyqtgraph/pyqtgraph/blob/6632355719173c1a64448e4e1eadcd06a841f693/pyqtgraph/opengl/GLViewWidget.py#L374 , where already fixes are done. Note that this is not necessary for https://github.com/pyqtgraph/pyqtgraph/blob/6632355719173c1a64448e4e1eadcd06a841f693/pyqtgraph/graphicsItems/ViewBox/ViewBox.py#L1147, as there one does not deal with a QWheelEvent but with a QGraphicsSceneWheelEvent, which (obviously! ... ?) still only has the methods from Qt4 in Qt5: https://doc.qt.io/qt-5/qgraphicsscenewheelevent.html . Well.

Note that I tested the success of this PR with `examples/RemoteGraphicsView.py`, which does not occur in the examples list. Also note that I so far only tested with Qt5 - if you quickly can, please also test on other platforms (like Qt4).

Closes #426