### PR TITLE
Fix incorrect clipping of horizontal axis when stopAxisAtTick is set

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -900,16 +900,20 @@ class AxisItem(GraphicsWidget):
 
 
         if self.style['stopAxisAtTick'][0] is True:
-            stop = max(span[0].y(), min(map(min, tickPositions)))
+            minTickPosition = min(map(min, tickPositions))
             if axis == 0:
+                stop = max(span[0].y(), minTickPosition)
                 span[0].setY(stop)
             else:
+                stop = max(span[0].x(), minTickPosition)
                 span[0].setX(stop)
         if self.style['stopAxisAtTick'][1] is True:
-            stop = min(span[1].y(), max(map(max, tickPositions)))
+            maxTickPosition = max(map(max, tickPositions))
             if axis == 0:
+                stop = min(span[1].y(), maxTickPosition)
                 span[1].setY(stop)
             else:
+                stop = min(span[1].x(), maxTickPosition)
                 span[1].setX(stop)
         axisSpec = (self.pen(), span[0], span[1])
 

--- a/pyqtgraph/graphicsItems/tests/test_AxisItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_AxisItem.py
@@ -1,0 +1,30 @@
+import pyqtgraph as pg
+
+app = pg.mkQApp()
+
+def test_AxisItem_stopAxisAtTick(monkeypatch):
+    def test_bottom(p, axisSpec, tickSpecs, textSpecs):
+        assert view.mapToView(axisSpec[1]).x() == 0.25
+        assert view.mapToView(axisSpec[2]).x() == 0.75
+
+    def test_left(p, axisSpec, tickSpecs, textSpecs):
+        assert view.mapToView(axisSpec[1]).y() == 0.875
+        assert view.mapToView(axisSpec[2]).y() == 0.125
+
+    plot = pg.PlotWidget()
+    view = plot.plotItem.getViewBox()
+    bottom = plot.getAxis("bottom")
+    bottom.setRange(0, 1)
+    bticks = [(0.25, "a"), (0.6, "b"), (0.75, "c")]
+    bottom.setTicks([bticks, bticks])
+    bottom.setStyle(stopAxisAtTick=(True, True))
+    monkeypatch.setattr(bottom, "drawPicture", test_bottom)
+
+    left = plot.getAxis("left")
+    lticks = [(0.125, "a"), (0.55, "b"), (0.875, "c")]
+    left.setTicks([lticks, lticks])
+    left.setRange(0, 1)
+    left.setStyle(stopAxisAtTick=(True, True))
+    monkeypatch.setattr(left, "drawPicture", test_left)
+
+    plot.show()


### PR DESCRIPTION
Fixes #930.

Horizontal axes are incorrectly clipped when `stopAxisAtTick` is set to `(True, True)`. This happens because the code always takes the vertical coordinate of the span even if the axis is horizontal.