### PR TITLE
PlotItem.addLine now accepts 'pos' and 'angle' parameters

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -545,9 +545,9 @@ class PlotItem(GraphicsWidget):
         :func:`InfiniteLine.__init__() <pyqtgraph.InfiniteLine.__init__>`.
         Returns the item created.
         """
-        pos = kwds.get('pos', x if x is not None else y)
-        angle = kwds.get('angle', 0 if x is None else 90)
-        line = InfiniteLine(pos, angle, **kwds)
+        kwds['pos'] = kwds.get('pos', x if x is not None else y)
+        kwds['angle'] = kwds.get('angle', 0 if x is None else 90)
+        line = InfiniteLine(**kwds)
         self.addItem(line)
         if z is not None:
             line.setZValue(z)


### PR DESCRIPTION
The issue and this solution are discussed in issue #70:
> specifying the "angle" kwd on the addLine() call will lead to `InfiniteLine.__init__(pos, angle, **kwds)` being called with two angle keywords (the first, explicit one, and the one in **kwds).

Closes #70