### PR TITLE
Skip some test examples

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -56,7 +56,7 @@ exceptionCondition = namedtuple("exceptionCondition", ["condition", "reason"])
 conditionalExampleTests = {
     "hdf5.py": exceptionCondition(False, reason="Example requires user interaction and is not suitable for testing"),
     "RemoteSpeedTest.py": exceptionCondition(False, reason="Test is being problematic on CI machines"),
-    "optics_demos.py": exceptionCondition(frontends[Qt.PYSIDE], reason="Test fails due to PySide bug: https://bugreports.qt.io/browse/PYSIDE-671")
+    "optics_demos.py": exceptionCondition(not frontends[Qt.PYSIDE], reason="Test fails due to PySide bug: https://bugreports.qt.io/browse/PYSIDE-671")
 }
 
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -55,7 +55,8 @@ installedFrontends = sorted([frontend for frontend, isPresent in frontends.items
 exceptionCondition = namedtuple("exceptionCondition", ["condition", "reason"])
 conditionalExampleTests = {
     "hdf5.py": exceptionCondition(False, reason="Example requires user interaction and is not suitable for testing"),
-    "RemoteSpeedTest.py": exceptionCondition(False, reason="Test is being problematic on CI machines")
+    "RemoteSpeedTest.py": exceptionCondition(False, reason="Test is being problematic on CI machines"),
+    "optics_demos.py": exceptionCondition(frontends[Qt.PYSIDE], reason="Test fails due to PySide bug: https://bugreports.qt.io/browse/PYSIDE-671")
 }
 
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -54,7 +54,8 @@ installedFrontends = sorted([frontend for frontend, isPresent in frontends.items
 
 exceptionCondition = namedtuple("exceptionCondition", ["condition", "reason"])
 conditionalExampleTests = {
-    "hdf5.py": exceptionCondition(False, reason="Example requires user interaction and is not suitable for testing")
+    "hdf5.py": exceptionCondition(False, reason="Example requires user interaction and is not suitable for testing"),
+    "RemoteSpeedTest.py": exceptionCondition(False, reason="Test is being problematic on CI machines")
 }
 
 


### PR DESCRIPTION
This PR skips two tests

1. The remote plotting test is skipped, this is failing pretty consistently, and will likely take a fair amount of work/investigation to diagnose.
2. `optics_demo.py` is skipped when running with pyside1, this is due to a known bug that is even linked as a comment in the code.