### PR TITLE
[WIP] Fix checkOpenGLVersion raising exception on gl call

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -426,7 +426,10 @@ class GLViewWidget(QtOpenGL.QGLWidget):
 
     def checkOpenGLVersion(self, msg):
         ## Only to be called from within exception handler.
-        err = glGetError() # Catch possible errors before next gl call
+        try:
+            err = glGetError() # Catch possible errors before next gl call
+        except:
+            pass
         ver = glGetString(GL_VERSION).split()[0]
         if int(ver.split('.')[0]) < 2:
             from .. import debug

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -426,6 +426,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
 
     def checkOpenGLVersion(self, msg):
         ## Only to be called from within exception handler.
+        err = glGetError() # Catch possible errors before next gl call
         ver = glGetString(GL_VERSION).split()[0]
         if int(ver.split('.')[0]) < 2:
             from .. import debug


### PR DESCRIPTION
As can be seen in this stackoverflow post, seemingly OpenGL remembers errors and throws them as soon as it can, e.g. on the next function call: https://stackoverflow.com/a/36377085/8575607
That might cause errors to be raised in weird places. Fetching errors beforehand circumvents that problem.

(Hopefully) Fixes second error of #928.

This is a WIP and still a PR because I would like to see the according Azure tests. If they prove my assumption, this will be a regular PR.