### PR TITLE
[WIP] Fix checkOpenGLVersion raising exception on gl call [2]

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -9,6 +9,8 @@ from .. import functions as fn
 
 ShareWidget = None
 
+GLVersion = glGetString(GL_VERSION).split()[0]
+
 class GLViewWidget(QtOpenGL.QGLWidget):
     """
     Basic widget for displaying 3D data
@@ -193,6 +195,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         self.drawItemTree(useItemNames=useItemNames)
         
     def drawItemTree(self, item=None, useItemNames=False):
+        global GLVersion
         if item is None:
             items = [x for x in self.items if x.parentItem() is None]
         else:
@@ -213,8 +216,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
                     from .. import debug
                     debug.printExc()
                     msg = "Error while drawing item %s." % str(item)
-                    ver = glGetString(GL_VERSION)
-                    if ver is not None:
+                    if GLVersion is not None:
                         ver = ver.split()[0]
                         if int(ver.split(b'.')[0]) < 2:
                             print(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)
@@ -426,8 +428,8 @@ class GLViewWidget(QtOpenGL.QGLWidget):
 
     def checkOpenGLVersion(self, msg):
         ## Only to be called from within exception handler.
-        ver = glGetString(GL_VERSION).split()[0]
-        if int(ver.split('.')[0]) < 2:
+        global GLVersion
+        if int(GLVersion.split('.')[0]) < 2:
             from .. import debug
             debug.printExc()
             raise Exception(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -219,9 +219,9 @@ class GLViewWidget(QtOpenGL.QGLWidget):
                     debug.printExc()
                     msg = "Error while drawing item %s." % str(item)
                     if GLVersion is not None:
-                        ver = ver.split()[0]
+                        ver = GLVersion.split()[0]
                         if int(ver.split(b'.')[0]) < 2:
-                            print(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)
+                            print(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % GLVersion)
                         else:
                             print(msg)
                     

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -9,7 +9,7 @@ from .. import functions as fn
 
 ShareWidget = None
 
-GLVersion = glGetString(GL_VERSION).split()[0]
+GLVersion = None
 
 class GLViewWidget(QtOpenGL.QGLWidget):
     """
@@ -25,13 +25,17 @@ class GLViewWidget(QtOpenGL.QGLWidget):
     """
     
     def __init__(self, parent=None, devicePixelRatio=None):
-        global ShareWidget
+        global ShareWidget, GLVersion
 
         if ShareWidget is None:
             ## create a dummy widget to allow sharing objects (textures, shaders, etc) between views
             ShareWidget = QtOpenGL.QGLWidget()
             
         QtOpenGL.QGLWidget.__init__(self, parent, ShareWidget)
+        
+        self.makeCurrent()
+        
+        GLVersion = glGetString(GL_VERSION).split()[0]
         
         self.setFocusPolicy(QtCore.Qt.ClickFocus)
         
@@ -51,8 +55,6 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         self.keysPressed = {}
         self.keyTimer = QtCore.QTimer()
         self.keyTimer.timeout.connect(self.evalKeyState)
-        
-        self.makeCurrent()
 
     def addItem(self, item):
         self.items.append(item)


### PR DESCRIPTION
Follow-up on PR #940.
Fetching the OpenGL version before an error occurs should avoid later problems when OpenGL whyever is in an invalid state.

(Hopefully) Fixes second error of #928.

This is a WIP and still a PR because I would like to see the according Azure tests. If they prove my assumption, this will be a regular PR.