### PR TITLE
Warn if visible GraphicsView is garbage collected

### DIFF
--- a/pyqtgraph/graphicsItems/tests/test_ImageItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_ImageItem.py
@@ -121,7 +121,7 @@ def test_ImageItem(transpose=False):
     assertImageApproved(w, 'imageitem/resolution_with_downsampling_y', 'Resolution test with downsampling across y axis.')
     assert img._lastDownsample == (1, 4)
     
-    view.hide()
+    w.hide()
 
 def test_ImageItem_axisorder():
     # All image tests pass again using the opposite axis order

--- a/pyqtgraph/graphicsItems/tests/test_ROI.py
+++ b/pyqtgraph/graphicsItems/tests/test_ROI.py
@@ -147,6 +147,7 @@ def check_getArrayRegion(roi, name, testResize=True, transpose=False):
     # allow the roi to be re-used
     roi.scene().removeItem(roi)
 
+    win.hide()
 
 def test_PolyLineROI():
     rois = [
@@ -228,5 +229,6 @@ def test_PolyLineROI():
         r.setState(initState)
         assertImageApproved(plt, 'roi/polylineroi/'+name+'_setstate', 'Reset ROI to initial state.')
         assert len(r.getState()['points']) == 3
-        
+    
+    plt.hide()
     

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -399,7 +399,7 @@ class GraphicsView(QtGui.QGraphicsView):
         ev.ignore()  ## not sure why, but for some reason this class likes to consume drag events
 
     def __del__(self):
-        if self.isVisible():
+        if self.parentWidget() is None and self.isVisible():
             msg = "Visible window deleted. To prevent this, store a reference to the window object."
             warnings.warn(msg, RuntimeWarning, stacklevel=2)
 

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -15,6 +15,7 @@ except ImportError:
 
 from ..Point import Point
 import sys, os
+import warnings
 from .FileDialog import FileDialog
 from ..GraphicsScene import GraphicsScene
 import numpy as np
@@ -396,5 +397,9 @@ class GraphicsView(QtGui.QGraphicsView):
         
     def dragEnterEvent(self, ev):
         ev.ignore()  ## not sure why, but for some reason this class likes to consume drag events
-        
+
+    def __del__(self):
+        if self.isVisible():
+            msg = "Visible window deleted by Python Garbage Collection. To prevent this, store a reference to the window object."
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
 

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -398,8 +398,10 @@ class GraphicsView(QtGui.QGraphicsView):
     def dragEnterEvent(self, ev):
         ev.ignore()  ## not sure why, but for some reason this class likes to consume drag events
 
-    def __del__(self):
+    def _del(self):
         if self.parentWidget() is None and self.isVisible():
             msg = "Visible window deleted. To prevent this, store a reference to the window object."
             warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
+if sys.version_info[0] == 3 and sys.version_info[1] >= 4:
+    GraphicsView.__del__ = GraphicsView._del

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -400,6 +400,6 @@ class GraphicsView(QtGui.QGraphicsView):
 
     def __del__(self):
         if self.isVisible():
-            msg = "Visible window deleted by Python Garbage Collection. To prevent this, store a reference to the window object."
+            msg = "Visible window deleted. To prevent this, store a reference to the window object."
             warnings.warn(msg, RuntimeWarning, stacklevel=2)
 


### PR DESCRIPTION
Python Garbage Collection and Qt windows sometimes produce unexpected behaviour, causing windows to close. This PR aims at providing a warning if this happens so users can react properly.

Test code:
```python
import pyqtgraph as pg

def plot():
    pg.GraphicsWindow()

plot()
```

Warning:
```
C:\[...]\pyqtgraph\__init__.py
test.py:4: RuntimeWarning: Visible window deleted by Python Garbage Collection. To prevent this, store a reference to the window object.
  pg.GraphicsWindow()
```

Closes #936 