### PR TITLE
Update Travis according to new xvfb syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
     # - PYTHON=3.4 QT=pyside TEST=standard # pyside isn't available for 3.4 with conda
     #- PYTHON=3.2 QT=pyqt5 TEST=standard
 
+services:
+    - xvfb
 
 before_install:
     - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.5.5-Linux-x86_64.sh -O miniconda.sh; fi
@@ -74,7 +76,6 @@ install:
 before_script:
     # We need to create a (fake) display on Travis, let's use a funny resolution
     - export DISPLAY=:99.0
-    - "sh -e /etc/init.d/xvfb start"
     - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render
 
     # Make sure everyone uses the correct python (this is handled by conda)


### PR DESCRIPTION
Travis updated their syntax to start xvfb. This is further described here: https://benlimmer.com/2019/01/14/travis-ci-xvfb/