### PR TITLE
Add pytest-faulthandler to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ install:
       fi;
     - pip install pytest-xdist # multi-thread py.test
     - pip install pytest-cov # add coverage stats
+    - pip install pytest-faulthandler # activate faulthandler
 
     # Debugging helpers
     - uname -a


### PR DESCRIPTION
Follow-up to PR #944. Currently our `pytest.ini` requires to have `pytest-faulthandler` installed, and as it makes sense to have it installed in a CI, this PR adds it.
This is independent from the question whether it is good to require further packages for running pytest on the project in general.