### PR TITLE
Replaced usage of deprecated ROI classes in example

### DIFF
--- a/examples/ROItypes.py
+++ b/examples/ROItypes.py
@@ -92,10 +92,10 @@ def updateRoiPlot(roi, data=None):
 rois = []
 rois.append(pg.TestROI([0,  0], [20, 20], maxBounds=QtCore.QRectF(-10, -10, 230, 140), pen=(0,9)))
 rois.append(pg.LineROI([0,  0], [20, 20], width=5, pen=(1,9)))
-rois.append(pg.MultiLineROI([[0, 50], [50, 60], [60, 30]], width=5, pen=(2,9)))
+rois.append(pg.MultiRectROI([[0, 50], [50, 60], [60, 30]], width=5, pen=(2,9)))
 rois.append(pg.EllipseROI([110, 10], [30, 20], pen=(3,9)))
 rois.append(pg.CircleROI([110, 50], [20, 20], pen=(4,9)))
-rois.append(pg.PolygonROI([[2,0], [2.1,0], [2,.1]], pen=(5,9)))
+rois.append(pg.PolyLineROI([[2,0], [2.1,0], [2,.1]], pen=(5,9)))
 #rois.append(SpiralROI([20,30], [1,1], pen=mkPen(0)))
 
 ## Add each ROI to the scene and link its data to a plot curve with the same color


### PR DESCRIPTION
Both `MultiLineROI` and `PolygonROI` print deprecation warnings and therefore should not be used in examples. This pull request aims at replacing them with their active pendant.