### PR TITLE
Allow multiline parameters in configparser

### DIFF
--- a/pyqtgraph/configfile.py
+++ b/pyqtgraph/configfile.py
@@ -33,7 +33,7 @@ class ParseError(Exception):
             msg = "Error parsing string at line %d:\n" % self.lineNum
         else:
             msg = "Error parsing config file '%s' at line %d:\n" % (self.fileName, self.lineNum)
-        msg += "%s\n%s" % (self.line, self.message)
+        msg += "%s\n%s" % (self.line, Exception.__str__(self))
         return msg
         #raise Exception()
         

--- a/pyqtgraph/configfile.py
+++ b/pyqtgraph/configfile.py
@@ -35,7 +35,6 @@ class ParseError(Exception):
             msg = "Error parsing config file '%s' at line %d:\n" % (self.fileName, self.lineNum)
         msg += "%s\n%s" % (self.line, Exception.__str__(self))
         return msg
-        #raise Exception()
         
 
 def writeConfigFile(data, fname):
@@ -93,13 +92,14 @@ def genString(data, indent=''):
             s += indent + sk + ':\n'
             s += genString(data[k], indent + '    ')
         else:
-            s += indent + sk + ': ' + repr(data[k]) + '\n'
+            s += indent + sk + ': ' + repr(data[k]).replace("\n", "\\\n") + '\n'
     return s
     
 def parseString(lines, start=0):
     
     data = OrderedDict()
     if isinstance(lines, basestring):
+        lines = lines.replace("\\\n", "")
         lines = lines.split('\n')
         lines = [l for l in lines if re.search(r'\S', l) and not re.match(r'\s*#', l)]  ## remove empty lines
         

--- a/pyqtgraph/tests/test_configparser.py
+++ b/pyqtgraph/tests/test_configparser.py
@@ -6,7 +6,7 @@ def test_longArrays():
     """
     Test config saving and loading of long arrays.
     """
-    tmp = tempfile.mktemp(".py")
+    tmp = tempfile.mktemp(".cfg")
 
     arr = np.arange(20)
     configfile.writeConfigFile({'arr':arr}, tmp)
@@ -20,7 +20,7 @@ def test_multipleParameters():
     """
     Test config saving and loading of multiple parameters.
     """
-    tmp = tempfile.mktemp(".py")
+    tmp = tempfile.mktemp(".cfg")
 
     par1 = [1,2,3]
     par2 = "Test"

--- a/pyqtgraph/tests/test_configparser.py
+++ b/pyqtgraph/tests/test_configparser.py
@@ -1,0 +1,36 @@
+from pyqtgraph import configfile
+import numpy as np
+import tempfile, os
+
+def test_longArrays():
+    """
+    Test config saving and loading of long arrays.
+    """
+    tmp = tempfile.mktemp(".py")
+
+    arr = np.arange(20)
+    configfile.writeConfigFile({'arr':arr}, tmp)
+    config = configfile.readConfigFile(tmp)
+    
+    assert all(config['arr'] == arr)
+
+    os.remove(tmp)
+
+def test_multipleParameters():
+    """
+    Test config saving and loading of multiple parameters.
+    """
+    tmp = tempfile.mktemp(".py")
+
+    par1 = [1,2,3]
+    par2 = "Test"
+    par3 = {'a':3,'b':'c'}
+
+    configfile.writeConfigFile({'par1':par1, 'par2':par2, 'par3':par3}, tmp)
+    config = configfile.readConfigFile(tmp)
+    
+    assert config['par1'] == par1
+    assert config['par2'] == par2
+    assert config['par3'] == par3
+
+    os.remove(tmp)


### PR DESCRIPTION
Currently parameters may be written to multiple lines in config files but cannot be read, as described in the linked issue.

Fixes #491.