### PR TITLE
Fire a sigRegionChangeStarted Signal When Moving a Scale Handle

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -428,6 +428,7 @@ class ROI(GraphicsObject):
 
     def handleMoveStarted(self):
         self.preMoveState = self.getState()
+        self.sigRegionChangeStarted.emit(self)
     
     def addTranslateHandle(self, pos, axes=None, item=None, name=None, index=None):
         """


### PR DESCRIPTION
Fixes [https://github.com/pyqtgraph/pyqtgraph/issues/950](https://github.com/pyqtgraph/pyqtgraph/issues/950)

Moving a scale handle on a ROI object does not fire a sigRegionChangeStarted signal.  This patch adds the signal emit to handleMoveStarted() to cause the signal to be fired.