### PR TITLE
Fix RotateFree handle not rotating freely

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -928,6 +928,7 @@ class ROI(GraphicsObject):
             
             if h['type'] == 'rf':
                 h['item'].setPos(self.mapFromScene(p1))  ## changes ROI coordinates of handle
+                h['pos'] = self.mapFromParent(p1)
                 
         elif h['type'] == 'sr':
             if h['center'][0] == h['pos'][0]:


### PR DESCRIPTION
@alguryanow made a very good issue #174 explaining this. In short, handles added via `ROI.addRotateFreeHandle` behaved as if added via `ROI.addRotateHandle`, in that they did not allow the user to drag them towards or away from the center. This fixes that.

Closes #174