### PR TITLE
Fix HistogramLUTWidget with background parameter

### DIFF
--- a/pyqtgraph/tests/test_histogramlutwidget.py
+++ b/pyqtgraph/tests/test_histogramlutwidget.py
@@ -41,5 +41,4 @@ def testHistogramLUTWidget():
     w.setImageItem(img)
     
     QtGui.QApplication.processEvents()
-    pg.exit()
     

--- a/pyqtgraph/tests/test_histogramlutwidget.py
+++ b/pyqtgraph/tests/test_histogramlutwidget.py
@@ -1,0 +1,45 @@
+"""
+HistogramLUTWidget test:
+
+Tests the creation of a HistogramLUTWidget.
+"""
+
+import pyqtgraph as pg
+from ..Qt import QtGui
+import numpy as np
+
+def testHistogramLUTWidget():
+    pg.mkQApp()
+    
+    win = QtGui.QMainWindow()
+    win.show()
+
+    cw = QtGui.QWidget()
+    win.setCentralWidget(cw)
+
+    l = QtGui.QGridLayout()
+    cw.setLayout(l)
+    l.setSpacing(0)
+
+    v = pg.GraphicsView()
+    vb = pg.ViewBox()
+    vb.setAspectLocked()
+    v.setCentralItem(vb)
+    l.addWidget(v, 0, 0, 3, 1)
+
+    w = pg.HistogramLUTWidget(background='w')
+    l.addWidget(w, 0, 1)
+
+    data = pg.gaussianFilter(np.random.normal(size=(256, 256, 3)), (20, 20, 0))
+    for i in range(32):
+        for j in range(32):
+            data[i*8, j*8] += .1
+    img = pg.ImageItem(data)
+    vb.addItem(img)
+    vb.autoRange()
+
+    w.setImageItem(img)
+    
+    QtGui.QApplication.processEvents()
+    pg.exit()
+    

--- a/pyqtgraph/widgets/HistogramLUTWidget.py
+++ b/pyqtgraph/widgets/HistogramLUTWidget.py
@@ -12,7 +12,8 @@ __all__ = ['HistogramLUTWidget']
 
 class HistogramLUTWidget(GraphicsView):
     
-    def __init__(self, parent=None,  *args, background='default', **kargs):
+    def __init__(self, parent=None,  *args, **kargs):
+        background = kargs.pop('background', 'default')
         GraphicsView.__init__(self, parent, useOpenGL=False, background=background)
         self.item = HistogramLUTItem(*args, **kargs)
         self.setCentralItem(self.item)

--- a/pyqtgraph/widgets/HistogramLUTWidget.py
+++ b/pyqtgraph/widgets/HistogramLUTWidget.py
@@ -12,8 +12,7 @@ __all__ = ['HistogramLUTWidget']
 
 class HistogramLUTWidget(GraphicsView):
     
-    def __init__(self, parent=None,  *args, **kargs):
-        background = kargs.get('background', 'default')
+    def __init__(self, parent=None,  *args, background='default', **kargs):
         GraphicsView.__init__(self, parent, useOpenGL=False, background=background)
         self.item = HistogramLUTItem(*args, **kargs)
         self.setCentralItem(self.item)

--- a/pyqtgraph/widgets/tests/test_histogramlutwidget.py
+++ b/pyqtgraph/widgets/tests/test_histogramlutwidget.py
@@ -5,7 +5,7 @@ Tests the creation of a HistogramLUTWidget.
 """
 
 import pyqtgraph as pg
-from ..Qt import QtGui
+from pyqtgraph.Qt import QtGui
 import numpy as np
 
 def testHistogramLUTWidget():


### PR DESCRIPTION
HistogramLUTWidget cannot be initialized with the `background` parameter, because all parameters are also passed to the constructor of HistogramLUTItem which does not have a `background` parameter. This pull request fixes that issue by defining `background` explicitly as parameter in the function header.

Closes #175