### PR TITLE
Add mesa drivers to windows CI images and show openGL info during debug stage

### DIFF
--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -125,10 +125,7 @@ jobs:
       artifactName: Distributions
 
   - bash: |
-      if [ $(agent.os) == "Linux" ]
-      then
-        sudo apt-get install -y libxkbcommon-x11-0  # herbstluftwm
-      fi
+      sudo apt-get install -y libxkbcommon-x11-0  # herbstluftwm
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)
@@ -150,13 +147,10 @@ jobs:
       echo pyqtgraph system info
       python -c "import pyqtgraph as pg; pg.systemInfo()"
       echo display information
-      if [ $(agent.os) != 'Windows_NT' ]
+      if [ $(agent.os) == 'Linux' ]
       then
-        if [ $(agent.os) == 'Linux' ]
-        then
-          export DISPLAY=:99.0
-          Xvfb :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset &
-        fi
+        export DISPLAY=:99.0
+        Xvfb :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset &
         sleep 3
       fi
       python -m pyqtgraph.util.get_resolution

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -43,6 +43,23 @@ jobs:
       height: '1080'
     condition: eq(variables['agent.os'], 'Windows_NT' )
 
+  - script: |
+      curl -LJO https://github.com/pal1000/mesa-dist-win/releases/download/19.1.0/mesa3d-19.1.0-release-msvc.exe
+      7z x mesa3d-19.1.0-release-msvc.exe
+      cd x64
+      xcopy opengl32.dll C:\windows\system32\mesadrv.dll*
+      xcopy opengl32.dll C:\windows\syswow64\mesadrv.dll*
+      REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\OpenGLDrivers\MSOGL" /v DLL /t REG_SZ /d "mesadrv.dll" /f
+      REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\OpenGLDrivers\MSOGL" /v DriverVersion /t REG_DWORD /d 1 /f
+      REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\OpenGLDrivers\MSOGL" /v Flags /t REG_DWORD /d 1 /f
+      REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\OpenGLDrivers\MSOGL" /v Version /t REG_DWORD /d 2 /f
+      REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion\OpenGLDrivers\MSOGL" /v DLL /t REG_SZ /d "mesadrv.dll" /f
+      REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion\OpenGLDrivers\MSOGL" /v DriverVersion /t REG_DWORD /d 1 /f
+      REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion\OpenGLDrivers\MSOGL" /v Flags /t REG_DWORD /d 1 /f 
+      REG ADD "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion\OpenGLDrivers\MSOGL" /v Version /t REG_DWORD /d 2 /f 
+    displayName: "Install Windows-Mesa OpenGL DLL"
+    condition: eq(variables['agent.os'], 'Windows_NT')
+
   - task: UsePythonVersion@0
     inputs:
       versionSpec: $(python.version)
@@ -76,7 +93,7 @@ jobs:
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)
-        conda install -c conda-forge $(qt.bindings) numpy scipy pyopengl pytest flake8 six coverage --yes
+        conda install -c conda-forge $(qt.bindings) numpy scipy pyopengl pytest flake8 six coverage --yes --quiet
       else
         pip install $(qt.bindings) numpy scipy pyopengl pytest flake8 six coverage
       fi
@@ -108,15 +125,18 @@ jobs:
       artifactName: Distributions
 
   - bash: |
-      sudo apt-get install -y libxkbcommon-x11-0  # herbstluftwm
+      if [ $(agent.os) == "Linux" ]
+      then
+        sudo apt-get install -y libxkbcommon-x11-0  # herbstluftwm
+      fi
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)
       fi
       pip install pytest-xvfb
-    displayName: "Linux Virtual Display Setup"
+    displayName: "Virtual Display Setup"
     condition: eq(variables['agent.os'], 'Linux' )
-  
+
   - bash: |
       if [ $(install.method) == "conda" ]
       then
@@ -130,13 +150,18 @@ jobs:
       echo pyqtgraph system info
       python -c "import pyqtgraph as pg; pg.systemInfo()"
       echo display information
-      if [ $(agent.os) == 'Linux' ]
+      if [ $(agent.os) != 'Windows_NT' ]
       then
-        export DISPLAY=:99.0
-        Xvfb :99 -screen 0 1920x1080x24 &
+        if [ $(agent.os) == 'Linux' ]
+        then
+          export DISPLAY=:99.0
+          Xvfb :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset &
+        fi
         sleep 3
       fi
       python -m pyqtgraph.util.get_resolution
+      echo openGL information
+      python -c "from pyqtgraph.opengl.glInfo import GLTest"
     displayName: 'Debug Info'
     continueOnError: false
 

--- a/pyqtgraph/opengl/glInfo.py
+++ b/pyqtgraph/opengl/glInfo.py
@@ -6,10 +6,10 @@ class GLTest(QtOpenGL.QGLWidget):
     def __init__(self):
         QtOpenGL.QGLWidget.__init__(self)
         self.makeCurrent()
-        print("GL version:" + glGetString(GL_VERSION))
+        print("GL version:" + glGetString(GL_VERSION).decode("utf-8"))
         print("MAX_TEXTURE_SIZE: %d" % glGetIntegerv(GL_MAX_TEXTURE_SIZE))
         print("MAX_3D_TEXTURE_SIZE: %d" % glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE))
-        print("Extensions: " + glGetString(GL_EXTENSIONS))
+        print("Extensions: " + glGetString(GL_EXTENSIONS).decode("utf-8").replace(" ", "\n"))
 
 GLTest()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ xvfb_width = 1920
 xvfb_height = 1080
 # use this due to some issues with ndarray reshape errors on CI systems
 xvfb_colordepth = 24
+xvfb_args=-ac +extension GLX +render
 addopts = --faulthandler-timeout=15
 
 filterwarnings =


### PR DESCRIPTION
This PR primarily addresses the issue of outdated OpenGL drivers (`opengl32.dll`) on the Windows images.  It grabs pre-compiled drivers from the releases section of this repo, moves the DLL into `C:\Windows\system` and `C:\Windows\SysWOW64`, and updates the registry.  The suggestion came from [this stack overflow post](https://stackoverflow.com/a/48582129/5298841).

The other thing I did was add openGL information to the debug section of the CI run.  This was useful in determining if the drivers were working, but decided it should likely remain there.

EDIT:

fixes #938 #928 