### PR TITLE
Handle invalid file descriptor in exit

### DIFF
--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -369,8 +369,12 @@ def exit():
     ## close file handles
     if sys.platform == 'darwin':
         for fd in range(3, 4096):
-            if fd not in [7]:  # trying to close 7 produces an illegal instruction on the Mac.
+            if fd in [7]:  # trying to close 7 produces an illegal instruction on the Mac.
+                continue
+            try:
                 os.close(fd)
+            except OSError:
+                pass
     else:
         os.closerange(3, 4096) ## just guessing on the maximum descriptor count..
 


### PR DESCRIPTION
It looks to me like the special case of file descriptor 7 on OSX can't be handled with a try/except (illegal instruction doesn't raise an exception afaik), so this just brings the implementation for OSX closer to that of `closerange` (see https://docs.python.org/3/library/os.html#os.closerange).

Fixes #552 