### PR TITLE
Nicer legend

### DIFF
--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -148,12 +148,6 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         self.layout.addItem(label, self._numItems, 1)
         self._numItems += 1
         self.updateSize()
-
-        height = max(sample.minimumHeight(), label.minimumHeight())
-        self.layout.setRowMaximumHeight(row, height)
-        self.layout.setColumnSpacing(0, 10)
-        
-        self.updateSize()
     
     def removeItem(self, item):
         """

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -117,7 +117,7 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
     def setParentItem(self, p):
         ret = GraphicsWidget.setParentItem(self, p)
         if self.offset is not None:
-            offset = Point(self.offset)
+            offset = Point(self.opts['offset'])
             anchorx = 1 if offset[0] <= 0 else 0
             anchory = 1 if offset[1] <= 0 else 0
             anchor = (anchorx, anchory)

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -62,7 +62,7 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         self.opts = {
             'pen': fn.mkPen(pen),
             'brush': fn.mkBrush(brush),
-            'labelTextColor': fn.mkColor(labelTextColor),
+            'labelTextColor': labelTextColor,
             'offset': offset,
         }
 

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -72,7 +72,7 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
     def setOffset(self, offset):
         self.opts['offset'] = offset
 
-        offset = Point(self.offset)
+        offset = Point(self.opts['offset'])
         anchorx = 1 if offset[0] <= 0 else 0
         anchory = 1 if offset[1] <= 0 else 0
         anchor = (anchorx, anchory)

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -49,8 +49,10 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         GraphicsWidgetAnchor.__init__(self)
         self.setFlag(self.ItemIgnoresTransformations)
         self.layout = QtGui.QGraphicsGridLayout()
+        # self.layout.setContentsMargins(0, 0, 0, 0)        
         self.layout.setVerticalSpacing(verSpacing)
         self.layout.setHorizontalSpacing(horSpacing)
+        
         self.setLayout(self.layout)
         self.items = []
         self.size = size
@@ -218,7 +220,7 @@ class ItemSample(GraphicsWidget):
 
         if not isinstance(self.item, ScatterPlotItem):
             p.setPen(fn.mkPen(opts['pen']))
-            p.drawLine(-7, 11, 7, 11)
+            p.drawLine(0, 11, 20, 11)
 
         symbol = opts.get('symbol', None)
         if symbol is not None:

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -60,8 +60,6 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         if size is not None:
             self.setGeometry(QtCore.QRectF(0, 0, self.size[0], self.size[1]))
 
-        self._numItems = 0
-
         self.opts = {
             'pen': fn.mkPen(pen),
             'brush': fn.mkBrush(brush),
@@ -152,10 +150,10 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         else:
             sample = ItemSample(item)
 
+        row = self.layout.rowCount()
         self.items.append((sample, label))
-        self.layout.addItem(sample, self._numItems, 0)
-        self.layout.addItem(label, self._numItems, 1)
-        self._numItems += 1
+        self.layout.addItem(sample, row, 0)
+        self.layout.addItem(label, row, 1)
         self.updateSize()
 
     def removeItem(self, item):

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -143,7 +143,7 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         else:
             sample = ItemSample(item)
 
-        self.legendItems.append((sample, label))
+        self.items.append((sample, label))
         self.layout.addItem(sample, self._numItems, 0)
         self.layout.addItem(label, self._numItems, 1)
         self._numItems += 1


### PR DESCRIPTION
Improvements to the legend appearance:

- Give options for legend frame and background color (`pen` and `brush`, respectively) instead of hard-coded values. Default to no legend background or frame. This is especially useful for a white background.
- Control spacing of legend items through `horSpacing ` and `verSpacing ` (taken from PR #64).
- Give separate option `labelTextColor` for legend text color.
- New method `self.clear` to clear all legend items.
- New methods to get and set the `offset` relative to the legend's parent.
- Horizontal instead of tilted lines for legend pictures (also fixes #578).

An example of how the modified legend will look like from [keithleygui](https://github.com/OE-FET/keithleygui): 

![keithleygui screenshot](https://github.com/OE-FET/keithleygui/blob/master/screenshots/KeithleyGUI.png?raw=true)
