### PR TITLE
[WIP] Update max text size

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -301,18 +301,16 @@ class AxisItem(GraphicsWidget):
     def _updateMaxTextSize(self, x):
         ## Informs that the maximum tick size orthogonal to the axis has
         ## changed; we use this to decide whether the item needs to be resized
-        ## to accomodate.
+        ## to accommodate.
         if self.orientation in ['left', 'right']:
-            mx = max(self.textWidth, x)
-            if mx > self.textWidth or mx < self.textWidth-10:
-                self.textWidth = mx
+            if x > self.textWidth or x < self.textWidth-10:
+                self.textWidth = x
                 if self.style['autoExpandTextSpace'] is True:
                     self._updateWidth()
                     #return True  ## size has changed
         else:
-            mx = max(self.textHeight, x)
-            if mx > self.textHeight or mx < self.textHeight-10:
-                self.textHeight = mx
+            if x > self.textHeight or x < self.textHeight-10:
+                self.textHeight = x
                 if self.style['autoExpandTextSpace'] is True:
                     self._updateHeight()
                     #return True  ## size has changed

--- a/pyqtgraph/graphicsItems/tests/test_ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_ErrorBarItem.py
@@ -1,5 +1,6 @@
 import pyqtgraph as pg
 import numpy as np
+import time
 
 app = pg.mkQApp()
 
@@ -13,6 +14,8 @@ def test_ErrorBarItem_defer_data():
     curve = pg.PlotCurveItem(x=x, y=x)
     plot.addItem(curve)
     app.processEvents()
+    app.processEvents()
+
     r_no_ebi = plot.viewRect()
 
     # ErrorBarItem with no data shouldn't affect the view rect


### PR DESCRIPTION
This takes over from #838 which was reverted for causing the `ErrorBarItem` test to fail. Not sure if there's a cleaner way to re-implement with fixes, but hopefully this works.

I've found that I have to call `app.processEvents()` twice after initializing the plot window to get the test to pass but I'm not sure why (hence the WIP).

Here's a script that's similar to the test case with some sleeps added in so you can see what's happening. You can see that the second `app.processEvents` call causes the view rect to change because the y axis shifts to the left. It makes some sense that this would be caused by the `_updateMaxTextSize` change, but I haven't determined why it takes two cycles.

```python
import pyqtgraph as pg
import numpy as np
import time

app = pg.mkQApp()

x = np.arange(5) + 100
y = np.array([1, 2, 1, 3, 1])
e = np.array([1, 0.1, 0.5, 0.1, 3])

plt = pg.plot()

cur = pg.PlotCurveItem(x=x, y=y)
plt.addItem(cur)
app.processEvents()
print(plt.viewRect())
time.sleep(1)

app.processEvents()
print(plt.viewRect())

err = pg.ErrorBarItem()
plt.addItem(err)
app.processEvents()
print(plt.viewRect())
time.sleep(1)

err.setData(x=x, y=y, top=e, bottom=e)
app.processEvents()
print(plt.viewRect())
time.sleep(1)

err.setData(x=None, y=None)
app.processEvents()
print(plt.viewRect())
time.sleep(1)
```