### PR TITLE
Work around PySide setOverrideCursor bug in BusyCursor

### DIFF
--- a/pyqtgraph/widgets/BusyCursor.py
+++ b/pyqtgraph/widgets/BusyCursor.py
@@ -1,4 +1,4 @@
-from ..Qt import QtGui, QtCore
+from ..Qt import QtGui, QtCore, QT_LIB
 
 __all__ = ['BusyCursor']
 
@@ -17,7 +17,12 @@ class BusyCursor(object):
         app = QtCore.QCoreApplication.instance()
         isGuiThread = (app is not None) and (QtCore.QThread.currentThread() == app.thread())
         if isGuiThread and QtGui.QApplication.instance() is not None:
-            QtGui.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
+            if QT_LIB == 'PySide':
+                # pass CursorShape rather than QCursor for PySide
+                # see https://bugreports.qt.io/browse/PYSIDE-243
+                QtGui.QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
+            else:
+                QtGui.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
             BusyCursor.active.append(self)
             self._active = True
         else:
@@ -27,4 +32,3 @@ class BusyCursor(object):
         if self._active:
             BusyCursor.active.pop(-1)
             QtGui.QApplication.restoreOverrideCursor()
-        


### PR DESCRIPTION
This should fix failures observed in CI with PySide and `examples/VideoSpeedTest.py` on Linux. See https://bugreports.qt.io/browse/PYSIDE-243. It doesn't look like the issue was ever resolved though at least it doesn't produce a segfault like it did at one time.

I selectively use the workaround for PySide, but passing the [CursorShape](https://doc.qt.io/qt-5/qt.html#CursorShape-enum) directly to [setOverrideCursor](https://doc.qt.io/qt-5/qguiapplication.html#setOverrideCursor) seems to work for all Qt implementations despite not being documented.