### PR TITLE
[WIP] Fix pg.exit test in case pyqtgraph is not installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,9 +128,14 @@ before_script:
 script:
 
     - source activate test_env
-    
+
     # Check system info
     - python -c "import pyqtgraph as pg; pg.systemInfo()"
+
+    # Check install works
+    - start_test "install test";
+      python setup.py --quiet install;
+      check_output "install test";
 
     # Run unit tests
     - start_test "unit tests";
@@ -163,11 +168,6 @@ script:
         python setup.py style &&
         check_output "style check";
       fi;
-
-    # Check install works
-    - start_test "install test";
-      python setup.py --quiet install;
-      check_output "install test";
 
     # Check double-install fails
     # Note the bash -c is because travis strips off the ! otherwise.

--- a/pyqtgraph/tests/test_exit_crash.py
+++ b/pyqtgraph/tests/test_exit_crash.py
@@ -69,10 +69,12 @@ def test_exit_crash():
 def test_pg_exit():
     # test the pg.exit() function
     code = textwrap.dedent("""
+        import sys
+        sys.path.insert(0, '{path}')
         import pyqtgraph as pg
         app = pg.mkQApp()
         pg.plot()
         pg.exit()
-    """)
+    """.format(path=os.path.dirname(pg.__file__)))
     rc = call_with_timeout([sys.executable, '-c', code], timeout=5)
     assert rc == 0

--- a/pyqtgraph/tests/test_exit_crash.py
+++ b/pyqtgraph/tests/test_exit_crash.py
@@ -70,10 +70,11 @@ def test_pg_exit():
     # test the pg.exit() function
     code = textwrap.dedent("""
         import sys
+        sys.path.insert(0, '{path}')
         import pyqtgraph as pg
         app = pg.mkQApp()
         pg.plot()
         pg.exit()
-    """)
+    """.format(path=os.path.dirname(pg.__file__)))
     rc = call_with_timeout([sys.executable, '-c', code], timeout=5, shell=True)
     assert rc == 0

--- a/pyqtgraph/tests/test_exit_crash.py
+++ b/pyqtgraph/tests/test_exit_crash.py
@@ -70,11 +70,10 @@ def test_pg_exit():
     # test the pg.exit() function
     code = textwrap.dedent("""
         import sys
-        sys.path.insert(0, '{path}')
         import pyqtgraph as pg
         app = pg.mkQApp()
         pg.plot()
         pg.exit()
-    """.format(path=os.path.dirname(pg.__file__)))
-    rc = call_with_timeout([sys.executable, '-c', code], timeout=5)
+    """)
+    rc = call_with_timeout([sys.executable, '-c', code], timeout=5, shell=True)
     assert rc == 0

--- a/pyqtgraph/tests/test_exit_crash.py
+++ b/pyqtgraph/tests/test_exit_crash.py
@@ -69,12 +69,10 @@ def test_exit_crash():
 def test_pg_exit():
     # test the pg.exit() function
     code = textwrap.dedent("""
-        import sys
-        sys.path.insert(0, '{path}')
         import pyqtgraph as pg
         app = pg.mkQApp()
         pg.plot()
         pg.exit()
-    """.format(path=os.path.dirname(pg.__file__)))
-    rc = call_with_timeout([sys.executable, '-c', code], timeout=5, shell=True)
+    """)
+    rc = call_with_timeout([sys.executable, '-c', code], timeout=5)
     assert rc == 0


### PR DESCRIPTION
Stole the implementation from the other test in `test_exit_crash.py` even though it's skipped. This test should now work on Travis where we don't install pyqtgraph until after the tests are run.