### PR TITLE
Preventing conda from updating in CI builds

### DIFF
--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -88,14 +88,15 @@ jobs:
     inputs:
       environmentName: 'test-environment-$(python.version)'
       packageSpecs: 'python=$(python.version)'
+      updateConda: false
 
   - bash: |
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)
-        conda install -c conda-forge $(qt.bindings) numpy scipy pyopengl pytest flake8 six coverage --yes --quiet
+        conda install -c conda-forge $(qt.bindings) numpy scipy pyopengl pytest six coverage --yes --quiet
       else
-        pip install $(qt.bindings) numpy scipy pyopengl pytest flake8 six coverage
+        pip install $(qt.bindings) numpy scipy pyopengl pytest six coverage
       fi
       pip install pytest-xdist pytest-cov pytest-faulthandler
     displayName: "Install Dependencies"


### PR DESCRIPTION
With conda 4.7.5, azure pipelines was having a hard time constructing our test environment for python2; solution is to prevent conda from updating, and hopefully what ever issue they have is resolved before azure pipelines default to conda 4.7.X.

Fixes 964