### PR TITLE
Skip GL* examples if on macOS with python2 and qt4 bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Requirements
   * `numpy`, `scipy`
 * Optional
   * `pyopengl` for 3D graphics
+    * macOS with Python2 and Qt4 bindings (PyQt4 or PySide) do not work with 3D OpenGL graphics
     * `pyqtgraph.opengl` will be depreciated in a future version and replaced with `VisPy`
   * `hdf5` for large hdf5 binary format support
 * Known to run on Windows, Linux, and macOS.
@@ -41,7 +42,8 @@ Below is a table of the configurations we test and have confidence pyqtgraph wil
 | 3.6             | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | 3.7             | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
-* pyqtgraph has had some incompatabilities with PySide2-5.6, and we recommend you avoid those bindings if possible.  
+* pyqtgraph has had some incompatabilities with PySide2-5.6, and we recommend you avoid those bindings if possible
+* on macOS with Python 2.7 and Qt4 bindings (PyQt4 or PySide) the openGL related visualizations do not work
 
 Support
 -------

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -56,9 +56,16 @@ exceptionCondition = namedtuple("exceptionCondition", ["condition", "reason"])
 conditionalExampleTests = {
     "hdf5.py": exceptionCondition(False, reason="Example requires user interaction and is not suitable for testing"),
     "RemoteSpeedTest.py": exceptionCondition(False, reason="Test is being problematic on CI machines"),
-    "optics_demos.py": exceptionCondition(not frontends[Qt.PYSIDE], reason="Test fails due to PySide bug: https://bugreports.qt.io/browse/PYSIDE-671")
+    "optics_demos.py": exceptionCondition(not frontends[Qt.PYSIDE], reason="Test fails due to PySide bug: https://bugreports.qt.io/browse/PYSIDE-671"),
+    'GLVolumeItem.py': exceptionCondition(not(sys.platform == "darwin" and sys.version_info[0] == 2 and (frontends[Qt.PYQT4] or frontends[Qt.PYSIDE])), reason="glClear does not work on macOS + Python2.7 + Qt4: https://github.com/pyqtgraph/pyqtgraph/issues/939"),
+    'GLIsosurface.py': exceptionCondition(not(sys.platform == "darwin" and sys.version_info[0] == 2 and (frontends[Qt.PYQT4] or frontends[Qt.PYSIDE])), reason="glClear does not work on macOS + Python2.7 + Qt4: https://github.com/pyqtgraph/pyqtgraph/issues/939"),
+    'GLSurfacePlot.py': exceptionCondition(not(sys.platform == "darwin" and sys.version_info[0] == 2 and (frontends[Qt.PYQT4] or frontends[Qt.PYSIDE])), reason="glClear does not work on macOS + Python2.7 + Qt4: https://github.com/pyqtgraph/pyqtgraph/issues/939"),
+    'GLScatterPlotItem.py': exceptionCondition(not(sys.platform == "darwin" and sys.version_info[0] == 2 and (frontends[Qt.PYQT4] or frontends[Qt.PYSIDE])), reason="glClear does not work on macOS + Python2.7 + Qt4: https://github.com/pyqtgraph/pyqtgraph/issues/939"),
+    'GLshaders.py': exceptionCondition(not(sys.platform == "darwin" and sys.version_info[0] == 2 and (frontends[Qt.PYQT4] or frontends[Qt.PYSIDE])), reason="glClear does not work on macOS + Python2.7 + Qt4: https://github.com/pyqtgraph/pyqtgraph/issues/939"),
+    'GLLinePlotItem.py': exceptionCondition(not(sys.platform == "darwin" and sys.version_info[0] == 2 and (frontends[Qt.PYQT4] or frontends[Qt.PYSIDE])), reason="glClear does not work on macOS + Python2.7 + Qt4: https://github.com/pyqtgraph/pyqtgraph/issues/939"),
+    'GLMeshItem.py': exceptionCondition(not(sys.platform == "darwin" and sys.version_info[0] == 2 and (frontends[Qt.PYQT4] or frontends[Qt.PYSIDE])), reason="glClear does not work on macOS + Python2.7 + Qt4: https://github.com/pyqtgraph/pyqtgraph/issues/939"),
+    'GLImageItem.py': exceptionCondition(not(sys.platform == "darwin" and sys.version_info[0] == 2 and (frontends[Qt.PYQT4] or frontends[Qt.PYSIDE])), reason="glClear does not work on macOS + Python2.7 + Qt4: https://github.com/pyqtgraph/pyqtgraph/issues/939")
 }
-
 
 @pytest.mark.parametrize(
 	"frontend, f",


### PR DESCRIPTION
Due to an error in `glClear` and macOS's implementation of openGL, the GL examples don't work when running on python 2 with qt4 bindings.  Use qt4 bindings with python3? you're good, use qt5 bindings with python2? you're good... 

As this hasn't really worked in some time, and we don't see an issue about it, we've elected to skip those examples from our test suite, and make a note on `README.md` about that configuration not working. 