### PR TITLE
Always update transform when setting angle of a TextItem

### DIFF
--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -111,7 +111,7 @@ class TextItem(GraphicsObject):
         
     def setAngle(self, angle):
         self.angle = angle
-        self.updateTransform()
+        self.updateTransform(force=True)
         
     def setAnchor(self, anchor):
         self.anchor = Point(anchor)
@@ -169,7 +169,7 @@ class TextItem(GraphicsObject):
             p.setRenderHint(p.Antialiasing, True)
             p.drawPolygon(self.textItem.mapToParent(self.textItem.boundingRect()))
         
-    def updateTransform(self):
+    def updateTransform(self, force=False):
         # update transform such that this item has the correct orientation
         # and scaling relative to the scene, but inherits its position from its
         # parent.
@@ -181,7 +181,7 @@ class TextItem(GraphicsObject):
         else:
             pt = p.sceneTransform()
         
-        if pt == self._lastTransform:
+        if not force and pt == self._lastTransform:
             return
 
         t = pt.inverted()[0]

--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -110,9 +110,16 @@ class TextItem(GraphicsObject):
         self.updateTextPos()
         
     def setAngle(self, angle):
+        """
+        Set the angle of the text in degrees.
+
+        This sets the rotation angle of the text as a whole, measured
+        counter-clockwise from the x axis of the parent. Note that this rotation
+        angle does not depend on horizontal/vertical scaling of the parent.
+        """
         self.angle = angle
         self.updateTransform(force=True)
-        
+
     def setAnchor(self, anchor):
         self.anchor = Point(anchor)
         self.updateTextPos()

--- a/pyqtgraph/graphicsItems/tests/test_TextItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_TextItem.py
@@ -1,0 +1,22 @@
+import pytest
+import pyqtgraph as pg
+from numpy.testing import assert_almost_equal, assert_raises
+
+app = pg.mkQApp()
+
+
+@pytest.mark.parametrize("lock_aspect", [True, False])
+def test_TextItem_setAngle(lock_aspect):
+    plt = pg.plot()
+    plt.setXRange(-1, 1)
+    plt.setYRange(-10, 10)
+    plt.setAspectLocked(lock_aspect)
+    item = pg.TextItem(text="test")
+    plt.addItem(item)
+
+    assert item.transformAngle() == 0.0
+
+    for angle in [10, -30, 90]:
+        item.setAngle(angle)
+        # negative because transformAngle measures from item to parent
+        assert_almost_equal(-item.transformAngle() % 360, angle % 360)

--- a/pyqtgraph/graphicsItems/tests/test_TextItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_TextItem.py
@@ -5,18 +5,20 @@ from numpy.testing import assert_almost_equal, assert_raises
 app = pg.mkQApp()
 
 
-@pytest.mark.parametrize("lock_aspect", [True, False])
-def test_TextItem_setAngle(lock_aspect):
+def test_TextItem_setAngle():
     plt = pg.plot()
-    plt.setXRange(-1, 1)
-    plt.setYRange(-10, 10)
-    plt.setAspectLocked(lock_aspect)
+    plt.setXRange(-10, 10)
+    plt.setYRange(-20, 20)
     item = pg.TextItem(text="test")
     plt.addItem(item)
 
-    assert item.transformAngle() == 0.0
+    t1 = item.transform()
 
-    for angle in [10, -30, 90]:
-        item.setAngle(angle)
-        # negative because transformAngle measures from item to parent
-        assert_almost_equal(-item.transformAngle() % 360, angle % 360)
+    item.setAngle(30)
+    app.processEvents()
+
+    t2 = item.transform()
+
+    assert t1 != t2
+    assert not t1.isRotating()
+    assert t2.isRotating()

--- a/pyqtgraph/graphicsItems/tests/test_TextItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_TextItem.py
@@ -1,6 +1,5 @@
 import pytest
 import pyqtgraph as pg
-from numpy.testing import assert_almost_equal, assert_raises
 
 app = pg.mkQApp()
 


### PR DESCRIPTION
As demonstrated in #871, calling `TextItem.setAngle()` with a new angle doesn't actually rotate the `TextItem` visually because `updateTransform` uses a cached transform to avoid extra computation if it hasn't changed, but setting the `angle` attr of the `TextItem` doesn't invalidate it.

I decided to use a keyword arg instead of setting `self._lastTransform = None` right before calling `self.updateTransform()` for readability. I don't know if `force` is the right name (maybe `use_cache` with inverted logic?), but it's not really a user method so maybe it doesn't matter much.

Fixes #871