### PR TITLE
FIX: RecursionError when instanciating CtrlNode

### DIFF
--- a/pyqtgraph/flowchart/library/common.py
+++ b/pyqtgraph/flowchart/library/common.py
@@ -91,14 +91,15 @@ class CtrlNode(Node):
     sigStateChanged = QtCore.Signal(object)
     
     def __init__(self, name, ui=None, terminals=None):
+        if terminals is None:
+            terminals = {'In': {'io': 'in'}, 'Out': {'io': 'out', 'bypass': 'In'}}
+        Node.__init__(self, name=name, terminals=terminals)
+        
         if ui is None:
             if hasattr(self, 'uiTemplate'):
                 ui = self.uiTemplate
             else:
                 ui = []
-        if terminals is None:
-            terminals = {'In': {'io': 'in'}, 'Out': {'io': 'out', 'bypass': 'In'}}
-        Node.__init__(self, name=name, terminals=terminals)
         
         self.ui, self.stateGroup, self.ctrls = generateUi(ui)
         self.stateGroup.sigChanged.connect(self.changed)


### PR DESCRIPTION
CtrlNode checks this:
https://github.com/pyqtgraph/pyqtgraph/blob/23b4e174f073bb1d444ff8390641dc2c7c52e0a0/pyqtgraph/flowchart/library/common.py#L95

Problem is: If 'uiTemplate' does not exist (it could exist via subclassing CtrlNode), it calls `Node.__getattr__`, with the important line
https://github.com/pyqtgraph/pyqtgraph/blob/23b4e174f073bb1d444ff8390641dc2c7c52e0a0/pyqtgraph/flowchart/Node.py#L192

, before `Node.__init__` is called. Therefore `self.terminals` does not yet exist (it is initialized in `Node.__init__`), which causes a new call to `Node.__getattr__` - you spot the recursion.

This pull request fixes this by calling `Node.__init__` before the call of `hasattr`.

This is a follow-up to #973, where I missed two lines that set defaults that are used for the `__init__`. 

Fixes #296.