### PR TITLE
Remove pytest-faulthandler from test dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,11 @@ install:
     - pip install pytest-xdist # multi-thread pytest
     - pip install pytest-cov # add coverage stats
 
+    # faulthandler support not built in to pytest for python 2.7
+    - if [ "${PYTHON}" == "2.7" ]; then
+        pip install pytest-faulthandler;
+      fi;
+
     # Debugging helpers
     - uname -a
     - cat /etc/issue
@@ -139,7 +144,7 @@ script:
 
     # Run unit tests
     - start_test "unit tests";
-      PYTHONPATH=. pytest --cov pyqtgraph -sv;
+      PYTHONPATH=. pytest --cov pyqtgraph -sv -o faulthandler_timeout=15;
       check_output "unit tests";
     - echo "test script finished. Current directory:"
     - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ install:
       fi;
     - pip install pytest-xdist # multi-thread pytest
     - pip install pytest-cov # add coverage stats
-    - pip install pytest-faulthandler # activate faulthandler
 
     # Debugging helpers
     - uname -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ script:
 
     # Run unit tests
     - start_test "unit tests";
-      PYTHONPATH=. pytest --cov pyqtgraph -sv -o faulthandler_timeout=15;
+      PYTHONPATH=. pytest --cov pyqtgraph -sv;
       check_output "unit tests";
     - echo "test script finished. Current directory:"
     - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ install:
     # faulthandler support not built in to pytest for python 2.7
     - if [ "${PYTHON}" == "2.7" ]; then
         pip install pytest-faulthandler;
+        export PYTEST_ADDOPTS="--faulthandler-timeout=15";
       fi;
 
     # Debugging helpers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,10 @@ Please use the following guidelines when preparing changes:
 * pytest-xdist
 * Optional: pytest-xvfb
 
+If you have pytest < 5, you may also want to install the pytest-faulthandler
+plugin to output extra debugging information in case of test failures. This
+isn't necessary with pytest 5+ as the plugin was merged into core pytest.
+
 ### Tox
 
 As PyQtGraph supports a wide array of Qt-bindings, and python versions, we make use of `tox` to test against most of the configurations in our test matrix.  As some of the qt-bindings are only installable via `conda`, `conda` needs to be in your `PATH`, and we utilize the `tox-conda` plugin.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,6 @@ Please use the following guidelines when preparing changes:
 * pytest
 * pytest-cov
 * pytest-xdist
-* pytest-faulthandler
 * Optional: pytest-xvfb
 
 ### Tox

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -102,6 +102,7 @@ jobs:
       if [ $(python.version) == "2.7" ]
       then
         pip install pytest-faulthandler
+        export PYTEST_ADDOPTS="--faulthandler-timeout=15"
       fi
     displayName: "Install Dependencies"
   

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -174,8 +174,7 @@ jobs:
       # echo "https://dev.azure.com/pyqtgraph/pyqtgraph/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=Screenshots&api-version=5.0"
       pytest . -sv \
         --junitxml=junit/test-results.xml \
-        -n 1 --cov pyqtgraph --cov-report=xml --cov-report=html \
-        -o faulthandler_timeout=15
+        -n 1 --cov pyqtgraph --cov-report=xml --cov-report=html
     displayName: 'Unit tests' 
     env:
       AZURE: 1

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -99,6 +99,10 @@ jobs:
         pip install $(qt.bindings) numpy scipy pyopengl pytest six coverage
       fi
       pip install pytest-xdist pytest-cov
+      if [ $(python.version) == "2.7" ]
+      then
+        pip install pytest-faulthandler
+      fi
     displayName: "Install Dependencies"
   
   - bash: |
@@ -170,7 +174,8 @@ jobs:
       # echo "https://dev.azure.com/pyqtgraph/pyqtgraph/_apis/build/builds/$(Build.BuildId)/artifacts?artifactName=Screenshots&api-version=5.0"
       pytest . -sv \
         --junitxml=junit/test-results.xml \
-        -n 1 --cov pyqtgraph --cov-report=xml --cov-report=html
+        -n 1 --cov pyqtgraph --cov-report=xml --cov-report=html \
+        -o faulthandler_timeout=15
     displayName: 'Unit tests' 
     env:
       AZURE: 1

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -98,7 +98,7 @@ jobs:
       else
         pip install $(qt.bindings) numpy scipy pyopengl pytest six coverage
       fi
-      pip install pytest-xdist pytest-cov pytest-faulthandler
+      pip install pytest-xdist pytest-cov
     displayName: "Install Dependencies"
   
   - bash: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,6 @@ xvfb_height = 1080
 # use this due to some issues with ndarray reshape errors on CI systems
 xvfb_colordepth = 24
 xvfb_args=-ac +extension GLX +render
-addopts = --faulthandler-timeout=15
 
 filterwarnings =
     # comfortable skipping these warnings runtime warnings

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ xvfb_height = 1080
 # use this due to some issues with ndarray reshape errors on CI systems
 xvfb_colordepth = 24
 xvfb_args=-ac +extension GLX +render
+faulthandler_timeout = 15
 
 filterwarnings =
     # comfortable skipping these warnings runtime warnings

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,6 @@ deps=
     {[base]deps}
     pytest-cov
     pytest-xdist
-    pytest-faulthandler
     pyside2-pip: pyside2
     pyqt5-pip: pyqt5
 


### PR DESCRIPTION
As of a few days ago, the pytest-faulthandler plugin was merged into pytest: https://github.com/pytest-dev/pytest/pull/5441

Along with this, the `--faulthandler-timeout` command line option was moved to an ini option `faulthandler_timeout`, causing most CI environments to fail.

This PR introduces `pytest>=5` as a requirement so we can just assume the new ini option is available and remove `pytest-faulthandler`.