### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- In the following, please describe your issue in detail! -->
+<!-- If some of the sections do not apply, just remove them. -->
+
+### Short description
+<!-- This should summarize the issue. -->
+
+### Code to reproduce
+```python
+import pyqtgraph as pg
+import numpy as np
+# This is a placeholder for a minimal working example that reproduces the issue.
+```
+
+### Expected behavior
+<!-- What should happen? -->
+
+### Real behavior
+<!-- What happens? -->
+
+```
+An error occurred?
+Post it inside these 'code fences'!
+```
+
+### Tested environment(s)
+
+ * PyQtGraph version: <!-- output of pyqtgraph.__version__ -->
+ * Qt Python binding: <!-- output of pyqtgraph.Qt.VERSION_INFO -->
+ * Python version: 
+ * NumPy version: <!-- output of numpy.__version__ -->
+ * Operating system: 
+
+### Additional context

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,10 +14,11 @@ assignees: ''
 <!-- This should summarize the issue. -->
 
 ### Code to reproduce
+<!-- Please provide a minimal working example that reproduces the issue in the code block below.
+     Ideally, this should be a full example someone else could run without additional setup. -->
 ```python
 import pyqtgraph as pg
 import numpy as np
-# This is a placeholder for a minimal working example that reproduces the issue.
 ```
 
 ### Expected behavior
@@ -28,7 +29,7 @@ import numpy as np
 
 ```
 An error occurred?
-Post it inside these 'code fences'!
+Post the full traceback inside these 'code fences'!
 ```
 
 ### Tested environment(s)
@@ -38,5 +39,6 @@ Post it inside these 'code fences'!
  * Python version: 
  * NumPy version: <!-- output of numpy.__version__ -->
  * Operating system: 
+ * Installation method: <!-- e.g. pip, conda, system packages, ... -->
 
 ### Additional context


### PR DESCRIPTION
Using an issue template improves the amount of information given when an issue is opened and provides guidance. I tried to create an issue template that fits PyQtGraph, that I hereby propose.

I would be glad about feedback regarding the tone and style of this template. It can be tested here: https://github.com/2xB/pyqtgraph/issues/new/choose