### PR TITLE
Reduce test window size for OSX compatibility

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
@@ -63,7 +63,7 @@ def test_ViewBox():
     assertMapping(vb, view1, size1)
     
     # test tall resize
-    win.resize(400, 800)
+    win.resize(200, 400)
     app.processEvents()
     w = vb.geometry().width()
     h = vb.geometry().height()


### PR DESCRIPTION
May fix some broken OSX tests. The main problem is that OSX reports its window size in _logical_ pixels rather than _physical_ pixels, which means that on some systems we can have unexpectedly small maximum window sizes. This causes the test window to shrink vertically, changing the aspect ratio and breaking the test. (solution is just to use a smaller window with the same aspect ratio)