### PR TITLE
relax image comparison for failing windows test

### DIFF
--- a/pyqtgraph/graphicsItems/tests/test_ROI.py
+++ b/pyqtgraph/graphicsItems/tests/test_ROI.py
@@ -133,7 +133,8 @@ def check_getArrayRegion(roi, name, testResize=True, transpose=False):
     rgn = roi.getArrayRegion(data, img1, axes=(1, 2))
     img2.setImage(rgn[0, ..., 0])
     app.processEvents()
-    assertImageApproved(win, name+'/roi_getarrayregion_inverty', 'Simple ROI region selection, view inverted.')
+    # on windows, one edge of one ROI handle is shifted slightly; letting this slide with pxCount=10
+    assertImageApproved(win, name+'/roi_getarrayregion_inverty', 'Simple ROI region selection, view inverted.', pxCount=10)
 
     roi.setState(initState)
     img1.resetTransform()

--- a/pyqtgraph/graphicsItems/tests/test_ROI.py
+++ b/pyqtgraph/graphicsItems/tests/test_ROI.py
@@ -1,3 +1,4 @@
+import sys
 import numpy as np
 import pytest
 import pyqtgraph as pg
@@ -134,7 +135,11 @@ def check_getArrayRegion(roi, name, testResize=True, transpose=False):
     img2.setImage(rgn[0, ..., 0])
     app.processEvents()
     # on windows, one edge of one ROI handle is shifted slightly; letting this slide with pxCount=10
-    assertImageApproved(win, name+'/roi_getarrayregion_inverty', 'Simple ROI region selection, view inverted.', pxCount=10)
+    if sys.platform == 'win32' and pg.Qt.QT_LIB in ('PyQt4', 'PySide'):
+        pxCount = 10
+    else:
+        pxCount=-1
+    assertImageApproved(win, name+'/roi_getarrayregion_inverty', 'Simple ROI region selection, view inverted.', pxCount=pxCount)
 
     roi.setState(initState)
     img1.resetTransform()


### PR DESCRIPTION
One ROI test was failing on windows/py27 due to a single edge of a single handle shifting by a pixel. Fixed by relaxing the image comparison criteria for that test.