### PR TITLE
Merge master into develop

### DIFF
--- a/pyqtgraph/Point.py
+++ b/pyqtgraph/Point.py
@@ -2,7 +2,7 @@
 """
 Point.py -  Extension of QPointF which adds a few missing methods.
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 """
 
 from .Qt import QtCore

--- a/pyqtgraph/Vector.py
+++ b/pyqtgraph/Vector.py
@@ -2,7 +2,7 @@
 """
 Vector.py -  Extension of QVector3D which adds a few missing methods.
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 """
 
 from .Qt import QtGui, QtCore, QT_LIB

--- a/pyqtgraph/WidgetGroup.py
+++ b/pyqtgraph/WidgetGroup.py
@@ -2,7 +2,7 @@
 """
 WidgetGroup.py -  WidgetGroup class for easily managing lots of Qt widgets
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 
 This class addresses the problem of having to save and restore the state
 of a large group of widgets. 

--- a/pyqtgraph/configfile.py
+++ b/pyqtgraph/configfile.py
@@ -2,7 +2,7 @@
 """
 configfile.py - Human-readable text configuration file library 
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 
 Used for reading and writing dictionary objects to a python-like configuration
 file format. Data structures may be nested and contain any data type as long

--- a/pyqtgraph/debug.py
+++ b/pyqtgraph/debug.py
@@ -2,7 +2,7 @@
 """
 debug.py - Functions to aid in debugging 
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 """
 
 from __future__ import print_function

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -2,7 +2,7 @@
 """
 functions.py -  Miscellaneous functions with no other home
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 """
 
 from __future__ import division

--- a/pyqtgraph/graphicsItems/MultiPlotItem.py
+++ b/pyqtgraph/graphicsItems/MultiPlotItem.py
@@ -2,7 +2,7 @@
 """
 MultiPlotItem.py -  Graphics item used for displaying an array of PlotItems
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 """
 
 from numpy import ndarray

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -2,7 +2,7 @@
 """
 ROI.py -  Interactive graphics items for GraphicsView (ROI widgets)
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 
 Implements a series of graphics items which display movable/scalable/rotatable shapes
 for use as region-of-interest markers. ROI class automatically handles extraction 

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -2,7 +2,7 @@
 """
 ImageView.py -  Widget for basic image dispay and analysis
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 
 Widget used for displaying 2D or 3D data. Features:
   - float or int (including 16-bit int) image display via ImageItem

--- a/pyqtgraph/metaarray/MetaArray.py
+++ b/pyqtgraph/metaarray/MetaArray.py
@@ -2,7 +2,7 @@
 """
 MetaArray.py -  Class encapsulating ndarray with meta data
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 
 MetaArray is an array class based on numpy.ndarray that allows storage of per-axis meta data
 such as axis values, names, units, column names, etc. It also enables several

--- a/pyqtgraph/pgcollections.py
+++ b/pyqtgraph/pgcollections.py
@@ -2,7 +2,7 @@
 """
 advancedTypes.py - Basic data structures not included with python 
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 
 Includes:
   - OrderedDict - Dictionary which preserves the order of its elements

--- a/pyqtgraph/ptime.py
+++ b/pyqtgraph/ptime.py
@@ -2,7 +2,7 @@
 """
 ptime.py -  Precision time function made os-independent (should have been taken care of by python)
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 """
 
 

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -2,7 +2,7 @@
 """
 GraphicsView.py -   Extension of QGraphicsView
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 """
 
 from ..Qt import QtCore, QtGui, QT_LIB

--- a/pyqtgraph/widgets/MultiPlotWidget.py
+++ b/pyqtgraph/widgets/MultiPlotWidget.py
@@ -2,7 +2,7 @@
 """
 MultiPlotWidget.py -  Convenience class--GraphicsView widget displaying a MultiPlotItem
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 """
 from ..Qt import QtCore
 from .GraphicsView import GraphicsView

--- a/pyqtgraph/widgets/PlotWidget.py
+++ b/pyqtgraph/widgets/PlotWidget.py
@@ -2,7 +2,7 @@
 """
 PlotWidget.py -  Convenience class--GraphicsView widget displaying a single PlotItem
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 """
 
 from ..Qt import QtCore, QtGui


### PR DESCRIPTION
This PR merges `master` into `develop`, so the branches are no longer diverging. That effectively only causes one spelling error to be corrected.

`pyqtgraph/graphicsItems/PlotItem/PlotItem.py` and `pyqtgraph/graphicsWindows.py` had merge conflicts in documentation strings that I resolved in favor of the version from `develop`.