### PR TITLE
[WIP] Fix segfaults in GLViewWidget on Mac

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,4 +35,4 @@ jobs:
   - template: azure-test-template.yml
     parameters:
       name: MacOS
-      vmImage: 'macOS-10.14'
+      vmImage: 'macOS-10.13'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,4 +35,4 @@ jobs:
   - template: azure-test-template.yml
     parameters:
       name: MacOS
-      vmImage: 'macOS-10.13'
+      vmImage: 'macOS-10.14'

--- a/examples/GLSurfacePlot.py
+++ b/examples/GLSurfacePlot.py
@@ -82,11 +82,14 @@ p4.shader()['colorMap'] = np.array([0.2, 2, 0.5, 0.2, 1, 1, 0.2, 0, 2])
 p4.translate(10, 10, 0)
 w.addItem(p4)
 
+w.update() # Only necessary if running headless
+
 index = 0
 def update():
     global p4, z, index
     index -= 1
     p4.setData(z=z[index%z.shape[0]])
+    w.update() # Only necessary if running headless
     
 timer = QtCore.QTimer()
 timer.timeout.connect(update)

--- a/examples/GLSurfacePlot.py
+++ b/examples/GLSurfacePlot.py
@@ -82,14 +82,14 @@ p4.shader()['colorMap'] = np.array([0.2, 2, 0.5, 0.2, 1, 1, 0.2, 0, 2])
 p4.translate(10, 10, 0)
 w.addItem(p4)
 
-w.update() # Only necessary if running headless
+w.updateGL() # Only necessary if running headless
 
 index = 0
 def update():
     global p4, z, index
     index -= 1
     p4.setData(z=z[index%z.shape[0]])
-    w.update() # Only necessary if running headless
+    w.updateGL() # Only necessary if running headless
     
 timer = QtCore.QTimer()
 timer.timeout.connect(update)

--- a/examples/GLSurfacePlot.py
+++ b/examples/GLSurfacePlot.py
@@ -82,14 +82,11 @@ p4.shader()['colorMap'] = np.array([0.2, 2, 0.5, 0.2, 1, 1, 0.2, 0, 2])
 p4.translate(10, 10, 0)
 w.addItem(p4)
 
-w.paintGL() # Only necessary if running headless
-
 index = 0
 def update():
     global p4, z, index
     index -= 1
     p4.setData(z=z[index%z.shape[0]])
-    w.paintGL() # Only necessary if running headless
     
 timer = QtCore.QTimer()
 timer.timeout.connect(update)

--- a/examples/GLSurfacePlot.py
+++ b/examples/GLSurfacePlot.py
@@ -11,6 +11,7 @@ from pyqtgraph.Qt import QtCore, QtGui
 import pyqtgraph as pg
 import pyqtgraph.opengl as gl
 import numpy as np
+qtest = pg.Qt.QtTest.QTest
 
 ## Create a GL View widget to display data
 app = QtGui.QApplication([])
@@ -91,6 +92,8 @@ def update():
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(30)
+
+qtest.qWaitForWindowShown(w)
 
 ## Start Qt event loop unless running in interactive mode.
 if __name__ == '__main__':

--- a/examples/GLSurfacePlot.py
+++ b/examples/GLSurfacePlot.py
@@ -82,14 +82,14 @@ p4.shader()['colorMap'] = np.array([0.2, 2, 0.5, 0.2, 1, 1, 0.2, 0, 2])
 p4.translate(10, 10, 0)
 w.addItem(p4)
 
-w.updateGL() # Only necessary if running headless
+w.paintGL() # Only necessary if running headless
 
 index = 0
 def update():
     global p4, z, index
     index -= 1
     p4.setData(z=z[index%z.shape[0]])
-    w.updateGL() # Only necessary if running headless
+    w.paintGL() # Only necessary if running headless
     
 timer = QtCore.QTimer()
 timer.timeout.connect(update)

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -4,6 +4,7 @@ import OpenGL.GL.framebufferobjects as glfbo
 import numpy as np
 from .. import Vector
 from .. import functions as fn
+import warnings
 
 ##Vector = QtGui.QVector3D
 
@@ -195,7 +196,12 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         self.setModelview()
         bgcolor = self.opts['bgcolor']
         glClearColor(*bgcolor)
-        glGetError()
+        while True:
+            err = glGetError()
+            if err != GL_NO_ERROR:
+                warnings.warn("GL Error:", err, file=sys.stderr)
+            else:
+                break
         glClear( GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT )
         self.drawItemTree(useItemNames=useItemNames)
         

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -195,7 +195,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         self.setProjection(region=region)
         self.setModelview()
         bgcolor = self.opts['bgcolor']
-        raise RuntimeError("BG color: {}".format(repr(bgcolor))) # This is a debug line and should never be in any official pyqtgraph branch
+        warnings.warn("BG color: {}".format(repr(bgcolor))) # This is a debug line and should never be in any official pyqtgraph branch
         glClearColor(*bgcolor)
         while True:
             err = glGetError()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -5,6 +5,7 @@ import numpy as np
 from .. import Vector
 from .. import functions as fn
 import warnings
+import sys
 
 ##Vector = QtGui.QVector3D
 
@@ -185,7 +186,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         if viewport is None:
             viewport = self.getViewport()
             
-        raise RuntimeError("paintGL called. region={}, viewport={}, useItemNames={}".format(repr(region), repr(viewport), repr(useItemNames)))
+        sys.exit("paintGL called. region={}, viewport={}, useItemNames={}".format(repr(region), repr(viewport), repr(useItemNames)))
             
         glViewport(*viewport)
             

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -195,6 +195,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         self.setModelview()
         bgcolor = self.opts['bgcolor']
         glClearColor(*bgcolor)
+        glGetError()
         glClear( GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT )
         self.drawItemTree(useItemNames=useItemNames)
         

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -189,6 +189,8 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         if not self.isValid():
             raise RuntimeError("OpenGL context is invalid")
         
+        self.makeCurrent()
+        
         self.setProjection(region=region)
         self.setModelview()
         bgcolor = self.opts['bgcolor']

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -185,6 +185,10 @@ class GLViewWidget(QtOpenGL.QGLWidget):
             glViewport(*self.getViewport())
         else:
             glViewport(*viewport)
+            
+        if not self.isValid():
+            raise RuntimeError("OpenGL context is invalid")
+        
         self.setProjection(region=region)
         self.setModelview()
         bgcolor = self.opts['bgcolor']

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -185,7 +185,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         if viewport is None:
             viewport = self.getViewport()
             
-        raise RuntimeError("paintGL called. region={}, viewport={}, useItemNames={}".format(repr(region), repr(viewport), repr(useItemNames))
+        raise RuntimeError("paintGL called. region={}, viewport={}, useItemNames={}".format(repr(region), repr(viewport), repr(useItemNames)))
             
         glViewport(*viewport)
             

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -190,12 +190,14 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         if not self.isValid():
             raise RuntimeError("OpenGL context is invalid")
         
+        raise RuntimeError("paintGL is run") # This is a debug line and should never be in any official pyqtgraph branch
+        
         self.makeCurrent()
         
         self.setProjection(region=region)
         self.setModelview()
         bgcolor = self.opts['bgcolor']
-        warnings.warn("BG color:", bgcolor)
+        warnings.warn("BG color:", bgcolor) # This is a debug line and should never be in any official pyqtgraph branch
         glClearColor(*bgcolor)
         while True:
             err = glGetError()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -186,8 +186,8 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         if viewport is None:
             viewport = self.getViewport()
             
-        sys.exit("paintGL called. region={}, viewport={}, useItemNames={}".format(repr(region), repr(viewport), repr(useItemNames)))
-            
+        print("paintGL called. region={}, viewport={}, useItemNames={}\n".format(repr(region), repr(viewport), repr(useItemNames)), )
+        
         glViewport(*viewport)
             
         if not self.isValid():

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -183,9 +183,11 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         Note that we may use viewport != self.opts['viewport'] when exporting.
         """
         if viewport is None:
-            glViewport(*self.getViewport())
-        else:
-            glViewport(*viewport)
+            viewport = self.getViewport()
+            
+        raise RuntimeError("paintGL called. region={}, viewport={}, useItemNames={}".format(repr(region), repr(viewport), repr(useItemNames))
+            
+        glViewport(*viewport)
             
         if not self.isValid():
             raise RuntimeError("OpenGL context is invalid")

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -190,14 +190,12 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         if not self.isValid():
             raise RuntimeError("OpenGL context is invalid")
         
-        raise RuntimeError("paintGL is run") # This is a debug line and should never be in any official pyqtgraph branch
-        
         self.makeCurrent()
         
         self.setProjection(region=region)
         self.setModelview()
         bgcolor = self.opts['bgcolor']
-        warnings.warn("BG color:", bgcolor) # This is a debug line and should never be in any official pyqtgraph branch
+        raise RuntimeError("BG color: {}".format(repr(bgcolor))) # This is a debug line and should never be in any official pyqtgraph branch
         glClearColor(*bgcolor)
         while True:
             err = glGetError()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -186,7 +186,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         if viewport is None:
             viewport = self.getViewport()
             
-        print("paintGL called. region={}, viewport={}, useItemNames={}\n".format(repr(region), repr(viewport), repr(useItemNames)), )
+        raise RuntimeError("paintGL called. region={}, viewport={}, useItemNames={}\n".format(repr(region), repr(viewport), repr(useItemNames)), )
         
         glViewport(*viewport)
             

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -195,6 +195,7 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         self.setProjection(region=region)
         self.setModelview()
         bgcolor = self.opts['bgcolor']
+        warnings.warn("BG color:", bgcolor)
         glClearColor(*bgcolor)
         while True:
             err = glGetError()


### PR DESCRIPTION
This is a work in progress. `glClear` is said to fail if there is no valid OpenGL context, so the first step is to check if that is the case.

Aims at fixing #967 