### PR TITLE
FIX: Curves are automatically set visible when one is deleted

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -925,9 +925,7 @@ class PlotItem(GraphicsWidget):
         curves = self.curves[:]
         split = len(curves) - numCurves
         for i in range(len(curves)):
-            if numCurves == -1 or i >= split:
-                curves[i].show()
-            else:
+            if numCurves != -1 and i >= split:
                 if self.ctrl.forgetTracesCheck.isChecked():
                     curves[i].clear()
                     self.removeItem(curves[i])

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -924,13 +924,13 @@ class PlotItem(GraphicsWidget):
             
         curves = self.curves[:]
         split = len(curves) - numCurves
-        for i in range(len(curves)):
-            if numCurves != -1 and i >= split:
+        for curve in curves[split:]:
+            if numCurves != -1:
                 if self.ctrl.forgetTracesCheck.isChecked():
-                    curves[i].clear()
+                    curve.clear()
                     self.removeItem(curves[i])
                 else:
-                    curves[i].hide()        
+                    curve.hide()        
       
     def updateAlpha(self, *args):
         (alpha, auto) = self.alphaState()


### PR DESCRIPTION
On call of `PlotItem.removeItem`, `PlotItem.updateDecimation` is called, which sets invisible curves visible. This behavior seems unintended.

Fixes #985.