### PR TITLE
Disable the downsample ratio spinbox when you have autodownsampling enabled

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -898,6 +898,12 @@ class PlotItem(GraphicsWidget):
             
         auto = self.ctrl.downsampleCheck.isChecked() and self.ctrl.autoDownsampleCheck.isChecked()
             
+        if auto:
+            self.ctrl.downsampleSpin.setEnabled(True)
+        else:
+            self.ctrl.downsampleSpin.setEnabled(False)
+
+
         if self.ctrl.subsampleRadio.isChecked():
             method = 'subsample' 
         elif self.ctrl.meanRadio.isChecked():


### PR DESCRIPTION
Basically, right now, the plotitem context menu has the option to configure downsampling. However, when you turn on automatic downsampling, you can still manually set the downsampling ratio (which is then ignored).

This can be very confusing, so this sets the downsampling spinbox to disabled when you have autodownsampling enabled.

I'd like to have the actual downsampling ratio percolate back up and change the value in the read-only spinbox, but doing that involves a lot of changes, and if you have two datasets with different x-axis spacings, there is no single value you can put in the spinbox anyways, so this just does the simpler thing.

