### PR TITLE
Fix QtProcess proxy transmitting small multidimensional arrays

### DIFF
--- a/pyqtgraph/multiprocess/remoteproxy.py
+++ b/pyqtgraph/multiprocess/remoteproxy.py
@@ -458,7 +458,7 @@ class RemoteEventHandler(object):
             ## follow up by sending byte messages
             if byteData is not None:
                 for obj in byteData:  ## Remote process _must_ be prepared to read the same number of byte messages!
-                    self.conn.send_bytes(obj)
+                    self.conn.send_bytes(bytes(obj))
                 self.debugMsg('  sent %d byte messages', len(byteData))
             
             self.debugMsg('  call sync: %s', callSync)


### PR DESCRIPTION
This fixes issue #461 as a workaround for https://bugs.python.org/issue37637 by transforming all objects into bytes objects before transmitting them using `send_bytes`.

Note: I did not notice any performance decrease using the example `RemoteSpeedTest.py` with this workaround.