### PR TITLE
Make outline around fillLevel optional

### DIFF
--- a/examples/histogram.py
+++ b/examples/histogram.py
@@ -22,7 +22,7 @@ y,x = np.histogram(vals, bins=np.linspace(-3, 8, 40))
 
 ## Using stepMode=True causes the plot to draw two lines for each sample.
 ## notice that len(x) == len(y)+1
-plt1.plot(x, y, stepMode=True, fillLevel=0, brush=(0,0,255,150))
+plt1.plot(x, y, stepMode=True, fillLevel=0, fillOutline=True, brush=(0,0,255,150))
 
 ## Now draw all points as a nicely-spaced scatter plot
 y = pg.pseudoScatter(vals, spacing=0.15)

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -61,6 +61,7 @@ class PlotCurveItem(GraphicsObject):
         self.opts = {
             'shadowPen': None,
             'fillLevel': None,
+            'fillOutline': False,
             'brush': None,
             'stepMode': False,
             'name': None,
@@ -291,7 +292,7 @@ class PlotCurveItem(GraphicsObject):
         self.fillPath = None
         self.invalidateBounds()
         self.update()
-
+        
     def setData(self, *args, **kargs):
         """
         =============== ========================================================
@@ -305,6 +306,8 @@ class PlotCurveItem(GraphicsObject):
                         :func:`mkPen <pyqtgraph.mkPen>` is allowed.
         fillLevel       (float or None) Fill the area 'under' the curve to
                         *fillLevel*
+        fillOutline     (bool) If True, an outline surrounding the *fillLevel*
+                        area is drawn.
         brush           QBrush to use when filling. Any single argument accepted
                         by :func:`mkBrush <pyqtgraph.mkBrush>` is allowed.
         antialias       (bool) Whether to use antialiasing when drawing. This
@@ -394,6 +397,8 @@ class PlotCurveItem(GraphicsObject):
             self.setShadowPen(kargs['shadowPen'])
         if 'fillLevel' in kargs:
             self.setFillLevel(kargs['fillLevel'])
+        if 'fillOutline' in kargs:
+            self.opts['fillOutline'] = kargs['fillOutline']
         if 'brush' in kargs:
             self.setBrush(kargs['brush'])
         if 'antialias' in kargs:
@@ -501,7 +506,7 @@ class PlotCurveItem(GraphicsObject):
             p.setPen(sp)
             p.drawPath(path)
         p.setPen(cp)
-        if self.fillPath is not None:
+        if self.opts['fillOutline'] and self.fillPath is not None:
             p.drawPath(self.fillPath)
         else:
             p.drawPath(path)

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -67,6 +67,8 @@ class PlotDataItem(GraphicsObject):
             shadowPen    Pen for secondary line to draw behind the primary line. disabled by default.
                          May be any single argument accepted by :func:`mkPen() <pyqtgraph.mkPen>`
             fillLevel    Fill the area between the curve and fillLevel
+            fillOutline  (bool) If True, an outline surrounding the *fillLevel*
+                         area is drawn.
             fillBrush    Fill to use when fillLevel is specified. 
                          May be any single argument accepted by :func:`mkBrush() <pyqtgraph.mkBrush>`
             stepMode     If True, two orthogonal lines are drawn for each sample
@@ -154,6 +156,7 @@ class PlotDataItem(GraphicsObject):
             'pen': (200,200,200),
             'shadowPen': None,
             'fillLevel': None,
+            'fillOutline': False,
             'fillBrush': None,
             'stepMode': None, 
             
@@ -474,7 +477,7 @@ class PlotDataItem(GraphicsObject):
     def updateItems(self):
         
         curveArgs = {}
-        for k,v in [('pen','pen'), ('shadowPen','shadowPen'), ('fillLevel','fillLevel'), ('fillBrush', 'brush'), ('antialias', 'antialias'), ('connect', 'connect'), ('stepMode', 'stepMode')]:
+        for k,v in [('pen','pen'), ('shadowPen','shadowPen'), ('fillLevel','fillLevel'), ('fillOutline', 'fillOutline'), ('fillBrush', 'brush'), ('antialias', 'antialias'), ('connect', 'connect'), ('stepMode', 'stepMode')]:
             curveArgs[v] = self.opts[k]
         
         scatterArgs = {}


### PR DESCRIPTION
PR #922 introduced outlines surrounding fillLevel areas. This is a design element that is not always wanted: In some scientific use cases, multiple lines in the same color are commonly interpreted as a bifurcation or hysteresis. This PR aims at providing a boolean option `fillOutline` to be used together with `fillLevel` to activate outlines.

An example of a confusing outline can be seen in the bottom left plot of example `Plotting.py`:
![](https://user-images.githubusercontent.com/31772910/61583890-f9df6500-ab3e-11e9-8232-355c377f85c0.png)

This Pull Request demonstrates the new option in the example `histogram.py`:
![](https://user-images.githubusercontent.com/31772910/61583914-52aefd80-ab3f-11e9-8e0e-a1530188b270.png)

Further, API documentation is added.