### PR TITLE
Fix: colormap: Support various arguments as color

### DIFF
--- a/pyqtgraph/colormap.py
+++ b/pyqtgraph/colormap.py
@@ -69,10 +69,11 @@ class ColorMap(object):
         self.pos = np.array(pos)
         order = np.argsort(self.pos)
         self.pos = self.pos[order]
-        self.color = []
-        for color in np.array(color)[order]:
-            self.color.append(mkColor(color).getRgb())
-        self.color = np.array(self.color)
+        self.color = np.apply_along_axis(
+            func1d = lambda x: mkColor(x).getRgb(),
+            axis   = -1,
+            arr    = color,
+            )[order]
         if mode is None:
             mode = np.ones(len(pos))
         self.mode = mode

--- a/pyqtgraph/colormap.py
+++ b/pyqtgraph/colormap.py
@@ -1,6 +1,7 @@
 import numpy as np
 from .Qt import QtGui, QtCore
 from .python2_3 import basestring
+from .functions import mkColor
 
 
 class ColorMap(object):
@@ -56,9 +57,9 @@ class ColorMap(object):
         ===============     ==============================================================
         **Arguments:**
         pos                 Array of positions where each color is defined
-        color               Array of RGBA colors.
-                            Integer data types are interpreted as 0-255; float data types
-                            are interpreted as 0.0-1.0
+        color               Array of colors.
+                            Values are interpreted via 
+                            :func:`mkColor() <pyqtgraph.mkColor>`.
         mode                Array of color modes (ColorMap.RGB, HSV_POS, or HSV_NEG)
                             indicating the color space that should be used when
                             interpolating between stops. Note that the last mode value is
@@ -68,7 +69,10 @@ class ColorMap(object):
         self.pos = np.array(pos)
         order = np.argsort(self.pos)
         self.pos = self.pos[order]
-        self.color = np.array(color)[order]
+        self.color = []
+        for color in np.array(color)[order]:
+            self.color.append(mkColor(color).getRgb())
+        self.color = np.array(self.color)
         if mode is None:
             mode = np.ones(len(pos))
         self.mode = mode
@@ -225,7 +229,7 @@ class ColorMap(object):
         x = np.linspace(start, stop, nPts)
         table = self.map(x, mode)
         
-        if not alpha:
+        if not alpha and mode != self.QCOLOR:
             return table[:,:3]
         else:
             return table


### PR DESCRIPTION
Currently, `colormap`s may be provided with RGB values, but internally treat `self.color` as an array of RGBA values. Examples are provided in issue #1009.

This PR fixes that by allowing to pass any type of color to `colormap` that `mkColor` accepts.

Fixes #1009 