### PR TITLE
Always convert PlotDataItem data to NumPy array

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -448,9 +448,9 @@ class PlotDataItem(GraphicsObject):
         if y is not None and x is None:
             x = np.arange(len(y))
         
-        if isinstance(x, list):
+        if not isinstance(x, np.ndarray):
             x = np.array(x)
-        if isinstance(y, list):
+        if not isinstance(y, np.ndarray):
             y = np.array(y)
         
         self.xData = x.view(np.ndarray)  ## one last check to make sure there are no MetaArrays getting by


### PR DESCRIPTION
Currently, the following code does not work:

```python3
import pyqtgraph as pg

pg.plot(range(3), range(3))
```

This is because only lists are converted to NumPy arrays, not e.g. iterators like `range(...)`. This PR fixes this by converting everything that is not a NumPy array.