### PR TITLE
Fix: GLScatterPlotItem and GLImageItem initializeGL only executed once

### DIFF
--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -29,8 +29,11 @@ class GLImageItem(GLGraphicsItem):
         GLGraphicsItem.__init__(self)
         self.setData(data)
         self.setGLOptions(glOptions)
+        self.texture = None
         
     def initializeGL(self):
+        if self.texture is not None:
+            return
         glEnable(GL_TEXTURE_2D)
         self.texture = glGenTextures(1)
         

--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -20,6 +20,7 @@ class GLScatterPlotItem(GLGraphicsItem):
         self.pxMode = True
         #self.vbo = {}      ## VBO does not appear to improve performance very much.
         self.setData(**kwds)
+        self.shader = None
     
     def setData(self, **kwds):
         """
@@ -54,6 +55,8 @@ class GLScatterPlotItem(GLGraphicsItem):
         self.update()
 
     def initializeGL(self):
+        if self.shader is not None:
+            return
         
         ## Generate texture for rendering points
         w = 64


### PR DESCRIPTION
If a `GLScatterPlotItem` is for example removed from and readded to a plot, its `initializeGL` function is executed twice (called through `GLViewWidget.addItem`). This causes GLGridItems to disappear, as can be currently tested on develop with this code:

```python3
from pyqtgraph.Qt import QtCore, QtGui, QtWidgets
import pyqtgraph.opengl as gl
import pyqtgraph as pg
import numpy as np

app = QtGui.QApplication([])
w = gl.GLViewWidget()
w.show()

gx = gl.GLGridItem()
w.addItem(gx)

plt3 = gl.GLScatterPlotItem(pos=np.zeros((1, 3)))
w.addItem(plt2)
w.addItem(plt3)

app.processEvents()
plt2.initializeGL()

if __name__ == '__main__':
    import sys
    if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
        QtGui.QApplication.instance().exec_()
```

This PR fixes that by checking if this function was called before.

Fixes #1018 