### PR TITLE
Fix: Allow wrapped GraphicsLayoutWidget to be deleted before its Python object

### DIFF
--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -399,9 +399,12 @@ class GraphicsView(QtGui.QGraphicsView):
         ev.ignore()  ## not sure why, but for some reason this class likes to consume drag events
 
     def _del(self):
-        if self.parentWidget() is None and self.isVisible():
-            msg = "Visible window deleted. To prevent this, store a reference to the window object."
-            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+        try:
+            if self.parentWidget() is None and self.isVisible():
+                msg = "Visible window deleted. To prevent this, store a reference to the window object."
+                warnings.warn(msg, RuntimeWarning, stacklevel=2)
+        except RuntimeError:
+            pass
 
 if sys.version_info[0] == 3 and sys.version_info[1] >= 4:
     GraphicsView.__del__ = GraphicsView._del


### PR DESCRIPTION
With #942, I introduced a warning when a Python `GraphicsView` window is closed by GC. This introduced issue #1021. This PR fixes #1021, by catching RuntimeExceptions that occur if the wrapped `GraphicsLayoutWidget` is removed before its associated `GraphicsView` is deleted.

An associated question is whether #942 should be reverted completely. Regarding this: PyQtGraph advertises "learning by doing" and "learning by trying and editing examples", as opposed to a tutorial-rich documentation, which makes it unlikely for people to read through documentation to this topic, especially since they would not know where exactly to search for. But I also understand other opinions here - I would also be fine with it being removed again, if that is favored. This PR gives only the opportunity to keep this warning if wanted.

Fixes #1021.