### PR TITLE
Prevent element-wise string comparison, second try

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -488,7 +488,7 @@ class ImageItem(GraphicsObject):
             step = (step, step)
         stepData = self.image[::step[0], ::step[1]]
 
-        if 'auto' == bins:
+        if isinstance(bins, str) and bins == 'auto':
             mn = np.nanmin(stepData)
             mx = np.nanmax(stepData)
             if mx == mn:


### PR DESCRIPTION
As discussed in issue #835, the former solution from #921 did not work to prevent `np.ndarray.__eq__` to element-wise compare a string against an array. This Pull Request adds a type check so the comparison is only executed against strings, not against arrays. It is just copy-pasted from @flutefreak7 s comment on issue #835.

Fixes #835.