### PR TITLE
Fix: Reset ParentItem to None on removing from PlotItem/ViewBox

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -563,8 +563,8 @@ class PlotItem(GraphicsWidget):
         if item in self.dataItems:
             self.dataItems.remove(item)
             
-        if item.scene() is not None:
-            self.vb.removeItem(item)
+        self.vb.removeItem(item)
+        
         if item in self.curves:
             self.curves.remove(item)
             self.updateDecimation()

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -399,10 +399,12 @@ class ViewBox(GraphicsWidget):
         """
         if item.zValue() < self.zValue():
             item.setZValue(self.zValue()+1)
+            
         scene = self.scene()
         if scene is not None and scene is not item.scene():
             scene.addItem(item)  ## Necessary due to Qt bug: https://bugreports.qt-project.org/browse/QTBUG-18616
         item.setParentItem(self.childGroup)
+        
         if not ignoreBounds:
             self.addedItems.append(item)
         self.updateAutoRange()
@@ -413,7 +415,12 @@ class ViewBox(GraphicsWidget):
             self.addedItems.remove(item)
         except:
             pass
-        self.scene().removeItem(item)
+        
+        scene = self.scene()
+        if scene is not None:
+            scene.removeItem(item)
+        item.setParentItem(None)
+        
         self.updateAutoRange()
 
     def clear(self):


### PR DESCRIPTION
When a GraphicsItem is removed from a PlotItem, it keeps the `ViewBox.childGroup` as parent. When it is removed from a ViewBox, also an error is risen when the item does not have an axxessible GraphicsScene.
In both cases this prevents the item from being removed if it does not have an accessible GraphicsScene. Example for both:

```python3
import sys
from PyQt5 import QtGui, QtCore, QtWidgets
import pyqtgraph as pg

class Ellipse(QtWidgets.QGraphicsItem):
    def __init__(self, rect):
        super(Ellipse, self).__init__()
        
        self.rect = QtCore.QRectF(rect[0], rect[1], rect[2], rect[3])

    def boundingRect(self):
        return self.rect

    def paint(self, painter, option, widget=None):
        painter.drawEllipse(self.rect)
        
app = QtWidgets.QApplication(sys.argv)

gv = pg.GraphicsLayoutWidget()
gv.show()

vb = pg.ViewBox() # or pg.PlotItem
gv.addItem(vb, 0, 0)

item = Ellipse((0,1,2,3))
vb.addItem(item)

gv.removeItem(vb)
vb.removeItem(item)
gv.addItem(vb)

if __name__ == '__main__':
    sys.exit(app.exec_())

```

Fixes #1028 