### PR TITLE
Raise AttributeError in __getattr__

### DIFF
--- a/pyqtgraph/graphicsWindows.py
+++ b/pyqtgraph/graphicsWindows.py
@@ -48,7 +48,7 @@ class TabWindow(QtGui.QMainWindow):
         if hasattr(self.cw, attr):
             return getattr(self.cw, attr)
         else:
-            raise NameError(attr)
+            raise AttributeError(attr)
     
 
 class PlotWindow(PlotWidget):

--- a/pyqtgraph/graphicsWindows.py
+++ b/pyqtgraph/graphicsWindows.py
@@ -45,10 +45,7 @@ class TabWindow(QtGui.QMainWindow):
         self.show()
         
     def __getattr__(self, attr):
-        if hasattr(self.cw, attr):
-            return getattr(self.cw, attr)
-        else:
-            raise AttributeError(attr)
+        return getattr(self.cw, attr)
     
 
 class PlotWindow(PlotWidget):


### PR DESCRIPTION
It's in a deprecated class, but might as well fix it while it's still in the code. In Python 2, any exception means `hasattr` returns False, but now it needs to be an `AttributeError`. edit: actually I realized there's a simpler way.

Fixes #525 