### PR TITLE
Fix: InfiniteLine bounding box wrong

### DIFF
--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -314,8 +314,8 @@ class InfiniteLine(GraphicsObject):
         length = br.width()
         left = br.left() + length * self.span[0]
         right = br.left() + length * self.span[1]
-        br.setLeft(left - w)
-        br.setRight(right + w)
+        br.setLeft(left)
+        br.setRight(right)
         br = br.normalized()
         
         vs = self.getViewBox().size()


### PR DESCRIPTION
The bounding box of `InfiniteLine`s is wrong: Currently the pen width is translated into a width `w` relative to the plot range in one direction. But `w` is then used in both directions, x and y. Since `w` is only necessary in one direction, this PR removes its influence in the bounding box in the other direction.

Fixes #1037 