### PR TITLE
Remove global for CONFIG_OPTIONS in setConfigOption

### DIFF
--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -64,7 +64,6 @@ CONFIG_OPTIONS = {
 
 
 def setConfigOption(opt, value):
-    global CONFIG_OPTIONS
     if opt not in CONFIG_OPTIONS:
         raise KeyError('Unknown configuration option "%s"' % opt)
     if opt == 'imageAxisOrder' and value not in ('row-major', 'col-major'):


### PR DESCRIPTION
This PR removes `global` for `CONFIG_OPTIONS` in `setConfigOption` because it is redundant for dictionary.