### PR TITLE
Avoid Qt receiving nan values

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1492,18 +1492,29 @@ def arrayToQPath(x, y, connect='all'):
     arr[1:-1]['x'] = x
     arr[1:-1]['y'] = y
 
+    non_finite_values = np.logical_not(np.isfinite(x) & np.isfinite(y))
+
+    arr[1:-1]['x'][non_finite_values] = np.roll(x,-1)[non_finite_values]
+    arr[1:-1]['y'][non_finite_values] = np.roll(y,-1)[non_finite_values]
+    
     # decide which points are connected by lines
     if eq(connect, 'all'):
         arr[1:-1]['c'] = 1
-    elif eq(connect, 'pairs'):
-        arr[1:-1]['c'][::2] = 1
-        arr[1:-1]['c'][1::2] = 0
-    elif eq(connect, 'finite'):
-        arr[1:-1]['c'] = np.isfinite(x) & np.isfinite(y)
+        if non_finite_values[-1] and len(non_finite_values) > 1:
+            arr[1:-1]['c'][-2] = 0
     elif isinstance(connect, np.ndarray):
         arr[1:-1]['c'] = connect
     else:
-        raise Exception('connect argument must be "all", "pairs", "finite", or array')
+        if eq(connect, 'pairs'):
+            arr[1:-1]['c'][::2] = 1
+            arr[1:-1]['c'][1::2] = 0
+        elif eq(connect, 'finite'):
+            arr[1:-1]['c'] = 1
+        else:
+            raise Exception('connect argument must be "all", "pairs", "finite", or array')
+        
+        arr[1:-1]['c'][non_finite_values] = 0
+        arr[1:-1]['c'][np.roll(non_finite_values,-1)] = 0
 
     #profiler('fill array')
     # write last 0

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1494,8 +1494,8 @@ def arrayToQPath(x, y, connect='all'):
 
     non_finite_values = np.logical_not(np.isfinite(x) & np.isfinite(y))
 
-    arr[1:-1]['x'][non_finite_values] = np.roll(x,-1)[non_finite_values]
-    arr[1:-1]['y'][non_finite_values] = np.roll(y,-1)[non_finite_values]
+    arr[1:-1]['x'][non_finite_values] = np.interp(np.flatnonzero(non_finite_values), np.flatnonzero(~non_finite_values), arr[1:-1]['x'][~non_finite_values])
+    arr[1:-1]['y'][non_finite_values] = np.interp(np.flatnonzero(non_finite_values), np.flatnonzero(~non_finite_values), arr[1:-1]['y'][~non_finite_values])
     
     # decide which points are connected by lines
     if eq(connect, 'all'):

--- a/pyqtgraph/tests/image_testing.py
+++ b/pyqtgraph/tests/image_testing.py
@@ -271,7 +271,7 @@ def assertImageMatch(im1, im2, minCorr=None, pxThreshold=50.,
     pxdiff = diff.max(axis=2)  # largest value difference per pixel
     mask = np.abs(pxdiff) >= pxThreshold
     if pxCount is not None:
-        assert mask.sum() <= pxCount
+        assert mask.sum() <= pxCount, "Invalid pixels: {} of {} allowed".format(mask.sum(), pxCount)
 
     maskedDiff = diff[mask]
     if maxPxDiff is not None and maskedDiff.size > 0:


### PR DESCRIPTION
Since Qt 5.13.1, paths containing non-finite values are not drawn. This PR avoids passing non-finite values to Qt. Also, as long as `connect` is neither `'all'` nor an array, it also draws paths unconnected at places where a non-finite value occurs.

Fixes #1057.