### PR TITLE
Fix: AttributeError in ViewBox.setEnableMenu

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -324,7 +324,8 @@ class ViewBox(GraphicsWidget):
         if self.state['enableMenu'] and self.menu is None:
             self.menu = ViewBoxMenu(self)
             self.updateViewLists()
-        else:
+        elif not self.state['enableMenu'] and self.menu is not None:
+            self.menu.setParent(None)
             self.menu = None
 
         self.updateViewRange()
@@ -380,11 +381,10 @@ class ViewBox(GraphicsWidget):
 
     def setMenuEnabled(self, enableMenu=True):
         self.state['enableMenu'] = enableMenu
-        if enableMenu:
-            if self.menu is None:
-                self.menu = ViewBoxMenu(self)
-                self.updateViewLists()
-        else:
+        if enableMenu and self.menu is None:
+            self.menu = ViewBoxMenu(self)
+            self.updateViewLists()
+        elif not enableMenu and self.menu is not None:
             self.menu.setParent(None)
             self.menu = None
         self.sigStateChanged.emit(self)

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -321,13 +321,7 @@ class ViewBox(GraphicsWidget):
 
         self.state.update(state)
 
-        if self.state['enableMenu'] and self.menu is None:
-            self.menu = ViewBoxMenu(self)
-            self.updateViewLists()
-        elif not self.state['enableMenu'] and self.menu is not None:
-            self.menu.setParent(None)
-            self.menu = None
-
+        self._applyMenuEnabled()
         self.updateViewRange()
         self.sigStateChanged.emit(self)
 
@@ -381,16 +375,20 @@ class ViewBox(GraphicsWidget):
 
     def setMenuEnabled(self, enableMenu=True):
         self.state['enableMenu'] = enableMenu
+        self._applyMenuEnabled()
+        self.sigStateChanged.emit(self)
+
+    def menuEnabled(self):
+        return self.state.get('enableMenu', True)
+
+    def _applyMenuEnabled(self):
+        enableMenu = self.state.get("enableMenu", True)
         if enableMenu and self.menu is None:
             self.menu = ViewBoxMenu(self)
             self.updateViewLists()
         elif not enableMenu and self.menu is not None:
             self.menu.setParent(None)
             self.menu = None
-        self.sigStateChanged.emit(self)
-
-    def menuEnabled(self):
-        return self.state.get('enableMenu', True)
 
     def addItem(self, item, ignoreBounds=False):
         """

--- a/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
@@ -74,6 +74,14 @@ def test_ViewBox():
     win.close()
 
 
+def test_ViewBox_setMenuEnabled():
+    init_viewbox()
+    vb.setMenuEnabled(True)
+    assert vb.menu is not None
+    vb.setMenuEnabled(False)
+    assert vb.menu is None
+
+
 skipreason = "Skipping this test until someone has time to fix it."
 @pytest.mark.skipif(True, reason=skipreason)
 def test_limits_and_resize():


### PR DESCRIPTION
### Issue

Executing
```python
from PyQt5.QtWidgets import QApplication
import pyqtgraph as pg

app = QApplication([])

view = pg.PlotWidget()
viewbox = view.plotItem.vb
viewbox.setMenuEnabled(False)
viewbox.setMenuEnabled(False)  # <- error here
```
raises a 
```
Traceback (most recent call last):
  File "<stdin>", line 9, in <module>
  File "/Users/aleserjavec/workspace/pyqtgraph/pyqtgraph/graphicsItems/ViewBox/ViewBox.py", line 388, in setMenuEnabled
    self.menu.setParent(None)
AttributeError: 'NoneType' object has no attribute 'setParent'
```
in the second call to setMenuEnabled(False)

Fixed by validating the current menu state and only deleting it when necessary.