### PR TITLE
Allow actions to display title instead of name

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -612,7 +612,10 @@ class ActionParameterItem(ParameterItem):
         self.layout = QtGui.QHBoxLayout()
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.layoutWidget.setLayout(self.layout)
-        self.button = QtGui.QPushButton(param.name())
+        title = param.opts.get('title', None)
+        if title is None:
+            title = param.name()
+        self.button = QtGui.QPushButton(title)
         #self.layout.addSpacing(100)
         self.layout.addWidget(self.button)
         self.layout.addStretch()


### PR DESCRIPTION
ActionParameterItem changed so that if there is
a title it will be displayed, otherwise displays name.