### PR TITLE
Reset currentRow and currentCol on GraphicsLayout.clear()

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsLayout.py
+++ b/pyqtgraph/graphicsItems/GraphicsLayout.py
@@ -167,6 +167,8 @@ class GraphicsLayout(GraphicsWidget):
     def clear(self):
         for i in list(self.items.keys()):
             self.removeItem(i)
+        self.currentRow = 0
+        self.currentCol = 0
 
     def setContentsMargins(self, *args):
         # Wrap calls to layout. This should happen automatically, but there


### PR DESCRIPTION
If a GraphicsLayout has multiple columns and GraphicsLayout.clear() is called, then when adding new plot items, there will be an offset in the first row which propagates to all remaining rows.

This is a simple fix.

actual behavior:
![image](https://user-images.githubusercontent.com/2853022/68752675-ff881b80-0603-11ea-86f3-a4b00577f6c4.png)

desired behavior:
![image](https://user-images.githubusercontent.com/2853022/68752755-234b6180-0604-11ea-8ef6-3f6436f39e29.png)
