### PR TITLE
fix faulty SVG export of scatter plots (KeyError: 'resolutionScale')

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -98,7 +98,7 @@ class GraphicsItem(object):
         Extends deviceTransform to automatically determine the viewportTransform.
         """
         if self._exportOpts is not False and 'painter' in self._exportOpts: ## currently exporting; device transform may be different.
-            scaler = self._exportOpts['resolutionScale']
+            scaler = self._exportOpts.get('resolutionScale', 1.0)
             return self.sceneTransform() * QtGui.QTransform(scaler, 0, 0, scaler, 1, 1)
 
         if viewportTransform is None:


### PR DESCRIPTION
This PR fixes the SVG export of scatter plots.

Steps to reproduce:

- Ubuntu 18.04.3 LTS
- pyqtgraph develop
- Python 3.6.8
- PyQt5==5.13.2

1. run "GraphicsItems/ScatterPlot" example

2. Right click on the plot and "Export..."

3. Choose entire scene and SVG export.

Expected Result: Entire plot is exported.

Actual Result:
![GraphicsScene_1](https://user-images.githubusercontent.com/2853022/69478573-43450700-0df4-11ea-9c35-9829d5473954.png)


In addition, the following message is printed:
```
[13:05:51]  Ignored exception:

    |==============================>>
    |  Traceback (most recent call last):
    |    File "/pyqtgraph_issue/pyqtgraph/examples/ScatterPlot.py", line 122, in <module>
    |      QtGui.QApplication.instance().exec_()
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/exporters/Exporter.py", line 77, in fileSaveFinished
    |      self.export(fileName=fileName, **self.fileDialog.opts)
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/exporters/SVGExporter.py", line 54, in export
    |      xml = generateSvg(self.item, options)
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/exporters/SVGExporter.py", line 77, in generateSvg
    |      node, defs = _generateItemSvg(item, options=options)
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/exporters/SVGExporter.py", line 255, in _generateItemSvg
    |      csvg = _generateItemSvg(ch, nodes, root, options=options)
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/exporters/SVGExporter.py", line 255, in _generateItemSvg
    |      csvg = _generateItemSvg(ch, nodes, root, options=options)
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/exporters/SVGExporter.py", line 255, in _generateItemSvg
    |      csvg = _generateItemSvg(ch, nodes, root, options=options)
    |    [Previous line repeated 2 more times]
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/exporters/SVGExporter.py", line 186, in _generateItemSvg
    |      item.paint(p, opt, None)
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/debug.py", line 93, in w
    |      printExc('Ignored exception:')
    |    --- exception caught here ---
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/debug.py", line 91, in w
    |      func(*args, **kwds)
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/graphicsItems/ScatterPlotItem.py", line 753, in paint
    |      pts = self.mapPointsToDevice(pts)
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/graphicsItems/ScatterPlotItem.py", line 709, in mapPointsToDevice
    |      tr = self.deviceTransform()
    |    File "/pyqtgraph_issue/pyqtgraph/pyqtgraph/graphicsItems/GraphicsItem.py", line 101, in deviceTransform
    |      scaler = self._exportOpts['resolutionScale']
    |  KeyError: 'resolutionScale'
    |==============================<<
```

This PR sets the scale to 1.0 if it is not set (setting a scale for SVG export does not make sense).
Result:
![GraphicsScene_2](https://user-images.githubusercontent.com/2853022/69478563-214b8480-0df4-11ea-963b-e3e9c4e67d87.png)

(I converted the images to png using inkscape)
