### PR TITLE
fix wrong offset when drawing symbol

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -781,7 +781,7 @@ class ScatterPlotItem(GraphicsObject):
                 pts = pts[:,viewMask]
                 for i, rec in enumerate(data):
                     p.resetTransform()
-                    p.translate(pts[0,i] + rec['width'], pts[1,i] + rec['width']/2)
+                    p.translate(pts[0,i] + rec['width']/2, pts[1,i] + rec['width']/2)
                     drawSymbol(p, *self.getSpotOpts(rec, scale))
         else:
             if self.picture is None:


### PR DESCRIPTION
I believe this was not correctly implemented in #88.
Note that this fix has nothing to do with #176.