### PR TITLE
Update ptime.py for 3.8 compatibility

### DIFF
--- a/pyqtgraph/ptime.py
+++ b/pyqtgraph/ptime.py
@@ -28,7 +28,7 @@ def unixTime():
     return system_time()
 
 if sys.platform.startswith('win'):
-    cstart = clock()  ### Required to start the clock in windows
+    cstart = systime.perf_counter()  ### Required to start the clock in windows
     START_TIME = system_time() - cstart
     
     time = winTime


### PR DESCRIPTION
systime.clock() is no longer supported for Python 3.8. perf_counter works well. Tested in Windows 10