### PR TITLE
avoid App Nap on macOS >= 10.9

### DIFF
--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -29,6 +29,10 @@ if sys.version_info[0] < 2 or (sys.version_info[0] == 2 and sys.version_info[1] 
 ## helpers for 2/3 compatibility
 from . import python2_3
 
+## avoid App Nap in macOS >= 10.9
+import appnope
+appnope.nope()
+
 ## in general openGL is poorly supported with Qt+GraphicsView.
 ## we only enable it where the performance benefit is critical.
 ## Note this only applies to 2D graphics; 3D graphics always use OpenGL.
@@ -39,10 +43,10 @@ elif 'darwin' in sys.platform: ## openGL can have a major impact on mac, but als
     if QtGui.QApplication.instance() is not None:
         print('Warning: QApplication was created before pyqtgraph was imported; there may be problems (to avoid bugs, call QApplication.setGraphicsSystem("raster") before the QApplication is created).')
     if QtGui.QApplication.setGraphicsSystem:
-        QtGui.QApplication.setGraphicsSystem('raster')  ## work around a variety of bugs in the native graphics system 
+        QtGui.QApplication.setGraphicsSystem('raster')  ## work around a variety of bugs in the native graphics system
 else:
-    useOpenGL = False  ## on windows there's a more even performance / bugginess tradeoff. 
-                
+    useOpenGL = False  ## on windows there's a more even performance / bugginess tradeoff.
+
 CONFIG_OPTIONS = {
     'useOpenGL': useOpenGL, ## by default, this is platform-dependent (see widgets/GraphicsView). Set to True or False to explicitly enable/disable opengl.
     'leftButtonPan': True,  ## if false, left button drags a rubber band for zooming in viewbox
@@ -60,7 +64,7 @@ CONFIG_OPTIONS = {
                                  # For 'col-major', image data is expected in reversed (col, row) order.
                                  # The default is 'col-major' for backward compatibility, but this may
                                  # change in the future.
-} 
+}
 
 
 def setConfigOption(opt, value):
@@ -71,9 +75,9 @@ def setConfigOption(opt, value):
     CONFIG_OPTIONS[opt] = value
 
 def setConfigOptions(**opts):
-    """Set global configuration options. 
-    
-    Each keyword argument sets one global option. 
+    """Set global configuration options.
+
+    Each keyword argument sets one global option.
     """
     for k,v in opts.items():
         setConfigOption(k, v)
@@ -89,7 +93,7 @@ def systemInfo():
     print("sys.version: %s" % sys.version)
     from .Qt import VERSION_INFO
     print("qt bindings: %s" % VERSION_INFO)
-    
+
     global __version__
     rev = None
     if __version__ is None:  ## this code was probably checked out from bzr; look up the last-revision file
@@ -97,7 +101,7 @@ def systemInfo():
         if os.path.exists(lastRevFile):
             with open(lastRevFile, 'r') as fd:
                 rev = fd.read().strip()
-    
+
     print("pyqtgraph: %s; %s" % (__version__, rev))
     print("config:")
     import pprint
@@ -105,16 +109,16 @@ def systemInfo():
 
 ## Rename orphaned .pyc files. This is *probably* safe :)
 ## We only do this if __version__ is None, indicating the code was probably pulled
-## from the repository. 
+## from the repository.
 def renamePyc(startDir):
     ### Used to rename orphaned .pyc files
     ### When a python file changes its location in the repository, usually the .pyc file
-    ### is left behind, possibly causing mysterious and difficult to track bugs. 
+    ### is left behind, possibly causing mysterious and difficult to track bugs.
 
     ### Note that this is no longer necessary for python 3.2; from PEP 3147:
-    ### "If the py source file is missing, the pyc file inside __pycache__ will be ignored. 
+    ### "If the py source file is missing, the pyc file inside __pycache__ will be ignored.
     ### This eliminates the problem of accidental stale pyc file imports."
-    
+
     printed = False
     startDir = os.path.abspath(startDir)
     for path, dirs, files in os.walk(startDir):
@@ -137,7 +141,7 @@ def renamePyc(startDir):
                 print("  " + fileName + "  ==>")
                 print("  " + name2)
                 os.rename(fileName, name2)
-                
+
 path = os.path.split(__file__)[0]
 if __version__ is None and not hasattr(sys, 'frozen') and sys.version_info[0] == 2: ## If we are frozen, there's a good chance we don't have the original .py files anymore.
     renamePyc(path)
@@ -149,8 +153,8 @@ if __version__ is None and not hasattr(sys, 'frozen') and sys.version_info[0] ==
 #from . import frozenSupport
 #def importModules(path, globals, locals, excludes=()):
     #"""Import all modules residing within *path*, return a dict of name: module pairs.
-    
-    #Note that *path* MUST be relative to the module doing the import.    
+
+    #Note that *path* MUST be relative to the module doing the import.
     #"""
     #d = os.path.join(os.path.split(globals['__file__'])[0], path)
     #files = set()
@@ -161,7 +165,7 @@ if __version__ is None and not hasattr(sys, 'frozen') and sys.version_info[0] ==
             #files.add(f[:-3])
         #elif f[-4:] == '.pyc' and f != '__init__.pyc':
             #files.add(f[:-4])
-        
+
     #mods = {}
     #path = path.replace(os.sep, '.')
     #for modName in files:
@@ -178,7 +182,7 @@ if __version__ is None and not hasattr(sys, 'frozen') and sys.version_info[0] ==
             #traceback.print_stack()
             #sys.excepthook(*sys.exc_info())
             #print("[Error importing module: %s]" % modName)
-            
+
     #return mods
 
 #def importAll(path, globals, locals, excludes=()):
@@ -198,67 +202,67 @@ if __version__ is None and not hasattr(sys, 'frozen') and sys.version_info[0] ==
 #importAll('widgets', globals(), locals(),
           #excludes=['MatplotlibWidget', 'RawImageWidget', 'RemoteGraphicsView'])
 
-from .graphicsItems.VTickGroup import * 
-from .graphicsItems.GraphicsWidget import * 
-from .graphicsItems.ScaleBar import * 
-from .graphicsItems.PlotDataItem import * 
-from .graphicsItems.GraphItem import * 
-from .graphicsItems.TextItem import * 
-from .graphicsItems.GraphicsLayout import * 
-from .graphicsItems.UIGraphicsItem import * 
-from .graphicsItems.GraphicsObject import * 
-from .graphicsItems.PlotItem import * 
-from .graphicsItems.ROI import * 
-from .graphicsItems.InfiniteLine import * 
-from .graphicsItems.HistogramLUTItem import * 
-from .graphicsItems.GridItem import * 
-from .graphicsItems.GradientLegend import * 
-from .graphicsItems.GraphicsItem import * 
-from .graphicsItems.BarGraphItem import * 
-from .graphicsItems.ViewBox import * 
-from .graphicsItems.ArrowItem import * 
-from .graphicsItems.ImageItem import * 
-from .graphicsItems.AxisItem import * 
-from .graphicsItems.LabelItem import * 
-from .graphicsItems.CurvePoint import * 
-from .graphicsItems.GraphicsWidgetAnchor import * 
-from .graphicsItems.PlotCurveItem import * 
-from .graphicsItems.ButtonItem import * 
-from .graphicsItems.GradientEditorItem import * 
-from .graphicsItems.MultiPlotItem import * 
-from .graphicsItems.ErrorBarItem import * 
-from .graphicsItems.IsocurveItem import * 
-from .graphicsItems.LinearRegionItem import * 
-from .graphicsItems.FillBetweenItem import * 
-from .graphicsItems.LegendItem import * 
-from .graphicsItems.ScatterPlotItem import * 
-from .graphicsItems.ItemGroup import * 
+from .graphicsItems.VTickGroup import *
+from .graphicsItems.GraphicsWidget import *
+from .graphicsItems.ScaleBar import *
+from .graphicsItems.PlotDataItem import *
+from .graphicsItems.GraphItem import *
+from .graphicsItems.TextItem import *
+from .graphicsItems.GraphicsLayout import *
+from .graphicsItems.UIGraphicsItem import *
+from .graphicsItems.GraphicsObject import *
+from .graphicsItems.PlotItem import *
+from .graphicsItems.ROI import *
+from .graphicsItems.InfiniteLine import *
+from .graphicsItems.HistogramLUTItem import *
+from .graphicsItems.GridItem import *
+from .graphicsItems.GradientLegend import *
+from .graphicsItems.GraphicsItem import *
+from .graphicsItems.BarGraphItem import *
+from .graphicsItems.ViewBox import *
+from .graphicsItems.ArrowItem import *
+from .graphicsItems.ImageItem import *
+from .graphicsItems.AxisItem import *
+from .graphicsItems.LabelItem import *
+from .graphicsItems.CurvePoint import *
+from .graphicsItems.GraphicsWidgetAnchor import *
+from .graphicsItems.PlotCurveItem import *
+from .graphicsItems.ButtonItem import *
+from .graphicsItems.GradientEditorItem import *
+from .graphicsItems.MultiPlotItem import *
+from .graphicsItems.ErrorBarItem import *
+from .graphicsItems.IsocurveItem import *
+from .graphicsItems.LinearRegionItem import *
+from .graphicsItems.FillBetweenItem import *
+from .graphicsItems.LegendItem import *
+from .graphicsItems.ScatterPlotItem import *
+from .graphicsItems.ItemGroup import *
 
-from .widgets.MultiPlotWidget import * 
-from .widgets.ScatterPlotWidget import * 
-from .widgets.ColorMapWidget import * 
-from .widgets.FileDialog import * 
-from .widgets.ValueLabel import * 
-from .widgets.HistogramLUTWidget import * 
-from .widgets.CheckTable import * 
-from .widgets.BusyCursor import * 
-from .widgets.PlotWidget import * 
-from .widgets.ComboBox import * 
-from .widgets.GradientWidget import * 
-from .widgets.DataFilterWidget import * 
-from .widgets.SpinBox import * 
-from .widgets.JoystickButton import * 
-from .widgets.GraphicsLayoutWidget import * 
-from .widgets.TreeWidget import * 
-from .widgets.PathButton import * 
-from .widgets.VerticalLabel import * 
-from .widgets.FeedbackButton import * 
-from .widgets.ColorButton import * 
-from .widgets.DataTreeWidget import * 
-from .widgets.DiffTreeWidget import * 
-from .widgets.GraphicsView import * 
-from .widgets.LayoutWidget import * 
-from .widgets.TableWidget import * 
+from .widgets.MultiPlotWidget import *
+from .widgets.ScatterPlotWidget import *
+from .widgets.ColorMapWidget import *
+from .widgets.FileDialog import *
+from .widgets.ValueLabel import *
+from .widgets.HistogramLUTWidget import *
+from .widgets.CheckTable import *
+from .widgets.BusyCursor import *
+from .widgets.PlotWidget import *
+from .widgets.ComboBox import *
+from .widgets.GradientWidget import *
+from .widgets.DataFilterWidget import *
+from .widgets.SpinBox import *
+from .widgets.JoystickButton import *
+from .widgets.GraphicsLayoutWidget import *
+from .widgets.TreeWidget import *
+from .widgets.PathButton import *
+from .widgets.VerticalLabel import *
+from .widgets.FeedbackButton import *
+from .widgets.ColorButton import *
+from .widgets.DataTreeWidget import *
+from .widgets.DiffTreeWidget import *
+from .widgets.GraphicsView import *
+from .widgets.LayoutWidget import *
+from .widgets.TableWidget import *
 from .widgets.ProgressDialog import *
 from .widgets.GroupBox import GroupBox
 from .widgets.RemoteGraphicsView import RemoteGraphicsView
@@ -279,7 +283,7 @@ from .Qt import isQObjectAlive
 
 
 ##############################################################
-## PyQt and PySide both are prone to crashing on exit. 
+## PyQt and PySide both are prone to crashing on exit.
 ## There are two general approaches to dealing with this:
 ##  1. Install atexit handlers that assist in tearing down to avoid crashes.
 ##     This helps, but is never perfect.
@@ -293,12 +297,12 @@ def cleanup():
     global _cleanupCalled
     if _cleanupCalled:
         return
-    
+
     if not getConfigOption('exitCleanup'):
         return
-    
+
     ViewBox.quit()  ## tell ViewBox that it doesn't need to deregister views anymore.
-    
+
     ## Workaround for Qt exit crash:
     ## ALL QGraphicsItems must have a scene before they are deleted.
     ## This is potentially very expensive, but preferred over crashing.
@@ -317,7 +321,7 @@ def cleanup():
                     sys.stderr.write('Error: graphics item without scene. '
                         'Make sure ViewBox.close() and GraphicsView.close() '
                         'are properly called before app shutdown (%s)\n' % (o,))
-                
+
                 s.addItem(o)
         except (RuntimeError, ReferenceError):  ## occurs if a python wrapper no longer has its underlying C++ object
             continue
@@ -342,28 +346,28 @@ def _connectCleanup():
 def exit():
     """
     Causes python to exit without garbage-collecting any objects, and thus avoids
-    calling object destructor methods. This is a sledgehammer workaround for 
+    calling object destructor methods. This is a sledgehammer workaround for
     a variety of bugs in PyQt and Pyside that cause crashes on exit.
-    
+
     This function does the following in an attempt to 'safely' terminate
     the process:
-    
+
     * Invoke atexit callbacks
     * Close all open file handles
     * os._exit()
-    
+
     Note: there is some potential for causing damage with this function if you
     are using objects that _require_ their destructors to be called (for example,
     to properly terminate log files, disconnect from devices, etc). Situations
     like this are probably quite rare, but use at your own risk.
     """
-    
+
     ## first disable our own cleanup function; won't be needing it.
     setConfigOptions(exitCleanup=False)
-    
+
     ## invoke atexit callbacks
     atexit._run_exitfuncs()
-    
+
     ## close file handles
     if sys.platform == 'darwin':
         for fd in range(3, 4096):
@@ -377,7 +381,7 @@ def exit():
         os.closerange(3, 4096) ## just guessing on the maximum descriptor count..
 
     os._exit(0)
-    
+
 
 
 ## Convenience functions for command-line use
@@ -388,7 +392,7 @@ QAPP = None
 
 def plot(*args, **kargs):
     """
-    Create and return a :class:`PlotWindow <pyqtgraph.PlotWindow>` 
+    Create and return a :class:`PlotWindow <pyqtgraph.PlotWindow>`
     (this is just a window with :class:`PlotWidget <pyqtgraph.PlotWidget>` inside), plot data in it.
     Accepts a *title* argument to set the title of the window.
     All other arguments are used to plot data. (see :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>`)
@@ -401,7 +405,7 @@ def plot(*args, **kargs):
         #w = PlotWindow()
     #if len(args)+len(kargs) > 0:
         #w.plot(*args, **kargs)
-        
+
     pwArgList = ['title', 'labels', 'name', 'left', 'right', 'top', 'bottom', 'background']
     pwArgs = {}
     dataArgs = {}
@@ -410,17 +414,17 @@ def plot(*args, **kargs):
             pwArgs[k] = kargs[k]
         else:
             dataArgs[k] = kargs[k]
-        
+
     w = PlotWindow(**pwArgs)
     if len(args) > 0 or len(dataArgs) > 0:
         w.plot(*args, **dataArgs)
     plots.append(w)
     w.show()
     return w
-    
+
 def image(*args, **kargs):
     """
-    Create and return an :class:`ImageWindow <pyqtgraph.ImageWindow>` 
+    Create and return an :class:`ImageWindow <pyqtgraph.ImageWindow>`
     (this is just a window with :class:`ImageView <pyqtgraph.ImageView>` widget inside), show image data inside.
     Will show 2D or 3D image data.
     Accepts a *title* argument to set the title of the window.
@@ -436,7 +440,7 @@ show = image  ## for backward compatibility
 def dbg(*args, **kwds):
     """
     Create a console window and begin watching for exceptions.
-    
+
     All arguments are passed to :func:`ConsoleWidget.__init__() <pyqtgraph.console.ConsoleWidget.__init__>`.
     """
     mkQApp()
@@ -455,7 +459,7 @@ def dbg(*args, **kwds):
 def stack(*args, **kwds):
     """
     Create a console window and show the current stack trace.
-    
+
     All arguments are passed to :func:`ConsoleWidget.__init__() <pyqtgraph.console.ConsoleWidget.__init__>`.
     """
     mkQApp()


### PR DESCRIPTION
This solves several errors rising up in an application that uses realtime plotting based on pyqtgraph.
The problem is that macOS will activate App Nap for an application when it is minimised or not displayed on the screen. The moment when it happens it is up to the OS.
If this happens it is not possible to communicate with the application anymore and errors like timeout will occur. Also as a side effect code might get slow.
![Screenshot 2019-12-06 at 16 22 38](https://user-images.githubusercontent.com/31376402/70334113-13125500-1845-11ea-8eaa-e985fd47c502.png)

This might not be the right way of doing it but is the solution I found. It avoids runtime errors which are cryptic and hard to debug.

Might also not be the correct file to put this lines of code.
Might also not be a good idea to do it at all as it defeats the purpose of App Nap.
I just wanted to share this with the world. Maybe it solves other issues.

Maybe this should be a concern for each application that make use of pyqtgraph. In my case I cannot fix it on the level of my application because it is being built on top another python module that uses pyqtgraph under the hood.

Related readings:
- [https://github.com/msorvig/qt-and-app-nap](url)
- [https://codereview.qt-project.org/c/qt/qtbase/+/202515](url)

P.S. Ignore lines below 35, just whitespaces that my editor removed