### PR TITLE
pretty-print log-scale axes labels

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -3,6 +3,7 @@ from ..python2_3 import asUnicode
 import numpy as np
 from ..Point import Point
 from .. import debug as debug
+import sys
 import weakref
 from .. import functions as fn
 from .. import getConfigOption
@@ -800,32 +801,37 @@ class AxisItem(GraphicsWidget):
         return strings
 
     def logTickStrings(self, values, scale, spacing):
-        convdict = {"0": "⁰",
-                    "1": "¹",
-                    "2": "²",
-                    "3": "³",
-                    "4": "⁴",
-                    "5": "⁵",
-                    "6": "⁶",
-                    "7": "⁷",
-                    "8": "⁸",
-                    "9": "⁹",
-                    }
         estrings = ["%0.1g"%x for x in 10 ** np.array(values).astype(float) * np.array(scale)]
-        dstrings = []
-        for e in estrings:
-            if e.count("e"):
-                v, p = e.split("e")
-                sign = "⁻" if p[0] == "-" else ""
-                pot = "".join([convdict[pp] for pp in p[1:].lstrip("0")])
-                if v == "1":
-                    v = ""
+
+        if sys.version_info < (3, 0):
+            # python 2 does not support unicode strings like that
+            return estrings
+        else:  # python 3+
+            convdict = {"0": "⁰",
+                        "1": "¹",
+                        "2": "²",
+                        "3": "³",
+                        "4": "⁴",
+                        "5": "⁵",
+                        "6": "⁶",
+                        "7": "⁷",
+                        "8": "⁸",
+                        "9": "⁹",
+                        }
+            dstrings = []
+            for e in estrings:
+                if e.count("e"):
+                    v, p = e.split("e")
+                    sign = "⁻" if p[0] == "-" else ""
+                    pot = "".join([convdict[pp] for pp in p[1:].lstrip("0")])
+                    if v == "1":
+                        v = ""
+                    else:
+                        v = v + "·"
+                    dstrings.append(v + "10" + sign + pot)
                 else:
-                    v = v + "·"
-                dstrings.append(v + "10" + sign + pot)
-            else:
-                dstrings.append(e)
-        return dstrings
+                    dstrings.append(e)
+            return dstrings
 
     def generateDrawSpecs(self, p):
         """

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -800,7 +800,32 @@ class AxisItem(GraphicsWidget):
         return strings
 
     def logTickStrings(self, values, scale, spacing):
-        return ["%0.1g"%x for x in 10 ** np.array(values).astype(float) * np.array(scale)]
+        convdict = {"0": "⁰",
+                    "1": "¹",
+                    "2": "²",
+                    "3": "³",
+                    "4": "⁴",
+                    "5": "⁵",
+                    "6": "⁶",
+                    "7": "⁷",
+                    "8": "⁸",
+                    "9": "⁹",
+                    }
+        estrings = ["%0.1g"%x for x in 10 ** np.array(values).astype(float) * np.array(scale)]
+        dstrings = []
+        for e in estrings:
+            if e.count("e"):
+                v, p = e.split("e")
+                sign = "⁻" if p[0] == "-" else ""
+                pot = "".join([convdict[pp] for pp in p[1:].lstrip("0")])
+                if v == "1":
+                    v = ""
+                else:
+                    v = v + "·"
+                dstrings.append(v + "10" + sign + pot)
+            else:
+                dstrings.append(e)
+        return dstrings
 
     def generateDrawSpecs(self, p):
         """


### PR DESCRIPTION
This patch pretty-prints log-scale axes tick labels.

before:
![1](https://user-images.githubusercontent.com/2853022/70899527-1650d200-1ff7-11ea-87fc-93d3cad4082a.png)
after:
![2](https://user-images.githubusercontent.com/2853022/70899529-1650d200-1ff7-11ea-86a8-551eb3cf55cf.png)

This probably does not work for Python2 because of the unicode characters in the labels.