### PR TITLE
#406 does not work for 3D data

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1115,7 +1115,6 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False):
         nanMask = np.isnan(data)
         if data.ndim > 2:
             nanMask = np.any(nanMask, axis=-1)
-        nanMask = np.isnan(data)
     # Apply levels if given
     if levels is not None:
         if isinstance(levels, np.ndarray) and levels.ndim == 2:

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1111,7 +1111,10 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False):
     # awkward, but fastest numpy native nan evaluation
     # 
     nanMask = None
-    if data.ndim == 2 and data.dtype.kind == 'f' and np.isnan(data.min()):
+    if data.dtype.kind == 'f' and np.isnan(data.min()):
+        nanMask = np.isnan(data)
+        if data.ndim > 2:
+            nanMask = np.any(nanMask, axis=-1)
         nanMask = np.isnan(data)
     # Apply levels if given
     if levels is not None:
@@ -2501,6 +2504,5 @@ class SignalBlock(object):
     def __exit__(self, *args):
         if self.reconnect:
             self.signal.connect(self.slot)
-
 
 

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1111,7 +1111,7 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False):
     # awkward, but fastest numpy native nan evaluation
     # 
     nanMask = None
-    if data.dtype.kind == 'f' and np.isnan(data.min()):
+    if data.ndim == 2 and data.dtype.kind == 'f' and np.isnan(data.min()):
         nanMask = np.isnan(data)
     # Apply levels if given
     if levels is not None:


### PR DESCRIPTION
Without the PR on gets the following error for RGB data

```
Traceback (most recent call last):
  File "/home/jkotan/sources/lavue/lavuelib/imageDisplayWidget.py", line 64, in paint
    _pg.ImageItem.paint(self, p, *args)
  File "/home/jkotan/testinst/lib/python2.7/site-packages/pyqtgraph/graphicsItems/ImageItem.py", line 439, in paint
    self.render()
  File "/home/jkotan/testinst/lib/python2.7/site-packages/pyqtgraph/graphicsItems/ImageItem.py", line 431, in render
    argb, alpha = fn.makeARGB(image, lut=lut, levels=levels)
  File "/home/jkotan/testinst/lib/python2.7/site-packages/pyqtgraph/functions.py", line 1187, in makeARGB
    imgData[nanMask, 3] = 0
IndexError: too many indices for array
```