### PR TITLE
Embed pyside2uic from pyside2 5.13

### DIFF
--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -104,7 +104,10 @@ def _loadUiType(uiFile):
     if QT_LIB == "PYSIDE":
         import pysideuic
     else:
-        import pyside2uic as pysideuic
+        try:
+            import pyside2uic as pysideuic
+        except ImportError:
+            from .util import pyside2uic
     import xml.etree.ElementTree as xml
 
     parsed = xml.parse(uiFile)

--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -107,7 +107,7 @@ def _loadUiType(uiFile):
         try:
             import pyside2uic as pysideuic
         except ImportError:
-            from .util import pyside2uic
+            from .util import pyside2uic as pysideuic
     import xml.etree.ElementTree as xml
 
     parsed = xml.parse(uiFile)

--- a/pyqtgraph/util/pyside2uic/Compiler/__init__.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/__init__.py
@@ -1,0 +1,22 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2009 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+

--- a/pyqtgraph/util/pyside2uic/Compiler/compiler.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/compiler.py
@@ -1,0 +1,103 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import sys
+
+from pyside2uic.properties import Properties
+from pyside2uic.uiparser import UIParser
+from pyside2uic.Compiler import qtproxies
+from pyside2uic.Compiler.indenter import createCodeIndenter, getIndenter, \
+        write_code
+from pyside2uic.Compiler.qobjectcreator import CompilerCreatorPolicy
+from pyside2uic.Compiler.misc import write_import
+
+
+class UICompiler(UIParser):
+    def __init__(self):
+        UIParser.__init__(self, qtproxies.QtCore, qtproxies.QtGui, qtproxies.QtWidgets,
+                CompilerCreatorPolicy())
+
+    def reset(self):
+        qtproxies.i18n_strings = []
+        UIParser.reset(self)
+
+    def setContext(self, context):
+        qtproxies.i18n_context = context
+
+    def createToplevelWidget(self, classname, widgetname):
+        indenter = getIndenter()
+        indenter.level = 0
+
+        indenter.write("from PySide2 import QtCore, QtGui, QtWidgets")
+        indenter.write("")
+
+        indenter.write("class Ui_%s(object):" % self.uiname)
+        indenter.indent()
+        indenter.write("def setupUi(self, %s):" % widgetname)
+        indenter.indent()
+        w = self.factory.createQObject(classname, widgetname, (),
+                                   is_attribute = False,
+                                   no_instantiation = True)
+        w.baseclass = classname
+        w.uiclass = "Ui_%s" % self.uiname
+        return w
+
+    def setDelayedProps(self):
+        write_code("")
+        write_code("self.retranslateUi(%s)" % self.toplevelWidget)
+        UIParser.setDelayedProps(self)
+
+    def finalize(self):
+        indenter = getIndenter()
+        indenter.level = 1
+        indenter.write("")
+        indenter.write("def retranslateUi(self, %s):" % self.toplevelWidget)
+        indenter.indent()
+
+        if qtproxies.i18n_strings:
+            for s in qtproxies.i18n_strings:
+                indenter.write(s)
+        else:
+            indenter.write("pass")
+
+        indenter.dedent()
+        indenter.dedent()
+
+        # Make a copy of the resource modules to import because the parser will
+        # reset() before returning.
+        self._resources = self.resources
+
+    def compileUi(self, input_stream, output_stream, from_imports):
+        createCodeIndenter(output_stream)
+        w = self.parse(input_stream)
+
+        indenter = getIndenter()
+        indenter.write("")
+
+        self.factory._cpolicy._writeOutImports()
+
+        for res in self._resources:
+            write_import(res, from_imports)
+
+        return {"widgetname": str(w),
+                "uiclass" : w.uiclass,
+                "baseclass" : w.baseclass}

--- a/pyqtgraph/util/pyside2uic/Compiler/compiler.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/compiler.py
@@ -22,13 +22,13 @@
 
 import sys
 
-from pyside2uic.properties import Properties
-from pyside2uic.uiparser import UIParser
-from pyside2uic.Compiler import qtproxies
-from pyside2uic.Compiler.indenter import createCodeIndenter, getIndenter, \
+from ..properties import Properties
+from ..uiparser import UIParser
+from .import qtproxies
+from .indenter import createCodeIndenter, getIndenter, \
         write_code
-from pyside2uic.Compiler.qobjectcreator import CompilerCreatorPolicy
-from pyside2uic.Compiler.misc import write_import
+from .qobjectcreator import CompilerCreatorPolicy
+from .misc import write_import
 
 
 class UICompiler(UIParser):

--- a/pyqtgraph/util/pyside2uic/Compiler/indenter.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/indenter.py
@@ -1,0 +1,59 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2009 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+indentwidth = 4
+
+_indenter = None
+
+class _IndentedCodeWriter(object):
+    def __init__(self, output):
+        self.level = 0
+        self.output = output
+
+    def indent(self):
+        self.level += 1
+
+    def dedent(self):
+        self.level -= 1
+
+    def write(self, line):
+        if line.strip():
+            if indentwidth > 0:
+                indent = " " * indentwidth
+                line = line.replace("\t", indent)
+            else:
+                indent = "\t"
+
+            self.output.write("%s%s\n" % (indent * self.level, line))
+        else:
+            self.output.write("\n")
+
+
+def createCodeIndenter(output):
+    global _indenter
+    _indenter = _IndentedCodeWriter(output)
+
+def getIndenter():
+    return _indenter
+
+def write_code(string):
+    _indenter.write(string)

--- a/pyqtgraph/util/pyside2uic/Compiler/misc.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/misc.py
@@ -1,0 +1,52 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+
+from pyside2uic.Compiler.indenter import write_code
+
+
+def write_import(module_name, from_imports):
+    if from_imports:
+        write_code("from . import %s" % module_name)
+    else:
+        write_code("import %s" % module_name)
+
+
+def moduleMember(module, name):
+    if module:
+        return "%s.%s" % (module, name)
+
+    return name
+
+
+class Literal(object):
+    """Literal(string) -> new literal
+
+    string will not be quoted when put into an argument list"""
+    def __init__(self, string):
+        self.string = string
+
+    def __str__(self):
+        return self.string
+
+    def __or__(self, r_op):
+        return Literal("%s|%s" % (self, r_op))

--- a/pyqtgraph/util/pyside2uic/Compiler/misc.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/misc.py
@@ -21,7 +21,7 @@
 # 02110-1301 USA
 
 
-from pyside2uic.Compiler.indenter import write_code
+from .indenter import write_code
 
 
 def write_import(module_name, from_imports):

--- a/pyqtgraph/util/pyside2uic/Compiler/proxy_type.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/proxy_type.py
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301 USA
 
-from pyside2uic.Compiler.misc import Literal, moduleMember
+from .misc import Literal, moduleMember
 
 
 class ProxyType(type):
@@ -42,7 +42,7 @@ class ProxyType(type):
                 raise
 
             # Avoid a circular import.
-            from pyside2uic.Compiler.qtproxies import LiteralProxyClass
+            from .qtproxies import LiteralProxyClass
 
             return type(name, (LiteralProxyClass, ),
                         {"module": moduleMember(type.__getattribute__(cls, "module"),

--- a/pyqtgraph/util/pyside2uic/Compiler/proxy_type.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/proxy_type.py
@@ -1,0 +1,59 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+from pyside2uic.Compiler.misc import Literal, moduleMember
+
+
+class ProxyType(type):
+    def __init__(*args):
+        type.__init__(*args)
+        for cls in args[0].__dict__.values():
+            if type(cls) is ProxyType:
+                cls.module = args[0].__name__
+
+        if not hasattr(args[0], "module"):
+            args[0].module = ""
+
+    def __getattribute__(cls, name):
+        try:
+            return type.__getattribute__(cls, name)
+        except AttributeError:
+            # Handle internal (ie. non-PySide) attributes as normal.
+            if name == "module":
+                raise
+
+            # Avoid a circular import.
+            from pyside2uic.Compiler.qtproxies import LiteralProxyClass
+
+            return type(name, (LiteralProxyClass, ),
+                        {"module": moduleMember(type.__getattribute__(cls, "module"),
+                                                type.__getattribute__(cls, "__name__"))})
+
+    def __str__(cls):
+        return moduleMember(type.__getattribute__(cls, "module"),
+                            type.__getattribute__(cls, "__name__"))
+
+    def __or__(self, r_op):
+        return Literal("%s|%s" % (self, r_op))
+
+    def __eq__(self, other):
+        return str(self) == str(other)

--- a/pyqtgraph/util/pyside2uic/Compiler/qobjectcreator.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/qobjectcreator.py
@@ -28,8 +28,8 @@ try:
 except NameError:
     from sets import Set as set
 
-from pyside2uic.Compiler.indenter import write_code
-from pyside2uic.Compiler.qtproxies import (QtWidgets, QtGui, Literal,
+from .indenter import write_code
+from .qtproxies import (QtWidgets, QtGui, Literal,
                                            strict_getattr)
 
 

--- a/pyqtgraph/util/pyside2uic/Compiler/qobjectcreator.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/qobjectcreator.py
@@ -1,0 +1,165 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+
+import logging
+
+try:
+    set()
+except NameError:
+    from sets import Set as set
+
+from pyside2uic.Compiler.indenter import write_code
+from pyside2uic.Compiler.qtproxies import (QtWidgets, QtGui, Literal,
+                                           strict_getattr)
+
+
+logger = logging.getLogger(__name__)
+DEBUG = logger.debug
+
+
+class _QtGuiWrapper(object):
+    def search(clsname):
+        try:
+            return strict_getattr(QtGui, clsname)
+        except AttributeError:
+            return None
+
+    search = staticmethod(search)
+
+
+class _QtWidgetsWrapper(object):
+    def search(clsname):
+        try:
+            return strict_getattr(QtWidgets, clsname)
+        except AttributeError:
+            return None
+
+    search = staticmethod(search)
+
+
+class _ModuleWrapper(object):
+    def __init__(self, name, classes):
+        if "." in name:
+            idx = name.rfind(".")
+            self._package = name[:idx]
+            self._module = name[idx + 1:]
+        else:
+            self._package = None
+            self._module = name
+
+        self._classes = set(classes)
+        self._used = False
+
+    def search(self, cls):
+        if cls in self._classes:
+            self._used = True
+            return type(cls, (QtWidgets.QWidget,), {"module": self._module})
+        else:
+            return None
+
+    def _writeImportCode(self):
+        if self._used:
+            if self._package is None:
+                write_code("import %s" % self._module)
+            else:
+                write_code("from %s import %s" % (self._package, self._module))
+
+
+class _CustomWidgetLoader(object):
+    def __init__(self):
+        self._widgets = {}
+        self._usedWidgets = set()
+
+    def addCustomWidget(self, widgetClass, baseClass, module):
+        assert widgetClass not in self._widgets
+        self._widgets[widgetClass] = (baseClass, module)
+
+
+    def _resolveBaseclass(self, baseClass):
+        try:
+            for x in range(0, 10):
+                try: return strict_getattr(QtWidgets, baseClass)
+                except AttributeError: pass
+
+                baseClass = self._widgets[baseClass][0]
+            else:
+                raise ValueError("baseclass resolve took too long, check custom widgets")
+
+        except KeyError:
+            raise ValueError("unknown baseclass %s" % baseClass)
+
+
+    def search(self, cls):
+        try:
+            self._usedWidgets.add(cls)
+            baseClass = self._resolveBaseclass(self._widgets[cls][0])
+            DEBUG("resolved baseclass of %s: %s" % (cls, baseClass))
+
+            return type(cls, (baseClass,),
+                        {"module" : ""})
+
+        except KeyError:
+            return None
+
+    def _writeImportCode(self):
+        imports = {}
+        for widget in self._usedWidgets:
+            _, module = self._widgets[widget]
+            imports.setdefault(module, []).append(widget)
+
+        for module, classes in imports.items():
+            write_code("from %s import %s" % (module, ", ".join(classes)))
+
+
+class CompilerCreatorPolicy(object):
+    def __init__(self):
+        self._modules = []
+
+    def createQtGuiWrapper(self):
+        return _QtGuiWrapper
+
+    def createQtWidgetsWrapper(self):
+        return _QtWidgetsWrapper
+
+    def createModuleWrapper(self, name, classes):
+        mw = _ModuleWrapper(name, classes)
+        self._modules.append(mw)
+        return mw
+
+    def createCustomWidgetLoader(self):
+        cw = _CustomWidgetLoader()
+        self._modules.append(cw)
+        return cw
+
+    def instantiate(self, clsObject, objectname, ctor_args, is_attribute=True, no_instantiation=False):
+        return clsObject(objectname, is_attribute, ctor_args, no_instantiation)
+
+    def invoke(self, rname, method, args):
+        return method(rname, *args)
+
+    def getSlot(self, object, slotname):
+        return Literal("%s.%s" % (object, slotname))
+
+    def _writeOutImports(self):
+        for module in self._modules:
+            module._writeImportCode()

--- a/pyqtgraph/util/pyside2uic/Compiler/qtproxies.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/qtproxies.py
@@ -24,15 +24,15 @@
 import sys
 import re
 
-from pyside2uic.Compiler.indenter import write_code
-from pyside2uic.Compiler.misc import Literal, moduleMember
+from .indenter import write_code
+from .misc import Literal, moduleMember
 
 if sys.hexversion >= 0x03000000:
-    from pyside2uic.port_v3.proxy_base import ProxyBase
-    from pyside2uic.port_v3.as_string import as_string
+    from ..port_v3.proxy_base import ProxyBase
+    from ..port_v3.as_string import as_string
 else:
-    from pyside2uic.port_v2.proxy_base import ProxyBase
-    from pyside2uic.port_v2.as_string import as_string
+    from ..port_v2.proxy_base import ProxyBase
+    from ..port_v2.as_string import as_string
 
 i18n_strings = []
 i18n_context = ""

--- a/pyqtgraph/util/pyside2uic/Compiler/qtproxies.py
+++ b/pyqtgraph/util/pyside2uic/Compiler/qtproxies.py
@@ -1,0 +1,408 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+
+import sys
+import re
+
+from pyside2uic.Compiler.indenter import write_code
+from pyside2uic.Compiler.misc import Literal, moduleMember
+
+if sys.hexversion >= 0x03000000:
+    from pyside2uic.port_v3.proxy_base import ProxyBase
+    from pyside2uic.port_v3.as_string import as_string
+else:
+    from pyside2uic.port_v2.proxy_base import ProxyBase
+    from pyside2uic.port_v2.as_string import as_string
+
+i18n_strings = []
+i18n_context = ""
+
+def i18n_print(string):
+    i18n_strings.append(string)
+
+def i18n_void_func(name):
+    def _printer(self, *args):
+        i18n_print("%s.%s(%s)" % (self, name, ", ".join(map(as_string, args))))
+    return _printer
+
+def i18n_func(name):
+    def _printer(self, rname, *args):
+        i18n_print("%s = %s.%s(%s)" % (rname, self, name, ", ".join(map(as_string, args))))
+        return Literal(rname)
+
+    return _printer
+
+def strict_getattr(module, clsname):
+    cls = getattr(module, clsname)
+    if issubclass(cls, LiteralProxyClass):
+        raise AttributeError(cls)
+    else:
+        return cls
+
+
+class i18n_string(object):
+    def __init__(self, string, disambig):
+        self.string = string
+        self.disambig = disambig
+
+    def __str__(self):
+        if self.disambig is None:
+            disambig = "None"
+        else:
+            disambig = as_string(self.disambig, encode=False)
+
+        return 'QtWidgets.QApplication.translate("%s", %s, %s, -1)' % (i18n_context, as_string(self.string, encode=False), disambig)
+
+
+# Classes with this flag will be handled as literal values. If functions are
+# called on these classes, the literal value changes.
+# Example:
+# the code
+# >>> QSize(9,10).expandedTo(...)
+# will print just that code.
+AS_ARGUMENT = 2
+
+# ATTENTION: currently, classes can either be literal or normal. If a class
+# should need both kinds of behaviour, the code has to be changed.
+
+class ProxyClassMember(object):
+    def __init__(self, proxy, function_name, flags):
+        self.proxy = proxy
+        self.function_name = function_name
+        self.flags = flags
+
+    def __str__(self):
+        return "%s.%s" % (self.proxy, self.function_name)
+
+    def __call__(self, *args):
+        func_call = "%s.%s(%s)" % (self.proxy,
+                                   self.function_name,
+                                   ", ".join(map(as_string, args)))
+        if self.flags & AS_ARGUMENT:
+            self.proxy._uic_name = func_call
+            return self.proxy
+        else:
+            needs_translation = False
+            for arg in args:
+                if isinstance(arg, i18n_string):
+                    needs_translation = True
+            if needs_translation:
+                i18n_print(func_call)
+            else:
+                write_code(func_call)
+
+
+class ProxyClass(ProxyBase):
+    flags = 0
+
+    def __init__(self, objectname, is_attribute, args=(), noInstantiation=False):
+        if objectname:
+            if is_attribute:
+                objectname = "self." + objectname
+
+            self._uic_name = objectname
+        else:
+            self._uic_name = "Unnamed"
+
+        if not noInstantiation:
+            funcall = "%s(%s)" % \
+                    (moduleMember(self.module, self.__class__.__name__),
+                    ", ".join(map(str, args)))
+
+            if objectname:
+                funcall = "%s = %s" % (objectname, funcall)
+
+            write_code(funcall)
+
+    def __str__(self):
+        return self._uic_name
+
+    def __getattribute__(self, attribute):
+        try:
+            return object.__getattribute__(self, attribute)
+        except AttributeError:
+            return ProxyClassMember(self, attribute, self.flags)
+
+
+class LiteralProxyClass(ProxyClass):
+    """LiteralObject(*args) -> new literal class
+
+    a literal class can be used as argument in a function call
+
+    >>> class Foo(LiteralProxyClass): pass
+    >>> str(Foo(1,2,3)) == "Foo(1,2,3)"
+    """
+    flags = AS_ARGUMENT
+    def __init__(self, *args):
+        self._uic_name = "%s(%s)" % \
+                     (moduleMember(self.module, self.__class__.__name__),
+                      ", ".join(map(as_string, args)))
+
+
+class ProxyNamespace(ProxyBase):
+    pass
+
+
+# These are all the Qt classes used by pyuic4 in their namespaces. If a class
+# is missing, the compiler will fail, normally with an AttributeError.
+#
+# For adding new classes:
+#     - utility classes used as literal values do not need to be listed
+#       because they are created on the fly as subclasses of LiteralProxyClass
+#     - classes which are *not* QWidgets inherit from ProxyClass and they
+#       have to be listed explicitly in the correct namespace. These classes
+#       are created via a ProxyQObjectCreator
+#     - new QWidget-derived classes have to inherit from qtproxies.QWidget
+#       If the widget does not need any special methods, it can be listed
+#       in _qwidgets
+
+class QtCore(ProxyNamespace):
+    class Qt(ProxyNamespace):
+        pass
+
+    ## connectSlotsByName and connect have to be handled as class methods,
+    ## otherwise they would be created as LiteralProxyClasses and never be
+    ## printed
+    class QMetaObject(ProxyClass):
+        def connectSlotsByName(cls, *args):
+            ProxyClassMember(cls, "connectSlotsByName", 0)(*args)
+        connectSlotsByName = classmethod(connectSlotsByName)
+
+
+    class QObject(ProxyClass):
+        def metaObject(self):
+            class _FakeMetaObject(object):
+                def className(*args):
+                    return self.__class__.__name__
+            return _FakeMetaObject()
+
+        def objectName(self):
+            return self._uic_name.split(".")[-1]
+
+        def connect(cls, *args):
+            # Handle slots that have names corresponding to Python keywords.
+            slot_name = str(args[-1])
+            if slot_name.endswith('.raise'):
+                args = list(args[:-1])
+                args.append(Literal(slot_name + '_'))
+
+            ProxyClassMember(cls, "connect", 0)(*args)
+        connect = classmethod(connect)
+
+class QtGui(ProxyNamespace):
+    class QIcon(ProxyClass): pass
+    class QConicalGradient(ProxyClass): pass
+    class QLinearGradient(ProxyClass): pass
+    class QRadialGradient(ProxyClass): pass
+    class QBrush(ProxyClass): pass
+    class QPainter(ProxyClass): pass
+    class QPalette(ProxyClass): pass
+    class QFont(ProxyClass): pass
+
+# These sub-class QWidget but aren't themselves sub-classed.
+_qwidgets = ("QCalendarWidget", "QDialogButtonBox", "QDockWidget", "QGroupBox",
+             "QLineEdit", "QMainWindow", "QMenuBar", "QProgressBar", "QStatusBar",
+             "QToolBar", "QWizardPage")
+
+class QtWidgets(ProxyNamespace):
+    class QApplication(QtCore.QObject):
+        def translate(uiname, text, disambig, encoding):
+            return i18n_string(text or "", disambig)
+        translate = staticmethod(translate)
+
+    class QSpacerItem(ProxyClass): pass
+    class QSizePolicy(ProxyClass): pass
+    ## QActions inherit from QObject for the metaobject stuff
+    ## and the hierarchy has to be correct since we have a
+    ## isinstance(x, QtWidgets.QLayout) call in the ui parser
+    class QAction(QtCore.QObject): pass
+    class QActionGroup(QtCore.QObject): pass
+    class QButtonGroup(QtCore.QObject): pass
+    class QLayout(QtCore.QObject):
+        def setMargin(self, v):
+            ProxyClassMember(self, "setContentsMargins", 0)(v, v, v, v);
+
+    class QGridLayout(QLayout): pass
+    class QBoxLayout(QLayout): pass
+    class QHBoxLayout(QBoxLayout): pass
+    class QVBoxLayout(QBoxLayout): pass
+    class QFormLayout(QLayout): pass
+
+    class QWidget(QtCore.QObject):
+        def font(self):
+            return Literal("%s.font()" % self)
+
+        def minimumSizeHint(self):
+            return Literal("%s.minimumSizeHint()" % self)
+
+        def sizePolicy(self):
+            sp = LiteralProxyClass()
+            sp._uic_name = "%s.sizePolicy()" % self
+            return sp
+
+    class QDialog(QWidget): pass
+    class QWizard(QDialog): pass
+
+    class QAbstractSlider(QWidget): pass
+    class QDial(QAbstractSlider): pass
+    class QScrollBar(QAbstractSlider): pass
+    class QSlider(QAbstractSlider): pass
+
+    class QMenu(QWidget):
+        def menuAction(self):
+            return Literal("%s.menuAction()" % self)
+
+    class QTabWidget(QWidget):
+        def addTab(self, *args):
+            text = args[-1]
+
+            if isinstance(text, i18n_string):
+                i18n_print("%s.setTabText(%s.indexOf(%s), %s)" % \
+                        (self._uic_name, self._uic_name, args[0], text))
+                args = args[:-1] + ("", )
+
+            ProxyClassMember(self, "addTab", 0)(*args)
+
+        def indexOf(self, page):
+            return Literal("%s.indexOf(%s)" % (self, page))
+
+    class QComboBox(QWidget): pass
+    class QFontComboBox(QComboBox): pass
+
+    class QAbstractSpinBox(QWidget): pass
+    class QDoubleSpinBox(QAbstractSpinBox): pass
+    class QSpinBox(QAbstractSpinBox): pass
+
+    class QDateTimeEdit(QAbstractSpinBox): pass
+    class QDateEdit(QDateTimeEdit): pass
+    class QTimeEdit(QDateTimeEdit): pass
+
+    class QFrame(QWidget): pass
+    class QLabel(QFrame): pass
+    class QLCDNumber(QFrame): pass
+    class QSplitter(QFrame): pass
+    class QStackedWidget(QFrame): pass
+
+    class QToolBox(QFrame):
+        def addItem(self, *args):
+            text = args[-1]
+
+            if isinstance(text, i18n_string):
+                i18n_print("%s.setItemText(%s.indexOf(%s), %s)" % \
+                        (self._uic_name, self._uic_name, args[0], text))
+                args = args[:-1] + ("", )
+
+            ProxyClassMember(self, "addItem", 0)(*args)
+
+        def indexOf(self, page):
+            return Literal("%s.indexOf(%s)" % (self, page))
+
+        def layout(self):
+            return QtWidgets.QLayout("%s.layout()" % self,
+                    False, (), noInstantiation=True)
+
+    class QAbstractScrollArea(QFrame): pass
+    class QGraphicsView(QAbstractScrollArea): pass
+    class QMdiArea(QAbstractScrollArea): pass
+    class QPlainTextEdit(QAbstractScrollArea): pass
+    class QScrollArea(QAbstractScrollArea): pass
+
+    class QTextEdit(QAbstractScrollArea): pass
+    class QTextBrowser(QTextEdit): pass
+
+    class QAbstractItemView(QAbstractScrollArea): pass
+    class QColumnView(QAbstractItemView): pass
+    class QHeaderView(QAbstractItemView): pass
+    class QListView(QAbstractItemView): pass
+
+    class QTableView(QAbstractItemView):
+        def horizontalHeader(self):
+            return QtWidgets.QHeaderView("%s.horizontalHeader()" % self,
+                    False, (), noInstantiation=True)
+
+        def verticalHeader(self):
+            return QtWidgets.QHeaderView("%s.verticalHeader()" % self,
+                    False, (), noInstantiation=True)
+
+    class QTreeView(QAbstractItemView):
+        def header(self):
+            return QtWidgets.QHeaderView("%s.header()" % self,
+                    False, (), noInstantiation=True)
+
+    class QListWidgetItem(ProxyClass): pass
+
+    class QListWidget(QListView):
+        isSortingEnabled = i18n_func("isSortingEnabled")
+        setSortingEnabled = i18n_void_func("setSortingEnabled")
+
+        def item(self, row):
+            return QtWidgets.QListWidgetItem("%s.item(%i)" % (self, row), False,
+                    (), noInstantiation=True)
+
+    class QTableWidgetItem(ProxyClass): pass
+
+    class QTableWidget(QTableView):
+        isSortingEnabled = i18n_func("isSortingEnabled")
+        setSortingEnabled = i18n_void_func("setSortingEnabled")
+
+        def item(self, row, col):
+            return QtWidgets.QTableWidgetItem("%s.item(%i, %i)" % (self, row, col),
+                    False, (), noInstantiation=True)
+
+        def horizontalHeaderItem(self, col):
+            return QtWidgets.QTableWidgetItem("%s.horizontalHeaderItem(%i)" % (self, col),
+                    False, (), noInstantiation=True)
+
+        def verticalHeaderItem(self, row):
+            return QtWidgets.QTableWidgetItem("%s.verticalHeaderItem(%i)" % (self, row),
+                    False, (), noInstantiation=True)
+
+    class QTreeWidgetItem(ProxyClass):
+        def child(self, index):
+            return QtWidgets.QTreeWidgetItem("%s.child(%i)" % (self, index),
+                    False, (), noInstantiation=True)
+
+    class QTreeWidget(QTreeView):
+        isSortingEnabled = i18n_func("isSortingEnabled")
+        setSortingEnabled = i18n_void_func("setSortingEnabled")
+
+        def headerItem(self):
+            return QtWidgets.QWidget("%s.headerItem()" % self, False, (),
+                    noInstantiation=True)
+
+        def topLevelItem(self, index):
+            return QtWidgets.QTreeWidgetItem("%s.topLevelItem(%i)" % (self, index),
+                    False, (), noInstantiation=True)
+
+    class QAbstractButton(QWidget): pass
+    class QCheckBox(QAbstractButton): pass
+    class QRadioButton(QAbstractButton): pass
+    class QToolButton(QAbstractButton): pass
+
+    class QPushButton(QAbstractButton): pass
+    class QCommandLinkButton(QPushButton): pass
+
+    # Add all remaining classes.
+    for _class in _qwidgets:
+        if _class not in locals():
+            locals()[_class] = type(_class, (QWidget, ), {})

--- a/pyqtgraph/util/pyside2uic/LICENSE
+++ b/pyqtgraph/util/pyside2uic/LICENSE
@@ -1,0 +1,372 @@
+Copyright (c) 2005,2006 Torsten Marek <shlomme@gmx.net>.
+All rights reserved.
+
+The software module is double-licensed under the revised BSD and GPL
+licenses.
+
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+	51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year  name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/pyqtgraph/util/pyside2uic/README
+++ b/pyqtgraph/util/pyside2uic/README
@@ -1,2 +1,2 @@
-This is pyside2uic extracted from pyside2-tools, which disappeared in pyside2 version 5.14.
+This is pyside2uic extracted from pyside2 5.13
 

--- a/pyqtgraph/util/pyside2uic/README
+++ b/pyqtgraph/util/pyside2uic/README
@@ -1,0 +1,2 @@
+This is pyside2uic extracted from pyside2-tools, which disappeared in pyside2 version 5.14.
+

--- a/pyqtgraph/util/pyside2uic/__init__.py
+++ b/pyqtgraph/util/pyside2uic/__init__.py
@@ -24,7 +24,7 @@ __all__ = ("compileUi", "compileUiDir", "widgetPluginPath")
 
 __version__ = ""
 
-from pyside2uic.Compiler import indenter, compiler
+from .Compiler import indenter, compiler
 
 _header = """# -*- coding: utf-8 -*-
 

--- a/pyqtgraph/util/pyside2uic/__init__.py
+++ b/pyqtgraph/util/pyside2uic/__init__.py
@@ -1,0 +1,150 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+__all__ = ("compileUi", "compileUiDir", "widgetPluginPath")
+
+__version__ = ""
+
+from pyside2uic.Compiler import indenter, compiler
+
+_header = """# -*- coding: utf-8 -*-
+
+# Form implementation generated from reading ui file '%s',
+# licensing of '%s' applies.
+#
+# Created: %s
+#      by: pyside2-uic %s running on PySide2 %s
+#
+# WARNING! All changes made in this file will be lost!
+
+"""
+
+_display_code = """
+if __name__ == "__main__":
+\timport sys
+\tapp = QtWidgets.QApplication(sys.argv)
+\t%(widgetname)s = QtWidgets.%(baseclass)s()
+\tui = %(uiclass)s()
+\tui.setupUi(%(widgetname)s)
+\t%(widgetname)s.show()
+\tsys.exit(app.exec_())
+"""
+
+
+def compileUiDir(dir, recurse=False, map=None, **compileUi_args):
+    """compileUiDir(dir, recurse=False, map=None, **compileUi_args)
+
+    Creates Python modules from Qt Designer .ui files in a directory or
+    directory tree.
+
+    dir is the name of the directory to scan for files whose name ends with
+    '.ui'.  By default the generated Python module is created in the same
+    directory ending with '.py'.
+    recurse is set if any sub-directories should be scanned.  The default is
+    False.
+    map is an optional callable that is passed the name of the directory
+    containing the '.ui' file and the name of the Python module that will be
+    created.  The callable should return a tuple of the name of the directory
+    in which the Python module will be created and the (possibly modified)
+    name of the module.  The default is None.
+    compileUi_args are any additional keyword arguments that are passed to
+    the compileUi() function that is called to create each Python module.
+    """
+
+    import os
+
+    # Compile a single .ui file.
+    def compile_ui(ui_dir, ui_file):
+        # Ignore if it doesn't seem to be a .ui file.
+        if ui_file.endswith('.ui'):
+            py_dir = ui_dir
+            py_file = ui_file[:-3] + '.py'
+
+            # Allow the caller to change the name of the .py file or generate
+            # it in a different directory.
+            if map is not None:
+                py_dir, py_file = map(py_dir, py_file)
+
+            # Make sure the destination directory exists.
+            try:
+                os.makedirs(py_dir)
+            except:
+                pass
+
+            ui_path = os.path.join(ui_dir, ui_file)
+            py_path = os.path.join(py_dir, py_file)
+
+            ui_file = open(ui_path, 'r')
+            py_file = open(py_path, 'w')
+
+            try:
+                compileUi(ui_file, py_file, **compileUi_args)
+            finally:
+                ui_file.close()
+                py_file.close()
+
+    if recurse:
+        for root, _, files in os.walk(dir):
+            for ui in files:
+                compile_ui(root, ui)
+    else:
+        for ui in os.listdir(dir):
+            if os.path.isfile(os.path.join(dir, ui)):
+                compile_ui(dir, ui)
+
+
+def compileUi(uifile, pyfile, execute=False, indent=4, from_imports=False):
+    """compileUi(uifile, pyfile, execute=False, indent=4, from_imports=False)
+
+    Creates a Python module from a Qt Designer .ui file.
+
+    uifile is a file name or file-like object containing the .ui file.
+    pyfile is the file-like object to which the Python code will be written to.
+    execute is optionally set to generate extra Python code that allows the
+    code to be run as a standalone application.  The default is False.
+    indent is the optional indentation width using spaces.  If it is 0 then a
+    tab is used.  The default is 4.
+    from_imports is optionally set to generate import statements that are
+    relative to '.'.
+    """
+
+    from time import ctime
+    import PySide2
+
+    try:
+        uifname = uifile.name
+    except AttributeError:
+        uifname = uifile
+
+    indenter.indentwidth = indent
+
+    global PySideToolsVersion
+    pyfile.write(_header % (uifname, uifname, ctime(), __version__, PySide2.__version__))
+
+    winfo = compiler.UICompiler().compileUi(uifile, pyfile, from_imports)
+
+    if execute:
+        indenter.write_code(_display_code % winfo)
+
+
+# The list of directories that are searched for widget plugins.
+from pyside2uic.objcreator import widgetPluginPath

--- a/pyqtgraph/util/pyside2uic/__init__.py
+++ b/pyqtgraph/util/pyside2uic/__init__.py
@@ -147,4 +147,4 @@ def compileUi(uifile, pyfile, execute=False, indent=4, from_imports=False):
 
 
 # The list of directories that are searched for widget plugins.
-from pyside2uic.objcreator import widgetPluginPath
+from .objcreator import widgetPluginPath

--- a/pyqtgraph/util/pyside2uic/driver.py
+++ b/pyqtgraph/util/pyside2uic/driver.py
@@ -24,7 +24,7 @@
 import sys
 import logging
 
-from pyside2uic import compileUi
+from . import compileUi
 
 
 class Driver(object):

--- a/pyqtgraph/util/pyside2uic/driver.py
+++ b/pyqtgraph/util/pyside2uic/driver.py
@@ -1,0 +1,128 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+
+import sys
+import logging
+
+from pyside2uic import compileUi
+
+
+class Driver(object):
+    """ This encapsulates access to the pyuic functionality so that it can be
+    called by code that is Python v2/v3 specific.
+    """
+
+    LOGGER_NAME = 'PySide2.uic'
+
+    def __init__(self, opts, ui_file):
+        """ Initialise the object.  opts is the parsed options.  ui_file is the
+        name of the .ui file.
+        """
+
+        if opts.debug:
+            logger = logging.getLogger(self.LOGGER_NAME)
+            handler = logging.StreamHandler()
+            handler.setFormatter(logging.Formatter("%(name)s: %(message)s"))
+            logger.addHandler(handler)
+            logger.setLevel(logging.DEBUG)
+
+        self._opts = opts
+        self._ui_file = ui_file
+
+    def invoke(self):
+        """ Invoke the action as specified by the parsed options.  Returns 0 if
+        there was no error.
+        """
+
+        if self._opts.preview:
+            return self._preview()
+
+        self._generate()
+
+        return 0
+
+    def _preview(self):
+        """ Preview the .ui file.  Return the exit status to be passed back to
+        the parent process.
+        """
+
+        from PySide2 import QtUiTools
+        from PySide2 import QtGui
+        from PySide2 import QtWidgets
+
+        app = QtWidgets.QApplication([self._ui_file])
+        widget = QtUiTools.QUiLoader().load(self._ui_file)
+        widget.show()
+
+        return app.exec_()
+
+    def _generate(self):
+        """ Generate the Python code. """
+
+        if sys.hexversion >= 0x03000000:
+            if self._opts.output == '-':
+                from io import TextIOWrapper
+
+                pyfile = TextIOWrapper(sys.stdout.buffer, encoding='utf8')
+            else:
+                pyfile = open(self._opts.output, 'wt', encoding='utf8')
+        else:
+            if self._opts.output == '-':
+                pyfile = sys.stdout
+            else:
+                pyfile = open(self._opts.output, 'wt')
+
+        compileUi(self._ui_file, pyfile, self._opts.execute, self._opts.indent, self._opts.from_imports)
+
+    def on_IOError(self, e):
+        """ Handle an IOError exception. """
+
+        sys.stderr.write("Error: %s: \"%s\"\n" % (e.strerror, e.filename))
+
+    def on_SyntaxError(self, e):
+        """ Handle a SyntaxError exception. """
+
+        sys.stderr.write("Error in input file: %s\n" % e)
+
+    def on_NoSuchWidgetError(self, e):
+        """ Handle a NoSuchWidgetError exception. """
+
+        if e.args[0].startswith("Q3"):
+            sys.stderr.write("Error: Q3Support widgets are not supported by PySide2.\n")
+        else:
+            sys.stderr.write(str(e) + "\n")
+
+    def on_Exception(self, e):
+        """ Handle a generic exception. """
+
+        if logging.getLogger(self.LOGGER_NAME).level == logging.DEBUG:
+            import traceback
+
+            traceback.print_exception(*sys.exc_info())
+        else:
+            from PySide2 import QtCore
+
+            sys.stderr.write("""An unexpected error occurred.
+Check that you are using the latest version of PySide2 and report the error to
+http://bugs.openbossa.org, including the ui file used to trigger the error.
+""")

--- a/pyqtgraph/util/pyside2uic/exceptions.py
+++ b/pyqtgraph/util/pyside2uic/exceptions.py
@@ -1,0 +1,31 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2009 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+class NoSuchWidgetError(Exception):
+    def __str__(self):
+        return "Unknown Qt widget: %s" % (self.args[0],)
+
+class UnsupportedPropertyError(Exception):
+    pass
+
+class WidgetPluginError(Exception):
+    pass

--- a/pyqtgraph/util/pyside2uic/icon_cache.py
+++ b/pyqtgraph/util/pyside2uic/icon_cache.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# This file is part of the PySide project.
+#
+# Copyright (C) 2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+
+import os.path
+
+
+class IconCache(object):
+    """Maintain a cache of icons.  If an icon is used more than once by a GUI
+    then ensure that only one copy is created.
+    """
+
+    def __init__(self, object_factory, qtgui_module):
+        """Initialise the cache."""
+
+        self._object_factory = object_factory
+        self._qtgui_module = qtgui_module
+        self._base_dir = ''
+        self._cache = []
+
+    def set_base_dir(self, base_dir):
+        """ Set the base directory to be used for all relative filenames. """
+
+        self._base_dir = base_dir
+
+    def get_icon(self, iconset):
+        """Return an icon described by the given iconset tag."""
+
+        iset = _IconSet(iconset, self._base_dir)
+
+        try:
+            idx = self._cache.index(iset)
+        except ValueError:
+            idx = -1
+
+        if idx >= 0:
+            # Return the icon from the cache.
+            iset = self._cache[idx]
+        else:
+            # Follow uic's naming convention.
+            name = 'icon'
+            idx = len(self._cache)
+
+            if idx > 0:
+                name += str(idx)
+
+            icon = self._object_factory.createQObject("QIcon", name, (),
+                    is_attribute=False)
+            iset.set_icon(icon, self._qtgui_module)
+            self._cache.append(iset)
+
+        return iset.icon
+
+
+class _IconSet(object):
+    """An icon set, ie. the mode and state and the pixmap used for each."""
+
+    def __init__(self, iconset, base_dir):
+        """Initialise the icon set from an XML tag."""
+
+        # Set the pre-Qt v4.4 fallback (ie. with no roles).
+        self._fallback = self._file_name(iconset.text, base_dir)
+        self._use_fallback = True
+
+        # Parse the icon set.
+        self._roles = {}
+
+        for i in iconset:
+            file_name = i.text
+            if file_name is not None:
+                file_name = self._file_name(file_name, base_dir)
+
+            self._roles[i.tag] = file_name
+            self._use_fallback = False
+
+        # There is no real icon yet.
+        self.icon = None
+
+    @staticmethod
+    def _file_name(fname, base_dir):
+        """ Convert a relative filename if we have a base directory. """
+
+        fname = fname.replace("\\", "\\\\")
+
+        if base_dir != '' and fname[0] != ':' and not os.path.isabs(fname):
+            fname = os.path.join(base_dir, fname)
+
+        return fname
+
+    def set_icon(self, icon, qtgui_module):
+        """Save the icon and set its attributes."""
+
+        if self._use_fallback:
+            icon.addFile(self._fallback)
+        else:
+            for role, pixmap in self._roles.items():
+                if role.endswith("off"):
+                    mode = role[:-3]
+                    state = qtgui_module.QIcon.Off
+                elif role.endswith("on"):
+                    mode = role[:-2]
+                    state = qtgui_module.QIcon.On
+                else:
+                    continue
+
+                mode = getattr(qtgui_module.QIcon, mode.title())
+
+                if pixmap:
+                    icon.addPixmap(qtgui_module.QPixmap(pixmap), mode, state)
+                else:
+                    icon.addPixmap(qtgui_module.QPixmap(), mode, state)
+
+        self.icon = icon
+
+    def __eq__(self, other):
+        """Compare two icon sets for equality."""
+
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        if self._use_fallback:
+            if other._use_fallback:
+                return self._fallback == other._fallback
+
+            return False
+
+        if other._use_fallback:
+            return False
+
+        return self._roles == other._roles

--- a/pyqtgraph/util/pyside2uic/objcreator.py
+++ b/pyqtgraph/util/pyside2uic/objcreator.py
@@ -23,12 +23,12 @@
 import sys
 import os.path
 
-from pyside2uic.exceptions import NoSuchWidgetError, WidgetPluginError
+from .exceptions import NoSuchWidgetError, WidgetPluginError
 
 if sys.hexversion >= 0x03000000:
-    from pyside2uic.port_v3.load_plugin import load_plugin
+    from .port_v3.load_plugin import load_plugin
 else:
-    from pyside2uic.port_v2.load_plugin import load_plugin
+    from .port_v2.load_plugin import load_plugin
 
 
 # The list of directories that are searched for widget plugins.  This is

--- a/pyqtgraph/util/pyside2uic/objcreator.py
+++ b/pyqtgraph/util/pyside2uic/objcreator.py
@@ -1,0 +1,113 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import sys
+import os.path
+
+from pyside2uic.exceptions import NoSuchWidgetError, WidgetPluginError
+
+if sys.hexversion >= 0x03000000:
+    from pyside2uic.port_v3.load_plugin import load_plugin
+else:
+    from pyside2uic.port_v2.load_plugin import load_plugin
+
+
+# The list of directories that are searched for widget plugins.  This is
+# exposed as part of the API.
+widgetPluginPath = [os.path.join(os.path.dirname(__file__), 'widget-plugins')]
+
+
+MATCH = True
+NO_MATCH = False
+MODULE = 0
+CW_FILTER = 1
+
+
+class QObjectCreator(object):
+    def __init__(self, creatorPolicy):
+        self._cpolicy = creatorPolicy
+
+        self._cwFilters = []
+        self._modules = [self._cpolicy.createQtWidgetsWrapper(),
+                         self._cpolicy.createQtGuiWrapper()]
+
+        # Get the optional plugins.
+        for plugindir in widgetPluginPath:
+            try:
+                plugins = os.listdir(plugindir)
+            except:
+                plugins = []
+
+            for filename in plugins:
+                if not filename.endswith('.py') or filename == '__init__.py':
+                    continue
+
+                filename = os.path.join(plugindir, filename)
+
+                plugin_globals = {
+                    "MODULE": MODULE,
+                    "CW_FILTER": CW_FILTER,
+                    "MATCH": MATCH,
+                    "NO_MATCH": NO_MATCH}
+
+                plugin_locals = {}
+
+                if load_plugin(open(filename), plugin_globals, plugin_locals):
+                    pluginType = plugin_locals["pluginType"]
+                    if pluginType == MODULE:
+                        modinfo = plugin_locals["moduleInformation"]()
+                        self._modules.append(self._cpolicy.createModuleWrapper(*modinfo))
+                    elif pluginType == CW_FILTER:
+                        self._cwFilters.append(plugin_locals["getFilter"]())
+                    else:
+                        raise WidgetPluginError("Unknown plugin type of %s" % filename)
+
+        self._customWidgets = self._cpolicy.createCustomWidgetLoader()
+        self._modules.append(self._customWidgets)
+
+    def createQObject(self, classname, *args, **kwargs):
+        classType = self.findQObjectType(classname)
+        if classType:
+            return self._cpolicy.instantiate(classType, *args, **kwargs)
+        raise NoSuchWidgetError(classname)
+
+    def invoke(self, rname, method, args=()):
+        return self._cpolicy.invoke(rname, method, args)
+
+    def findQObjectType(self, classname):
+        for module in self._modules:
+            w = module.search(classname)
+            if w is not None:
+                return w
+        return None
+
+    def getSlot(self, obj, slotname):
+        return self._cpolicy.getSlot(obj, slotname)
+
+    def addCustomWidget(self, widgetClass, baseClass, module):
+        for cwFilter in self._cwFilters:
+            match, result = cwFilter(widgetClass, baseClass, module)
+            if match:
+                widgetClass, baseClass, module = result
+                break
+
+        self._customWidgets.addCustomWidget(widgetClass, baseClass, module)

--- a/pyqtgraph/util/pyside2uic/port_v3/__init__.py
+++ b/pyqtgraph/util/pyside2uic/port_v3/__init__.py
@@ -1,0 +1,20 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA

--- a/pyqtgraph/util/pyside2uic/port_v3/as_string.py
+++ b/pyqtgraph/util/pyside2uic/port_v3/as_string.py
@@ -1,0 +1,41 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import re
+
+
+def as_string(obj, encode=True):
+    if isinstance(obj, str):
+        s = '"' + _escape(obj) + '"'
+        
+        return s
+
+    return str(obj)
+
+
+_esc_regex = re.compile(r"(\"|\'|\\)")
+
+def _escape(text):
+    # This escapes any escaped single or double quote or backslash.
+    x = _esc_regex.sub(r"\\\1", text)
+
+    # This replaces any '\n' with an escaped version and a real line break.
+    return re.sub(r'\n', r'\\n"\n"', x)

--- a/pyqtgraph/util/pyside2uic/port_v3/ascii_upper.py
+++ b/pyqtgraph/util/pyside2uic/port_v3/ascii_upper.py
@@ -1,0 +1,30 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+
+# A translation table for converting ASCII lower case to upper case.
+_ascii_trans_table = bytes.maketrans(b'abcdefghijklmnopqrstuvwxyz',
+        b'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+
+
+# Convert a string to ASCII upper case irrespective of the current locale.
+def ascii_upper(s):
+    return s.translate(_ascii_trans_table)

--- a/pyqtgraph/util/pyside2uic/port_v3/invoke.py
+++ b/pyqtgraph/util/pyside2uic/port_v3/invoke.py
@@ -1,0 +1,48 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+from pyside2uic.exceptions import NoSuchWidgetError
+
+
+def invoke(driver):
+    """ Invoke the given command line driver.  Return the exit status to be
+    passed back to the parent process.
+    """
+
+    exit_status = 1
+
+    try:
+        exit_status = driver.invoke()
+
+    except IOError as e:
+        driver.on_IOError(e)
+
+    except SyntaxError as e:
+        driver.on_SyntaxError(e)
+
+    except NoSuchWidgetError as e:
+        driver.on_NoSuchWidgetError(e)
+
+    except Exception as e:
+        driver.on_Exception(e)
+
+    return exit_status

--- a/pyqtgraph/util/pyside2uic/port_v3/invoke.py
+++ b/pyqtgraph/util/pyside2uic/port_v3/invoke.py
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301 USA
 
-from pyside2uic.exceptions import NoSuchWidgetError
+from ..exceptions import NoSuchWidgetError
 
 
 def invoke(driver):

--- a/pyqtgraph/util/pyside2uic/port_v3/load_plugin.py
+++ b/pyqtgraph/util/pyside2uic/port_v3/load_plugin.py
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301 USA
 
-from pyside2uic.exceptions import WidgetPluginError
+from ..exceptions import WidgetPluginError
 
 
 def load_plugin(plugin, plugin_globals, plugin_locals):

--- a/pyqtgraph/util/pyside2uic/port_v3/load_plugin.py
+++ b/pyqtgraph/util/pyside2uic/port_v3/load_plugin.py
@@ -1,0 +1,39 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+from pyside2uic.exceptions import WidgetPluginError
+
+
+def load_plugin(plugin, plugin_globals, plugin_locals):
+    """ Load the given plugin (which is an open file).  Return True if the
+    plugin was loaded, or False if it wanted to be ignored.  Raise an exception
+    if there was an error.
+    """
+
+    try:
+        exec(plugin.read(), plugin_globals, plugin_locals)
+    except ImportError:
+        return False
+    except Exception as e:
+        raise WidgetPluginError("%s: %s" % (e.__class__, str(e)))
+
+    return True

--- a/pyqtgraph/util/pyside2uic/port_v3/proxy_base.py
+++ b/pyqtgraph/util/pyside2uic/port_v3/proxy_base.py
@@ -1,0 +1,27 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+from pyside2uic.Compiler.proxy_type import ProxyType
+
+
+class ProxyBase(metaclass=ProxyType):
+    pass

--- a/pyqtgraph/util/pyside2uic/port_v3/proxy_base.py
+++ b/pyqtgraph/util/pyside2uic/port_v3/proxy_base.py
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 # 02110-1301 USA
 
-from pyside2uic.Compiler.proxy_type import ProxyType
+from ..Compiler.proxy_type import ProxyType
 
 
 class ProxyBase(metaclass=ProxyType):

--- a/pyqtgraph/util/pyside2uic/port_v3/string_io.py
+++ b/pyqtgraph/util/pyside2uic/port_v3/string_io.py
@@ -1,0 +1,24 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+
+# Import the StringIO object.
+from io import StringIO

--- a/pyqtgraph/util/pyside2uic/properties.py
+++ b/pyqtgraph/util/pyside2uic/properties.py
@@ -1,0 +1,489 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import logging
+import os.path
+import sys
+
+from pyside2uic.exceptions import UnsupportedPropertyError
+from pyside2uic.icon_cache import IconCache
+
+if sys.hexversion >= 0x03000000:
+    from pyside2uic.port_v3.ascii_upper import ascii_upper
+else:
+    from pyside2uic.port_v2.ascii_upper import ascii_upper
+
+logger = logging.getLogger(__name__)
+DEBUG = logger.debug
+
+QtCore = None
+QtGui = None
+QtWidgets = None
+
+
+def int_list(prop):
+    return [int(child.text) for child in prop]
+
+def float_list(prop):
+    return [float(child.text) for child in prop]
+
+bool_ = lambda v: v == "true"
+
+def needsWidget(func):
+    func.needsWidget = True
+    return func
+
+
+class Properties(object):
+    def __init__(self, factory, QtCore_mod, QtGui_mod, QtWidgets_mod):
+        global QtGui, QtCore, QtWidgets
+        QtWidgets = QtWidgets_mod
+        QtGui = QtGui_mod
+        QtCore = QtCore_mod
+        self.factory = factory
+
+        self._base_dir = ''
+
+        self.reset()
+
+    def set_base_dir(self, base_dir):
+        """ Set the base directory to be used for all relative filenames. """
+
+        self._base_dir = base_dir
+        self.icon_cache.set_base_dir(base_dir)
+
+    def reset(self):
+        self.buddies = []
+        self.delayed_props = []
+        self.icon_cache = IconCache(self.factory, QtGui)
+
+    def _pyEnumMember(self, cpp_name):
+        try:
+            prefix, membername = cpp_name.split("::")
+        except ValueError:
+            prefix = "Qt"
+            membername = cpp_name
+
+        if prefix == "Qt":
+            return getattr(QtCore.Qt, membername)
+
+        scope = self.factory.findQObjectType(prefix)
+        if scope is None:
+            raise AttributeError("unknown enum %s" % cpp_name)
+
+        return getattr(scope, membername)
+
+    def _set(self, prop):
+        expr = [self._pyEnumMember(v) for v in prop.text.split('|')]
+
+        value = expr[0]
+        for v in expr[1:]:
+            value |= v
+
+        return value
+
+    def _enum(self, prop):
+        return self._pyEnumMember(prop.text)
+
+    def _number(self, prop):
+        return int(prop.text)
+
+    _uInt = _longLong = _uLongLong = _number
+
+    def _double(self, prop):
+        return float(prop.text)
+
+    def _bool(self, prop):
+        return prop.text == 'true'
+
+    def _stringlist(self, prop):
+        return [self._string(p, notr='true') for p in prop]
+
+    def _string(self, prop, notr=None):
+        text = prop.text
+
+        if text is None:
+            return ""
+
+        if prop.get('notr', notr) == 'true':
+            return text
+
+        return QtWidgets.QApplication.translate(self.uiname, text,
+                prop.get('comment'), -1)
+
+    _char = _string
+
+    def _cstring(self, prop):
+        return str(prop.text)
+
+    def _color(self, prop):
+        args = int_list(prop)
+
+        # Handle the optional alpha component.
+        alpha = int(prop.get("alpha", "255"))
+
+        if alpha != 255:
+            args.append(alpha)
+
+        return QtGui.QColor(*args)
+
+    def _point(self, prop):
+        return QtCore.QPoint(*int_list(prop))
+
+    def _pointf(self, prop):
+        return QtCore.QPointF(*float_list(prop))
+
+    def _rect(self, prop):
+        return QtCore.QRect(*int_list(prop))
+
+    def _rectf(self, prop):
+        return QtCore.QRectF(*float_list(prop))
+
+    def _size(self, prop):
+        return QtCore.QSize(*int_list(prop))
+
+    def _sizef(self, prop):
+        return QtCore.QSizeF(*float_list(prop))
+
+    def _pixmap(self, prop):
+        if prop.text:
+            fname = prop.text.replace("\\", "\\\\")
+            if self._base_dir != '' and fname[0] != ':' and not os.path.isabs(fname):
+                fname = os.path.join(self._base_dir, fname)
+
+            return QtGui.QPixmap(fname)
+
+        # Don't bother to set the property if the pixmap is empty.
+        return None
+
+    def _iconset(self, prop):
+        return self.icon_cache.get_icon(prop)
+
+    def _url(self, prop):
+        return QtCore.QUrl(prop[0].text)
+
+    def _locale(self, prop):
+        lang = getattr(QtCore.QLocale, prop.attrib['language'])
+        country = getattr(QtCore.QLocale, prop.attrib['country'])
+        return QtCore.QLocale(lang, country)
+
+    def _cursor(self, prop):
+        return QtGui.QCursor(QtCore.Qt.CursorShape(int(prop.text)))
+
+    def _date(self, prop):
+        return QtCore.QDate(*int_list(prop))
+
+    def _datetime(self, prop):
+        args = int_list(prop)
+        return QtCore.QDateTime(QtCore.QDate(*args[-3:]), QtCore.QTime(*args[:-3]))
+
+    def _time(self, prop):
+        return QtCore.QTime(*int_list(prop))
+
+    def _gradient(self, prop):
+        name = 'gradient'
+
+        # Create the specific gradient.
+        gtype = prop.get('type', '')
+
+        if gtype == 'LinearGradient':
+            startx = float(prop.get('startx'))
+            starty = float(prop.get('starty'))
+            endx = float(prop.get('endx'))
+            endy = float(prop.get('endy'))
+            gradient = self.factory.createQObject('QLinearGradient', name,
+                    (startx, starty, endx, endy), is_attribute=False)
+
+        elif gtype == 'ConicalGradient':
+            centralx = float(prop.get('centralx'))
+            centraly = float(prop.get('centraly'))
+            angle = float(prop.get('angle'))
+            gradient = self.factory.createQObject('QConicalGradient', name,
+                    (centralx, centraly, angle), is_attribute=False)
+
+        elif gtype == 'RadialGradient':
+            centralx = float(prop.get('centralx'))
+            centraly = float(prop.get('centraly'))
+            radius = float(prop.get('radius'))
+            focalx = float(prop.get('focalx'))
+            focaly = float(prop.get('focaly'))
+            gradient = self.factory.createQObject('QRadialGradient', name,
+                    (centralx, centraly, radius, focalx, focaly),
+                    is_attribute=False)
+
+        else:
+            raise UnsupportedPropertyError(prop.tag)
+
+        # Set the common values.
+        spread = prop.get('spread')
+        if spread:
+            gradient.setSpread(getattr(QtGui.QGradient, spread))
+
+        cmode = prop.get('coordinatemode')
+        if cmode:
+            gradient.setCoordinateMode(getattr(QtGui.QGradient, cmode))
+
+        # Get the gradient stops.
+        for gstop in prop:
+            if gstop.tag != 'gradientstop':
+                raise UnsupportedPropertyError(gstop.tag)
+
+            position = float(gstop.get('position'))
+            color = self._color(gstop[0])
+
+            gradient.setColorAt(position, color)
+
+        return name
+
+    def _palette(self, prop):
+        palette = self.factory.createQObject("QPalette", "palette", (),
+                is_attribute=False)
+
+        for palette_elem in prop:
+            sub_palette = getattr(QtGui.QPalette, palette_elem.tag.title())
+            for role, color in enumerate(palette_elem):
+                if color.tag == 'color':
+                    # Handle simple colour descriptions where the role is
+                    # implied by the colour's position.
+                    palette.setColor(sub_palette,
+                            QtGui.QPalette.ColorRole(role), self._color(color))
+                elif color.tag == 'colorrole':
+                    role = getattr(QtGui.QPalette, color.get('role'))
+                    brush = self._brush(color[0])
+                    palette.setBrush(sub_palette, role, brush)
+                else:
+                    raise UnsupportedPropertyError(color.tag)
+
+        return palette
+
+    def _brush(self, prop):
+        brushstyle = prop.get('brushstyle')
+
+        if brushstyle in ('LinearGradientPattern', 'ConicalGradientPattern', 'RadialGradientPattern'):
+            gradient = self._gradient(prop[0])
+            brush = self.factory.createQObject("QBrush", "brush", (gradient, ),
+                    is_attribute=False)
+        else:
+            color = self._color(prop[0])
+            brush = self.factory.createQObject("QBrush", "brush", (color, ),
+                    is_attribute=False)
+
+            brushstyle = getattr(QtCore.Qt, brushstyle)
+            brush.setStyle(brushstyle)
+
+        return brush
+
+    #@needsWidget
+    def _sizepolicy(self, prop, widget):
+        values = [int(child.text) for child in prop]
+
+        if len(values) == 2:
+            # Qt v4.3.0 and later.
+            horstretch, verstretch = values
+            hsizetype = getattr(QtWidgets.QSizePolicy, prop.get('hsizetype'))
+            vsizetype = getattr(QtWidgets.QSizePolicy, prop.get('vsizetype'))
+        else:
+            hsizetype, vsizetype, horstretch, verstretch = values
+            hsizetype = QtWidgets.QSizePolicy.Policy(hsizetype)
+            vsizetype = QtWidgets.QSizePolicy.Policy(vsizetype)
+
+        sizePolicy = self.factory.createQObject("QSizePolicy", "sizePolicy",
+                (hsizetype, vsizetype), is_attribute=False)
+        sizePolicy.setHorizontalStretch(horstretch)
+        sizePolicy.setVerticalStretch(verstretch)
+        sizePolicy.setHeightForWidth(widget.sizePolicy().hasHeightForWidth())
+        return sizePolicy
+    _sizepolicy = needsWidget(_sizepolicy)
+
+    # font needs special handling/conversion of all child elements.
+    _font_attributes = (("Family",    str),
+                        ("PointSize", int),
+                        ("Weight",    int),
+                        ("Italic",    bool_),
+                        ("Underline", bool_),
+                        ("StrikeOut", bool_),
+                        ("Bold",      bool_))
+
+    def _font(self, prop):
+        newfont = self.factory.createQObject("QFont", "font", (),
+                                                     is_attribute = False)
+        for attr, converter in self._font_attributes:
+            v = prop.findtext("./%s" % (attr.lower(),))
+            if v is None:
+                continue
+
+            getattr(newfont, "set%s" % (attr,))(converter(v))
+        return newfont
+
+    def _cursorShape(self, prop):
+        return getattr(QtCore.Qt, prop.text)
+
+    def convert(self, prop, widget=None):
+        try:
+            func = getattr(self, "_" + prop[0].tag)
+        except AttributeError:
+            raise UnsupportedPropertyError(prop[0].tag)
+        else:
+            args = {}
+            if getattr(func, "needsWidget", False):
+                assert widget is not None
+                args["widget"] = widget
+
+            return func(prop[0], **args)
+
+
+    def _getChild(self, elem_tag, elem, name, default=None):
+        for prop in elem.findall(elem_tag):
+            if prop.attrib["name"] == name:
+                return self.convert(prop)
+        else:
+            return default
+
+    def getProperty(self, elem, name, default=None):
+        return self._getChild("property", elem, name, default)
+
+    def getAttribute(self, elem, name, default=None):
+        return self._getChild("attribute", elem, name, default)
+
+    def setProperties(self, widget, elem):
+        try:
+            self.wclass = elem.attrib["class"]
+        except KeyError:
+            pass
+        for prop in elem.findall("property"):
+            prop_name = prop.attrib["name"]
+            DEBUG("setting property %s" % (prop_name,))
+
+            try:
+                stdset = bool(int(prop.attrib["stdset"]))
+            except KeyError:
+                stdset = True
+
+            if not stdset:
+                self._setViaSetProperty(widget, prop)
+            elif hasattr(self, prop_name):
+                getattr(self, prop_name)(widget, prop)
+            else:
+                prop_value = self.convert(prop, widget)
+                if prop_value is not None:
+                    getattr(widget, "set%s%s" % (ascii_upper(prop_name[0]), prop_name[1:]))(prop_value)
+
+    # SPECIAL PROPERTIES
+    # If a property has a well-known value type but needs special,
+    # context-dependent handling, the default behaviour can be overridden here.
+
+    # Delayed properties will be set after the whole widget tree has been
+    # populated.
+    def _delayed_property(self, widget, prop):
+        prop_value = self.convert(prop)
+        if prop_value is not None:
+            prop_name = prop.attrib["name"]
+            self.delayed_props.append((widget, False,
+                    'set%s%s' % (ascii_upper(prop_name[0]), prop_name[1:]),
+                    prop_value))
+
+    # These properties will be set with a widget.setProperty call rather than
+    # calling the set<property> function.
+    def _setViaSetProperty(self, widget, prop):
+        prop_value = self.convert(prop)
+        if prop_value is not None:
+            widget.setProperty(prop.attrib["name"], prop_value)
+
+    # Ignore the property.
+    def _ignore(self, widget, prop):
+        pass
+
+    # Define properties that use the canned handlers.
+    currentIndex = _delayed_property
+    currentRow = _delayed_property
+
+    showDropIndicator = _setViaSetProperty
+    intValue = _setViaSetProperty
+    value = _setViaSetProperty
+
+    objectName = _ignore
+    leftMargin = _ignore
+    topMargin = _ignore
+    rightMargin = _ignore
+    bottomMargin = _ignore
+    horizontalSpacing = _ignore
+    verticalSpacing = _ignore
+
+    # tabSpacing is actually the spacing property of the widget's layout.
+    def tabSpacing(self, widget, prop):
+        prop_value = self.convert(prop)
+        if prop_value is not None:
+            self.delayed_props.append((widget, True, 'setSpacing', prop_value))
+
+    # buddy setting has to be done after the whole widget tree has been
+    # populated.  We can't use delay here because we cannot get the actual
+    # buddy yet.
+    def buddy(self, widget, prop):
+        buddy_name = prop[0].text
+        if buddy_name:
+            self.buddies.append((widget, buddy_name))
+
+    # geometry is handled specially if set on the toplevel widget.
+    def geometry(self, widget, prop):
+        if widget.objectName() == self.uiname:
+            geom = int_list(prop[0])
+            widget.resize(geom[2], geom[3])
+        else:
+            widget.setGeometry(self._rect(prop[0]))
+
+    def orientation(self, widget, prop):
+        # If the class is a QFrame, it's a line.
+        if widget.metaObject().className() == "QFrame":
+            widget.setFrameShape(
+                {"Qt::Horizontal": QtWidgets.QFrame.HLine,
+                 "Qt::Vertical"  : QtWidgets.QFrame.VLine}[prop[0].text])
+
+            # In Qt Designer, lines appear to be sunken, QFormBuilder loads
+            # them as such, uic generates plain lines.  We stick to the look in
+            # Qt Designer.
+            widget.setFrameShadow(QtWidgets.QFrame.Sunken)
+        else:
+            widget.setOrientation(self._enum(prop[0]))
+
+    # The isWrapping attribute of QListView is named inconsistently, it should
+    # be wrapping.
+    def isWrapping(self, widget, prop):
+        widget.setWrapping(self.convert(prop))
+
+    # This is a pseudo-property injected to deal with setContentsMargin()
+    # introduced in Qt v4.3.
+    def pyuicContentsMargins(self, widget, prop):
+        widget.setContentsMargins(*int_list(prop))
+
+    # This is a pseudo-property injected to deal with setHorizontalSpacing()
+    # and setVerticalSpacing() introduced in Qt v4.3.
+    def pyuicSpacing(self, widget, prop):
+        horiz, vert = int_list(prop)
+
+        if horiz == vert:
+            widget.setSpacing(horiz)
+        else:
+            if horiz >= 0:
+                widget.setHorizontalSpacing(horiz)
+
+            if vert >= 0:
+                widget.setVerticalSpacing(vert)

--- a/pyqtgraph/util/pyside2uic/properties.py
+++ b/pyqtgraph/util/pyside2uic/properties.py
@@ -24,13 +24,13 @@ import logging
 import os.path
 import sys
 
-from pyside2uic.exceptions import UnsupportedPropertyError
-from pyside2uic.icon_cache import IconCache
+from .exceptions import UnsupportedPropertyError
+from .icon_cache import IconCache
 
 if sys.hexversion >= 0x03000000:
-    from pyside2uic.port_v3.ascii_upper import ascii_upper
+    from .port_v3.ascii_upper import ascii_upper
 else:
-    from pyside2uic.port_v2.ascii_upper import ascii_upper
+    from .port_v2.ascii_upper import ascii_upper
 
 logger = logging.getLogger(__name__)
 DEBUG = logger.debug

--- a/pyqtgraph/util/pyside2uic/uiparser.py
+++ b/pyqtgraph/util/pyside2uic/uiparser.py
@@ -1,0 +1,891 @@
+# This file is part of the PySide project.
+#
+# Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+# Copyright (C) 2010 Riverbank Computing Limited.
+# Copyright (C) 2009 Torsten Marek
+#
+# Contact: PySide team <pyside@openbossa.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import sys
+import logging
+import os.path
+import re
+
+try:
+    from xml.etree.cElementTree import parse, SubElement
+except ImportError:
+    from xml.etree.ElementTree import parse, SubElement
+
+
+from pyside2uic.exceptions import NoSuchWidgetError
+from pyside2uic.objcreator import QObjectCreator
+from pyside2uic.properties import Properties
+
+
+logger = logging.getLogger(__name__)
+DEBUG = logger.debug
+
+if sys.version_info < (2,4,0):
+    def reversed(seq):
+        for i in xrange(len(seq)-1, -1, -1):
+            yield seq[i]
+
+QtCore = None
+QtGui = None
+QtWidgets = None
+
+
+def gridPosition(elem):
+    """gridPosition(elem) -> tuple
+
+    Return the 4-tuple of (row, column, rowspan, colspan)
+    for a widget element, or an empty tuple.
+    """
+    try:
+        return (int(elem.attrib["row"]),
+                int(elem.attrib["column"]),
+                int(elem.attrib.get("rowspan", 1)),
+                int(elem.attrib.get("colspan", 1)))
+    except KeyError:
+        return ()
+
+
+class WidgetStack(list):
+    topwidget = None
+    def push(self, item):
+        DEBUG("push %s %s" % (item.metaObject().className(),
+                              item.objectName()))
+        self.append(item)
+        if isinstance(item, QtWidgets.QWidget):
+            self.topwidget = item
+
+    def popLayout(self):
+        layout = list.pop(self)
+        DEBUG("pop layout %s %s" % (layout.metaObject().className(),
+                                    layout.objectName()))
+        return layout
+
+    def popWidget(self):
+        widget = list.pop(self)
+        DEBUG("pop widget %s %s" % (widget.metaObject().className(),
+                                    widget.objectName()))
+        for item in reversed(self):
+            if isinstance(item, QtWidgets.QWidget):
+                self.topwidget = item
+                break
+        else:
+            self.topwidget = None
+        DEBUG("new topwidget %s" % (self.topwidget,))
+        return widget
+
+    def peek(self):
+        return self[-1]
+
+    def topIsLayout(self):
+        return isinstance(self[-1], QtWidgets.QLayout)
+
+
+class UIParser(object):
+    def __init__(self, QtCoreModule, QtGuiModule, QtWidgetsModule, creatorPolicy):
+        self.factory = QObjectCreator(creatorPolicy)
+        self.wprops = Properties(self.factory, QtCoreModule, QtGuiModule, QtWidgetsModule)
+
+        global QtCore, QtGui, QtWidgets
+        QtCore = QtCoreModule
+        QtGui = QtGuiModule
+        QtWidgets = QtWidgetsModule
+
+        self.column_counter = 0
+        self.row_counter = 0
+        self.item_nr = 0
+        self.itemstack = []
+        self.sorting_enabled = None
+
+        self.reset()
+
+    def uniqueName(self, name):
+        """UIParser.uniqueName(string) -> string
+
+        Create a unique name from a string.
+        >>> p = UIParser(QtCore, QtGui, QtWidgets)
+        >>> p.uniqueName("foo")
+        'foo'
+        >>> p.uniqueName("foo")
+        'foo1'
+        """
+        try:
+            suffix = self.name_suffixes[name]
+        except KeyError:
+            self.name_suffixes[name] = 0
+            return name
+
+        suffix += 1
+        self.name_suffixes[name] = suffix
+
+        return "%s%i" % (name, suffix)
+
+    def reset(self):
+        try: self.wprops.reset()
+        except AttributeError: pass
+        self.toplevelWidget = None
+        self.stack = WidgetStack()
+        self.name_suffixes = {}
+        self.defaults = {"spacing": 6, "margin": 0}
+        self.actions = []
+        self.currentActionGroup = None
+        self.resources = []
+        self.button_groups = []
+        self.layout_widget = False
+
+    def setupObject(self, clsname, parent, branch, is_attribute = True):
+        name = self.uniqueName(branch.attrib.get("name") or clsname[1:].lower())
+        if parent is None:
+            args = ()
+        else:
+            args = (parent, )
+        obj =  self.factory.createQObject(clsname, name, args, is_attribute)
+        self.wprops.setProperties(obj, branch)
+        obj.setObjectName(name)
+        if is_attribute:
+            setattr(self.toplevelWidget, name, obj)
+        return obj
+
+    def createWidget(self, elem):
+
+        widget_class = elem.attrib['class'].replace('::', '.')
+        if widget_class == 'Line':
+            widget_class = 'QFrame'
+
+        # Ignore the parent if it is a container
+        parent = self.stack.topwidget
+
+        # if is a Menubar on MacOS
+        macMenu = (sys.platform == 'darwin') and (widget_class == 'QMenuBar')
+
+        if isinstance(parent, (QtWidgets.QDockWidget, QtWidgets.QMdiArea,
+                               QtWidgets.QScrollArea, QtWidgets.QStackedWidget,
+                               QtWidgets.QToolBox, QtWidgets.QTabWidget,
+                               QtWidgets.QWizard)) or macMenu:
+            parent = None
+
+
+        # See if this is a layout widget.
+        if widget_class == 'QWidget':
+            if parent is not None:
+                if not isinstance(parent, QtWidgets.QMainWindow):
+                    self.layout_widget = True
+
+        self.stack.push(self.setupObject(widget_class, parent, elem))
+
+        if isinstance(self.stack.topwidget, QtWidgets.QTableWidget):
+            self.stack.topwidget.setColumnCount(len(elem.findall("column")))
+            self.stack.topwidget.setRowCount(len(elem.findall("row")))
+
+        self.traverseWidgetTree(elem)
+        widget = self.stack.popWidget()
+
+        self.layout_widget = False
+
+        if isinstance(widget, QtWidgets.QTreeView):
+            self.handleHeaderView(elem, "header", widget.header())
+
+        elif isinstance(widget, QtWidgets.QTableView):
+            self.handleHeaderView(elem, "horizontalHeader",
+                    widget.horizontalHeader())
+            self.handleHeaderView(elem, "verticalHeader",
+                    widget.verticalHeader())
+
+        elif isinstance(widget, QtWidgets.QAbstractButton):
+            bg_i18n = self.wprops.getAttribute(elem, "buttonGroup")
+            if bg_i18n is not None:
+                if isinstance(bg_i18n, str):
+                    bg_name = bg_i18n
+                else:
+                    bg_name = bg_i18n.string
+
+                for bg in self.button_groups:
+                    if bg.objectName() == bg_name:
+                        break
+                else:
+                    bg = self.factory.createQObject("QButtonGroup", bg_name,
+                            (self.toplevelWidget, ))
+                    bg.setObjectName(bg_name)
+                    self.button_groups.append(bg)
+
+                bg.addButton(widget)
+
+        if self.sorting_enabled is not None:
+            widget.setSortingEnabled(self.sorting_enabled)
+            self.sorting_enabled = None
+
+        if self.stack.topIsLayout():
+            lay = self.stack.peek()
+            gp = elem.attrib["grid-position"]
+
+            if isinstance(lay, QtWidgets.QFormLayout):
+                lay.setWidget(gp[0], self._form_layout_role(gp), widget)
+            else:
+                lay.addWidget(widget, *gp)
+
+        topwidget = self.stack.topwidget
+
+        if isinstance(topwidget, QtWidgets.QToolBox):
+            icon = self.wprops.getAttribute(elem, "icon")
+            if icon is not None:
+                topwidget.addItem(widget, icon, self.wprops.getAttribute(elem, "label"))
+            else:
+                topwidget.addItem(widget, self.wprops.getAttribute(elem, "label"))
+
+            tooltip = self.wprops.getAttribute(elem, "toolTip")
+            if tooltip is not None:
+                topwidget.setItemToolTip(topwidget.indexOf(widget), tooltip)
+
+        elif isinstance(topwidget, QtWidgets.QTabWidget):
+            icon = self.wprops.getAttribute(elem, "icon")
+            if icon is not None:
+                topwidget.addTab(widget, icon, self.wprops.getAttribute(elem, "title"))
+            else:
+                topwidget.addTab(widget, self.wprops.getAttribute(elem, "title"))
+
+            tooltip = self.wprops.getAttribute(elem, "toolTip")
+            if tooltip is not None:
+                topwidget.setTabToolTip(topwidget.indexOf(widget), tooltip)
+
+        elif isinstance(topwidget, QtWidgets.QWizard):
+            topwidget.addPage(widget)
+
+        elif isinstance(topwidget, QtWidgets.QStackedWidget):
+            topwidget.addWidget(widget)
+
+        elif isinstance(topwidget, (QtWidgets.QDockWidget, QtWidgets.QScrollArea)):
+            topwidget.setWidget(widget)
+
+        elif isinstance(topwidget, QtWidgets.QMainWindow):
+            if type(widget) == QtWidgets.QWidget:
+                topwidget.setCentralWidget(widget)
+            elif isinstance(widget, QtWidgets.QToolBar):
+                tbArea = self.wprops.getAttribute(elem, "toolBarArea")
+
+                if tbArea is None:
+                    topwidget.addToolBar(widget)
+                else:
+                    topwidget.addToolBar(tbArea, widget)
+
+                tbBreak = self.wprops.getAttribute(elem, "toolBarBreak")
+
+                if tbBreak:
+                    topwidget.insertToolBarBreak(widget)
+
+            elif isinstance(widget, QtWidgets.QMenuBar):
+                topwidget.setMenuBar(widget)
+            elif isinstance(widget, QtWidgets.QStatusBar):
+                topwidget.setStatusBar(widget)
+            elif isinstance(widget, QtWidgets.QDockWidget):
+                dwArea = self.wprops.getAttribute(elem, "dockWidgetArea")
+                topwidget.addDockWidget(QtCore.Qt.DockWidgetArea(dwArea),
+                        widget)
+
+    def handleHeaderView(self, elem, name, header):
+        value = self.wprops.getAttribute(elem, name + "Visible")
+        if value is not None:
+            header.setVisible(value)
+
+        value = self.wprops.getAttribute(elem, name + "CascadingSectionResizes")
+        if value is not None:
+            header.setCascadingSectionResizes(value)
+
+        value = self.wprops.getAttribute(elem, name + "DefaultSectionSize")
+        if value is not None:
+            header.setDefaultSectionSize(value)
+
+        value = self.wprops.getAttribute(elem, name + "HighlightSections")
+        if value is not None:
+            header.setHighlightSections(value)
+
+        value = self.wprops.getAttribute(elem, name + "MinimumSectionSize")
+        if value is not None:
+            header.setMinimumSectionSize(value)
+
+        value = self.wprops.getAttribute(elem, name + "ShowSortIndicator")
+        if value is not None:
+            header.setSortIndicatorShown(value)
+
+        value = self.wprops.getAttribute(elem, name + "StretchLastSection")
+        if value is not None:
+            header.setStretchLastSection(value)
+
+    def createSpacer(self, elem):
+        width = elem.findtext("property/size/width")
+        height = elem.findtext("property/size/height")
+
+        if width is None or height is None:
+            size_args = ()
+        else:
+            size_args = (int(width), int(height))
+
+        sizeType = self.wprops.getProperty(elem, "sizeType",
+                QtWidgets.QSizePolicy.Expanding)
+
+        policy = (QtWidgets.QSizePolicy.Minimum, sizeType)
+
+        if self.wprops.getProperty(elem, "orientation") == QtCore.Qt.Horizontal:
+            policy = policy[1], policy[0]
+
+        spacer = self.factory.createQObject("QSpacerItem",
+                self.uniqueName("spacerItem"), size_args + policy,
+                is_attribute=False)
+
+        if self.stack.topIsLayout():
+            lay = self.stack.peek()
+            gp = elem.attrib["grid-position"]
+
+            if isinstance(lay, QtWidgets.QFormLayout):
+                lay.setItem(gp[0], self._form_layout_role(gp), spacer)
+            else:
+                lay.addItem(spacer, *gp)
+
+    def createLayout(self, elem):
+        # Qt v4.3 introduced setContentsMargins() and separate values for each
+        # of the four margins which are specified as separate properties.  This
+        # doesn't really fit the way we parse the tree (why aren't the values
+        # passed as attributes of a single property?) so we create a new
+        # property and inject it.  However, if we find that they have all been
+        # specified and have the same value then we inject a different property
+        # that is compatible with older versions of Qt.
+        left = self.wprops.getProperty(elem, 'leftMargin', -1)
+        top = self.wprops.getProperty(elem, 'topMargin', -1)
+        right = self.wprops.getProperty(elem, 'rightMargin', -1)
+        bottom = self.wprops.getProperty(elem, 'bottomMargin', -1)
+
+        # Count the number of properties and if they had the same value.
+        def comp_property(m, so_far=-2, nr=0):
+            if m >= 0:
+                nr += 1
+
+                if so_far == -2:
+                    so_far = m
+                elif so_far != m:
+                    so_far = -1
+
+            return so_far, nr
+
+        margin, nr_margins = comp_property(left)
+        margin, nr_margins = comp_property(top, margin, nr_margins)
+        margin, nr_margins = comp_property(right, margin, nr_margins)
+        margin, nr_margins = comp_property(bottom, margin, nr_margins)
+
+        if nr_margins > 0:
+            if nr_margins == 4 and margin >= 0:
+                # We can inject the old margin property.
+                me = SubElement(elem, 'property', name='margin')
+                SubElement(me, 'number').text = str(margin)
+            else:
+                # We have to inject the new internal property.
+                cme = SubElement(elem, 'property', name='pyuicContentsMargins')
+                SubElement(cme, 'number').text = str(left)
+                SubElement(cme, 'number').text = str(top)
+                SubElement(cme, 'number').text = str(right)
+                SubElement(cme, 'number').text = str(bottom)
+        elif self.layout_widget:
+            margin = self.wprops.getProperty(elem, 'margin', -1)
+            if margin < 0:
+                # The layouts of layout widgets have no margin.
+                me = SubElement(elem, 'property', name='margin')
+                SubElement(me, 'number').text = '0'
+
+            # In case there are any nested layouts.
+            self.layout_widget = False
+
+        # We do the same for setHorizontalSpacing() and setVerticalSpacing().
+        horiz = self.wprops.getProperty(elem, 'horizontalSpacing', -1)
+        vert = self.wprops.getProperty(elem, 'verticalSpacing', -1)
+
+        if horiz >= 0 or vert >= 0:
+            # We inject the new internal property.
+            cme = SubElement(elem, 'property', name='pyuicSpacing')
+            SubElement(cme, 'number').text = str(horiz)
+            SubElement(cme, 'number').text = str(vert)
+
+        classname = elem.attrib["class"]
+        if self.stack.topIsLayout():
+            parent = None
+        else:
+            parent = self.stack.topwidget
+        if "name" not in elem.attrib:
+            elem.attrib["name"] = classname[1:].lower()
+        self.stack.push(self.setupObject(classname, parent, elem))
+        self.traverseWidgetTree(elem)
+
+        layout = self.stack.popLayout()
+        self.configureLayout(elem, layout)
+
+        if self.stack.topIsLayout():
+            top_layout = self.stack.peek()
+            gp = elem.attrib["grid-position"]
+
+            if isinstance(top_layout, QtWidgets.QFormLayout):
+                top_layout.setLayout(gp[0], self._form_layout_role(gp), layout)
+            else:
+                top_layout.addLayout(layout, *gp)
+
+    def configureLayout(self, elem, layout):
+        if isinstance(layout, QtWidgets.QGridLayout):
+            self.setArray(elem, 'columnminimumwidth',
+                    layout.setColumnMinimumWidth)
+            self.setArray(elem, 'rowminimumheight',
+                    layout.setRowMinimumHeight)
+            self.setArray(elem, 'columnstretch', layout.setColumnStretch)
+            self.setArray(elem, 'rowstretch', layout.setRowStretch)
+
+        elif isinstance(layout, QtWidgets.QBoxLayout):
+            self.setArray(elem, 'stretch', layout.setStretch)
+
+    def setArray(self, elem, name, setter):
+        array = elem.attrib.get(name)
+        if array:
+            for idx, value in enumerate(array.split(',')):
+                value = int(value)
+                if value > 0:
+                    setter(idx, value)
+
+    def handleItem(self, elem):
+        if self.stack.topIsLayout():
+            elem[0].attrib["grid-position"] = gridPosition(elem)
+            self.traverseWidgetTree(elem)
+        else:
+            w = self.stack.topwidget
+
+            if isinstance(w, QtWidgets.QComboBox):
+                text = self.wprops.getProperty(elem, "text")
+                icon = self.wprops.getProperty(elem, "icon")
+
+                if icon:
+                    w.addItem(icon, '')
+                else:
+                    w.addItem('')
+
+                w.setItemText(self.item_nr, text)
+
+            elif isinstance(w, QtWidgets.QListWidget):
+                text = self.wprops.getProperty(elem, "text")
+                icon = self.wprops.getProperty(elem, "icon")
+                flags = self.wprops.getProperty(elem, "flags")
+                check_state = self.wprops.getProperty(elem, "checkState")
+                background = self.wprops.getProperty(elem, "background")
+                foreground = self.wprops.getProperty(elem, "foreground")
+
+                if icon or flags or check_state:
+                    item_name = "item"
+                else:
+                    item_name = None
+
+                item = self.factory.createQObject("QListWidgetItem", item_name,
+                        (w, ), False)
+
+                if self.item_nr == 0:
+                    self.sorting_enabled = self.factory.invoke("__sortingEnabled", w.isSortingEnabled)
+                    w.setSortingEnabled(False)
+
+                if text:
+                    w.item(self.item_nr).setText(text)
+
+                if icon:
+                    item.setIcon(icon)
+
+                if flags:
+                    item.setFlags(flags)
+
+                if check_state:
+                    item.setCheckState(check_state)
+
+                if background:
+                    item.setBackground(background)
+
+                if foreground:
+                    item.setForeground(foreground)
+
+            elif isinstance(w, QtWidgets.QTreeWidget):
+                if self.itemstack:
+                    parent, _ = self.itemstack[-1]
+                    _, nr_in_root = self.itemstack[0]
+                else:
+                    parent = w
+                    nr_in_root = self.item_nr
+
+                item = self.factory.createQObject("QTreeWidgetItem",
+                        "item_%d" % len(self.itemstack), (parent, ), False)
+
+                if self.item_nr == 0 and not self.itemstack:
+                    self.sorting_enabled = self.factory.invoke("__sortingEnabled", w.isSortingEnabled)
+                    w.setSortingEnabled(False)
+
+                self.itemstack.append((item, self.item_nr))
+                self.item_nr = 0
+
+                # We have to access the item via the tree when setting the
+                # text.
+                titm = w.topLevelItem(nr_in_root)
+                for child, nr_in_parent in self.itemstack[1:]:
+                    titm = titm.child(nr_in_parent)
+
+                column = -1
+                for prop in elem.findall("property"):
+                    c_prop = self.wprops.convert(prop)
+                    c_prop_name = prop.attrib["name"]
+
+                    if c_prop_name == "text":
+                        column += 1
+                        if c_prop:
+                            titm.setText(column, c_prop)
+                    elif c_prop_name == "icon":
+                        item.setIcon(column, c_prop)
+                    elif c_prop_name == "flags":
+                        item.setFlags(c_prop)
+                    elif c_prop_name == "checkState":
+                        item.setCheckState(column, c_prop)
+                    elif c_prop_name == "background":
+                        item.setBackground(column, c_prop)
+                    elif c_prop_name == "foreground":
+                        item.setForeground(column, c_prop)
+
+                self.traverseWidgetTree(elem)
+                _, self.item_nr = self.itemstack.pop()
+
+            elif isinstance(w, QtWidgets.QTableWidget):
+                text = self.wprops.getProperty(elem, "text")
+                icon = self.wprops.getProperty(elem, "icon")
+                flags = self.wprops.getProperty(elem, "flags")
+                check_state = self.wprops.getProperty(elem, "checkState")
+                background = self.wprops.getProperty(elem, "background")
+                foreground = self.wprops.getProperty(elem, "foreground")
+
+                item = self.factory.createQObject("QTableWidgetItem", "item",
+                        (), False)
+
+                if self.item_nr == 0:
+                    self.sorting_enabled = self.factory.invoke("__sortingEnabled", w.isSortingEnabled)
+                    w.setSortingEnabled(False)
+
+                row = int(elem.attrib["row"])
+                col = int(elem.attrib["column"])
+
+                if icon:
+                    item.setIcon(icon)
+
+                if flags:
+                    item.setFlags(flags)
+
+                if check_state:
+                    item.setCheckState(check_state)
+
+                if background:
+                    item.setBackground(background)
+
+                if foreground:
+                    item.setForeground(foreground)
+
+                w.setItem(row, col, item)
+
+                if text:
+                    # Text is translated so we don't have access to the item
+                    # attribute when generating code so we must get it from the
+                    # widget after it has been set.
+                    w.item(row, col).setText(text)
+
+            self.item_nr += 1
+
+    def addAction(self, elem):
+        self.actions.append((self.stack.topwidget, elem.attrib["name"]))
+
+    def addHeader(self, elem):
+        w = self.stack.topwidget
+
+        if isinstance(w, QtWidgets.QTreeWidget):
+            text = self.wprops.getProperty(elem, "text")
+            icon = self.wprops.getProperty(elem, "icon")
+
+            if text:
+                w.headerItem().setText(self.column_counter, text)
+
+            if icon:
+                w.headerItem().setIcon(self.column_counter, icon)
+
+            self.column_counter += 1
+
+        elif isinstance(w, QtWidgets.QTableWidget):
+            if len(elem) == 0:
+                return
+
+            text = self.wprops.getProperty(elem, "text")
+            icon = self.wprops.getProperty(elem, "icon")
+            whatsThis = self.wprops.getProperty(elem, "whatsThis")
+
+            item = self.factory.createQObject("QTableWidgetItem", "item",
+                        (), False)
+
+            if elem.tag == "column":
+                print(self.column_counter)
+                w.setHorizontalHeaderItem(self.column_counter, item)
+
+                if text:
+                    w.horizontalHeaderItem(self.column_counter).setText(text)
+
+                if icon:
+                    item.setIcon(icon)
+
+                if whatsThis:
+                    w.horizontalHeaderItem(self.column_counter).setWhatsThis(whatsThis)
+
+                self.column_counter += 1
+            elif elem.tag == "row":
+                w.setVerticalHeaderItem(self.row_counter, item)
+
+                if text:
+                    w.verticalHeaderItem(self.row_counter).setText(text)
+
+                if icon:
+                    item.setIcon(icon)
+
+                if whatsThis:
+                    w.verticalHeaderItem(self.row_counter).setWhatsThis(whatsThis)
+
+                self.row_counter += 1
+
+    def createAction(self, elem):
+        self.setupObject("QAction", self.currentActionGroup or self.toplevelWidget,
+                         elem)
+
+    def createActionGroup(self, elem):
+        action_group = self.setupObject("QActionGroup", self.toplevelWidget, elem)
+        self.currentActionGroup = action_group
+        self.traverseWidgetTree(elem)
+        self.currentActionGroup = None
+
+    widgetTreeItemHandlers = {
+        "widget"    : createWidget,
+        "addaction" : addAction,
+        "layout"    : createLayout,
+        "spacer"    : createSpacer,
+        "item"      : handleItem,
+        "action"    : createAction,
+        "actiongroup": createActionGroup,
+        "column"    : addHeader,
+        "row"       : addHeader,
+        }
+
+    def traverseWidgetTree(self, elem):
+        for child in iter(elem):
+            try:
+                handler = self.widgetTreeItemHandlers[child.tag]
+            except KeyError:
+                continue
+
+            handler(self, child)
+
+    def createUserInterface(self, elem):
+        # Get the names of the class and widget.
+        cname = elem.attrib["class"]
+        wname = elem.attrib["name"]
+
+        # If there was no widget name then derive it from the class name.
+        if not wname:
+            wname = cname
+
+            if wname.startswith("Q"):
+                wname = wname[1:]
+
+            wname = wname[0].lower() + wname[1:]
+
+        self.toplevelWidget = self.createToplevelWidget(cname, wname)
+        self.toplevelWidget.setObjectName(wname)
+        DEBUG("toplevel widget is %s",
+              self.toplevelWidget.metaObject().className())
+        self.wprops.setProperties(self.toplevelWidget, elem)
+        self.stack.push(self.toplevelWidget)
+        self.traverseWidgetTree(elem)
+        self.stack.popWidget()
+        self.addActions()
+        self.setBuddies()
+        self.setDelayedProps()
+
+    def addActions(self):
+        for widget, action_name in self.actions:
+            if action_name == "separator":
+                widget.addSeparator()
+            else:
+                DEBUG("add action %s to %s", action_name, widget.objectName())
+                action_obj = getattr(self.toplevelWidget, action_name)
+                if isinstance(action_obj, QtWidgets.QMenu):
+                    widget.addAction(action_obj.menuAction())
+                elif not isinstance(action_obj, QtWidgets.QActionGroup):
+                    widget.addAction(action_obj)
+
+    def setDelayedProps(self):
+        for widget, layout, setter, args in self.wprops.delayed_props:
+            if layout:
+                widget = widget.layout()
+
+            setter = getattr(widget, setter)
+            setter(args)
+
+    def setBuddies(self):
+        for widget, buddy in self.wprops.buddies:
+            DEBUG("%s is buddy of %s", buddy, widget.objectName())
+            try:
+                widget.setBuddy(getattr(self.toplevelWidget, buddy))
+            except AttributeError:
+                DEBUG("ERROR in ui spec: %s (buddy of %s) does not exist",
+                      buddy, widget.objectName())
+
+    def classname(self, elem):
+        DEBUG("uiname is %s", elem.text)
+        name = elem.text
+
+        if name is None:
+            name = ""
+
+        self.uiname = name
+        self.wprops.uiname = name
+        self.setContext(name)
+
+    def setContext(self, context):
+        """
+        Reimplemented by a sub-class if it needs to know the translation
+        context.
+        """
+        pass
+
+    def readDefaults(self, elem):
+        self.defaults["margin"] = int(elem.attrib["margin"])
+        self.defaults["spacing"] = int(elem.attrib["spacing"])
+
+    def setTaborder(self, elem):
+        lastwidget = None
+        for widget_elem in elem:
+            widget = getattr(self.toplevelWidget, widget_elem.text)
+
+            if lastwidget is not None:
+                self.toplevelWidget.setTabOrder(lastwidget, widget)
+
+            lastwidget = widget
+
+    def readResources(self, elem):
+        """
+        Read a "resources" tag and add the module to import to the parser's
+        list of them.
+        """
+        for include in elem.getiterator("include"):
+            loc = include.attrib.get("location")
+
+            # Assume our convention for naming the Python files generated by
+            # pyrcc4.
+            if loc and loc.endswith('.qrc'):
+                self.resources.append(os.path.basename(loc[:-4] + '_rc'))
+
+    def createConnections(self, elem):
+        def name2object(obj):
+            if obj == self.uiname:
+                return self.toplevelWidget
+            else:
+                return getattr(self.toplevelWidget, obj)
+        for conn in iter(elem):
+            QtCore.QObject.connect(name2object(conn.findtext("sender")),
+                                   QtCore.SIGNAL(conn.findtext("signal")),
+                                   self.factory.getSlot(name2object(conn.findtext("receiver")),
+                                                    conn.findtext("slot").split("(")[0]))
+        QtCore.QMetaObject.connectSlotsByName(self.toplevelWidget)
+
+    def customWidgets(self, elem):
+        def header2module(header):
+            """header2module(header) -> string
+
+            Convert paths to C++ header files to according Python modules
+            >>> header2module("foo/bar/baz.h")
+            'foo.bar.baz'
+            """
+            if header.endswith(".h"):
+                header = header[:-2]
+
+            mpath = []
+            for part in header.split('/'):
+                # Ignore any empty parts or those that refer to the current
+                # directory.
+                if part not in ('', '.'):
+                    if part == '..':
+                        # We should allow this for Python3.
+                        raise SyntaxError("custom widget header file name may not contain '..'.")
+
+                    mpath.append(part)
+
+            return '.'.join(mpath)
+
+        for custom_widget in iter(elem):
+            classname = custom_widget.findtext("class")
+            if classname.startswith("Q3"):
+                raise NoSuchWidgetError(classname)
+            self.factory.addCustomWidget(classname,
+                                     custom_widget.findtext("extends") or "QWidget",
+                                     header2module(custom_widget.findtext("header")))
+
+    def createToplevelWidget(self, classname, widgetname):
+        raise NotImplementedError
+
+    # finalize will be called after the whole tree has been parsed and can be
+    # overridden.
+    def finalize(self):
+        pass
+
+    def parse(self, filename, base_dir=''):
+        self.wprops.set_base_dir(base_dir)
+
+        # The order in which the different branches are handled is important.
+        # The widget tree handler relies on all custom widgets being known, and
+        # in order to create the connections, all widgets have to be populated.
+        branchHandlers = (
+            ("layoutdefault", self.readDefaults),
+            ("class",         self.classname),
+            ("customwidgets", self.customWidgets),
+            ("widget",        self.createUserInterface),
+            ("connections",   self.createConnections),
+            ("tabstops",      self.setTaborder),
+            ("resources",     self.readResources),
+        )
+
+        document = parse(filename)
+        version = document.getroot().attrib["version"]
+        DEBUG("UI version is %s" % (version,))
+        # Right now, only version 4.0 is supported.
+        assert version in ("4.0",)
+        for tagname, actor in branchHandlers:
+            elem = document.find(tagname)
+            if elem is not None:
+                actor(elem)
+        self.finalize()
+        w = self.toplevelWidget
+        self.reset()
+        return w
+
+    @staticmethod
+    def _form_layout_role(grid_position):
+        if grid_position[3] > 1:
+            role = QtWidgets.QFormLayout.SpanningRole
+        elif grid_position[1] == 1:
+            role = QtWidgets.QFormLayout.FieldRole
+        else:
+            role = QtWidgets.QFormLayout.LabelRole
+
+        return role

--- a/pyqtgraph/util/pyside2uic/uiparser.py
+++ b/pyqtgraph/util/pyside2uic/uiparser.py
@@ -31,9 +31,9 @@ except ImportError:
     from xml.etree.ElementTree import parse, SubElement
 
 
-from pyside2uic.exceptions import NoSuchWidgetError
-from pyside2uic.objcreator import QObjectCreator
-from pyside2uic.properties import Properties
+from .exceptions import NoSuchWidgetError
+from .objcreator import QObjectCreator
+from .properties import Properties
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This fixes #1102 by copying pyside2uic out of pyside2 v5.13 and embedding it inside pyqtgraph.util. 
I have also copied the license file from https://code.qt.io/cgit/pyside/pyside-tools.git/tree/LICENSE-uic, which is dual BSD/GPL. I have no idea what legal repercussions this has (if any) for pyqtgraph users.

This solution makes me squirm, so I am leaving it here for discussion and review. I don't immediately see anything better, though. As far as I can tell, there is no replacement in pyside2 5.14 for the `loadUiType` functionality that was lost when they dropped pyside2uic (and furthermore the new ui compiler chokes on `examples/designerExample.ui`).

Another possible fix is just to declare pyqtgraph's incompatibility with 5.14 (actually the last version I could find that worked at all was 5.11) in some way. Maybe this can be done in setup.py, or maybe we can just raise an exception recommending 5.11.