### PR TITLE
GraphicsObject.py, GraphicsObject().itemChange():

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsObject.py
+++ b/pyqtgraph/graphicsItems/GraphicsObject.py
@@ -18,6 +18,8 @@ class GraphicsObject(GraphicsItem, QtGui.QGraphicsObject):
         GraphicsItem.__init__(self)
         
     def itemChange(self, change, value):
+        if value == QtCore.QVariant():
+            value = None
         ret = QtGui.QGraphicsObject.itemChange(self, change, value)
         if change in [self.ItemParentHasChanged, self.ItemSceneHasChanged]:
             self.parentChanged()


### PR DESCRIPTION
fixes "TypeError: unable to convert a QVariant back to a Python object" by replacing value == QtCore.QVariant() with None