### PR TITLE
Pass showAxRect keyword arguments to setRange

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1303,8 +1303,11 @@ class ViewBox(GraphicsWidget):
         self.rbScaleBox.scale(r.width(), r.height())
         self.rbScaleBox.show()
 
-    def showAxRect(self, ax):
-        self.setRange(ax.normalized()) # be sure w, h are correct coordinates
+    def showAxRect(self, ax, **kwargs):
+        """Set the visible range to the given rectangle
+        Passes keyword arguments to setRange
+        """
+        self.setRange(ax.normalized(), **kwargs) # be sure w, h are correct coordinates
         self.sigRangeChangedManually.emit(self.state['mouseEnabled'])
 
     def allChildren(self, item=None):


### PR DESCRIPTION
Subclasses of ViewBox may wish to, for example, set padding when executing a scale or translation.