### PR TITLE
fix bug of add context menu to dockarea cause crash and give float dock a window title

### DIFF
--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -323,14 +323,16 @@ class DockLabel(VerticalLabel):
             ev.accept()
         
     def mouseMoveEvent(self, ev):
-        if not self.startedDrag and (ev.pos() - self.pressPos).manhattanLength() > QtGui.QApplication.startDragDistance():
-            self.dock.startDrag()
+        if ev.button() == QtCore.Qt.LeftButton:
+            if not self.startedDrag and (ev.pos() - self.pressPos).manhattanLength() > QtGui.QApplication.startDragDistance():
+                self.dock.startDrag()
         ev.accept()
             
     def mouseReleaseEvent(self, ev):
         ev.accept()
-        if not self.startedDrag:
-            self.sigClicked.emit(self, ev)
+        if ev.button() == QtCore.Qt.LeftButton:
+            if not self.startedDrag:
+                self.sigClicked.emit(self, ev)
         
     def mouseDoubleClickEvent(self, ev):
         if ev.button() == QtCore.Qt.LeftButton:

--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -179,6 +179,7 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
         """Removes *dock* from this DockArea and places it in a new window."""
         area = self.addTempArea()
         area.win.resize(dock.size())
+        area.win.setWindowTitle(dock.title())
         area.moveDock(dock, 'top', None)
         
     def removeTempArea(self, area):
@@ -319,7 +320,7 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
         #print "apoptose area:", self.temporary, self.topContainer, self.topContainer.count()
         if self.topContainer is None or self.topContainer.count() == 0:
             self.topContainer = None
-            if self.temporary:
+            if self.temporary and self.home::
                 self.home.removeTempArea(self)
                 #self.close()
                 


### PR DESCRIPTION
1. when float a dock, change the window title of dock to dock name, not the default "python";
2. when add contextmenu to dockarea, using the mouse right button will make the app crash, need to detinguish which mouse button event to make sure only the left button is using for drag and release
3. when closing the last dock of the dockarea, the dockarae.home change to None, removeTempArea make the app crash, need to check the home first.