### PR TITLE
SVGExporter: Correct image pixelation.

### DIFF
--- a/pyqtgraph/exporters/SVGExporter.py
+++ b/pyqtgraph/exporters/SVGExporter.py
@@ -69,6 +69,13 @@ xmlHeader = """\
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  version="1.2" baseProfile="tiny">
 <title>pyqtgraph SVG export</title>
 <desc>Generated with Qt and pyqtgraph</desc>
+<style>
+    image {
+        image-rendering: crisp-edges;
+        image-rendering: -moz-crisp-edges;
+        image-rendering: pixelated;
+    }
+</style>
 """
 
 def generateSvg(item, options={}):


### PR DESCRIPTION
This PR adds the following tag to every exported SVG:

```
<style>
    image {
        image-rendering: crisp-edges;
        image-rendering: -moz-crisp-edges;
        image-rendering: pixelated;
    }
</style>
```
This is needed because otherwise, pixel images are interpolated. See example in #1155.

The correct way according to CSS specifications would be to use `image-rendering: pixelated`, as seen in e.g. https://developer.mozilla.org/de/docs/Web/CSS/image-rendering or https://stackoverflow.com/a/25278886/8575607. As seen in the first link, `pixelated` is not supported by e.g. Firefox. Therefore, to keep compatibility, all the applicable image-rendering options are given in inverse preference order. I tested this to work with Inkscape, Firefox and Chromium.

An example for this PR with screenshots from Inkscape is given in #1155.

Fixes #1155.