### PR TITLE
Fix: Update axes after data is set

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -365,11 +365,12 @@ class PlotCurveItem(GraphicsObject):
 
         #self.setCacheMode(QtGui.QGraphicsItem.NoCache)  ## Disabling and re-enabling the cache works around a bug in Qt 4.6 causing the cached results to display incorrectly
                                                         ##    Test this bug with test_PlotWidget and zoom in on the animated plot
+        self.yData = kargs['y'].view(np.ndarray)
+        self.xData = kargs['x'].view(np.ndarray)
+        
         self.invalidateBounds()
         self.prepareGeometryChange()
         self.informViewBoundsChanged()
-        self.yData = kargs['y'].view(np.ndarray)
-        self.xData = kargs['x'].view(np.ndarray)
 
         profiler('copy')
 


### PR DESCRIPTION
On data changes on PlotCurveItems, bounds are updated before the new data is set, leading to axes not performing autoscaling directly. This PR changes the order of execution for setting data and updating bounds to fix that.

Fixes #1144