### PR TITLE
[Discussion] How to proceed with failing pyqtgraph exit test

### DIFF
--- a/pyqtgraph/tests/test_exit_crash.py
+++ b/pyqtgraph/tests/test_exit_crash.py
@@ -76,5 +76,5 @@ def test_pg_exit():
         pg.plot()
         pg.exit()
     """)
-    rc = call_with_timeout([sys.executable, '-c', code], timeout=5, shell=False)
+    rc = call_with_timeout([sys.executable, '-c', code], timeout=10, shell=False)
     assert rc == 0


### PR DESCRIPTION
test_pg_exit fails inconsistently, as seen in #1159. It seems like PyQtGraph is not exiting in time, which would be fixed by increasing the timeout for that test, which is what this PR aims at.

This is just a quick suggestion and open for discussion! A counter-argument would be that we then no longer test whether PyQtGraph exits *fast*.

As @j9ac9k pointed out in #1159, this failure was also observed by @ixjlyons . Does someone have any input on this?

[Edit] Update: The pipelines indicate that this fix did not work.