### PR TITLE
pg.mkQApp: Pass non-empty string array to QApplication() as default

### DIFF
--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -329,9 +329,18 @@ if m is not None and list(map(int, m.groups())) < versionReq:
 
 
 QAPP = None
-def mkQApp():
-    global QAPP    
+def mkQApp(name="pyqtgraph", qt_args=[]):
+    """
+    Creates new QApplication or returns current instance if existing.
+    
+    ==============  =================================================================================
+    **Arguments:**
+    name            Application name, passed to Qt
+    qt_args         Array of command line arguments passed to Qt
+    ==============  =================================================================================
+    """
+    global QAPP
     QAPP = QtGui.QApplication.instance()
     if QAPP is None:
-        QAPP = QtGui.QApplication([])
+        QAPP = QtGui.QApplication([name] + qt_args)
     return QAPP


### PR DESCRIPTION
According to Qt documentation, the `QApplication` initializer should never be called with an empty array: See warning in https://doc.qt.io/qt-5/qapplication.html#QApplication .
This manifests in a warning being printed to the console:
```
QSettings::value: Empty key passed
QSettings::value: Empty key passed
```

This PR changes `pg.mkQApp()` to pass "pyqtgraph" as application name and adds parameters to pass a different name and Qt command line arguments.
Further, some documentation to the function is added.

I do not know what the status of this function is, but I find it very convenient. Most examples use `QApplication([])` though, generating said warning. Therefore if this idea finds support, I'd extend this PR to replace every call to `QApplication([])` by `pg.mkQApp`, removing unnecessary warnings arising when launching the examples.

Fixes #1165.