### PR TITLE
GraphicsLayout: Always call processEvents after adding items

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsLayout.py
+++ b/pyqtgraph/graphicsItems/GraphicsLayout.py
@@ -134,6 +134,8 @@ class GraphicsLayout(GraphicsWidget):
         item.geometryChanged.connect(self._updateItemBorder)
 
         self.layout.addItem(item, row, col, rowspan, colspan)
+        QtGui.QApplication.processEvents() # Process events, propagating element sizes
+        
         self.nextColumn()
 
     def getItem(self, row, col):


### PR DESCRIPTION
Items added to a `GraphicsLayout` need a call to `processEvents` to receive their size information.
Needing to call `processEvents` is unintuitive, leading to multiple issues (see below).
This commit fixes that by always calling `processEvents` after adding items.

Fixes #8
Fixes #1136