### PR TITLE
GroupParameterItem: Did not pass changed options to ParameterItem

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -437,8 +437,10 @@ class GroupParameterItem(ParameterItem):
         else:
             ParameterItem.addChild(self, child)
             
-    def optsChanged(self, param, changed):
-        if 'addList' in changed:
+    def optsChanged(self, param, opts):
+        ParameterItem.optsChanged(self, param, opts)
+        
+        if 'addList' in opts:
             self.updateAddList()
                 
     def updateAddList(self):


### PR DESCRIPTION
`ParameterItem` handles visibility changes in `optsChanged`. 
`GroupParameterItem` overrides this function, but never calls
the super function, resulting in visibility changes not being
applied. This PR fixes this by calling said function.

Fixes #788