### PR TITLE
GraphicsLayout: Always call layout.activate() after adding items

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsLayout.py
+++ b/pyqtgraph/graphicsItems/GraphicsLayout.py
@@ -134,6 +134,9 @@ class GraphicsLayout(GraphicsWidget):
         item.geometryChanged.connect(self._updateItemBorder)
 
         self.layout.addItem(item, row, col, rowspan, colspan)
+        self.layout.activate() # Update layout, recalculating bounds.
+                               # Allows some PyQtGraph features to also work without Qt event loop.
+        
         self.nextColumn()
 
     def getItem(self, row, col):


### PR DESCRIPTION
When items are added to a `GraphicsLayout` items in the layout only learn their updated size information after the internal `QGraphicsGridLayout` recalculates the layout.
This is happening as a slot in the Qt event queue.
Not having updated geometry bounds directly after adding an item leads to multiple issues when not executing the Qt event loop in time (see below). This commit fixes that by always calling `layout.activate()` after adding items, updating item sizes directly.

This is a follow-up to PR #1167, where introducing a direct call to `processEvents` was suspected to be able to cause side effects.

Notifying @j9ac9k and @campagnola, as they were involved in #1167.

Testing code used next to MWE from issues below:
```python3
import pyqtgraph as pg
pg.mkQApp()

win = pg.GraphicsLayoutWidget()
win.show()

p1 = pg.PlotItem()
p2 = pg.PlotItem()
win.addItem(p1, None, None, 1, 1)
win.resize(800,800)
win.addItem(p2, None, None, 1, 1)
# pg.QtGui.QApplication.processEvents() # <-- workaround
print(p1.boundingRect()) # Should return something slightly smaller than (0,0,400,800)
print(p2.boundingRect()) # Should return something slightly smaller than (0,0,400,800)
```

Fixes #8
Fixes #1136