### PR TITLE
Fixed a possible race condition with linked views

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1098,23 +1098,26 @@ class AxisItem(GraphicsWidget):
             self._updateHeight()
 
     def wheelEvent(self, ev):
-        if self.linkedView() is None:
+        lv = self.linkedView()
+        if lv is None:
             return
         if self.orientation in ['left', 'right']:
-            self.linkedView().wheelEvent(ev, axis=1)
+            lv.wheelEvent(ev, axis=1)
         else:
-            self.linkedView().wheelEvent(ev, axis=0)
+            lv.wheelEvent(ev, axis=0)
         ev.accept()
 
     def mouseDragEvent(self, event):
-        if self.linkedView() is None:
+        lv = self.linkedView()
+        if lv is None:
             return
         if self.orientation in ['left', 'right']:
-            return self.linkedView().mouseDragEvent(event, axis=1)
+            return lv.mouseDragEvent(event, axis=1)
         else:
-            return self.linkedView().mouseDragEvent(event, axis=0)
+            return lv.mouseDragEvent(event, axis=0)
 
     def mouseClickEvent(self, event):
-        if self.linkedView() is None:
+        lv = self.linkedView()
+        if lv is None:
             return
-        return self.linkedView().mouseClickEvent(event)
+        return lv.mouseClickEvent(event)


### PR DESCRIPTION
The `linkedView()`-function of the `AxisItem` uses the attribute `_linkedView`, which is a weakref (or `None`). The current implementation of the changed event-handlers leaves a small timeframe for the corresponding viewbox to be deleted after the check against `None` but before being used. This is remedied by introducing a temporary local variable `lv`, which holds a strong reference, thereby preventing the deletion while the function is running.

I did not actually experience any crashes due to that issue and producing an error-case would be probably very hard, since the timeframe is very small and the problem can only appear if the gc is working on a different thread. However, the problem exists in theory and this fix is the clean solution to it.