### PR TITLE
Fix: Parameter tree ignores user-set 'expanded' state

### DIFF
--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -135,9 +135,12 @@ class Parameter(QtCore.QObject):
                                      (default=False)
         removable                    If True, the user may remove this Parameter.
                                      (default=False)
-        expanded                     If True, the Parameter will appear expanded when
-                                     displayed in a ParameterTree (its children will be
-                                     visible). (default=True)
+        expanded                     If True, the Parameter will initially be expanded in
+                                     ParameterTrees: Its children will be visible.
+                                     (default=True)
+        syncExpanded                 If True, the `expanded` state of this Parameter is
+                                     synchronized with all ParameterTrees it is displayed in.
+                                     (default=False)
         title                        (str or None) If specified, then the parameter will be 
                                      displayed to the user using this string as its name. 
                                      However, the parameter will still be referred to 
@@ -159,6 +162,7 @@ class Parameter(QtCore.QObject):
             'removable': False,
             'strictNaming': False,  # forces name to be usable as a python variable
             'expanded': True,
+            'syncExpanded': False,
             'title': None,
             #'limits': None,  ## This is a bad plan--each parameter type may have a different data type for limits.
         }
@@ -453,7 +457,7 @@ class Parameter(QtCore.QObject):
         Set any arbitrary options on this parameter.
         The exact behavior of this function will depend on the parameter type, but
         most parameters will accept a common set of options: value, name, limits,
-        default, readonly, removable, renamable, visible, enabled, and expanded.
+        default, readonly, removable, renamable, visible, enabled, expanded and syncExpanded.
         
         See :func:`Parameter.__init__ <pyqtgraph.parametertree.Parameter.__init__>`
         for more information on default options.

--- a/pyqtgraph/parametertree/ParameterItem.py
+++ b/pyqtgraph/parametertree/ParameterItem.py
@@ -146,10 +146,12 @@ class ParameterItem(QtGui.QTreeWidgetItem):
     def optsChanged(self, param, opts):
         """Called when any options are changed that are not
         name, value, default, or limits"""
-        #print opts
         if 'visible' in opts:
             self.setHidden(not opts['visible'])
         
+        if 'expanded' in opts:
+            self.setExpanded(opts['expanded'])
+    
     def editName(self):
         self.treeWidget().editItem(self, 0)
         

--- a/pyqtgraph/parametertree/ParameterItem.py
+++ b/pyqtgraph/parametertree/ParameterItem.py
@@ -175,6 +175,11 @@ class ParameterItem(QtGui.QTreeWidgetItem):
             if self.param.opts['syncExpanded']:
                 if self.isExpanded() != opts['expanded']:
                     self.setExpanded(opts['expanded'])
+        
+        if 'syncExpanded' in opts:
+            if opts['syncExpanded']:
+                if self.isExpanded() != self.param.opts['expanded']:
+                    self.setExpanded(self.param.opts['expanded'])
 
         self.updateFlags()
 

--- a/pyqtgraph/parametertree/ParameterItem.py
+++ b/pyqtgraph/parametertree/ParameterItem.py
@@ -129,6 +129,10 @@ class ParameterItem(QtGui.QTreeWidgetItem):
                 self.nameChanged(self, newName)  ## If the parameter rejects the name change, we need to set it back.
             finally:
                 self.ignoreNameColumnChange = False
+    
+    def expandedChangedEvent(self, expanded):
+        if self.param.opts['syncExpanded']:
+            self.param.setOpts(expanded=expanded)
                 
     def nameChanged(self, param, name):
         ## called when the parameter's name has changed.
@@ -150,7 +154,9 @@ class ParameterItem(QtGui.QTreeWidgetItem):
             self.setHidden(not opts['visible'])
         
         if 'expanded' in opts:
-            self.setExpanded(opts['expanded'])
+            if self.param.opts['syncExpanded']:
+                if self.isExpanded() != opts['expanded']:
+                    self.setExpanded(opts['expanded'])
     
     def editName(self):
         self.treeWidget().editItem(self, 0)

--- a/pyqtgraph/parametertree/ParameterTree.py
+++ b/pyqtgraph/parametertree/ParameterTree.py
@@ -28,6 +28,8 @@ class ParameterTree(TreeWidget):
         self.header().setResizeMode(QtGui.QHeaderView.ResizeToContents)
         self.setHeaderHidden(not showHeader)
         self.itemChanged.connect(self.itemChangedEvent)
+        self.itemExpanded.connect(self.itemExpandedEvent)
+        self.itemCollapsed.connect(self.itemCollapsedEvent)
         self.lastSel = None
         self.setRootIsDecorated(False)
         
@@ -134,6 +136,14 @@ class ParameterTree(TreeWidget):
     def itemChangedEvent(self, item, col):
         if hasattr(item, 'columnChangedEvent'):
             item.columnChangedEvent(col)
+    
+    def itemExpandedEvent(self, item):
+        if hasattr(item, 'expandedChangedEvent'):
+            item.expandedChangedEvent(True)
+    
+    def itemCollapsedEvent(self, item):
+        if hasattr(item, 'expandedChangedEvent'):
+            item.expandedChangedEvent(False)
             
     def selectionChanged(self, *args):
         sel = self.selectedItems()

--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -44,10 +44,6 @@ class WidgetParameterItem(ParameterItem):
         self.widget = w
         self.eventProxy = EventProxy(w, self.widgetEventFilter)
         
-        opts = self.param.opts
-        if 'tip' in opts:
-            w.setToolTip(opts['tip'])
-        
         self.defaultBtn = QtGui.QPushButton()
         self.defaultBtn.setFixedWidth(20)
         self.defaultBtn.setFixedHeight(20)
@@ -73,6 +69,7 @@ class WidgetParameterItem(ParameterItem):
             w.sigChanging.connect(self.widgetValueChanging)
             
         ## update value shown in widget. 
+        opts = self.param.opts
         if opts.get('value', None) is not None:
             self.valueChanged(self, opts['value'], force=True)
         else:
@@ -80,6 +77,8 @@ class WidgetParameterItem(ParameterItem):
             self.widgetValueChanged()
 
         self.updateDefaultBtn()
+        
+        self.optsChanged(self.param, self.param.opts)
 
     def makeWidget(self):
         """
@@ -279,6 +278,9 @@ class WidgetParameterItem(ParameterItem):
             self.updateDefaultBtn()
             if isinstance(self.widget, (QtGui.QCheckBox,ColorButton)):
                 self.widget.setEnabled(not opts['readonly'])
+        
+        if 'tip' in opts:
+            self.widget.setToolTip(opts['tip'])
         
         ## If widget is a SpinBox, pass options straight through
         if isinstance(self.widget, SpinBox):


### PR DESCRIPTION
When setting the 'expanded' state of parameters, this change is not applied
in the graphically visible tree. This commit changes that behaviour by
adding a clause in `ParameterItem.optsChanged` to react to that.

Also, an old and trivial out-commented debugging code line is removed.

Fixes #1130