### PR TITLE
DateAxisItem: AxisItem unlinking tests and doc fixed

### DIFF
--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from .AxisItem import AxisItem
 from ..pgcollections import OrderedDict
 
-__all__ = ['DateAxisItem', 'ZoomLevel']
+__all__ = ['DateAxisItem']
 
 MS_SPACING = 1/1000.0
 SECOND_SPACING = 1

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -260,9 +260,8 @@ class DateAxisItem(AxisItem):
         overriding this function or setting a different set of zoom levels
         than the default one. The `zoomLevels` variable is a dictionary with the
         maximal distance of ticks in seconds which are allowed for each zoom level
-        before the axis switches to the next coarser level. To create custom
-        zoom levels, override this function and provide custom `zoomLevelWidths` and
-        `zoomLevels`.
+        before the axis switches to the next coarser level. To customize the zoom level
+        selection, override this function.
         """
         padding = 10
         

--- a/pyqtgraph/graphicsItems/tests/test_AxisItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_AxisItem.py
@@ -30,3 +30,60 @@ def test_AxisItem_stopAxisAtTick(monkeypatch):
     plot.show()
     app.processEvents()
     plot.close()
+
+
+def test_AxisItem_viewUnlink(monkeypatch):
+    plot = pg.PlotWidget()
+    view = plot.plotItem.getViewBox()
+    axis = plot.getAxis("bottom")
+    assert axis.linkedView() == view
+    axis.linkToView(None)
+    assert axis.linkedView() is None
+
+
+class FakeSignal:
+
+    def __init__(self):
+        self.calls = []
+
+    def connect(self, *args, **kwargs):
+        self.calls.append('connect')
+
+    def disconnect(self, *args, **kwargs):
+        self.calls.append('disconnect')
+
+
+class FakeView:
+
+    def __init__(self):
+        self.sigYRangeChanged = FakeSignal()
+        self.sigXRangeChanged = FakeSignal()
+        self.sigResized = FakeSignal()
+
+
+def test_AxisItem_bottomRelink(monkeypatch):
+    axis = pg.AxisItem('bottom')
+    fake_view = FakeView()
+    axis.linkToView(fake_view)
+    assert axis.linkedView() == fake_view
+    assert fake_view.sigYRangeChanged.calls == []
+    assert fake_view.sigXRangeChanged.calls == ['connect']
+    assert fake_view.sigResized.calls == ['connect']
+    axis.linkToView(None)
+    assert fake_view.sigYRangeChanged.calls == []
+    assert fake_view.sigXRangeChanged.calls == ['connect', 'disconnect']
+    assert fake_view.sigResized.calls == ['connect', 'disconnect']
+
+
+def test_AxisItem_leftRelink(monkeypatch):
+    axis = pg.AxisItem('left')
+    fake_view = FakeView()
+    axis.linkToView(fake_view)
+    assert axis.linkedView() == fake_view
+    assert fake_view.sigYRangeChanged.calls == ['connect']
+    assert fake_view.sigXRangeChanged.calls == []
+    assert fake_view.sigResized.calls == ['connect']
+    axis.linkToView(None)
+    assert fake_view.sigYRangeChanged.calls == ['connect', 'disconnect']
+    assert fake_view.sigXRangeChanged.calls == []
+    assert fake_view.sigResized.calls == ['connect', 'disconnect']

--- a/pyqtgraph/graphicsItems/tests/test_AxisItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_AxisItem.py
@@ -32,7 +32,7 @@ def test_AxisItem_stopAxisAtTick(monkeypatch):
     plot.close()
 
 
-def test_AxisItem_viewUnlink(monkeypatch):
+def test_AxisItem_viewUnlink():
     plot = pg.PlotWidget()
     view = plot.plotItem.getViewBox()
     axis = plot.getAxis("bottom")
@@ -61,7 +61,7 @@ class FakeView:
         self.sigResized = FakeSignal()
 
 
-def test_AxisItem_bottomRelink(monkeypatch):
+def test_AxisItem_bottomRelink():
     axis = pg.AxisItem('bottom')
     fake_view = FakeView()
     axis.linkToView(fake_view)
@@ -75,7 +75,7 @@ def test_AxisItem_bottomRelink(monkeypatch):
     assert fake_view.sigResized.calls == ['connect', 'disconnect']
 
 
-def test_AxisItem_leftRelink(monkeypatch):
+def test_AxisItem_leftRelink():
     axis = pg.AxisItem('left')
     fake_view = FakeView()
     axis.linkToView(fake_view)

--- a/pyqtgraph/graphicsItems/tests/test_AxisItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_AxisItem.py
@@ -37,7 +37,7 @@ def test_AxisItem_viewUnlink(monkeypatch):
     view = plot.plotItem.getViewBox()
     axis = plot.getAxis("bottom")
     assert axis.linkedView() == view
-    axis.linkToView(None)
+    axis.unlinkFromView()
     assert axis.linkedView() is None
 
 
@@ -69,7 +69,7 @@ def test_AxisItem_bottomRelink(monkeypatch):
     assert fake_view.sigYRangeChanged.calls == []
     assert fake_view.sigXRangeChanged.calls == ['connect']
     assert fake_view.sigResized.calls == ['connect']
-    axis.linkToView(None)
+    axis.unlinkFromView()
     assert fake_view.sigYRangeChanged.calls == []
     assert fake_view.sigXRangeChanged.calls == ['connect', 'disconnect']
     assert fake_view.sigResized.calls == ['connect', 'disconnect']
@@ -83,7 +83,7 @@ def test_AxisItem_leftRelink(monkeypatch):
     assert fake_view.sigYRangeChanged.calls == ['connect']
     assert fake_view.sigXRangeChanged.calls == []
     assert fake_view.sigResized.calls == ['connect']
-    axis.linkToView(None)
+    axis.unlinkFromView()
     assert fake_view.sigYRangeChanged.calls == ['connect', 'disconnect']
     assert fake_view.sigXRangeChanged.calls == []
     assert fake_view.sigResized.calls == ['connect', 'disconnect']


### PR DESCRIPTION
This is a small follow-up to #1154. It implements the results from discussion with @ixjlyons and @axil in https://github.com/pyqtgraph/pyqtgraph/pull/1154/files#diff-9e1abc92379d2b4c257b8f4c5692cda7 and https://github.com/pyqtgraph/pyqtgraph/pull/1154/files#diff-aefdb23660d0963df0dff3a116baded8 :

 * #917 implements a feature similar to `AxisItem.unlinkFromView()`, and provides tests. This PR uses those tests (found by @ixjlyons , code by @mliberty1 ).
 * `ZoomLevel` is not needed to be accessible from the outside. (comment by @axil )
 * Do not recommend users to change the `DateAxisItem.zoomLevels` dict (and a no longer existing variable)  (comment by @axil )

Replaces #917.