### PR TITLE
Fix: AxisItem tickFont is defined in two places while only one is used

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -82,7 +82,6 @@ class AxisItem(GraphicsWidget):
         self.labelUnitPrefix = unitPrefix
         self.labelStyle = args
         self.logMode = False
-        self.tickFont = None
 
         self._tickLevels = None  ## used to override the automatic ticking system with explicit ticks
         self._tickSpacing = None  # used to override default tickSpacing method
@@ -205,7 +204,11 @@ class AxisItem(GraphicsWidget):
         self.update()
 
     def setTickFont(self, font):
-        self.tickFont = font
+        """
+        (QFont or None) Determines the font used for tick values. 
+        Use None for the default font.
+        """
+        self.style['tickFont'] = font
         self.picture = None
         self.prepareGeometryChange()
         ## Need to re-allocate space depending on font size?
@@ -1084,8 +1087,8 @@ class AxisItem(GraphicsWidget):
         profiler('draw ticks')
 
         # Draw all text
-        if self.tickFont is not None:
-            p.setFont(self.tickFont)
+        if self.style['tickFont'] is not None:
+            p.setFont(self.style['tickFont'])
         p.setPen(self.textPen())
         for rect, flags, text in textSpecs:
             p.drawText(rect, int(flags), text)

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -308,8 +308,8 @@ class DateAxisItem(AxisItem):
         # Get font metrics from QPainter
         # Not happening in "paint", as the QPainter p there is a different one from the one here,
         # so changing that font could cause unwanted side effects
-        if self.tickFont is not None:
-            p.setFont(self.tickFont)
+        if self.style['tickFont'] is not None:
+            p.setFont(self.style['tickFont'])
         
         self.fontMetrics = p.fontMetrics()
         


### PR DESCRIPTION
To set the tick font of `AxisItem`s, there are two options:
`setStyle({"tickFont":...})` and `setTickFont(...)`.
The first option sets `AxisItem.style['tickFont']`, the second
sets `self.tickFont`. Only `self.tickFont` is actually used.
This PR replaces all occurrences of the second variable with the first
variable, so both options work again. Also, documentation from
`setStyle` is copied to `setTickFont`.

Replaces former draft #1172.