### PR TITLE
Added support for plot curve to handle both fill and connect args.

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -167,7 +167,7 @@ class PlotCurveItem(GraphicsObject):
             b = np.percentile(d, [50 * (1 - frac), 50 * (1 + frac)])
 
         ## adjust for fill level
-        if ax == 1 and self.opts['fillLevel'] is not None:
+        if ax == 1 and self.opts['fillLevel'] not in [None, 'enclosed']:
             b = (min(b[0], self.opts['fillLevel']), max(b[1], self.opts['fillLevel']))
 
         ## Add pen width only if it is non-cosmetic.
@@ -480,9 +480,10 @@ class PlotCurveItem(GraphicsObject):
                 if x is None:
                     x,y = self.getData()
                 p2 = QtGui.QPainterPath(self.path)
-                p2.lineTo(x[-1], self.opts['fillLevel'])
-                p2.lineTo(x[0], self.opts['fillLevel'])
-                p2.lineTo(x[0], y[0])
+                if self.opts['fillLevel'] != 'enclosed':
+                    p2.lineTo(x[-1], self.opts['fillLevel'])
+                    p2.lineTo(x[0], self.opts['fillLevel'])
+                    p2.lineTo(x[0], y[0])
                 p2.closeSubpath()
                 self.fillPath = p2
 


### PR DESCRIPTION
Added option to handle both fill and connect options in plot curve to enclose shapes without having to plot them all separately.

Example use and screenshot of output attached.

[plot_example_using_fills_and_connect_py.txt](https://github.com/pyqtgraph/pyqtgraph/files/4584781/plot_example_using_fills_and_connect_py.txt)
![Screen Shot 2020-05-06 at 4 09 56 PM](https://user-images.githubusercontent.com/1945175/81137843-296b3b00-8fb4-11ea-85b5-12d2000be707.png)

.