### PR TITLE
Disable remove ROI menu action in handle context menu

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -758,6 +758,9 @@ class ROI(GraphicsObject):
             remAct.triggered.connect(self.removeClicked)
             self.menu.addAction(remAct)
             self.menu.remAct = remAct
+        # ROI menu may be requested when showing the handle context menu, so
+        # return the menu but disable it if the ROI isn't removable
+        self.menu.setEnabled(self.contextMenuEnabled())
         return self.menu
 
     def removeClicked(self):


### PR DESCRIPTION
This disables the ROI context menu in case the menu is requested from right clicking on a handle. Now for a non-removable ROI, the context menu is not shown at all if you right click in the middle of the ROI and the submenu is disabled if you right click a handle. It's shown/enabled in both cases if the ROI is removable.

Example:

```python
import pyqtgraph as pg

app = pg.mkQApp()

plotitem = pg.plot().plotItem

roi1 = pg.PolyLineROI([[0, 0], [1, 1], [0, 1]], closed=True, removable=True)
plotitem.addItem(roi1)
roi1.sigRemoveRequested.connect(plotitem.removeItem)

roi2 = pg.PolyLineROI([[2, 2], [3, 3], [2, 3]], closed=True, removable=False)
plotitem.addItem(roi2)

app.exec_()
```

Fixes #1186 