### PR TITLE
Get readthedocs working

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+python:
+  version: 3
+  install:
+    - requirements: doc/requirements.txt
+
+sphinx:
+  fail_on_warning: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 [![Build Status](https://pyqtgraph.visualstudio.com/pyqtgraph/_apis/build/status/pyqtgraph.pyqtgraph?branchName=develop)](https://pyqtgraph.visualstudio.com/pyqtgraph/_build/latest?definitionId=17&branchName=develop)
+[![Documentation Status](https://readthedocs.org/projects/pyqtgraph/badge/?version=latest)](https://pyqtgraph.readthedocs.io/en/latest/?badge=latest)
 
 PyQtGraph
 =========
@@ -72,4 +73,4 @@ Documentation
 
 The easiest way to learn pyqtgraph is to browse through the examples; run `python -m pyqtgraph.examples` for a menu.
 
-The official documentation lives at http://pyqtgraph.org/documentation
+The official documentation lives at https://pyqtgraph.readthedocs.io

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,5 +2,7 @@ pyside2
 numpy
 scipy
 h5py
+matplotlib
+pyopengl
 sphinx
 sphinx_rtd_theme

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,8 +1,5 @@
 pyside2
 numpy
-scipy
-h5py
-matplotlib
 pyopengl
 sphinx
 sphinx_rtd_theme

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,6 @@
+pyside2
+numpy
+scipy
+h5py
+sphinx
+sphinx_rtd_theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -122,7 +122,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -88,6 +88,7 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+autodoc_inherit_docstrings = False
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -89,6 +89,11 @@ pygments_style = 'sphinx'
 #modindex_common_prefix = []
 
 autodoc_inherit_docstrings = False
+autodoc_mock_imports = [
+    "scipy",
+    "h5py",
+    "matplotlib",
+]
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -290,7 +290,7 @@ class PlotItem(GraphicsWidget):
         Place axis items as given by `axisItems`. Initializes non-existing axis items.
         
         ==============  ==========================================================================================
-        **Arguments:**<
+        **Arguments:**
         *axisItems*     Optional dictionary instructing the PlotItem to use pre-constructed items
                         for its axes. The dict keys must be axis names ('left', 'bottom', 'right', 'top')
                         and the values must be instances of AxisItem (or at least compatible with AxisItem).


### PR DESCRIPTION
Results can be viewed here: https://pyqtgraph.readthedocs.io/en/rtd_build/index.html

The main thing that wasn't working previously was the API documentation because autodoc wasn't able to import the code without the dependencies installed. All that was really needed to fix it was adding the requirements.txt and readthedocs could figure out the rest. I added a config file [as they recommend](https://docs.readthedocs.io/en/stable/config-file/index.html) to be a little more explicit about the configuration and keep it in the repo itself.

Adding `fail_on_warning` may become annoying, but I think it's worth it.

One (possibly separate) issue I haven't quite figured out is how to get the `stable` docs working correctly to point to the latest tagged release. I *think* it's not parsing the `pyqtgraph-x.y.z` tag names the way it would parse `x.y.z`, but I haven't confirmed that. We can always manually activate versions as needed.