### PR TITLE
Image axis order bugfix

### DIFF
--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -586,7 +586,8 @@ class ImageView(QtGui.QWidget):
         # Extract image data from ROI
         axes = (self.axes['x'], self.axes['y'])
 
-        data, coords = self.roi.getArrayRegion(image.view(np.ndarray), self.imageItem, axes, returnMappedCoords=True)
+        #data, coords = self.roi.getArrayRegion(image.view(np.ndarray), self.imageItem, axes, returnMappedCoords=True)
+        data, coords = self.roi.getArrayRegion(image.view(np.ndarray), self.imageItem, returnMappedCoords=True)
         if data is None:
             return
 

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -595,7 +595,13 @@ class ImageView(QtGui.QWidget):
         if self.axes['t'] is None:
             # Average across y-axis of ROI
             data = data.mean(axis=axes[1])
-            coords = coords[:,:,0] - coords[:,0:1,0]
+
+            if axes == (0,1): ## there's probably a better way to do this slicing dynamically, but I'm not sure what it is.
+                coords = coords[:,:,0] - coords[:,0:1,0] 
+            elif axes == (1,0): ## we're in row-major order mode
+                coords = coords[:,0,:] - coords[:,0,0:1]
+            else:
+                raise Exception("Need to implement a better way to handle these axes: %s" %str(self.axes))
             xvals = (coords**2).sum(axis=0) ** 0.5
         else:
             # Average data within entire ROI for each frame

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -586,7 +586,6 @@ class ImageView(QtGui.QWidget):
         # Extract image data from ROI
         axes = (self.axes['x'], self.axes['y'])
 
-        #data, coords = self.roi.getArrayRegion(image.view(np.ndarray), self.imageItem, axes, returnMappedCoords=True)
         data, coords = self.roi.getArrayRegion(image.view(np.ndarray), self.imageItem, returnMappedCoords=True)
         if data is None:
             return

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -595,13 +595,10 @@ class ImageView(QtGui.QWidget):
         if self.axes['t'] is None:
             # Average across y-axis of ROI
             data = data.mean(axis=axes[1])
-
-            if axes == (0,1): ## there's probably a better way to do this slicing dynamically, but I'm not sure what it is.
-                coords = coords[:,:,0] - coords[:,0:1,0] 
-            elif axes == (1,0): ## we're in row-major order mode
+            if axes == (1,0): ## we're in row-major order mode -- there's probably a better way to do this slicing dynamically, but I've not figured it out yet.
                 coords = coords[:,0,:] - coords[:,0,0:1]
-            else:
-                raise Exception("Need to implement a better way to handle these axes: %s" %str(self.axes))
+            else: #default to old way
+                coords = coords[:,:,0] - coords[:,0:1,0] 
             xvals = (coords**2).sum(axis=0) ** 0.5
         else:
             # Average data within entire ROI for each frame


### PR DESCRIPTION
Lavinia B found a bug when using an roi to select part of an image displayed in ImageView when pyqtgraph's imageAxisOrder option was set to 'row-major'. (See this forum thread: https://groups.google.com/forum/#!topic/pyqtgraph/SE8KcK2LOv4)

This PR is a fix for these bugs. The bugs were occurring in ImageView.roiChanged because accounting for the axis order was only partially implemented. 

