### PR TITLE
Added context menu option to parametertree

### DIFF
--- a/examples/parametertree.py
+++ b/examples/parametertree.py
@@ -96,6 +96,16 @@ params = [
         {'name': 'Renamable', 'type': 'float', 'value': 1.2e6, 'siPrefix': True, 'suffix': 'Hz', 'renamable': True},
         {'name': 'Removable', 'type': 'float', 'value': 1.2e6, 'siPrefix': True, 'suffix': 'Hz', 'removable': True},
     ]},
+    {'name': 'Custom context menu', 'type': 'group', 'children': [
+        {'name': 'List contextMenu', 'type': 'float', 'value': 0, 'context': [
+            'menu1',
+            'menu2'
+        ]},
+        {'name': 'Dict contextMenu', 'type': 'float', 'value': 0, 'context': {
+            'changeName': 'Title',
+            'internal': 'What the user sees',
+        }},
+    ]},
     ComplexParameter(name='Custom parameter group (reciprocal values)'),
     ScalableGroup(name="Expandable Parameter Group", children=[
         {'name': 'ScalableParam 1', 'type': 'str', 'value': "default param 1"},

--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -55,6 +55,7 @@ class Parameter(QtCore.QObject):
     sigDefaultChanged(self, default)     Emitted when this parameter's default value has changed
     sigNameChanged(self, name)           Emitted when this parameter's name has changed
     sigOptionsChanged(self, opts)        Emitted when any of this parameter's options have changed
+    sigContextMenu(self, name)           Emitted when a context menu was clicked
     ===================================  =========================================================
     """
     ## name, type, limits, etc.
@@ -81,7 +82,8 @@ class Parameter(QtCore.QObject):
     ## (but only if monitorChildren() is called)
     sigTreeStateChanged = QtCore.Signal(object, object)  # self, changes
                                                          # changes = [(param, change, info), ...]
-    
+    sigContextMenu = QtCore.Signal(object, object)       # self, name
+
     # bad planning.
     #def __new__(cls, *args, **opts):
         #try:
@@ -199,12 +201,18 @@ class Parameter(QtCore.QObject):
         self.sigDefaultChanged.connect(lambda param, data: self.emitStateChanged('default', data))
         self.sigNameChanged.connect(lambda param, data: self.emitStateChanged('name', data))
         self.sigOptionsChanged.connect(lambda param, data: self.emitStateChanged('options', data))
+        self.sigContextMenu.connect(lambda param, data: self.emitStateChanged('contextMenu', data))
+
         
         #self.watchParam(self)  ## emit treechange signals if our own state changes
         
     def name(self):
         """Return the name of this Parameter."""
         return self.opts['name']
+
+    def contextMenu(self, name):
+        """"A context menu entry was clicked"""
+        self.sigContextMenu.emit(self, name)
 
     def setName(self, name):
         """Attempt to change the name of this parameter; return the actual name. 

--- a/pyqtgraph/parametertree/ParameterItem.py
+++ b/pyqtgraph/parametertree/ParameterItem.py
@@ -47,6 +47,17 @@ class ParameterItem(QtGui.QTreeWidgetItem):
             self.contextMenu.addAction('Rename').triggered.connect(self.editName)
         if opts.get('removable', False):
             self.contextMenu.addAction("Remove").triggered.connect(self.requestRemove)
+
+        # context menu
+        context = opts.get('context', None)
+        if isinstance(context, list):
+            for name in context:
+                self.contextMenu.addAction(name).triggered.connect(
+                    self.contextMenuTriggered(name))
+        elif isinstance(context, dict):
+            for name, title in context.items():
+                self.contextMenu.addAction(title).triggered.connect(
+                    self.contextMenuTriggered(name))
         
         ## handle movable / dropEnabled options
         if opts.get('movable', False):
@@ -57,7 +68,7 @@ class ParameterItem(QtGui.QTreeWidgetItem):
         
         ## flag used internally during name editing
         self.ignoreNameColumnChange = False
-    
+
     
     def valueChanged(self, param, val):
         ## called when the parameter's value has changed
@@ -106,7 +117,8 @@ class ParameterItem(QtGui.QTreeWidgetItem):
         pass
                 
     def contextMenuEvent(self, ev):
-        if not self.param.opts.get('removable', False) and not self.param.opts.get('renamable', False):
+        if not self.param.opts.get('removable', False) and not self.param.opts.get('renamable', False)\
+                and "context" not in self.param.opts:
             return
             
         self.contextMenu.popup(ev.globalPos())
@@ -149,7 +161,12 @@ class ParameterItem(QtGui.QTreeWidgetItem):
         #print opts
         if 'visible' in opts:
             self.setHidden(not opts['visible'])
-        
+
+    def contextMenuTriggered(self, name):
+        def trigger():
+            self.param.contextMenu(name)
+        return trigger
+
     def editName(self):
         self.treeWidget().editItem(self, 0)
         


### PR DESCRIPTION
Added custom context menu options in the parametertree
Usage: 
```python
{'name': 'Custom context menu', 'type': 'group', 'children': [
    {'name': 'List contextMenu', 'type': 'float', 'value': 0, 'context': [
        'menu1',
        'menu2'
    ]},
    {'name': 'Dict contextMenu', 'type': 'float', 'value': 0, 'context': {
        'changeName': 'Title',
        'internal': 'What the user sees',
    }},
]},
```
Result:

![List Menu](https://user-images.githubusercontent.com/60338487/82691978-1d8fa200-9c5f-11ea-9743-ca0ab9ce7aa9.png)
![Dict Menu](https://user-images.githubusercontent.com/60338487/82692020-3009db80-9c5f-11ea-8a7b-c1b0cff90abc.png)
