### PR TITLE
Pin PyVirtualDisplay Version

### DIFF
--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -129,7 +129,7 @@ jobs:
       then
         source activate test-environment-$(python.version)
       fi
-      pip install pytest-xvfb
+      pip install PyVirtualDisplay==0.2.5 pytest-xvfb
     displayName: "Virtual Display Setup"
     condition: eq(variables['agent.os'], 'Linux' )
 


### PR DESCRIPTION
@2xB found another issue describing the same problem we're seeing with our CI system where we have failures with xvfb.  A dependency of pytest-xvfb was updated, this commit merely pins the version back.