### PR TITLE
Skipping this test on python 5.9 configs

### DIFF
--- a/pyqtgraph/tests/test_exit_crash.py
+++ b/pyqtgraph/tests/test_exit_crash.py
@@ -67,7 +67,7 @@ def test_exit_crash():
 
     os.remove(tmp)
 
-
+@pytest.mark.skipif(pg.Qt.QtVersion.startswith("5.9"), reason="Functionality not well supported, failing only on this config")
 def test_pg_exit():
     # test the pg.exit() function
     code = textwrap.dedent("""


### PR DESCRIPTION
`test_pg_exit()` is behaving problematically on macOS pyqt 5.9.  It's failing as other code in the library is modified, and passes when run as a stand-alone.  To not hold up every other library and based on the discussion in #1163 seems like most folks agree to skip this test and move on, which is what this PR does.