### PR TITLE
Identify pyqt5 515 ci issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,11 +89,11 @@ stages:
     parameters:
       name: linux
       vmImage: 'Ubuntu 18.04'
-  - template: azure-test-template.yml
-    parameters:
-      name: windows
-      vmImage: 'windows-2019'
-  - template: azure-test-template.yml
-    parameters:
-      name: macOS
-      vmImage: 'macOS-10.15'
+  # - template: azure-test-template.yml
+  #   parameters:
+  #     name: windows
+  #     vmImage: 'windows-2019'
+  # - template: azure-test-template.yml
+  #   parameters:
+  #     name: macOS
+  #     vmImage: 'macOS-10.15'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,11 +89,11 @@ stages:
     parameters:
       name: linux
       vmImage: 'Ubuntu 18.04'
-  # - template: azure-test-template.yml
-  #   parameters:
-  #     name: windows
-  #     vmImage: 'windows-2019'
-  # - template: azure-test-template.yml
-  #   parameters:
-  #     name: macOS
-  #     vmImage: 'macOS-10.15'
+  - template: azure-test-template.yml
+    parameters:
+      name: windows
+      vmImage: 'windows-2019'
+  - template: azure-test-template.yml
+    parameters:
+      name: macOS
+      vmImage: 'macOS-10.15'

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -124,12 +124,12 @@ jobs:
     displayName: 'Install Wheel'
 
   - bash: |
-      sudo apt-get install -y libxcb-glx0-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-sync-dev libxcb-xinerama0-dev libxcb-xinput-dev libxcb-xkb-dev libxkbcommon-x11-dev
+      sudo apt-get install -y libxkbcommon-x11-dev libxcb-xfixes0
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)
       fi
-      pip install PyVirtualDisplay==1.3 pytest-xvfb
+      pip install PyVirtualDisplay==1.1 pytest-xvfb
     displayName: "Virtual Display Setup"
     condition: eq(variables['agent.os'], 'Linux' )
 

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -124,7 +124,7 @@ jobs:
     displayName: 'Install Wheel'
 
   - bash: |
-      sudo apt-get install -y libxkbcommon-x11-0  # herbstluftwm
+      sudo apt-get install -y libxcb-glx0-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-sync-dev libxcb-xinerama0-dev libxcb-xinput-dev libxcb-xkb-dev libxkbcommon-x11-dev
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -125,7 +125,7 @@ jobs:
 
   - bash: |
       sudo apt-get install -y libxkbcommon-x11-dev 
-      sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0
+      sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -26,7 +26,7 @@ jobs:
         python.version: "3.7"
         qt.bindings: "pyside2"
         install.method: "conda"
-      Python38-PyQt-5.14:
+      Python38-PyQt-Latest:
         python.version: '3.8'
         qt.bindings: "PyQt5"
         install.method: "pip"
@@ -125,6 +125,7 @@ jobs:
 
   - bash: |
       sudo apt-get install -y libxkbcommon-x11-dev 
+      # workaround for QTBUG-84489
       sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0
       if [ $(install.method) == "conda" ]
       then

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -129,7 +129,7 @@ jobs:
       then
         source activate test-environment-$(python.version)
       fi
-      pip install PyVirtualDisplay==0.2.5 pytest-xvfb
+      pip install PyVirtualDisplay==1.3 pytest-xvfb
     displayName: "Virtual Display Setup"
     condition: eq(variables['agent.os'], 'Linux' )
 

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -125,7 +125,7 @@ jobs:
 
   - bash: |
       sudo apt-get install -y libxkbcommon-x11-dev 
-      sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1
+      sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -125,7 +125,7 @@ jobs:
 
   - bash: |
       sudo apt-get install -y libxkbcommon-x11-dev 
-      sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0
+      sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -125,7 +125,7 @@ jobs:
 
   - bash: |
       sudo apt-get install -y libxkbcommon-x11-dev 
-      sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4 libxcb-image0
+      sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -124,7 +124,8 @@ jobs:
     displayName: 'Install Wheel'
 
   - bash: |
-      sudo apt-get install -y libxkbcommon-x11-dev libxcb-xfixes0
+      sudo apt-get install -y libxkbcommon-x11-dev 
+      sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -125,12 +125,12 @@ jobs:
 
   - bash: |
       sudo apt-get install -y libxkbcommon-x11-dev 
-      sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4
+      sudo apt-get install -y libxcb-xfixes0 libxcb-icccm4 libxcb-image0
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)
       fi
-      pip install PyVirtualDisplay==1.1 pytest-xvfb
+      pip install PyVirtualDisplay==0.2.5 pytest-xvfb
     displayName: "Virtual Display Setup"
     condition: eq(variables['agent.os'], 'Linux' )
 

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -134,6 +134,7 @@ jobs:
     condition: eq(variables['agent.os'], 'Linux' )
 
   - bash: |
+      export QT_DEBUG_PLUGINS=1
       if [ $(install.method) == "conda" ]
       then
         source activate test-environment-$(python.version)


### PR DESCRIPTION
Fixes #1220

With PyQt5 5.15.0 released, our CI system failed at the debug stage.  Some googling turned up QTBUG-84489 which the author there reported this being a new issue with Qt 5.15.0.  I suspect we'll likely see the same thing with PySide2 (speaking of which, we should add a "latest" PySide2 pipeline).

I also renamed the Python38-PyQt-5.14 pipeline to Python38-PyQt-Latest (as that is what it really is).