### PR TITLE
ParameterTree: Fix custom context menu

### DIFF
--- a/pyqtgraph/parametertree/ParameterItem.py
+++ b/pyqtgraph/parametertree/ParameterItem.py
@@ -117,7 +117,7 @@ class ParameterItem(QtGui.QTreeWidgetItem):
             self.contextMenu.addAction("Remove").triggered.connect(self.requestRemove)
         
         # context menu
-        context = opts.get('context', None)
+        context = self.param.opts.get('context', None)
         if isinstance(context, list):
             for name in context:
                 self.contextMenu.addAction(name).triggered.connect(

--- a/pyqtgraph/parametertree/ParameterItem.py
+++ b/pyqtgraph/parametertree/ParameterItem.py
@@ -104,20 +104,22 @@ class ParameterItem(QtGui.QTreeWidgetItem):
         pass
                 
     def contextMenuEvent(self, ev):
-        if not self.param.opts.get('removable', False) and not self.param.opts.get('renamable', False)\
-                and "context" not in self.param.opts:
+        opts = self.param.opts
+        
+        if not opts.get('removable', False) and not opts.get('renamable', False)\
+                and "context" not in opts:
             return
         
         ## Generate context menu for renaming/removing parameter
         self.contextMenu = QtGui.QMenu() # Put in global name space to prevent garbage collection
         self.contextMenu.addSeparator()
-        if self.param.opts.get('renamable', False):
+        if opts.get('renamable', False):
             self.contextMenu.addAction('Rename').triggered.connect(self.editName)
-        if self.param.opts.get('removable', False):
+        if opts.get('removable', False):
             self.contextMenu.addAction("Remove").triggered.connect(self.requestRemove)
         
         # context menu
-        context = self.param.opts.get('context', None)
+        context = opts.get('context', None)
         if isinstance(context, list):
             for name in context:
                 self.contextMenu.addAction(name).triggered.connect(


### PR DESCRIPTION
This issue was introduced in merging develop into #1175.
While refactoring for the merge, I did not attribute the change in namespace correctly, leading to the parameter `opts` to be assumed in local namespace when it isn't.