### PR TITLE
Wrap text in tables in docs

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -1,0 +1,14 @@
+/* Customizations to the theme */
+
+/* override table width restrictions */
+/* https://github.com/readthedocs/sphinx_rtd_theme/issues/117 */
+@media screen and (min-width: 768px) {
+    .wy-table-responsive table td, .wy-table-responsive table th {
+        white-space: normal !important;
+    }
+
+    .wy-table-responsive {
+        overflow: visible !important;
+        max-width: 100%;
+    }
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -131,7 +131,11 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
+
+# add the theme customizations
+def setup(app):
+    app.add_stylesheet("custom.css")
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/943602/83956479-86584c00-a813-11ea-83e1-fd29c228ec4a.png)

After:

![image](https://user-images.githubusercontent.com/943602/83956490-9b34df80-a813-11ea-90e2-87ed1ea40b7e.png)

Live example: https://pyqtgraph.readthedocs.io/en/rtd/graphicsItems/plotitem.html#pyqtgraph.PlotItem.setLabel