### PR TITLE
Update README for 0.11 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PyQtGraph
 
 A pure-Python graphics library for PyQt/PySide/PyQt5/PySide2
 
-Copyright 2019 Luke Campagnola, University of North Carolina at Chapel Hill
+Copyright 2020 Luke Campagnola, University of North Carolina at Chapel Hill
 
 <http://www.pyqtgraph.org>
 
@@ -19,18 +19,14 @@ heavy leverage of numpy for number crunching, Qt's GraphicsView framework for
 Requirements
 ------------
 
-* PyQt 4.8+, PySide, PyQt5, or PySide2
-  * PySide2 5.14 does not have loadUiType functionality, and thus the example application will not work.  You can follow along with restoring that functionality [here](https://bugreports.qt.io/browse/PYSIDE-1223).
 * Python 2.7, or 3.x
 * Required
+  * PyQt 4.8+, PySide, PyQt5, or PySide2
   * `numpy`
 * Optional
   * `scipy` for image processing
   * `pyopengl` for 3D graphics
-    * macOS with Python2 and Qt4 bindings (PyQt4 or PySide) do not work with 3D OpenGL graphics
-    * `pyqtgraph.opengl` will be depreciated in a future version and replaced with `VisPy`
   * `hdf5` for large hdf5 binary format support
-* Known to run on Windows, Linux, and macOS.
 
 Qt Bindings Test Matrix
 -----------------------
@@ -46,8 +42,8 @@ The following table represents the python environments we test in our CI system.
 | PyQt5-Latest   | :x:                | :x:                | :x:                | :white_check_mark: |
 | PySide2-Latest | :x:                | :x:                | :x:                | :white_check_mark: |
 
-* pyqtgraph has had some incompatibilities with PySide2-5.6, and we recommend you avoid those bindings if possible
-* on macOS with Python 2.7 and Qt4 bindings (PyQt4 or PySide) the openGL related visualizations do not work
+* pyqtgraph has had some incompatibilities with PySide2 versions 5.6-5.11, and we recommend you avoid those versions if possible
+* on macOS with Python 2.7 and Qt4 bindings (PyQt4 or PySide) the openGL related visualizations do not work reliably
 
 Support
 -------
@@ -60,18 +56,17 @@ Installation Methods
 
 * From PyPI:  
   * Last released version: `pip install pyqtgraph`
-  * Latest development version: `pip install git+https://github.com/pyqtgraph/pyqtgraph@develop`
+  * Latest development version: `pip install git+https://github.com/pyqtgraph/pyqtgraph@master`
 * From conda
-  * Last released version: `conda install pyqtgraph`
+  * Last released version: `conda install -c conda-forge pyqtgraph`
 * To install system-wide from source distribution: `python setup.py install`
 * Many linux package repositories have release versions.
 * To use with a specific project, simply copy the pyqtgraph subdirectory
   anywhere that is importable from your project.
-* For installation packages, see the website (pyqtgraph.org)
 
 Documentation
 -------------
 
-The easiest way to learn pyqtgraph is to browse through the examples; run `python -m pyqtgraph.examples` for a menu.
-
 The official documentation lives at https://pyqtgraph.readthedocs.io
+
+The easiest way to learn pyqtgraph is to browse through the examples; run `python -m pyqtgraph.examples` to launch the examples application.  


### PR DESCRIPTION
PR includes some updates for the README

* removes reference to installer packages on pyqtgraph.org 
* removes incorrect statement about examples app not working on PySide2 (testing of the example app didn't work, still works to call it manually)
* slight reworking on macos/py2/qt4 limitations
* says to install current development version to install from master branch (this is assuming we change our current master/develop workflow)
