### PR TITLE
AxisItem: Make painter (tick) font dependent

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -576,6 +576,8 @@ class AxisItem(GraphicsWidget):
             try:
                 picture = QtGui.QPicture()
                 painter = QtGui.QPainter(picture)
+                if self.style["tickFont"]:
+                    painter.setFont(self.style["tickFont"])
                 specs = self.generateDrawSpecs(painter)
                 profiler('generate specs')
                 if specs is not None:

--- a/pyqtgraph/graphicsItems/tests/test_AxisItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_AxisItem.py
@@ -87,3 +87,30 @@ def test_AxisItem_leftRelink():
     assert fake_view.sigYRangeChanged.calls == ['connect', 'disconnect']
     assert fake_view.sigXRangeChanged.calls == []
     assert fake_view.sigResized.calls == ['connect', 'disconnect']
+
+
+def test_AxisItem_tickFont(monkeypatch):
+    def collides(textSpecs):
+        fontMetrics = pg.Qt.QtGui.QFontMetrics(font)
+        for rect, _, text in textSpecs:
+            br = fontMetrics.tightBoundingRect(text)
+            if rect.height() < br.height() or rect.width() < br.width():
+                return True
+        return False
+
+    def test_collision(p, axisSpec, tickSpecs, textSpecs):
+        assert not collides(textSpecs)
+
+    plot = pg.PlotWidget()
+    bottom = plot.getAxis("bottom")
+    left = plot.getAxis("left")
+    font = bottom.linkedView().font()
+    font.setPointSize(25)
+    bottom.setStyle(tickFont=font)
+    left.setStyle(tickFont=font)
+    monkeypatch.setattr(bottom, "drawPicture", test_collision)
+    monkeypatch.setattr(left, "drawPicture", test_collision)
+
+    plot.show()
+    app.processEvents()
+    plot.close()


### PR DESCRIPTION
##### Issue
When setting a tick font manually, texts may collide since not considering the font.

##### Description of changes
Set painter's font before generating ticks specifications.
