### PR TITLE
Issue #1260: Added exception to checkOpenGLVersion to highlight OpenGL ES incompatibility on Raspberry Pi

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -4,6 +4,7 @@ import OpenGL.GL.framebufferobjects as glfbo
 import numpy as np
 from .. import Vector
 from .. import functions as fn
+from future_utils import raise_from
 
 ##Vector = QtGui.QVector3D
 
@@ -429,8 +430,8 @@ class GLViewWidget(QtOpenGL.QGLWidget):
         ver = glGetString(GL_VERSION).split()[0]
         try:
             verNumber = int(ver.split(b'.')[0]) < 2
-        except ValueError:
-            raise Exception("pyqtgraph.opengl: Requires > OpenGL 2.0 (not ES); Found %s" % glGetString(GL_VERSION)) from None
+        except ValueError as exc:
+            raise_from(Exception("pyqtgraph.opengl: Requires > OpenGL 2.0 (not ES); Found %s" % glGetString(GL_VERSION)), exc)
 
         if verNumber < 2:
             from .. import debug

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -427,12 +427,15 @@ class GLViewWidget(QtOpenGL.QGLWidget):
     def checkOpenGLVersion(self, msg):
         ## Only to be called from within exception handler.
         ver = glGetString(GL_VERSION).split()[0]
-        if int(ver.split(b'.')[0]) < 2:
-            from .. import debug
-            debug.printExc()
-            raise Exception(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)
-        else:
-            raise
+        try:
+            if int(ver.split(b'.')[0]) < 2:
+                from .. import debug
+                debug.printExc()
+                raise Exception(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)
+            else:
+                raise
+        except ValueError:
+            raise Exception("pyqtgraph requires OpenGL 2.0 (non-ES) for its 3D Features in GLViewWidget. Please check that you are not using OpenGL ES")
             
     def readQImage(self):
         """

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -427,16 +427,19 @@ class GLViewWidget(QtOpenGL.QGLWidget):
     def checkOpenGLVersion(self, msg):
         ## Only to be called from within exception handler.
         ver = glGetString(GL_VERSION).split()[0]
+        ver = None
         try:
-            if int(ver.split(b'.')[0]) < 2:
-                from .. import debug
-                debug.printExc()
-                raise Exception(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)
-            else:
-                raise
+            verNumber = int(ver.split(b'.')[0]) < 2
         except ValueError:
-            raise Exception("pyqtgraph requires OpenGL 2.0 (non-ES) for its 3D Features in GLViewWidget. Please check that you are not using OpenGL ES")
-            
+            raise Exception("pyqtgraph.opengl: Requires > OpenGL 2.0 (not ES); Found %s" % glGetString(GL_VERSION)) from None
+
+        if verNumber < 2:
+            from .. import debug
+            debug.printExc()
+            raise Exception(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)
+        else:
+            raise
+ 
     def readQImage(self):
         """
         Read the current buffer pixels out as a QImage.

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -427,7 +427,6 @@ class GLViewWidget(QtOpenGL.QGLWidget):
     def checkOpenGLVersion(self, msg):
         ## Only to be called from within exception handler.
         ver = glGetString(GL_VERSION).split()[0]
-        ver = None
         try:
             verNumber = int(ver.split(b'.')[0]) < 2
         except ValueError:


### PR DESCRIPTION
@2xB recommendation to output the correct exception when (incompatible) OpenGL ES is used to run GLViewWidget.py

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/pyqtgraph/pyqtgraph/opengl/GLViewWidget.py", line 431, in checkOpenGLVersion
    if int(ver.split(b'.')[0]) < 2:
ValueError: invalid literal for int() with base 10: b'OpenGL'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "GLScatterPlotItem.py", line 46, in <module>
    w.addItem(sp1)
  File "/home/ubuntu/pyqtgraph/pyqtgraph/opengl/GLViewWidget.py", line 62, in addItem
    self.checkOpenGLVersion('Error while adding item %s to GLViewWidget.' % str(item))
  File "/home/ubuntu/pyqtgraph/pyqtgraph/opengl/GLViewWidget.py", line 438, in checkOpenGLVersion
    raise Exception("pyqtgraph requires OpenGL 2.0 (non-ES) for its 3D Features in GLViewWidget. Please check that you are not using OpenGL ES")
Exception: pyqtgraph requires OpenGL 2.0 (non-ES) for its 3D Features in GLViewWidget. Please check that you are not using OpenGL ES
```

Replaces the previous ValueError exception where

```
File "pyqtgraph/opengl/GLViewWidget.py", line 430, in checkOpenGLVersion
    if int(ver.split(b'.')[0]) < 2:
ValueError: invalid literal for int() with base 10: b'OpenGL' 
```