### PR TITLE
Make the documentation reproducible

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,6 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import time
 import sys
 import os
 from datetime import datetime
@@ -46,7 +47,10 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'pyqtgraph'
-copyright = '2011 - {}, Luke Campagnola'.format(datetime.now().year)
+now = datetime.utcfromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+)
+copyright = '2011 - {}, Luke Campagnola'.format(now.year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that pyqtgraph could not be built reproducibly. This is because it generates copyright years from the current build date and therefore will vary on when you build it.

This commit uses [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) for the "current" build date.

This was originally filed in Debian as [#963124](https://bugs.debian.org/963124).