### PR TITLE
Add mouse event to PlotCurveItem sigClicked signature

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -29,15 +29,15 @@ class PlotCurveItem(GraphicsObject):
     - Fill under curve
     - Mouse interaction
 
-    ====================  ===============================================
+    =====================  ===============================================
     **Signals:**
-    sigPlotChanged(self)  Emitted when the data being plotted has changed
-    sigClicked(self)      Emitted when the curve is clicked
-    ====================  ===============================================
+    sigPlotChanged(self)   Emitted when the data being plotted has changed
+    sigClicked(self, ev)   Emitted when the curve is clicked
+    =====================  ===============================================
     """
 
     sigPlotChanged = QtCore.Signal(object)
-    sigClicked = QtCore.Signal(object)
+    sigClicked = QtCore.Signal(object, object)
 
     def __init__(self, *args, **kargs):
         """


### PR DESCRIPTION
Follow-up to #1242. Currently, clicking the curve in the bottom plot in examples/PlotWidget.py generates:

```
[23:00:47]  Error sending click event:

    |==============================>>
    |  Traceback (most recent call last):
    |    File "examples/PlotWidget.py", line 94, in <module>
    |      QtGui.QApplication.instance().exec_()
    |    File "/home/kenny/src/pyqtgraph/pyqtgraph/widgets/GraphicsView.py", line 363, in mouseReleaseEvent
    |      QtGui.QGraphicsView.mouseReleaseEvent(self, ev)
    |    File "/home/kenny/src/pyqtgraph/pyqtgraph/GraphicsScene/GraphicsScene.py", line 212, in mouseReleaseEvent
    |      if self.sendClickEvent(cev[0]):
    |    File "/home/kenny/src/pyqtgraph/pyqtgraph/GraphicsScene/GraphicsScene.py", line 359, in sendClickEvent
    |      debug.printExc("Error sending click event:")
    |    --- exception caught here ---
    |    File "/home/kenny/src/pyqtgraph/pyqtgraph/GraphicsScene/GraphicsScene.py", line 357, in sendClickEvent
    |      item.mouseClickEvent(ev)
    |    File "/home/kenny/src/pyqtgraph/pyqtgraph/graphicsItems/PlotCurveItem.py", line 616, in mouseClickEvent
    |      self.sigClicked.emit(self, ev)
    |  TypeError: PlotCurveItem.sigClicked[object] signal has 1 argument(s) but 2 provided
    |==============================<<
```

It may be worth noting `PlotDataItem` re-exposes a `sigClicked` signal via a slot connected to `PlotCurveItem.sigClicked`, but the slot doesn't take either signal argument, so I don't think anything needs to change there at the moment.