### PR TITLE
Check for container before setting dock orientation

### DIFF
--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from ..Qt import QtCore, QtGui
 
 from .DockDrop import *
@@ -138,6 +139,12 @@ class Dock(QtGui.QWidget, DockDrop):
         By default ('auto'), the orientation is determined
         based on the aspect ratio of the Dock.
         """
+        # setOrientation may be called before the container is set in some cases
+        # (via resizeEvent), so there's no need to do anything here until called
+        # again by containerChanged
+        if self.container() is None:
+            return
+
         if o == 'auto' and self.autoOrient:
             if self.container().type() == 'tab':
                 o = 'horizontal'


### PR DESCRIPTION
Fixes #833.

This is an alternative to #900. Yet another alternative would be `if self.container() is not None and self.container().type() == 'tab':`, but I don't see a reason to do any of the stuff in `setOrientation` until the container is set. Once the container *is* set, `setOrientation` is called thereafter anyway.

I played around with `examples/dockarea.py` for a while as well as the example in #833 and I haven't found any problems.
