### PR TITLE
LegendItem: fix clear() not closing widgets

### DIFF
--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -189,7 +189,9 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         """Remove all items from the legend."""
         for sample, label in self.items:
             self.layout.removeItem(sample)
+            sample.close()
             self.layout.removeItem(label)
+            label.close()
 
         self.items = []
         self.updateSize()


### PR DESCRIPTION
`LegendItem.clear()` did previously not call `.close()` on the child widgets after removing them from the layout. This caused them to still be rendered even after calling `.clear()`. It does the same as `LegendItem.removeItem()` now.

The issue I had was that after clearing all items and adding new ones, the old items were still visible underneath the newly added ones. My changes fixed this issue. Because `LegendItem.removeItem()` also calls `.close()`, I assume this is the correct way to do it.

I didn't add or modify and unit tests because I don't know how this could be tested. If somebody knows a way, let me know and I will implement it.