### PR TITLE
Fix Parameter.hasDefault

### DIFF
--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from ..Qt import QtGui, QtCore
 import os, weakref, re
 from ..pgcollections import OrderedDict
@@ -188,13 +189,11 @@ class Parameter(QtCore.QObject):
         
         self.addChildren(self.opts.pop('children', []))
         
-        self.opts['value'] = None
         if value is not None:
             self.setValue(value)
 
         if 'default' not in self.opts:
             self.opts['default'] = None
-            self.setDefault(self.opts['value'])
     
         ## Connect all state changed signals to the general sigStateChanged
         self.sigValueChanged.connect(lambda param, data: self.emitStateChanged('value', data))
@@ -420,7 +419,7 @@ class Parameter(QtCore.QObject):
 
     def hasDefault(self):
         """Returns True if this parameter has a default value."""
-        return 'default' in self.opts
+        return self.opts['default'] is not None
         
     def valueIsDefault(self):
         """Returns True if this parameter's value is equal to the default value."""

--- a/pyqtgraph/parametertree/tests/test_Parameter.py
+++ b/pyqtgraph/parametertree/tests/test_Parameter.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import pytest
+from pyqtgraph.parametertree import Parameter
+
+
+def test_parameter_hasdefault():
+    opts = {'name': 'param', 'type': int, 'value': 1}
+
+    # default unspecified
+    p = Parameter(**opts)
+    assert not p.hasDefault()
+
+    p.setDefault(1)
+    assert p.hasDefault()
+    assert p.defaultValue() == 1
+
+    # default specified
+    p = Parameter(default=0, **opts)
+    assert p.hasDefault()
+    assert p.defaultValue() == 0
+
+
+@pytest.mark.parametrize('passdefault', [True, False])
+def test_parameter_hasdefault_none(passdefault):
+    # test that Parameter essentially ignores defualt=None, same as not passing
+    # a default at all
+    opts = {'name': 'param', 'type': int, 'value': 0}
+    if passdefault:
+        opts['default'] = None
+
+    p = Parameter(**opts)
+    assert not p.hasDefault()
+    assert p.defaultValue() is None
+
+    p.setDefault(None)
+    assert not p.hasDefault()


### PR DESCRIPTION
This is a slightly different version of #847 and #331. There's some discussion in #847 for background.

Essentially, it seems we got stuck deciding whether or not explicitly passing `Parameter(default=None)` or calling `param.setDefault(None)` should make `param.hasDefault() == True`.

In this version, `param.hasDefault() == False` if you set it to `None` or don't set it at all. I eventually came around to lean toward this behavior by realizing that if `Parameter.__init__` didn't hide its argument structure in `**opts`, we'd have `default=None` and it wouldn't even be possible to tell whether or not the user set it explicitly. It's also fairly natural in Python for `None` to represent "unspecified."

I also implemented an alternative version where `param.hasDefualt() == True` when you `setDefault(None)`. You can see that here to compare: https://github.com/ixjlyons/pyqtgraph/commit/6d506f27d21ef0102de62f49167c45fd86aeda98

Fixes #847 
Fixes #846 
Fixes #331