### PR TITLE
convert connect='finite' to connect=ndarray

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1486,11 +1486,11 @@ def arrayToQPath(x, y, connect='all'):
     if eq(connect, 'finite'):
         # convert connect='finite' to connect=ndarray
         msk = np.isfinite(x) & np.isfinite(y)
-        connect = np.ones_like(msk)
+        connect = np.ones(len(msk)+1, dtype=bool)
         connect[np.where(~msk)[0] + 1] = 0
         x = x[msk]
         y = y[msk]
-        connect = connect[msk]
+        connect = connect[0:-1][msk]
 
     #profiler = debug.Profiler()
     n = x.shape[0]

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1486,11 +1486,11 @@ def arrayToQPath(x, y, connect='all'):
     if eq(connect, 'finite'):
         # convert connect='finite' to connect=ndarray
         msk = np.isfinite(x) & np.isfinite(y)
-        connect = np.ones(len(msk)+1, dtype=bool)
-        connect[np.where(~msk)[0] + 1] = 0
+        connect = np.zeros(len(msk)+1, dtype=bool)
+        connect[1:] = msk
+        connect = connect[:-1][msk]
         x = x[msk]
         y = y[msk]
-        connect = connect[0:-1][msk]
 
     #profiler = debug.Profiler()
     n = x.shape[0]

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1483,6 +1483,15 @@ def arrayToQPath(x, y, connect='all'):
 
     path = QtGui.QPainterPath()
 
+    if eq(connect, 'finite'):
+        # convert connect='finite' to connect=ndarray
+        msk = np.isfinite(x) & np.isfinite(y)
+        connect = np.ones_like(msk)
+        connect[np.where(~msk)[0] + 1] = 0
+        x = x[msk]
+        y = y[msk]
+        connect = connect[msk]
+
     #profiler = debug.Profiler()
     n = x.shape[0]
     # create empty array, pad with extra space on either end
@@ -1503,12 +1512,6 @@ def arrayToQPath(x, y, connect='all'):
     elif eq(connect, 'pairs'):
         arr[1:-1]['c'][::2] = 0
         arr[1:-1]['c'][1::2] = 1  # connect every 2nd point to every 1st one
-    elif eq(connect, 'finite'):
-        # Let's call a point with either x or y being nan is an invalid point.
-        # A point will anyway not connect to an invalid point regardless of the
-        # 'c' value of the invalid point. Therefore, we should set 'c' to 0 for
-        # the next point of an invalid point.
-        arr[2:]['c'] = np.isfinite(x) & np.isfinite(y)
     elif isinstance(connect, np.ndarray):
         arr[1:-1]['c'] = connect
     else:


### PR DESCRIPTION
Qt no longer accepts non-finite values for plotting as seen here:
https://github.com/qt/qtbase/blob/f6b7b64ed0168038e365b936a1daea9b3bcda335/src/gui/painting/qpainterpath.cpp#L2537

This would prevent PlotCurveItem.setData(connect='finite') from working.

This commit converts a call using connect='finite' to the equivalent call using connect=ndarray with all the non-finite elements removed.

Related to PR #1058 
Related to issue #1057