### PR TITLE
Disable autoSIPrefix for DateAxisItem by default

### DIFF
--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -221,6 +221,7 @@ class DateAxisItem(AxisItem):
             (30,          HMS_ZOOM_LEVEL),
             (1,           MS_ZOOM_LEVEL),
             ])
+        self.autoSIPrefix = False
     
     def tickStrings(self, values, scale, spacing):
         tickSpecs = self.zoomLevel.tickSpecs


### PR DESCRIPTION
When adding a label, it adds the offset for the epoch seconds, (1e09), which is not helpful for date axes