### PR TITLE
Get ImageView ROI working with both row and col major data

### DIFF
--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -590,30 +590,42 @@ class ImageView(QtGui.QWidget):
         self.ui.roiPlot.setVisible(showRoiPlot)
 
     def roiChanged(self):
+        # Extract image data from ROI
         if self.image is None:
             return
-            
+
         image = self.getProcessedImage()
 
-        # Extract image data from ROI
-        axes = (self.axes['x'], self.axes['y'])
+        # getArrayRegion axes should be (x, y) of data array for col-major,
+        # (y, x) for row-major
+        # can't just transpose input because ROI is axisOrder aware
+        colmaj = self.imageItem.axisOrder == 'col-major'
+        if colmaj:
+            axes = (self.axes['x'], self.axes['y'])
+        else:
+            axes = (self.axes['y'], self.axes['x'])
 
-        data, coords = self.roi.getArrayRegion(image.view(np.ndarray), self.imageItem, returnMappedCoords=True)
+        data, coords = self.roi.getArrayRegion(
+            image.view(np.ndarray), img=self.imageItem, axes=axes,
+            returnMappedCoords=True)
+
         if data is None:
             return
 
         # Convert extracted data into 1D plot data
         if self.axes['t'] is None:
             # Average across y-axis of ROI
-            data = data.mean(axis=axes[1])
-            if axes == (1,0): ## we're in row-major order mode -- there's probably a better way to do this slicing dynamically, but I've not figured it out yet.
-                coords = coords[:,0,:] - coords[:,0,0:1]
-            else: #default to old way
-                coords = coords[:,:,0] - coords[:,0:1,0] 
+            data = data.mean(axis=self.axes['y'])
+
+            # get coordinates along x axis of ROI mapped to range (0, roiwidth)
+            if colmaj:
+                coords = coords[:, :, 0] - coords[:, 0:1, 0]
+            else:
+                coords = coords[:, 0, :] - coords[:, 0, 0:1]
             xvals = (coords**2).sum(axis=0) ** 0.5
         else:
             # Average data within entire ROI for each frame
-            data = data.mean(axis=max(axes)).mean(axis=min(axes))
+            data = data.mean(axis=axes)
             xvals = self.tVals
 
         # Handle multi-channel data


### PR DESCRIPTION
Fixes #1280. The comment [here](https://groups.google.com/d/msg/pyqtgraph/SE8KcK2LOv4/Ic07AftBAAAJ) is implemented, plus there was a bug in the region averaging for the single-image case. Now the selection is averaged along the y axis of the ROI in both row-major and col-major cases (x axis of the `PlotItem` should correspond to the x axis of the ROI).

Script I used for testing (along with `examples/ImageView.py` for testing an image stack):

```python
from skimage import data
import pyqtgraph as pg
from pyqtgraph.Qt import QtGui
import numpy as np

# row-major: rows of array are rows of image
# col-major: cols of array are rows of image
rowmajor = False # should still work if this is switched

if rowmajor:
    pg.setConfigOptions(imageAxisOrder='row-major')

app = pg.mkQApp()

win = QtGui.QMainWindow()
win.resize(800, 800)
imv = pg.ImageView()
win.setCentralWidget(imv)
win.show()

# shape: (300, 451, 3), row-major as loaded
img_data = data.chelsea()
if not rowmajor:
    # as if loaded col-major data
    img_data = img_data.swapaxes(0, 1)

imv.setImage(img_data)
imv.roi.setSize((451, 5)) # width, height
imv.ui.roiBtn.click()

app.exec_()
```