### PR TITLE
console fixes

### DIFF
--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -109,8 +109,10 @@ class ConsoleWidget(QtGui.QWidget):
                 pickle.dump(pf, history)
         
     def runCmd(self, cmd):
-        self.stdout = sys.stdout
-        self.stderr = sys.stderr
+        #cmd = str(self.input.lastCmd)
+
+        orig_stdout = sys.stdout
+        orig_stderr = sys.stderr
         encCmd = re.sub(r'>', '&gt;', re.sub(r'<', '&lt;', cmd))
         encCmd = re.sub(r' ', '&nbsp;', encCmd)
         
@@ -132,8 +134,8 @@ class ConsoleWidget(QtGui.QWidget):
                 self.write("</div>\n", html=True, scrollToBottom=True)
                 
         finally:
-            sys.stdout = self.stdout
-            sys.stderr = self.stderr
+            sys.stdout = orig_stdout
+            sys.stderr = orig_stderr
             
             sb = self.ui.historyList.verticalScrollBar()
             sb.setValue(sb.maximum())
@@ -178,7 +180,6 @@ class ConsoleWidget(QtGui.QWidget):
             self.displayException()
             
     def execMulti(self, nextLine):
-        #self.stdout.write(nextLine+"\n")
         if nextLine.strip() != '':
             self.multiline += "\n" + nextLine
             return
@@ -214,7 +215,7 @@ class ConsoleWidget(QtGui.QWidget):
         """
         isGuiThread = QtCore.QThread.currentThread() == QtCore.QCoreApplication.instance().thread()
         if not isGuiThread:
-            self.stdout.write(strn)
+            sys.__stdout__.write(strn)
             return
 
         sb = self.output.verticalScrollBar()
@@ -236,6 +237,11 @@ class ConsoleWidget(QtGui.QWidget):
             sb.setValue(sb.maximum())
         else:
             sb.setValue(scroll)
+
+    
+    def fileno(self):
+        # Need to implement this since we temporarily occlude sys.stdout, and someone may be looking for it (faulthandler, for example)
+        return 1
 
     def displayException(self):
         """
@@ -319,8 +325,8 @@ class ConsoleWidget(QtGui.QWidget):
         if editor is None:
             return
         tb = self.currentFrame()
-        lineNum = tb.tb_lineno
-        fileName = tb.tb_frame.f_code.co_filename
+        lineNum = tb.f_lineno
+        fileName = tb.f_code.co_filename
         subprocess.Popen(self.editor.format(fileName=fileName, lineNum=lineNum), shell=True)
         
     def updateSysTrace(self):


### PR DESCRIPTION
- add fileno method since console occludes sys.stdout, and thus it needs to look like a file handle
- don't store sys.stdout, since this is not guaranteed to be the real stdout; instead use `sys.__stdout__`
- fix editor spawning
