### PR TITLE
Acq4 merge

### DIFF
--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -166,15 +166,20 @@ class ConsoleWidget(QtGui.QWidget):
         try:
             output = eval(cmd, self.globals(), self.locals())
             self.write(repr(output) + '\n')
+            return
         except SyntaxError:
-            try:
-                exec(cmd, self.globals(), self.locals())
-            except SyntaxError as exc:
-                if 'unexpected EOF' in exc.msg:
-                    self.multiline = cmd
-                else:
-                    self.displayException()
-            except:
+            pass
+        except:
+            self.displayException()
+            return
+
+        # eval failed with syntax error; try exec instead
+        try:
+            exec(cmd, self.globals(), self.locals())
+        except SyntaxError as exc:
+            if 'unexpected EOF' in exc.msg:
+                self.multiline = cmd
+            else:
                 self.displayException()
         except:
             self.displayException()
@@ -190,22 +195,28 @@ class ConsoleWidget(QtGui.QWidget):
             output = eval(cmd, self.globals(), self.locals())
             self.write(str(output) + '\n')
             self.multiline = None
+            return
         except SyntaxError:
-            try:
-                exec(cmd, self.globals(), self.locals())
-                self.multiline = None
-            except SyntaxError as exc:
-                if 'unexpected EOF' in exc.msg:
-                    self.multiline = cmd
-                else:
-                    self.displayException()
-                    self.multiline = None
-            except:
+            pass
+        except:
+            self.displayException()
+            self.multiline = None
+            return
+
+        # eval failed with syntax error; try exec instead
+        try:
+            exec(cmd, self.globals(), self.locals())
+            self.multiline = None
+        except SyntaxError as exc:
+            if 'unexpected EOF' in exc.msg:
+                self.multiline = cmd
+            else:
                 self.displayException()
                 self.multiline = None
         except:
             self.displayException()
             self.multiline = None
+
 
     def write(self, strn, html=False, scrollToBottom='auto'):
         """Write a string into the console.

--- a/pyqtgraph/ptime.py
+++ b/pyqtgraph/ptime.py
@@ -20,8 +20,7 @@ time = None
 
 def winTime():
     """Return the current time in seconds with high precision (windows version, use Manager.time() to stay platform independent)."""
-    return clock() - START_TIME
-    #return systime.time()
+    return clock() + START_TIME
 
 def unixTime():
     """Return the current time in seconds with high precision (unix version, use Manager.time() to stay platform independent)."""

--- a/pyqtgraph/reload.py
+++ b/pyqtgraph/reload.py
@@ -78,8 +78,11 @@ def reloadAll(prefix=None, debug=False):
 
         # if source file is newer than cache file, then it needs to be reloaded.
         pyc = getattr(mod, '__cached__', py + 'c')
-        
-        if os.path.isfile(pyc) and os.stat(pyc).st_mtime < os.stat(py).st_mtime:
+        if not os.path.isfile(pyc):
+            ret[modName] = (False, 'code has no pyc file to compare')
+            continue
+
+        if os.stat(pyc).st_mtime > os.stat(py).st_mtime:
             ret[modName] = (False, 'code has not changed since compile')
             continue
 

--- a/pyqtgraph/tests/test_reload.py
+++ b/pyqtgraph/tests/test_reload.py
@@ -1,4 +1,4 @@
-import tempfile, os, sys, shutil
+import tempfile, os, sys, shutil, time
 import pyqtgraph as pg
 import pyqtgraph.reload
 
@@ -64,7 +64,8 @@ def test_reload():
 
     # write again and reload
     open(mod, 'w').write(code.format(path_repr=pgpath_repr, msg="C.fn() Version2"))
-    remove_cache(mod)
+    time.sleep(1.1)
+    #remove_cache(mod)
     result1 = pg.reload.reloadAll(path, debug=True)
     if py3:
         v2 = (reload_test_mod.C, reload_test_mod.C.sig, reload_test_mod.C.fn, c.sig, c.fn, c.fn.__func__)
@@ -88,7 +89,8 @@ def test_reload():
 
     # write again and reload
     open(mod, 'w').write(code.format(path_repr=pgpath_repr, msg="C.fn() Version2"))
-    remove_cache(mod)
+    time.sleep(1.1)
+#    remove_cache(mod)
     result2 = pg.reload.reloadAll(path, debug=True)
     if py3:
         v3 = (reload_test_mod.C, reload_test_mod.C.sig, reload_test_mod.C.fn, c.sig, c.fn, c.fn.__func__)


### PR DESCRIPTION
- fix reload on py3 (again) -- don't automatically reload modules without pyc
- clean up exception messages in console -- don't raise from eval syntax error
- make ptime.time on py3 return precision wall-clock time 