### PR TITLE
Add a docs build job to CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,6 @@ stages:
         echo -e "Estimated content size difference = ${SIZE_DIFF} kB" &&
         test ${SIZE_DIFF} -lt 100;
       displayName: 'Diff Size Check'
-      continueOnError: true
 
   - job: "style_check"
     pool:
@@ -66,7 +65,6 @@ stages:
         pip install flake8
         python setup.py style
       displayName: 'flake8 check'
-      continueOnError: true
 
   - job: "build_wheel"
     pool:
@@ -95,9 +93,9 @@ stages:
         python -m pip install -r requirements.txt
         make html SPHINXOPTS='-W -v'
       displayName: "Build docs"
-      continueOnError: true
 
 - stage: "test"
+  condition: succeededOrFailed()
   jobs:
   - template: azure-test-template.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,7 +93,7 @@ stages:
     - script: |
         cd doc
         python -m pip install -r requirements.txt
-        make html
+        make html SPHINXOPTS='-W -v'
       displayName: "Build docs"
       continueOnError: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ variables:
   disable.coverage.autogenerate: 'true'
 
 stages:
-- stage: "pre_test"
+- stage: pre_build
   jobs:
   - job: check_diff_size
     pool:
@@ -53,7 +53,6 @@ stages:
         echo -e "Estimated content size difference = ${SIZE_DIFF} kB" &&
         test ${SIZE_DIFF} -lt 100;
       displayName: 'Diff Size Check'
-
   - job: "style_check"
     pool:
       vmImage: "Ubuntu 18.04"
@@ -65,7 +64,22 @@ stages:
         pip install flake8
         python setup.py style
       displayName: 'flake8 check'
+  - job: "build_docs"
+    pool:
+      vmImage: 'Ubuntu 18.04'
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.8
+    - script: |
+        cd doc
+        python -m pip install -r requirements.txt
+        make html SPHINXOPTS='-W -v'
+      displayName: "Build docs"
 
+- stage: build
+  dependsOn: []
+  jobs:
   - job: "build_wheel"
     pool:
       vmImage: 'Ubuntu 18.04'
@@ -81,21 +95,9 @@ stages:
     - publish: dist
       artifact: wheel
 
-  - job: "build_docs"
-    pool:
-      vmImage: 'Ubuntu 18.04'
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: 3.8
-    - script: |
-        cd doc
-        python -m pip install -r requirements.txt
-        make html SPHINXOPTS='-W -v'
-      displayName: "Build docs"
-
-- stage: "test"
-  condition: succeededOrFailed()
+- stage: test
+  displayName: "Test Suite"
+  dependsOn: build
   jobs:
   - template: azure-test-template.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,6 +83,20 @@ stages:
     - publish: dist
       artifact: wheel
 
+  - job: "build_docs"
+    pool:
+      vmImage: 'Ubuntu 18.04'
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.8
+    - script: |
+        cd doc
+        python -m pip install -r requirements.txt
+        make html
+      displayName: "Build docs"
+      continueOnError: true
+
 - stage: "test"
   jobs:
   - template: azure-test-template.yml

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -139,7 +139,7 @@ html_static_path = ['_static']
 
 # add the theme customizations
 def setup(app):
-    app.add_stylesheet("custom.css")
+    app.add_css_file("custom.css")
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -21,7 +21,7 @@ class AxisItem(GraphicsWidget):
 
     def __init__(self, orientation, pen=None, textPen=None, linkView=None, parent=None, maxTickLength=-5, showValues=True, text='', units='', unitPrefix='', **args):
         """
-        ==============  ===============================================================
+        =============== ===============================================================
         **Arguments:**
         orientation     one of 'left', 'right', 'top', or 'bottom'
         maxTickLength   (px) maximum length of ticks to draw. Negative values draw

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -14,7 +14,8 @@ __all__ = ['AxisItem']
 class AxisItem(GraphicsWidget):
     """
     GraphicsItem showing a single plot axis with ticks, values, and label.
-    Can be configured to fit on any side of a plot, and can automatically synchronize its displayed scale with ViewBox items.
+    Can be configured to fit on any side of a plot, 
+    Can automatically synchronize its displayed scale with ViewBox items.
     Ticks can be extended to draw a grid.
     If maxTickLength is negative, ticks point into the plot.
     """
@@ -39,7 +40,7 @@ class AxisItem(GraphicsWidget):
                         range of data displayed.
         args            All extra keyword arguments become CSS style options for
                         the <span> tag which will surround the axis label and units.
-        ==============  ===============================================================
+        =============== ===============================================================
         """
 
         GraphicsWidget.__init__(self, parent)


### PR DESCRIPTION
Just an idea - it might be nice to catch docs issues in PRs before merging and finding out via readthedocs.

Seems like it'd be easy to publish the built docs as an artifact, but I don't know if there's a reasonable way to look at them without downloading a zip and opening manually.

Also, feedback welcome on where this should go in the pipeline - I'm not sure pre-test is the right stage.