### PR TITLE
sip: switch to new PyQt5 api import, with fallback to the old impleme…

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -16,7 +16,10 @@ getMillis = lambda: int(round(time.time() * 1000))
 
 if hasattr(QtCore, 'PYQT_VERSION'):
     try:
-        import sip
+        try:
+            from PyQt5 import sip
+        except ImportError:
+            import sip
         HAVE_SIP = True
     except ImportError:
         HAVE_SIP = False

--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -320,7 +320,10 @@ if QT_LIB in [PYSIDE, PYSIDE2]:
 if QT_LIB in [PYQT4, PYQT5]:
     QtVersion = QtCore.QT_VERSION_STR
     
-    import sip
+    try:
+        from PyQt5 import sip
+    except ImportError:
+        import sip
     def isQObjectAlive(obj):
         return not sip.isdeleted(obj)
     

--- a/pyqtgraph/debug.py
+++ b/pyqtgraph/debug.py
@@ -1083,7 +1083,10 @@ def listQThreads():
     """Prints Thread IDs (Qt's, not OS's) for all QThreads."""
     thr = findObj('[Tt]hread')
     thr = [t for t in thr if isinstance(t, QtCore.QThread)]
-    import sip
+    try:
+        from PyQt5 import sip
+    except ImportError:
+        import sip
     for t in thr:
         print("--> ", t)
         print("     Qt ID: 0x%x" % sip.unwrapinstance(t))

--- a/pyqtgraph/dockarea/tests/test_dock.py
+++ b/pyqtgraph/dockarea/tests/test_dock.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-#import sip
-#sip.setapi('QString', 1)
+#try:
+#    from PyQt5 import sip
+#except ImportError:
+#    import sip
+#    sip.setapi('QString', 1)
 
 import pyqtgraph as pg
 pg.mkQApp()

--- a/pyqtgraph/graphicsItems/GraphicsObject.py
+++ b/pyqtgraph/graphicsItems/GraphicsObject.py
@@ -1,6 +1,9 @@
 from ..Qt import QtGui, QtCore, QT_LIB
 if QT_LIB in ['PyQt4', 'PyQt5']:
-    import sip
+    try:
+        from PyQt5 import sip
+    except ImportError:
+        import sip
 from .GraphicsItem import GraphicsItem
 
 __all__ = ['GraphicsObject']

--- a/pyqtgraph/graphicsItems/UIGraphicsItem.py
+++ b/pyqtgraph/graphicsItems/UIGraphicsItem.py
@@ -2,7 +2,10 @@ from ..Qt import QtGui, QtCore, QT_LIB
 import weakref
 from .GraphicsObject import GraphicsObject
 if QT_LIB in ['PyQt4', 'PyQt5']:
-    import sip
+    try:
+        from PyQt5 import sip
+    except ImportError:
+        import sip
 
 __all__ = ['UIGraphicsItem']
 class UIGraphicsItem(GraphicsObject):

--- a/pyqtgraph/multiprocess/bootstrap.py
+++ b/pyqtgraph/multiprocess/bootstrap.py
@@ -25,9 +25,12 @@ if __name__ == '__main__':
 
     pyqtapis = opts.pop('pyqtapis', None)
     if pyqtapis is not None:
-        import sip
-        for k,v in pyqtapis.items():
-            sip.setapi(k, v)
+        try:
+            from PyQt5 import sip
+        except ImportError:
+            import sip
+            for k,v in pyqtapis.items():
+                sip.setapi(k, v)
         
     qt_lib = opts.pop('qt_lib', None)
     if qt_lib == 'PySide':

--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -1,6 +1,9 @@
 from ..Qt import QtGui, QtCore, QT_LIB
 if QT_LIB in ['PyQt4', 'PyQt5']:
-    import sip
+    try:
+        from PyQt5 import sip
+    except ImportError:
+        import sip
 from .. import multiprocess as mp
 from .GraphicsView import GraphicsView
 from .. import CONFIG_OPTIONS


### PR DESCRIPTION
…ntation if not found.

Also calls to setapi are not needed anymore, so use them only with the old implementation.

See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=966045
for reference