### PR TITLE
Fix an error in ArrowItem constructor when passed a parent=... argument

### DIFF
--- a/pyqtgraph/graphicsItems/ArrowItem.py
+++ b/pyqtgraph/graphicsItems/ArrowItem.py
@@ -11,13 +11,13 @@ class ArrowItem(QtGui.QGraphicsPathItem):
     """
     
     
-    def __init__(self, **opts):
+    def __init__(self, parent=None, **opts):
         """
         Arrows can be initialized with any keyword arguments accepted by 
         the setStyle() method.
         """
         self.opts = {}
-        QtGui.QGraphicsPathItem.__init__(self, opts.pop('parent', None))
+        QtGui.QGraphicsPathItem.__init__(self, parent)
 
         if 'size' in opts:
             opts['headLen'] = opts['size']

--- a/pyqtgraph/graphicsItems/ArrowItem.py
+++ b/pyqtgraph/graphicsItems/ArrowItem.py
@@ -17,7 +17,7 @@ class ArrowItem(QtGui.QGraphicsPathItem):
         the setStyle() method.
         """
         self.opts = {}
-        QtGui.QGraphicsPathItem.__init__(self, opts.get('parent', None))
+        QtGui.QGraphicsPathItem.__init__(self, opts.pop('parent', None))
 
         if 'size' in opts:
             opts['headLen'] = opts['size']

--- a/pyqtgraph/graphicsItems/tests/test_ArrowItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_ArrowItem.py
@@ -3,7 +3,7 @@ import pyqtgraph as pg
 app = pg.mkQApp()
 
 
-def test_ArrowItem():
+def test_ArrowItem_parent():
     parent = pg.GraphicsObject()
     a = pg.ArrowItem(parent=parent, pos=(10, 10))
     assert a.parentItem() is parent

--- a/pyqtgraph/graphicsItems/tests/test_ArrowItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_ArrowItem.py
@@ -1,0 +1,10 @@
+import pyqtgraph as pg
+
+app = pg.mkQApp()
+
+
+def test_ArrowItem():
+    parent = pg.GraphicsObject()
+    a = pg.ArrowItem(parent=parent, pos=(10, 10))
+    assert a.parentItem() is parent
+    assert a.pos() == pg.Point(10, 10)


### PR DESCRIPTION
```python
import pyqtgraph as pg
app = pg.mkQApp()
parent = pg.GraphicsObject()
a = pg.ArrowItem(parent=parent)
```
Raises an 
```
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "/Users/aleserjavec/workspace/pyqtgraph/pyqtgraph/graphicsItems/ArrowItem.py", line 42, in __init__
    self.setStyle(**defaultOpts)
  File "/Users/aleserjavec/workspace/pyqtgraph/pyqtgraph/graphicsItems/ArrowItem.py", line 82, in setStyle
    raise KeyError('Invalid arrow style option "%s"' % k)
KeyError: 'Invalid arrow style option "parent"'
```
(since #1297)

Fixed by poping the 'parent' arg from opts.
