### PR TITLE
Vector init in qt5

### DIFF
--- a/pyqtgraph/Vector.py
+++ b/pyqtgraph/Vector.py
@@ -17,14 +17,14 @@ class Vector(QtGui.QVector3D):
 
         ==============  ================================================================================================
         **Arguments:**
-        *args*      Could be any of:
-                     * 3 numerics
-                     * 2 numerics (`0` assumed for z)
-                     * Either of the previous in a list-like collection
-                     * 1 QSizeF (`0` assumed for z)
-                     * 1 QPointF (`0` assumed for z)
-                     * Any other valid QVector3D init args.
-        ----------------------------------------------------------------------------------------------------------------
+        *args*          Could be any of:
+
+                         * 3 numerics (x, y, and z)
+                         * 2 numerics (x, y, and `0` assumed for z)
+                         * Either of the previous in a list-like collection
+                         * 1 QSizeF (`0` assumed for z)
+                         * 1 QPointF (`0` assumed for z)
+                         * Any other valid QVector3D init args.
         ==============  ================================================================================================
         """
         initArgs = args

--- a/pyqtgraph/Vector.py
+++ b/pyqtgraph/Vector.py
@@ -15,16 +15,17 @@ class Vector(QtGui.QVector3D):
         """
         Handle additional constructions of a Vector
 
-        Parameters
-        ----------
-        args
-            Could be any of:
-             * 3 numerics
-             * 2 numerics (`0` assumed for z)
-             * Either of the previous in a list-like collection
-             * 1 QSizeF (`0` assumed for z)
-             * 1 QPointF (`0` assumed for z)
-             * Any other valid QVector3D init args.
+        ==============  ================================================================================================
+        **Arguments:**
+        *args*      Could be any of:
+                     * 3 numerics
+                     * 2 numerics (`0` assumed for z)
+                     * Either of the previous in a list-like collection
+                     * 1 QSizeF (`0` assumed for z)
+                     * 1 QPointF (`0` assumed for z)
+                     * Any other valid QVector3D init args.
+        ----------------------------------------------------------------------------------------------------------------
+        ==============  ================================================================================================
         """
         initArgs = args
         if len(args) == 1:

--- a/pyqtgraph/Vector.py
+++ b/pyqtgraph/Vector.py
@@ -26,22 +26,22 @@ class Vector(QtGui.QVector3D):
              * 1 QPointF (`0` assumed for z)
              * Any other valid QVector3D init args.
         """
-        init_args = args
+        initArgs = args
         if len(args) == 1:
             if isinstance(args[0], QtCore.QSizeF):
-                init_args = (float(args[0].width()), float(args[0].height()), 0)
+                initArgs = (float(args[0].width()), float(args[0].height()), 0)
             elif isinstance(args[0], QtCore.QPoint) or isinstance(args[0], QtCore.QPointF):
-                init_args = (float(args[0].x()), float(args[0].y()), 0)
+                initArgs = (float(args[0].x()), float(args[0].y()), 0)
             elif hasattr(args[0], '__getitem__') and not isinstance(args[0], QtGui.QVector3D):
                 vals = list(args[0])
                 if len(vals) == 2:
                     vals.append(0)
                 if len(vals) != 3:
                     raise Exception('Cannot init Vector with sequence of length %d' % len(args[0]))
-                init_args = vals
+                initArgs = vals
         elif len(args) == 2:
-            init_args = (args[0], args[1], 0)
-        QtGui.QVector3D.__init__(self, *init_args)
+            initArgs = (args[0], args[1], 0)
+        QtGui.QVector3D.__init__(self, *initArgs)
 
     def __len__(self):
         return 3

--- a/pyqtgraph/Vector.py
+++ b/pyqtgraph/Vector.py
@@ -12,35 +12,36 @@ class Vector(QtGui.QVector3D):
     """Extension of QVector3D which adds a few helpful methods."""
     
     def __init__(self, *args):
+        """
+        Handle additional constructions of a Vector
+
+        Parameters
+        ----------
+        args
+            Could be any of:
+             * 3 numerics
+             * 2 numerics (`0` assumed for z)
+             * Either of the previous in a list-like collection
+             * 1 QSizeF (`0` assumed for z)
+             * 1 QPointF (`0` assumed for z)
+             * Any other valid QVector3D init args.
+        """
+        init_args = args
         if len(args) == 1:
             if isinstance(args[0], QtCore.QSizeF):
-                x = float(args[0].width())
-                y = float(args[0].height())
-                z = 0
+                init_args = (float(args[0].width()), float(args[0].height()), 0)
             elif isinstance(args[0], QtCore.QPoint) or isinstance(args[0], QtCore.QPointF):
-                x = float(args[0].x())
-                y = float(args[0].y())
-                z = 0
-            elif isinstance(args[0], QtGui.QVector3D):
-                x = args[0].x()
-                y = args[0].y()
-                z = args[0].z()
-            elif hasattr(args[0], '__getitem__'):
+                init_args = (float(args[0].x()), float(args[0].y()), 0)
+            elif hasattr(args[0], '__getitem__') and not isinstance(args[0], QtGui.QVector3D):
                 vals = list(args[0])
                 if len(vals) == 2:
-                    x, y = vals
-                    z = 0
-                elif len(vals) == 3:
-                    x, y, z = vals
-                else:
-                    raise ValueError('Cannot init Vector with sequence of length %d' % len(args[0]))
+                    vals.append(0)
+                if len(vals) != 3:
+                    raise Exception('Cannot init Vector with sequence of length %d' % len(args[0]))
+                init_args = vals
         elif len(args) == 2:
-            x, y = args
-            z = 0
-        else:
-            x, y, z = args  # Could raise ValueError
-
-        QtGui.QVector3D.__init__(self, x, y, z)
+            init_args = (args[0], args[1], 0)
+        QtGui.QVector3D.__init__(self, *init_args)
 
     def __len__(self):
         return 3


### PR DESCRIPTION
`Vector.__init__` improvements

 * add docstring
 * fix handling of QVector3D args (cannot list() them)
 * refactor to no longer need return statements

Also add Pa to the list of units.