### PR TITLE
Make ScatterPlotItem.paint aware of layout offset

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -835,11 +835,14 @@ class ScatterPlotItem(GraphicsObject):
             else:
                 # render each symbol individually
                 p.setRenderHint(p.Antialiasing, aa)
+                
+                vb = self.getViewBox()
+                offset = vb.parentItem().pos() if vb.parentItem() else vb.pos()
 
                 pts = pts[:,viewMask]
                 for i, rec in enumerate(data[viewMask]):
                     p.resetTransform()
-                    p.translate(pts[0,i] + rec['width']/2, pts[1,i] + rec['width']/2)
+                    p.translate(pts[0,i] + rec['width'], pts[1,i] + rec['width'])
                     drawSymbol(p, *self.getSpotOpts(rec, scale))
         else:
             if self.picture is None:


### PR DESCRIPTION
Without this addition the markers of the ScatterPlotItem are not visible in the export when the ScatterPlotItem is not located in the first panel of a Layout.