### PR TITLE
rename SignalProxy.block

### DIFF
--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -84,8 +84,8 @@ class SignalProxy(QtCore.QObject):
             self.sigDelayed.disconnect(self.slot)
         except:
             pass
-   
-    def block(self):
+
+    def signalBlockingContext(self):
         """Return a SignalBlocker that temporarily blocks input signals to this proxy.
         """
         return SignalBlock(self.signal, self.signalReceived)


### PR DESCRIPTION
`block` is being overwritten with a boolean by QObject in PyQt5. This method was added recently enough that we should be able to rename it without breaking anyone's code (exception: ACQ4 will have a complimentary PR).