### PR TITLE
Fix parametertree name/title handling

### DIFF
--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -213,6 +213,16 @@ class Parameter(QtCore.QObject):
         """Return the name of this Parameter."""
         return self.opts['name']
 
+    def title(self):
+        """Return the title of this Parameter.
+        
+        By default, the title is the same as the name unless it has been explicitly specified
+        otherwise."""
+        title = self.opts.get('title', None)
+        if title is None:
+            title = self.name()
+        return title
+
     def contextMenu(self, name):
         """"A context menu entry was clicked"""
         self.sigContextMenu.emit(self, name)

--- a/pyqtgraph/parametertree/ParameterItem.py
+++ b/pyqtgraph/parametertree/ParameterItem.py
@@ -16,10 +16,7 @@ class ParameterItem(QtGui.QTreeWidgetItem):
     """
     
     def __init__(self, param, depth=0):
-        title = param.opts.get('title', None)
-        if title is None:
-            title = param.name()
-        QtGui.QTreeWidgetItem.__init__(self, [title, ''])
+        QtGui.QTreeWidgetItem.__init__(self, [param.title(), ''])
 
         self.param = param
         self.param.registerItem(self)  ## let parameter know this item is connected to it (for debugging)
@@ -157,8 +154,12 @@ class ParameterItem(QtGui.QTreeWidgetItem):
     def nameChanged(self, param, name):
         ## called when the parameter's name has changed.
         if self.param.opts.get('title', None) is None:
-            self.setText(0, name)
-    
+            self.titleChanged()
+
+    def titleChanged(self):
+        # called when the user-visble title has changed (either opts['title'], or name if title is None)
+        self.setText(0, self.param.title())
+
     def limitsChanged(self, param, limits):
         """Called when the parameter's limits have changed"""
         pass
@@ -183,8 +184,10 @@ class ParameterItem(QtGui.QTreeWidgetItem):
                 if self.isExpanded() != self.param.opts['expanded']:
                     self.setExpanded(self.param.opts['expanded'])
 
-        self.updateFlags()
+        if 'title' in opts:
+            self.titleChanged()
 
+        self.updateFlags()
 
     def contextMenuTriggered(self, name):
         def trigger():

--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -597,16 +597,11 @@ class ActionParameterItem(ParameterItem):
         self.layout = QtGui.QHBoxLayout()
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.layoutWidget.setLayout(self.layout)
-        title = param.opts.get('title', None)
-        if title is None:
-            title = param.name()
-        self.button = QtGui.QPushButton(title)
+        self.button = QtGui.QPushButton(param.title())
         #self.layout.addSpacing(100)
         self.layout.addWidget(self.button)
         self.layout.addStretch()
         self.button.clicked.connect(self.buttonClicked)
-        param.sigNameChanged.connect(self.paramRenamed)
-        self.setText(0, '')
         
     def treeWidgetChanged(self):
         ParameterItem.treeWidgetChanged(self)
@@ -616,9 +611,10 @@ class ActionParameterItem(ParameterItem):
         
         tree.setFirstItemColumnSpanned(self, True)
         tree.setItemWidget(self, 0, self.layoutWidget)
-        
-    def paramRenamed(self, param, name):
-        self.button.setText(name)
+
+    def titleChanged(self):
+        self.button.setText(self.param.title())
+        ParameterItem.titleChanged(self)
         
     def buttonClicked(self):
         self.param.activate()


### PR DESCRIPTION
- Parameters now respond to title change in setOpts
- Add Parameter.title()
- Action parameter uses default name/title handling in addition to setting button text (fixes #1320)