### PR TITLE
Add "left" and "right" step Modes

### DIFF
--- a/examples/histogram.py
+++ b/examples/histogram.py
@@ -20,9 +20,9 @@ vals = np.hstack([np.random.normal(size=500), np.random.normal(size=260, loc=4)]
 ## compute standard histogram
 y,x = np.histogram(vals, bins=np.linspace(-3, 8, 40))
 
-## Using stepMode=True causes the plot to draw two lines for each sample.
+## Using stepMode="mid" causes the plot to draw two lines for each sample.
 ## notice that len(x) == len(y)+1
-plt1.plot(x, y, stepMode=True, fillLevel=0, fillOutline=True, brush=(0,0,255,150))
+plt1.plot(x, y, stepMode="mid", fillLevel=0, fillOutline=True, brush=(0,0,255,150))
 
 ## Now draw all points as a nicely-spaced scatter plot
 y = pg.pseudoScatter(vals, spacing=0.15)

--- a/examples/histogram.py
+++ b/examples/histogram.py
@@ -20,9 +20,9 @@ vals = np.hstack([np.random.normal(size=500), np.random.normal(size=260, loc=4)]
 ## compute standard histogram
 y,x = np.histogram(vals, bins=np.linspace(-3, 8, 40))
 
-## Using stepMode="mid" causes the plot to draw two lines for each sample.
+## Using stepMode="center" causes the plot to draw two lines for each sample.
 ## notice that len(x) == len(y)+1
-plt1.plot(x, y, stepMode="mid", fillLevel=0, fillOutline=True, brush=(0,0,255,150))
+plt1.plot(x, y, stepMode="center", fillLevel=0, fillOutline=True, brush=(0,0,255,150))
 
 ## Now draw all points as a nicely-spaced scatter plot
 y = pg.pseudoScatter(vals, spacing=0.15)

--- a/pyqtgraph/exporters/tests/test_csv.py
+++ b/pyqtgraph/exporters/tests/test_csv.py
@@ -28,7 +28,7 @@ def test_CSVExporter():
     
     y3 = [1,5,2,3,4,6,1,2,4,2,3,5,3]
     x3 = pg.np.linspace(0, 1.0, len(y3)+1)
-    plt.plot(x=x3, y=y3, stepMode=True)
+    plt.plot(x=x3, y=y3, stepMode="mid")
     
     ex = pg.exporters.CSVExporter(plt.plotItem)
     ex.export(fileName=tempfilename)

--- a/pyqtgraph/exporters/tests/test_csv.py
+++ b/pyqtgraph/exporters/tests/test_csv.py
@@ -28,7 +28,7 @@ def test_CSVExporter():
     
     y3 = [1,5,2,3,4,6,1,2,4,2,3,5,3]
     x3 = pg.np.linspace(0, 1.0, len(y3)+1)
-    plt.plot(x=x3, y=y3, stepMode="mid")
+    plt.plot(x=x3, y=y3, stepMode="center")
     
     ex = pg.exporters.CSVExporter(plt.plotItem)
     ex.export(fileName=tempfilename)

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -62,7 +62,7 @@ class PlotCurveItem(GraphicsObject):
             'fillLevel': None,
             'fillOutline': False,
             'brush': None,
-            'stepMode': False,
+            'stepMode': None,
             'name': None,
             'antialias': getConfigOption('antialias'),
             'connect': 'all',
@@ -315,14 +315,17 @@ class PlotCurveItem(GraphicsObject):
                         by :func:`mkBrush <pyqtgraph.mkBrush>` is allowed.
         antialias       (bool) Whether to use antialiasing when drawing. This
                         is disabled by default because it decreases performance.
-        stepMode        If True, a step is drawn using the x values as
-                        boundaries and the given y values are associated to the
-                        mid-points between the boundaries of each step.
-                        This is commonly used when drawing histograms. Note that
-                        in this case, len(x) == len(y) + 1.
+        stepMode        (str or None) If "mid", a step is drawn using the x
+                        values as boundaries and the given y values are
+                        associated to the mid-points between the boundaries of
+                        each step. This is commonly used when drawing
+                        histograms. Note that in this case, len(x) == len(y) + 1
                         If "left" or "right", the step is drawn assuming that
                         the y value is associated to the left or right boundary,
                         respectively. In this case len(x) == len(y)
+                        If not passed or an empty string or None is passed, the
+                        step mode is not enabled.
+                        Passing True is a deprecated equivalent to "mid".
         connect         Argument specifying how vertexes should be connected
                         by line segments. Default is "all", indicating full
                         connection. "pairs" causes only even-numbered segments
@@ -384,10 +387,10 @@ class PlotCurveItem(GraphicsObject):
         if 'stepMode' in kargs:
             self.opts['stepMode'] = kargs['stepMode']
 
-        if self.opts['stepMode'] is True:   ## if mode strictly **is** True
+        if self.opts['stepMode'] in ("mid", True):  ## check against True for backwards compatibility
             if len(self.xData) != len(self.yData)+1:  ## allow difference of 1 for step mode plots
                 raise Exception("len(X) must be len(Y)+1 since stepMode=True (got %s and %s)" % (self.xData.shape, self.yData.shape))
-        else:  ## mode may be `False` or `left` or `right`
+        else:
             if self.xData.shape != self.yData.shape:  ## allow difference of 1 for step mode plots
                 raise Exception("X and Y arrays must be the same shape--got %s and %s." % (self.xData.shape, self.yData.shape))
 
@@ -428,7 +431,7 @@ class PlotCurveItem(GraphicsObject):
                 x2 = np.empty((len(x) + 1, 2), dtype=x.dtype)
                 x2[1:] = x[:, np.newaxis]
                 x2[0] = x2[1]
-            else:
+            else:  # stepMode is "mid" (or True)
                 x2 = np.empty((len(x),2), dtype=x.dtype)
                 x2[:] = x[:, np.newaxis]
             if self.opts['fillLevel'] is None:

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -388,6 +388,9 @@ class PlotCurveItem(GraphicsObject):
             self.opts['stepMode'] = kargs['stepMode']
 
         if self.opts['stepMode'] in ("center", True):  ## check against True for backwards compatibility
+            if self.opts['stepMode'] is True:
+                import warnings
+                warnings.warn('stepMode=True is deprecated, use stepMode="center" instead', DeprecationWarning, stacklevel=3)
             if len(self.xData) != len(self.yData)+1:  ## allow difference of 1 for step mode plots
                 raise Exception("len(X) must be len(Y)+1 since stepMode=True (got %s and %s)" % (self.xData.shape, self.yData.shape))
         else:

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -384,10 +384,10 @@ class PlotCurveItem(GraphicsObject):
         if 'stepMode' in kargs:
             self.opts['stepMode'] = kargs['stepMode']
 
-        if self.opts['stepMode'] is True:
+        if self.opts['stepMode'] is True:   ## if mode strictly **is** True
             if len(self.xData) != len(self.yData)+1:  ## allow difference of 1 for step mode plots
                 raise Exception("len(X) must be len(Y)+1 since stepMode=True (got %s and %s)" % (self.xData.shape, self.yData.shape))
-        else:
+        else:  ## mode may be `False` or `left` or `right`
             if self.xData.shape != self.yData.shape:  ## allow difference of 1 for step mode plots
                 raise Exception("X and Y arrays must be the same shape--got %s and %s." % (self.xData.shape, self.yData.shape))
 

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -320,7 +320,7 @@ class PlotCurveItem(GraphicsObject):
                         point of the boundaries. This is commonly used when
                         drawing histograms. Note that in this case,
                         len(x) == len(y) + 1.
-                        If "lstep" or "rstep", the step is drawn assuming that
+                        If "left" or "right", the step is drawn assuming that
                         the y value is associated to the left or right boundary,
                         respectively. In this case len(x) == len(y)
         connect         Argument specifying how vertexes should be connected
@@ -420,11 +420,11 @@ class PlotCurveItem(GraphicsObject):
     def generatePath(self, x, y):
         if self.opts['stepMode']:
             ## each value in the x/y arrays generates 2 points.
-            if self.opts['stepMode'] == "rstep":
+            if self.opts['stepMode'] == "right":
                 x2 = np.empty((len(x) + 1, 2), dtype=x.dtype)
                 x2[:-1] = x[:, np.newaxis]
                 x2[-1] = x2[-2]
-            elif self.opts['stepMode'] == "lstep":
+            elif self.opts['stepMode'] == "left":
                 x2 = np.empty((len(x) + 1, 2), dtype=x.dtype)
                 x2[1:] = x[:, np.newaxis]
                 x2[0] = x2[1]

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -421,19 +421,22 @@ class PlotCurveItem(GraphicsObject):
         profiler('emit')
 
     def generatePath(self, x, y):
-        if self.opts['stepMode']:
+        stepMode = self.opts['stepMode']
+        if stepMode:
             ## each value in the x/y arrays generates 2 points.
-            if self.opts['stepMode'] == "right":
+            if stepMode == "right":
                 x2 = np.empty((len(x) + 1, 2), dtype=x.dtype)
                 x2[:-1] = x[:, np.newaxis]
                 x2[-1] = x2[-2]
-            elif self.opts['stepMode'] == "left":
+            elif stepMode == "left":
                 x2 = np.empty((len(x) + 1, 2), dtype=x.dtype)
                 x2[1:] = x[:, np.newaxis]
                 x2[0] = x2[1]
-            else:  # stepMode is "mid" (or True)
+            elif stepMode in ("mid", True):  ## support True for back-compat
                 x2 = np.empty((len(x),2), dtype=x.dtype)
                 x2[:] = x[:, np.newaxis]
+            else:
+                raise ValueError("Unsupported stepMode %s" % stepMode)
             if self.opts['fillLevel'] is None:
                 x = x2.reshape(x2.size)[1:-1]
                 y2 = np.empty((len(y),2), dtype=y.dtype)

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -315,7 +315,7 @@ class PlotCurveItem(GraphicsObject):
                         by :func:`mkBrush <pyqtgraph.mkBrush>` is allowed.
         antialias       (bool) Whether to use antialiasing when drawing. This
                         is disabled by default because it decreases performance.
-        stepMode        (str or None) If "mid", a step is drawn using the x
+        stepMode        (str or None) If "center", a step is drawn using the x
                         values as boundaries and the given y values are
                         associated to the mid-points between the boundaries of
                         each step. This is commonly used when drawing
@@ -325,7 +325,7 @@ class PlotCurveItem(GraphicsObject):
                         respectively. In this case len(x) == len(y)
                         If not passed or an empty string or None is passed, the
                         step mode is not enabled.
-                        Passing True is a deprecated equivalent to "mid".
+                        Passing True is a deprecated equivalent to "center".
         connect         Argument specifying how vertexes should be connected
                         by line segments. Default is "all", indicating full
                         connection. "pairs" causes only even-numbered segments
@@ -387,7 +387,7 @@ class PlotCurveItem(GraphicsObject):
         if 'stepMode' in kargs:
             self.opts['stepMode'] = kargs['stepMode']
 
-        if self.opts['stepMode'] in ("mid", True):  ## check against True for backwards compatibility
+        if self.opts['stepMode'] in ("center", True):  ## check against True for backwards compatibility
             if len(self.xData) != len(self.yData)+1:  ## allow difference of 1 for step mode plots
                 raise Exception("len(X) must be len(Y)+1 since stepMode=True (got %s and %s)" % (self.xData.shape, self.yData.shape))
         else:
@@ -432,7 +432,7 @@ class PlotCurveItem(GraphicsObject):
                 x2 = np.empty((len(x) + 1, 2), dtype=x.dtype)
                 x2[1:] = x[:, np.newaxis]
                 x2[0] = x2[1]
-            elif stepMode in ("mid", True):  ## support True for back-compat
+            elif stepMode in ("center", True):  ## support True for back-compat
                 x2 = np.empty((len(x),2), dtype=x.dtype)
                 x2[:] = x[:, np.newaxis]
             else:

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -316,10 +316,10 @@ class PlotCurveItem(GraphicsObject):
         antialias       (bool) Whether to use antialiasing when drawing. This
                         is disabled by default because it decreases performance.
         stepMode        If True, a step is drawn using the x values as
-                        boundaries and the y value is assumed to be at the mid
-                        point of the boundaries. This is commonly used when
-                        drawing histograms. Note that in this case,
-                        len(x) == len(y) + 1.
+                        boundaries and the given y values are associated to the
+                        mid-points between the boundaries of each step.
+                        This is commonly used when drawing histograms. Note that
+                        in this case, len(x) == len(y) + 1.
                         If "left" or "right", the step is drawn assuming that
                         the y value is associated to the left or right boundary,
                         respectively. In this case len(x) == len(y)

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -315,9 +315,14 @@ class PlotCurveItem(GraphicsObject):
                         by :func:`mkBrush <pyqtgraph.mkBrush>` is allowed.
         antialias       (bool) Whether to use antialiasing when drawing. This
                         is disabled by default because it decreases performance.
-        stepMode        If True, two orthogonal lines are drawn for each sample
-                        as steps. This is commonly used when drawing histograms.
-                        Note that in this case, len(x) == len(y) + 1
+        stepMode        If True, a step is drawn using the x values as
+                        boundaries and the y value is assumed to be at the mid
+                        point of the boundaries. This is commonly used when
+                        drawing histograms. Note that in this case,
+                        len(x) == len(y) + 1.
+                        If "lstep" or "rstep", the step is drawn assuming that
+                        the y value is associated to the left or right boundary,
+                        respectively. In this case len(x) == len(y)
         connect         Argument specifying how vertexes should be connected
                         by line segments. Default is "all", indicating full
                         connection. "pairs" causes only even-numbered segments
@@ -415,8 +420,17 @@ class PlotCurveItem(GraphicsObject):
     def generatePath(self, x, y):
         if self.opts['stepMode']:
             ## each value in the x/y arrays generates 2 points.
-            x2 = np.empty((len(x),2), dtype=x.dtype)
-            x2[:] = x[:,np.newaxis]
+            if self.opts['stepMode'] == "rstep":
+                x2 = np.empty((len(x) + 1, 2), dtype=x.dtype)
+                x2[:-1] = x[:, np.newaxis]
+                x2[-1] = x2[-2]
+            elif self.opts['stepMode'] == "lstep":
+                x2 = np.empty((len(x) + 1, 2), dtype=x.dtype)
+                x2[1:] = x[:, np.newaxis]
+                x2[0] = x2[1]
+            else:
+                x2 = np.empty((len(x),2), dtype=x.dtype)
+                x2[:] = x[:, np.newaxis]
             if self.opts['fillLevel'] is None:
                 x = x2.reshape(x2.size)[1:-1]
                 y2 = np.empty((len(y),2), dtype=y.dtype)

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -88,7 +88,6 @@ class PlotDataItem(GraphicsObject):
                          step mode is not enabled.
                          Passing True is a deprecated equivalent to "center".
                          (added in version 0.9.9)
-                         (str modes added in version 0.12.0)
             ============ ==============================================================================
         
         **Point style keyword arguments:**  (see :func:`ScatterPlotItem.setData() <pyqtgraph.ScatterPlotItem.setData>` for more information)

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -76,16 +76,19 @@ class PlotDataItem(GraphicsObject):
             fillOutline  (bool) If True, an outline surrounding the *fillLevel* area is drawn.
             fillBrush    Fill to use when fillLevel is specified.
                          May be any single argument accepted by :func:`mkBrush() <pyqtgraph.mkBrush>`
-            stepMode     If True, a step is drawn using the x values as
-                         boundaries and the given y values are associated to the
-                         mid-points between the boundaries of each step.
-                         This is commonly used when drawing histograms. Note that
-                         in this case, len(x) == len(y) + 1.
+            stepMode     (str or None) If "mid", a step is drawn using the x 
+                         values as boundaries and the given y values are
+                         associated to the mid-points between the boundaries of
+                         each step. This is commonly used when drawing
+                         histograms. Note that in this case, len(x) == len(y) + 1
                          If "left" or "right", the step is drawn assuming that
                          the y value is associated to the left or right boundary,
                          respectively. In this case len(x) == len(y)
+                         If not passed or an empty string or None is passed, the
+                         step mode is not enabled.
+                         Passing True is a deprecated equivalent to "mid".
                          (added in version 0.9.9)
-                         ("left" and "right" modes added in version 0.12.0)
+                         (str modes added in version 0.12.0)
             ============ ==============================================================================
         
         **Point style keyword arguments:**  (see :func:`ScatterPlotItem.setData() <pyqtgraph.ScatterPlotItem.setData>` for more information)
@@ -526,8 +529,8 @@ class PlotDataItem(GraphicsObject):
             self.curve.hide()
         
         if scatterArgs['symbol'] is not None:
-            ## use mid points only when stepMode **is** True (strictly)
-            if self.opts.get('stepMode', False) is True:
+            ## check against `True` too for backwards compatibility
+            if self.opts.get('stepMode', False) in ("mid", True):
                 x = 0.5 * (x[:-1] + x[1:])                
             self.scatter.setData(x=x, y=y, **scatterArgs)
             self.scatter.show()

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -76,9 +76,14 @@ class PlotDataItem(GraphicsObject):
             fillOutline  (bool) If True, an outline surrounding the *fillLevel* area is drawn.
             fillBrush    Fill to use when fillLevel is specified.
                          May be any single argument accepted by :func:`mkBrush() <pyqtgraph.mkBrush>`
-            stepMode     If True, two orthogonal lines are drawn for each sample
-                         as steps. This is commonly used when drawing histograms.
-                         Note that in this case, ``len(x) == len(y) + 1``
+            stepMode     If True, a step is drawn using the x values as
+                         boundaries and the given y values are associated to the
+                         mid-points between the boundaries of each step.
+                         This is commonly used when drawing histograms. Note that
+                         in this case, len(x) == len(y) + 1.
+                         If "left" or "right", the step is drawn assuming that
+                         the y value is associated to the left or right boundary,
+                         respectively. In this case len(x) == len(y)
                          (added in version 0.9.9)
             ============ ==============================================================================
         

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -384,6 +384,12 @@ class PlotDataItem(GraphicsObject):
         See :func:`__init__() <pyqtgraph.PlotDataItem.__init__>` for details; it accepts the same arguments.
         """
         #self.clear()
+        if kargs.get("stepMode", default=None) == True:
+            import warnings
+            warnings.warn(
+                'stepMode=True is deprecated, use stepMode="center" instead',
+                DeprecationWarning, stacklevel=3
+            )
         profiler = debug.Profiler()
         y = None
         x = None

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -85,6 +85,7 @@ class PlotDataItem(GraphicsObject):
                          the y value is associated to the left or right boundary,
                          respectively. In this case len(x) == len(y)
                          (added in version 0.9.9)
+                         ("left" and "right" modes added in version 0.12.0)
             ============ ==============================================================================
         
         **Point style keyword arguments:**  (see :func:`ScatterPlotItem.setData() <pyqtgraph.ScatterPlotItem.setData>` for more information)

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -384,7 +384,7 @@ class PlotDataItem(GraphicsObject):
         See :func:`__init__() <pyqtgraph.PlotDataItem.__init__>` for details; it accepts the same arguments.
         """
         #self.clear()
-        if kargs.get("stepMode", default=None) == True:
+        if kargs.get("stepMode", None) is True:
             import warnings
             warnings.warn(
                 'stepMode=True is deprecated, use stepMode="center" instead',

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -526,7 +526,7 @@ class PlotDataItem(GraphicsObject):
             self.curve.hide()
         
         if scatterArgs['symbol'] is not None:
-            
+            ## use mid points only when stepMode **is** True (strictly)
             if self.opts.get('stepMode', False) is True:
                 x = 0.5 * (x[:-1] + x[1:])                
             self.scatter.setData(x=x, y=y, **scatterArgs)

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -76,7 +76,7 @@ class PlotDataItem(GraphicsObject):
             fillOutline  (bool) If True, an outline surrounding the *fillLevel* area is drawn.
             fillBrush    Fill to use when fillLevel is specified.
                          May be any single argument accepted by :func:`mkBrush() <pyqtgraph.mkBrush>`
-            stepMode     (str or None) If "mid", a step is drawn using the x 
+            stepMode     (str or None) If "center", a step is drawn using the x
                          values as boundaries and the given y values are
                          associated to the mid-points between the boundaries of
                          each step. This is commonly used when drawing
@@ -86,7 +86,7 @@ class PlotDataItem(GraphicsObject):
                          respectively. In this case len(x) == len(y)
                          If not passed or an empty string or None is passed, the
                          step mode is not enabled.
-                         Passing True is a deprecated equivalent to "mid".
+                         Passing True is a deprecated equivalent to "center".
                          (added in version 0.9.9)
                          (str modes added in version 0.12.0)
             ============ ==============================================================================
@@ -530,7 +530,7 @@ class PlotDataItem(GraphicsObject):
         
         if scatterArgs['symbol'] is not None:
             ## check against `True` too for backwards compatibility
-            if self.opts.get('stepMode', False) in ("mid", True):
+            if self.opts.get('stepMode', False) in ("center", True):
                 x = 0.5 * (x[:-1] + x[1:])                
             self.scatter.setData(x=x, y=y, **scatterArgs)
             self.scatter.show()

--- a/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
@@ -61,7 +61,7 @@ def test_clear():
 
 def test_clear_in_step_mode():
     w = pg.PlotWidget()
-    c = pg.PlotDataItem([1,4,2,3], [5,7,6], stepMode="mid")
+    c = pg.PlotDataItem([1,4,2,3], [5,7,6], stepMode="center")
     w.addItem(c)
     c.clear()
 

--- a/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
@@ -61,7 +61,7 @@ def test_clear():
 
 def test_clear_in_step_mode():
     w = pg.PlotWidget()
-    c = pg.PlotDataItem([1,4,2,3], [5,7,6], stepMode=True)
+    c = pg.PlotDataItem([1,4,2,3], [5,7,6], stepMode="mid")
     w.addItem(c)
     c.clear()
 


### PR DESCRIPTION
stepMode is currently either `True` or `False`. If it is `True`,
it requires the user to make `len(x) = len(y)+1`. This is
inconvenient because it makes it difficult to change the
stepMode on a given curve (just as one would change, e.g.,
its color).

This commit extends the current situation by introducing
two more step modes: `"lstep"` and `"rstep"`, which do not require
passing an extra x value. In turn, this modes associate each
y value to either the left or the right boundary of the step.

For example, the `"rstep"` mode is handy when plotting "live"
digital signals in which x,y data pairs are appended as they
are read.

This commit does not modify the behavior in case of `stepMode=True`