### PR TITLE
DataTreeWidget exception with multivalue Terminal (flowchart)

### DIFF
--- a/pyqtgraph/flowchart/Terminal.py
+++ b/pyqtgraph/flowchart/Terminal.py
@@ -267,6 +267,11 @@ class Terminal(object):
     def saveState(self):
         return {'io': self._io, 'multi': self._multi, 'optional': self._optional, 'renamable': self._renamable, 'removable': self._removable, 'multiable': self._multiable}
 
+    def __lt__(self, other):
+        """When the terminal is multi value, the data passed to the DatTreeWidget for each input or output, is {Terminal: value}.
+        To make this sortable, we provide the < operator.
+        """
+        return self._name < other._name
 
 class TerminalGraphicsItem(GraphicsObject):
     


### PR DESCRIPTION
Fix exception in DataTreeWidget when clicking on a node with multivalue Terminal connected

The problem is that data for multi value Terminal is {Terminal: value}, but Terminal object is not sortable.
Adding the < operator to Terminal solve the problem.

To reproduce the problem: build a Flowchart with a connected multivalue Node Terminal, and click on the Node. An exception occurs in DataTreeWidget

```
Traceback (most recent call last):
  File "pyqtgraph\flowchart\Flowchart.py", line 910, in selectionChanged
self.selectedTree.setData(data, hideRoot=True)
  File "pyqtgraph\widgets\DataTreeWidget.py", line 35, in setData
self.buildTree(data, self.invisibleRootItem(), hideRoot=hideRoot)
  File "pyqtgraph\widgets\DataTreeWidget.py", line 72, in buildTree
self.buildTree(data, node, asUnicode(key), path=path+(key,))
  File "pyqtgraph\widgets\DataTreeWidget.py", line 72, in buildTree
self.buildTree(data, node, asUnicode(key), path=path+(key,))
  File "pyqtgraph\widgets\DataTreeWidget.py", line 50, in buildTree
typeStr, desc, childs, widget = self.parse(data)
  File "pyqtgraph\widgets\DataTreeWidget.py", line 96, in parse
childs = OrderedDict(sorted(data.items()))
TypeError
:
'<' not supported between instances of 'Terminal' and 'Terminal'
```