### PR TITLE
fix for log scaling being broken 

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -543,11 +543,6 @@ class PlotDataItem(GraphicsObject):
                 if self.opts['logMode'][0]:
                     x=x[1:]
                     y=y[1:]
-            else:          
-                if self.opts['logMode'][0]:
-                    x = np.log10(x)
-                if self.opts['logMode'][1]:
-                    y = np.log10(y)
             if self.opts['derivativeMode']:  # plot dV/dt
                 y = np.diff(self.yData)/np.diff(self.xData)
                 x = x[:-1]


### PR DESCRIPTION
Running examples/Plotting.py produced RuntimeWarnings and failed to display data for the middle plot (the example for log scaling). This PR fixes that.

-- log10 was being calculated twice, resulting in nan. Now it's only being calculated once.