### PR TITLE
AxisItem: Account for empty strings in the visibility of text and units

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -284,14 +284,14 @@ class AxisItem(GraphicsWidget):
 
         """
         show_label = False
-        if text is not None:
+        # Account empty string and `None` for units and text
+        if text:
             self.labelText = text
             show_label = True
-        if units is not None:
+        if units:
             self.labelUnits = units
             show_label = True
-        if show_label:
-            self.showLabel()
+        self.showLabel(show_label)
         if unitPrefix is not None:
             self.labelUnitPrefix = unitPrefix
         if len(args) > 0:

--- a/pyqtgraph/graphicsItems/tests/test_AxisItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_AxisItem.py
@@ -2,6 +2,7 @@ import pyqtgraph as pg
 
 app = pg.mkQApp()
 
+
 def test_AxisItem_stopAxisAtTick(monkeypatch):
     def test_bottom(p, axisSpec, tickSpecs, textSpecs):
         assert view.mapToView(axisSpec[1]).x() == 0.25
@@ -114,3 +115,31 @@ def test_AxisItem_tickFont(monkeypatch):
     plot.show()
     app.processEvents()
     plot.close()
+
+
+def test_AxisItem_label_visibility():
+    axis = pg.AxisItem('left')
+    assert axis.labelText == ''
+    assert axis.labelUnits == ''
+    assert not axis.label.isVisible()
+
+    axis.setLabel(text='Visible')
+    assert axis.label.isVisible()
+    assert axis.labelText == 'Visible'
+    assert axis.labelUnits == ''
+
+    axis.setLabel(text='')
+    assert not axis.label.isVisible()
+    assert axis.labelText == ''
+    assert axis.labelUnits == ''
+
+    axis.setLabel(units='m')
+    assert axis.label.isVisible()
+    assert axis.labelText == ''
+    assert axis.labelUnits == 'm'
+
+    axis.setLabel(units='')
+    assert not axis.label.isVisible()
+    assert axis.labelText == ''
+    assert axis.labelUnits == ''
+    assert not axis.label.isVisible()

--- a/pyqtgraph/graphicsItems/tests/test_AxisItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_AxisItem.py
@@ -118,27 +118,27 @@ def test_AxisItem_tickFont(monkeypatch):
 
 
 def test_AxisItem_label_visibility():
-    """Test the visibility of the axis item"""
-    axis = pg.AxisItem('left')
-    assert axis.labelText == ''
-    assert axis.labelUnits == ''
+    """Test the visibility of the axis item using `setLabel`"""
+    axis = pg.AxisItem("left")
+    assert axis.labelText == ""
+    assert axis.labelUnits == ""
     assert not axis.label.isVisible()
     axis.setLabel(text="Position", units="mm")
-    assert axis.labelText == 'Position'
-    assert axis.labelUnits == 'mm'
+    assert axis.labelText == "Position"
+    assert axis.labelUnits == "mm"
     assert axis.label.isVisible()
     # XXX: `None` is converted to empty strings.
     axis.setLabel(text=None, units=None)
-    assert axis.labelText == ''
-    assert axis.labelUnits == ''
+    assert axis.labelText == ""
+    assert axis.labelUnits == ""
     assert not axis.label.isVisible()
     axis.setLabel(text="Current", units=None)
-    assert axis.labelText == 'Current'
-    assert axis.labelUnits == ''
+    assert axis.labelText == "Current"
+    assert axis.labelUnits == ""
     assert axis.label.isVisible()
     axis.setLabel(text=None, units=None)
     assert not axis.label.isVisible()
     axis.setLabel(text="", units="V")
-    assert axis.labelText == ''
-    assert axis.labelUnits == 'V'
+    assert axis.labelText == ""
+    assert axis.labelUnits == "V"
     assert axis.label.isVisible()

--- a/pyqtgraph/graphicsItems/tests/test_AxisItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_AxisItem.py
@@ -119,26 +119,26 @@ def test_AxisItem_tickFont(monkeypatch):
 
 def test_AxisItem_label_visibility():
     """Test the visibility of the axis item using `setLabel`"""
-    axis = pg.AxisItem("left")
-    assert axis.labelText == ""
-    assert axis.labelUnits == ""
+    axis = pg.AxisItem('left')
+    assert axis.labelText == ''
+    assert axis.labelUnits == ''
     assert not axis.label.isVisible()
-    axis.setLabel(text="Position", units="mm")
-    assert axis.labelText == "Position"
-    assert axis.labelUnits == "mm"
+    axis.setLabel(text='Position', units='mm')
+    assert axis.labelText == 'Position'
+    assert axis.labelUnits == 'mm'
     assert axis.label.isVisible()
     # XXX: `None` is converted to empty strings.
     axis.setLabel(text=None, units=None)
-    assert axis.labelText == ""
-    assert axis.labelUnits == ""
+    assert axis.labelText == ''
+    assert axis.labelUnits == ''
     assert not axis.label.isVisible()
-    axis.setLabel(text="Current", units=None)
-    assert axis.labelText == "Current"
-    assert axis.labelUnits == ""
+    axis.setLabel(text='Current', units=None)
+    assert axis.labelText == 'Current'
+    assert axis.labelUnits == ''
     assert axis.label.isVisible()
     axis.setLabel(text=None, units=None)
     assert not axis.label.isVisible()
-    axis.setLabel(text="", units="V")
-    assert axis.labelText == ""
-    assert axis.labelUnits == "V"
+    axis.setLabel(text='', units='V')
+    assert axis.labelText == ''
+    assert axis.labelUnits == 'V'
     assert axis.label.isVisible()

--- a/pyqtgraph/graphicsItems/tests/test_AxisItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_AxisItem.py
@@ -118,7 +118,27 @@ def test_AxisItem_tickFont(monkeypatch):
 
 
 def test_AxisItem_label_visibility():
+    """Test the visibility of the axis item"""
     axis = pg.AxisItem('left')
     assert axis.labelText == ''
     assert axis.labelUnits == ''
     assert not axis.label.isVisible()
+    axis.setLabel(text="Position", units="mm")
+    assert axis.labelText == 'Position'
+    assert axis.labelUnits == 'mm'
+    assert axis.label.isVisible()
+    # XXX: `None` is converted to empty strings.
+    axis.setLabel(text=None, units=None)
+    assert axis.labelText == ''
+    assert axis.labelUnits == ''
+    assert not axis.label.isVisible()
+    axis.setLabel(text="Current", units=None)
+    assert axis.labelText == 'Current'
+    assert axis.labelUnits == ''
+    assert axis.label.isVisible()
+    axis.setLabel(text=None, units=None)
+    assert not axis.label.isVisible()
+    axis.setLabel(text="", units="V")
+    assert axis.labelText == ''
+    assert axis.labelUnits == 'V'
+    assert axis.label.isVisible()

--- a/pyqtgraph/graphicsItems/tests/test_AxisItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_AxisItem.py
@@ -122,24 +122,3 @@ def test_AxisItem_label_visibility():
     assert axis.labelText == ''
     assert axis.labelUnits == ''
     assert not axis.label.isVisible()
-
-    axis.setLabel(text='Visible')
-    assert axis.label.isVisible()
-    assert axis.labelText == 'Visible'
-    assert axis.labelUnits == ''
-
-    axis.setLabel(text='')
-    assert not axis.label.isVisible()
-    assert axis.labelText == ''
-    assert axis.labelUnits == ''
-
-    axis.setLabel(units='m')
-    assert axis.label.isVisible()
-    assert axis.labelText == ''
-    assert axis.labelUnits == 'm'
-
-    axis.setLabel(units='')
-    assert not axis.label.isVisible()
-    assert axis.labelText == ''
-    assert axis.labelUnits == ''
-    assert not axis.label.isVisible()


### PR DESCRIPTION
- Account for empty `text` and `units`
- Always reset the visibility of the label, in case of swap