### PR TITLE
Bug fix in PlotCurveItem.mouseClickEvent

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -612,8 +612,8 @@ class PlotCurveItem(GraphicsObject):
         if not self.clickable or ev.button() != QtCore.Qt.LeftButton:
             return
         if self.mouseShape().contains(ev.pos()):
-            ev.accept()
             self.sigClicked.emit(self)
+            ev.accept()
 
 
 


### PR DESCRIPTION
Move ev.accept() to follow sigClicked.emit so event is passed with sigClicked.