### PR TITLE
Fix deprecation warning in multiprocess module 

### DIFF
--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -429,7 +429,7 @@ class QtProcess(Process):
         This allows signals to be connected from the child process to the parent.
         """
         self.timer.timeout.connect(self.processRequests)
-        self.timer.start(interval*1000)
+        self.timer.start(int(interval*1000))
         
     def stopRequestProcessing(self):
         self.timer.stop()


### PR DESCRIPTION
The argument to qtimer.start should be an int not a float
and the current code raises a deprecation warning with python 3.8.
This fixes that by simply converting it to an int. 