### PR TITLE
Fix PlotItem.setAxisItems

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -325,7 +325,7 @@ class PlotItem(GraphicsWidget):
             if k in axisItems:
                 axis = axisItems[k]
                 if axis.scene() is not None:
-                    if self.axes.get(k) is None or axis != self.axes[k]["item"]:
+                    if k not in self.axes or axis != self.axes[k]["item"]:
                         raise RuntimeError(
                             "Can't add an axis to multiple plots. Shared axes"
                             " can be achieved with multiple AxisItem instances"

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -307,7 +307,7 @@ class PlotItem(GraphicsWidget):
         # Array containing visible axis items
         # Also containing potentially hidden axes, but they are not touched so it does not matter
         visibleAxes = ['left', 'bottom']
-        visibleAxes.append(axisItems.keys()) # Note that it does not matter that this adds
+        visibleAxes.extend(axisItems.keys()) # Note that it does not matter that this adds
                                              # some values to visibleAxes a second time
         
         for k, pos in (('top', (1,1)), ('bottom', (3,1)), ('left', (2,0)), ('right', (2,2))):
@@ -325,8 +325,11 @@ class PlotItem(GraphicsWidget):
             if k in axisItems:
                 axis = axisItems[k]
                 if axis.scene() is not None:
-                    if axis != self.axes[k]["item"]:
-                        raise RuntimeError("Can't add an axis to multiple plots.")
+                    if self.axes.get(k) is None or axis != self.axes[k]["item"]:
+                        raise RuntimeError(
+                            "Can't add an axis to multiple plots. Shared axes"
+                            " can be achieved with multiple AxisItem instances"
+                            " and set[X/Y]Link.")
             else:
                 axis = AxisItem(orientation=k, parent=self)
             

--- a/pyqtgraph/graphicsItems/PlotItem/tests/test_PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/tests/test_PlotItem.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+import pytest
+import pyqtgraph as pg
+
+app = pg.mkQApp()
+
+
+@pytest.mark.parametrize('orientation', ['left', 'right', 'top', 'bottom'])
+def test_PlotItem_shared_axis_items(orientation):
+    """Adding an AxisItem to multiple plots raises RuntimeError"""
+    ax1 = pg.AxisItem(orientation)
+    ax2 = pg.AxisItem(orientation)
+
+    layout = pg.GraphicsLayoutWidget()
+
+    pi1 = layout.addPlot(axisItems={orientation: ax1})
+
+    pi2 = layout.addPlot()
+    # left or bottom replaces, right or top adds new
+    pi2.setAxisItems({orientation: ax2})
+
+    with pytest.raises(RuntimeError):
+        pi2.setAxisItems({orientation: ax1})


### PR DESCRIPTION
Fixes #1358

I believe this is the intention of the logic that's there currently. Technically, it does appear to be possible to use a single `AxisItem` for multiple `PlotItem`s, but the conditions under which this works (and doesn't cause a segfault) aren't crystal clear to me. In the future, if someone figures out how to robustly detect when it's ok to do so, we can allow for it. For now this should make things work as intended and I'm pretty sure separate linked instances should work equivalently.