### PR TITLE
GraphicsView: Set a transparent background palette

### DIFF
--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -129,7 +129,12 @@ class GraphicsView(QtGui.QGraphicsView):
         self.mouseEnabled = False
         self.scaleCenter = False  ## should scaling center around view center (True) or mouse click (False)
         self.clickAccepted = False
-        
+
+        # Set a transparent background QPalette!
+        palette = self.palette()
+        palette.setColor(QtGui.QPalette.Background, QtCore.Qt.transparent)
+        self.setPalette(palette)
+
     def setAntialiasing(self, aa):
         """Enable or disable default antialiasing.
         Note that this will only affect items that do not specify their own antialiasing options."""


### PR DESCRIPTION
The background of the GraphicsView is blocking other features. In my example a grid in a designer. On the road to set a single viewbox background to white without affecting others:

- The background of the QPalette is set to transparent.

Before:

![qt_graph_no_transparency](https://user-images.githubusercontent.com/43136580/94341054-b1ef8400-0006-11eb-9913-8da6d83724c9.png)


After:

![qt_graph_transparency](https://user-images.githubusercontent.com/43136580/94341057-b87dfb80-0006-11eb-9fae-85091b5c45a1.png)

