### PR TITLE
Emit signal when GraphicScene.addItem() is used

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -56,6 +56,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
                            is given in scene coordinates.
     sigMouseHover(items)   Emitted when the mouse is moved over the scene. Items is a list
                            of items under the cursor.
+    sigItemAdded(item)     Emitted when an item is added via addItem(). The item is given.
     ====================== ==================================================================
     
     Mouse interaction is as follows:
@@ -90,6 +91,8 @@ class GraphicsScene(QtGui.QGraphicsScene):
     sigMouseClicked = QtCore.Signal(object)   ## emitted when mouse is clicked. Check for event.isAccepted() to see whether the event has already been acted on.
     
     sigPrepareForPaint = QtCore.Signal()  ## emitted immediately before the scene is about to be rendered
+
+    sigItemAdded = QtCore.Signal(object)  ## emits the item object just added
     
     _addressCache = weakref.WeakValueDictionary()
     
@@ -393,6 +396,12 @@ class GraphicsScene(QtGui.QGraphicsScene):
                             break
         self.sigMouseClicked.emit(ev)
         return ev.isAccepted()
+
+    def addItem(self, item):
+        # extend QGraphicsScene.addItem to emit a sigItemAdded signal
+        ret = QtGui.QGraphicsScene.addItem(self, item)
+        self.sigItemAdded.emit(item)
+        return ret
         
     def items(self, *args):
         items = QtGui.QGraphicsScene.items(self, *args)

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -46,7 +46,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
     *  Eats mouseMove events that occur too soon after a mouse press.
     *  Reimplements items() and itemAt() to circumvent PyQt bug
 
-    ====================== ==================================================================
+    ====================== ====================================================================
     **Signals**
     sigMouseClicked(event) Emitted when the mouse is clicked over the scene. Use ev.pos() to
                            get the click position relative to the item that was clicked on,
@@ -57,7 +57,8 @@ class GraphicsScene(QtGui.QGraphicsScene):
     sigMouseHover(items)   Emitted when the mouse is moved over the scene. Items is a list
                            of items under the cursor.
     sigItemAdded(item)     Emitted when an item is added via addItem(). The item is given.
-    ====================== ==================================================================
+    sigItemRemoved(item)   Emitted when an item is removed via removeItem(). The item is given.
+    ====================== ====================================================================
     
     Mouse interaction is as follows:
     
@@ -93,7 +94,8 @@ class GraphicsScene(QtGui.QGraphicsScene):
     sigPrepareForPaint = QtCore.Signal()  ## emitted immediately before the scene is about to be rendered
 
     sigItemAdded = QtCore.Signal(object)  ## emits the item object just added
-    
+    sigItemRemoved = QtCore.Signal(object)  ## emits the item object just removed
+
     _addressCache = weakref.WeakValueDictionary()
     
     ExportDirectory = None
@@ -401,6 +403,12 @@ class GraphicsScene(QtGui.QGraphicsScene):
         # extend QGraphicsScene.addItem to emit a sigItemAdded signal
         ret = QtGui.QGraphicsScene.addItem(self, item)
         self.sigItemAdded.emit(item)
+        return ret
+
+    def removeItem(self, item):
+        # extend QGraphicsScene.removeItem to emit a sigItemRemoved signal
+        ret = QtGui.QGraphicsScene.removeItem(self, item)
+        self.sigItemRemoved.emit(item)
         return ret
         
     def items(self, *args):


### PR DESCRIPTION
Emit a signal (`sigItemAdded`) just after adding an item to a scene.
The item object is emited as the only signal argument.
This signal is useful for code that may want to react to newly added
items of a plot.