### PR TITLE
caching for viewRect of LinearRegionItem to reduce CPU load

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -36,6 +36,7 @@ class GraphicsItem(object):
         self._viewBox = None
         self._connectedView = None
         self._exportOpts = False   ## If False, not currently exporting. Otherwise, contains dict of export options.
+        self._cachedView = None
         if register is not None and register:
             warnings.warn(
                 "'register' argument is deprecated and does nothing",
@@ -154,6 +155,10 @@ class GraphicsItem(object):
     def viewRect(self):
         """Return the visible bounds of this item's ViewBox or GraphicsWidget,
         in the local coordinate system of the item."""
+        if self._cachedView is not None:
+            return self._cachedView
+
+        # Note that in cases of early returns here, the view cache stays empty (None).
         view = self.getViewBox()
         if view is None:
             return None
@@ -163,10 +168,12 @@ class GraphicsItem(object):
 
         bounds = bounds.normalized()
         
+        self._cachedView = bounds
+            
         ## nah.
         #for p in self.getBoundingParents():
             #bounds &= self.mapRectFromScene(p.sceneBoundingRect())
-            
+
         return bounds
         
         
@@ -548,8 +555,9 @@ class GraphicsItem(object):
         """
         Called whenever the transformation matrix of the view has changed.
         (eg, the view range has changed or the view was resized)
+        Invalidates the viewRect cache.
         """
-        pass
+        self._cachedView = None
     
     #def prepareGeometryChange(self):
         #self._qtBaseClass.prepareGeometryChange(self)

--- a/pyqtgraph/graphicsItems/LinearRegionItem.py
+++ b/pyqtgraph/graphicsItems/LinearRegionItem.py
@@ -78,6 +78,7 @@ class LinearRegionItem(GraphicsObject):
         self.span = span
         self.swapMode = swapMode
         self._bounds = None
+        self._cachedView = None
         
         # note LinearRegionItem.Horizontal and LinearRegionItem.Vertical
         # are kept for backward compatibility.
@@ -189,6 +190,16 @@ class LinearRegionItem(GraphicsObject):
         self.lines[0].setSpan(mn, mx)
         self.lines[1].setSpan(mn, mx)
         self.update()
+
+    def viewRect(self):
+        if self._cachedView is not None:
+            return self._cachedView
+
+        self._cachedView = GraphicsObject.viewRect(self)
+        return self._cachedView
+
+    def viewTransformChanged(self):
+        self._cachedView = None
 
     def boundingRect(self):
         br = self.viewRect()  # bounds of containing ViewBox mapped to local coords.

--- a/pyqtgraph/graphicsItems/LinearRegionItem.py
+++ b/pyqtgraph/graphicsItems/LinearRegionItem.py
@@ -78,7 +78,6 @@ class LinearRegionItem(GraphicsObject):
         self.span = span
         self.swapMode = swapMode
         self._bounds = None
-        self._cachedView = None
         
         # note LinearRegionItem.Horizontal and LinearRegionItem.Vertical
         # are kept for backward compatibility.
@@ -190,16 +189,6 @@ class LinearRegionItem(GraphicsObject):
         self.lines[0].setSpan(mn, mx)
         self.lines[1].setSpan(mn, mx)
         self.update()
-
-    def viewRect(self):
-        if self._cachedView is not None:
-            return self._cachedView
-
-        self._cachedView = GraphicsObject.viewRect(self)
-        return self._cachedView
-
-    def viewTransformChanged(self):
-        self._cachedView = None
 
     def boundingRect(self):
         br = self.viewRect()  # bounds of containing ViewBox mapped to local coords.


### PR DESCRIPTION
## Issue

Having a LinearRegionItem inside a ViewBox causes large CPU loads on any mouse interaction - just moving the cursor around anywhere in the ViewBox (even outside the Item) takes up 2 threads at 100 % for me. This seems to be caused by `viewRect()` of the LinearRegionItem, which is called on every mouse event and does some heavy coordinate transforms.

## Solution
Similar issues elsewhere in Qt/pyqtgraph seem to be solved by caching the boundaries. I suspected that the `viewTransformChanged()` slot on pyqtgraph's GraphicsItem was intended specifically to allow that, so I set up a simple cache which is invalidated by `viewTransformChanged()`. This seems to work (CPU load reduced ~20x), but I'm not sure if that slot really catches every change that invalidates `viewRect`. Would be good if someone with better understanding could take a look.
