### PR TITLE
SignalProxy: Correct initialization without slot argument and tests

### DIFF
--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -79,7 +79,7 @@ class SignalProxy(QtCore.QObject):
         self.sigDelayed.emit(args)
         return True
 
-    def connect(self, slot):
+    def connectSignal(self, slot):
         """Connect the `SignalProxy` to an external slot"""
         assert self.slot is None, "Slot was already connected!"
         self.slot = weakref.ref(slot)

--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -36,14 +36,15 @@ class SignalProxy(QtCore.QObject):
         self.args = None
         self.timer = ThreadsafeTimer.ThreadsafeTimer()
         self.timer.timeout.connect(self.flush)
-        self.blockSignal = False
         self.lastFlushTime = None
         self.signal = signal
         if slot is not None:
+            self.blockSignal = False
             self.signal.connect(self.signalReceived)
             self.sigDelayed.connect(slot)
             self.slot = weakref.ref(slot)
         else:
+            self.blockSignal = True
             self.slot = None
 
     def setDelay(self, delay):

--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -40,9 +40,11 @@ class SignalProxy(QtCore.QObject):
         self.timer.timeout.connect(self.flush)
         self.blockSignal = False
         self.lastFlushTime = None
-        self.slot = weakref.ref(slot) if slot is not None else None
         if slot is not None:
             self.sigDelayed.connect(slot)
+            self.slot = weakref.ref(slot)
+        else:
+            self.slot = None
 
     def setDelay(self, delay):
         self.delay = delay

--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -95,7 +95,7 @@ class SignalProxy(QtCore.QObject):
             if self.slot is not None:
                 slot = self.slot()
                 self.sigDelayed.disconnect(slot)
-        except Exception as e:
+        except:
             pass
         finally:
             self.slot = None

--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -58,7 +58,7 @@ class SignalProxy(QtCore.QObject):
         self.args = args
         if self.rateLimit == 0:
             self.timer.stop()
-            self.timer.start((self.delay * 1000) + 1)
+            self.timer.start(int(self.delay * 1000) + 1)
         else:
             now = time()
             if self.lastFlushTime is None:
@@ -68,7 +68,7 @@ class SignalProxy(QtCore.QObject):
                 leakTime = max(0, (lastFlush + (1.0 / self.rateLimit)) - now)
 
             self.timer.stop()
-            self.timer.start((min(leakTime, self.delay) * 1000) + 1)
+            self.timer.start(int(min(leakTime, self.delay) * 1000) + 1)
 
     def flush(self):
         """If there is a signal queued up, send it now."""

--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -38,9 +38,9 @@ class SignalProxy(QtCore.QObject):
         self.timer.timeout.connect(self.flush)
         self.lastFlushTime = None
         self.signal = signal
+        self.signal.connect(self.signalReceived)
         if slot is not None:
             self.blockSignal = False
-            self.signal.connect(self.signalReceived)
             self.sigDelayed.connect(slot)
             self.slot = weakref.ref(slot)
         else:
@@ -87,7 +87,9 @@ class SignalProxy(QtCore.QObject):
         except:
             pass
         try:
-            self.sigDelayed.disconnect()
+            # XXX: This is a weakref, however segfaulting on PySide and
+            # Python 2. We come back later
+            self.sigDelayed.disconnect(self.slot)
         except:
             pass
         finally:
@@ -98,7 +100,6 @@ class SignalProxy(QtCore.QObject):
         assert self.slot is None, "Slot was already connected!"
         self.slot = weakref.ref(slot)
         self.sigDelayed.connect(slot)
-        self.signal.connect(self.signalReceived)
         self.blockSignal = False
 
     def block(self):

--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -93,8 +93,10 @@ class SignalProxy(QtCore.QObject):
             if self.slot is not None:
                 slot = self.slot()
                 self.sigDelayed.disconnect(slot)
-        except:
+        except Exception as e:
             pass
+        finally:
+            self.slot = None
 
     def block(self):
         """Return a SignalBlocker that temporarily blocks input signals to

--- a/pyqtgraph/tests/test_signalproxy.py
+++ b/pyqtgraph/tests/test_signalproxy.py
@@ -1,0 +1,130 @@
+import sys
+import pytest
+
+from ..Qt import QtCore
+from ..Qt import QtGui
+
+from ..SignalProxy import SignalProxy
+
+
+class Sender(QtCore.QObject):
+    signalSend = QtCore.pyqtSignal()
+
+    def __init__(self, parent=None):
+        super(Sender, self).__init__(parent)
+
+
+class Receiver(QtCore.QObject):
+
+    def __init__(self, parent=None):
+        super(Receiver, self).__init__(parent)
+        self.counter = 0
+
+    def slotReceive(self):
+        self.counter += 1
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QtGui.QApplication.instance()
+    if app is None:
+        app = QtGui.QApplication(sys.argv)
+    yield app
+
+    app.processEvents(QtCore.QEventLoop.AllEvents, 100)
+    app.deleteLater()
+
+
+def test_signal_proxy_slot(qapp):
+    """Test the normal work mode of SignalProxy with `signal` and `slot`"""
+    sender = Sender(parent=qapp)
+    receiver = Receiver(parent=qapp)
+    proxy = SignalProxy(sender.signalSend, delay=0.0, rateLimit=0.6,
+                        slot=receiver.slotReceive)
+
+    assert proxy.blockSignal is False
+    assert proxy is not None
+    assert sender is not None
+    assert receiver is not None
+
+    sender.signalSend.emit()
+    proxy.flush()
+    qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
+
+    assert receiver.counter == 1
+
+
+def test_signal_proxy_disconnect_slot(qapp):
+    """Test the disconnect of SignalProxy with `signal` and `slot`"""
+    sender = Sender(parent=qapp)
+    receiver = Receiver(parent=qapp)
+    proxy = SignalProxy(sender.signalSend, delay=0.0, rateLimit=0.6,
+                        slot=receiver.slotReceive)
+
+    assert proxy.blockSignal is False
+    assert proxy is not None
+    assert sender is not None
+    assert receiver is not None
+
+    proxy.disconnect()
+    sender.signalSend.emit()
+    proxy.flush()
+    qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
+
+    assert receiver.counter == 0
+
+
+def test_signal_proxy_no_slot_start(qapp):
+    """Test the connect mode of SignalProxy without slot at start`"""
+    sender = Sender(parent=qapp)
+    receiver = Receiver(parent=qapp)
+    proxy = SignalProxy(sender.signalSend, delay=0.0, rateLimit=0.6)
+
+    assert proxy.blockSignal is False
+    assert proxy is not None
+    assert sender is not None
+    assert receiver is not None
+
+    sender.signalSend.emit()
+    proxy.flush()
+    qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
+    assert receiver.counter == 0
+
+    # Start a connect
+    proxy.connect(receiver.slotReceive)
+    sender.signalSend.emit()
+    proxy.flush()
+    qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
+    assert receiver.counter == 1
+
+    # An additional connect should raise an AssertionError
+    with pytest.raises(AssertionError):
+        proxy.connect(receiver.slotReceive)
+
+
+def test_signal_proxy_slot_block(qapp):
+    """Test the block mode of SignalProxy with `signal` and `slot`"""
+    sender = Sender(parent=qapp)
+    receiver = Receiver(parent=qapp)
+    proxy = SignalProxy(sender.signalSend, delay=0.0, rateLimit=0.6,
+                        slot=receiver.slotReceive)
+
+    assert proxy.blockSignal is False
+    assert proxy is not None
+    assert sender is not None
+    assert receiver is not None
+
+    with proxy.block():
+        sender.signalSend.emit()
+        sender.signalSend.emit()
+        sender.signalSend.emit()
+        proxy.flush()
+        qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
+
+        assert receiver.counter == 0
+
+    sender.signalSend.emit()
+    proxy.flush()
+    qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
+
+    assert receiver.counter == 1

--- a/pyqtgraph/tests/test_signalproxy.py
+++ b/pyqtgraph/tests/test_signalproxy.py
@@ -24,7 +24,7 @@ class Receiver(QtCore.QObject):
         self.counter += 1
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def qapp():
     app = QtGui.QApplication.instance()
     if app is None:

--- a/pyqtgraph/tests/test_signalproxy.py
+++ b/pyqtgraph/tests/test_signalproxy.py
@@ -51,8 +51,7 @@ def test_signal_proxy_slot(qapp):
     proxy.flush()
     qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
 
-    assert receiver.counter == 1
-
+    assert receiver.counter > 0
     del proxy
     del sender
     del receiver
@@ -87,7 +86,7 @@ def test_signal_proxy_disconnect_slot(qapp):
     proxy.flush()
     qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
 
-    assert receiver.counter == 1
+    assert receiver.counter > 0
 
     del proxy
     del sender
@@ -116,7 +115,7 @@ def test_signal_proxy_no_slot_start(qapp):
     sender.signalSend.emit()
     proxy.flush()
     qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
-    assert receiver.counter == 1
+    assert receiver.counter > 0
 
     # An additional connect should raise an AssertionError
     with pytest.raises(AssertionError):
@@ -152,7 +151,7 @@ def test_signal_proxy_slot_block(qapp):
     proxy.flush()
     qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
 
-    assert receiver.counter == 1
+    assert receiver.counter > 0
 
     del proxy
     del sender

--- a/pyqtgraph/tests/test_signalproxy.py
+++ b/pyqtgraph/tests/test_signalproxy.py
@@ -73,6 +73,7 @@ def test_signal_proxy_disconnect_slot(qapp):
 
     proxy.disconnect()
     assert proxy.slot is None
+    assert proxy.blockSignal is True
 
     sender.signalSend.emit()
     proxy.flush()
@@ -81,6 +82,7 @@ def test_signal_proxy_disconnect_slot(qapp):
     assert receiver.counter == 0
 
     proxy.connectSlot(receiver.slotReceive)
+    assert proxy.blockSignal is False
     sender.signalSend.emit()
     proxy.flush()
     qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
@@ -98,7 +100,7 @@ def test_signal_proxy_no_slot_start(qapp):
     receiver = Receiver(parent=qapp)
     proxy = SignalProxy(sender.signalSend, delay=0.0, rateLimit=0.6)
 
-    assert proxy.blockSignal is False
+    assert proxy.blockSignal is True
     assert proxy is not None
     assert sender is not None
     assert receiver is not None
@@ -110,6 +112,7 @@ def test_signal_proxy_no_slot_start(qapp):
 
     # Start a connect
     proxy.connectSlot(receiver.slotReceive)
+    assert proxy.blockSignal is False
     sender.signalSend.emit()
     proxy.flush()
     qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)

--- a/pyqtgraph/tests/test_signalproxy.py
+++ b/pyqtgraph/tests/test_signalproxy.py
@@ -3,6 +3,7 @@ import pytest
 
 from ..Qt import QtCore
 from ..Qt import QtGui
+from ..Qt import QT_LIB, PYSIDE
 
 from ..SignalProxy import SignalProxy
 
@@ -57,6 +58,8 @@ def test_signal_proxy_slot(qapp):
     del receiver
 
 
+@pytest.mark.skipif(QT_LIB == PYSIDE and sys.version_info < (2, 8),
+                    reason="Crashing on PySide and Python 2.7")
 def test_signal_proxy_disconnect_slot(qapp):
     """Test the disconnect of SignalProxy with `signal` and `slot`"""
     sender = Sender(parent=qapp)

--- a/pyqtgraph/tests/test_signalproxy.py
+++ b/pyqtgraph/tests/test_signalproxy.py
@@ -8,7 +8,7 @@ from ..SignalProxy import SignalProxy
 
 
 class Sender(QtCore.QObject):
-    signalSend = QtCore.pyqtSignal()
+    signalSend = QtCore.Signal()
 
     def __init__(self, parent=None):
         super(Sender, self).__init__(parent)

--- a/pyqtgraph/tests/test_signalproxy.py
+++ b/pyqtgraph/tests/test_signalproxy.py
@@ -80,14 +80,6 @@ def test_signal_proxy_disconnect_slot(qapp):
 
     assert receiver.counter == 0
 
-    proxy.connectSlot(receiver.slotReceive)
-    assert proxy.blockSignal is False
-    sender.signalSend.emit()
-    proxy.flush()
-    qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
-
-    assert receiver.counter > 0
-
     del proxy
     del sender
     del receiver

--- a/pyqtgraph/tests/test_signalproxy.py
+++ b/pyqtgraph/tests/test_signalproxy.py
@@ -94,7 +94,7 @@ def test_signal_proxy_no_slot_start(qapp):
     assert receiver.counter == 0
 
     # Start a connect
-    proxy.connect(receiver.slotReceive)
+    proxy.connectSignal(receiver.slotReceive)
     sender.signalSend.emit()
     proxy.flush()
     qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
@@ -102,7 +102,7 @@ def test_signal_proxy_no_slot_start(qapp):
 
     # An additional connect should raise an AssertionError
     with pytest.raises(AssertionError):
-        proxy.connect(receiver.slotReceive)
+        proxy.connectSignal(receiver.slotReceive)
 
 
 def test_signal_proxy_slot_block(qapp):

--- a/pyqtgraph/tests/test_signalproxy.py
+++ b/pyqtgraph/tests/test_signalproxy.py
@@ -53,6 +53,10 @@ def test_signal_proxy_slot(qapp):
 
     assert receiver.counter == 1
 
+    del proxy
+    del sender
+    del receiver
+
 
 def test_signal_proxy_disconnect_slot(qapp):
     """Test the disconnect of SignalProxy with `signal` and `slot`"""
@@ -76,6 +80,17 @@ def test_signal_proxy_disconnect_slot(qapp):
 
     assert receiver.counter == 0
 
+    proxy.connectSlot(receiver.slotReceive)
+    sender.signalSend.emit()
+    proxy.flush()
+    qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
+
+    assert receiver.counter == 1
+
+    del proxy
+    del sender
+    del receiver
+
 
 def test_signal_proxy_no_slot_start(qapp):
     """Test the connect mode of SignalProxy without slot at start`"""
@@ -94,7 +109,7 @@ def test_signal_proxy_no_slot_start(qapp):
     assert receiver.counter == 0
 
     # Start a connect
-    proxy.connectSignal(receiver.slotReceive)
+    proxy.connectSlot(receiver.slotReceive)
     sender.signalSend.emit()
     proxy.flush()
     qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
@@ -102,7 +117,11 @@ def test_signal_proxy_no_slot_start(qapp):
 
     # An additional connect should raise an AssertionError
     with pytest.raises(AssertionError):
-        proxy.connectSignal(receiver.slotReceive)
+        proxy.connectSlot(receiver.slotReceive)
+
+    del proxy
+    del sender
+    del receiver
 
 
 def test_signal_proxy_slot_block(qapp):
@@ -131,3 +150,7 @@ def test_signal_proxy_slot_block(qapp):
     qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)
 
     assert receiver.counter == 1
+
+    del proxy
+    del sender
+    del receiver

--- a/pyqtgraph/tests/test_signalproxy.py
+++ b/pyqtgraph/tests/test_signalproxy.py
@@ -65,8 +65,11 @@ def test_signal_proxy_disconnect_slot(qapp):
     assert proxy is not None
     assert sender is not None
     assert receiver is not None
+    assert proxy.slot is not None
 
     proxy.disconnect()
+    assert proxy.slot is None
+
     sender.signalSend.emit()
     proxy.flush()
     qapp.processEvents(QtCore.QEventLoop.AllEvents, 10)


### PR DESCRIPTION
This PR will fix #1178 

- Provided a bunch of basic tests in addition
- Took the opportunity to clean up a bit the file