### PR TITLE
Disable mouse rate limiting on test_ROI

### DIFF
--- a/pyqtgraph/graphicsItems/tests/test_ROI.py
+++ b/pyqtgraph/graphicsItems/tests/test_ROI.py
@@ -8,6 +8,7 @@ from pyqtgraph.tests import assertImageApproved, mouseMove, mouseDrag, mouseClic
 import pytest
 
 app = pg.mkQApp()
+pg.setConfigOption("mouseRateLimit", 0)
 
 def test_getArrayRegion(transpose=False):
     pr = pg.PolyLineROI([[0, 0], [27, 0], [0, 28]], closed=True)


### PR DESCRIPTION
The mouse rate limiting appears to be causing issues with the test_ROI test suite.  This PR disables the limiting allowing for tests to pass w/o issue.