### PR TITLE
Fix width, height and background in SVG exporter

### DIFF
--- a/pyqtgraph/exporters/Exporter.py
+++ b/pyqtgraph/exporters/Exporter.py
@@ -1,7 +1,6 @@
 from ..widgets.FileDialog import FileDialog
 from ..Qt import QtGui, QtCore, QtSvg
 from ..python2_3 import asUnicode, basestring
-from ..GraphicsScene import GraphicsScene
 import os, re
 LastExportDirectory = None
 
@@ -77,21 +76,21 @@ class Exporter(object):
         self.export(fileName=fileName, **self.fileDialog.opts)
         
     def getScene(self):
-        if isinstance(self.item, GraphicsScene):
+        if isinstance(self.item, QtGui.QGraphicsScene):
             return self.item
         else:
             return self.item.scene()
         
     def getSourceRect(self):
-        if isinstance(self.item, GraphicsScene):
-            w = self.item.getViewWidget()
+        if isinstance(self.item, QtGui.QGraphicsScene):
+            w = self.item.views()[0]
             return w.viewportTransform().inverted()[0].mapRect(w.rect())
         else:
             return self.item.sceneBoundingRect()
         
     def getTargetRect(self):        
-        if isinstance(self.item, GraphicsScene):
-            return self.item.getViewWidget().rect()
+        if isinstance(self.item, QtGui.QGraphicsScene):
+            return self.item.views()[0].rect()
         else:
             return self.item.mapRectToDevice(self.item.boundingRect())
         

--- a/pyqtgraph/exporters/Exporter.py
+++ b/pyqtgraph/exporters/Exporter.py
@@ -1,6 +1,7 @@
 from ..widgets.FileDialog import FileDialog
 from ..Qt import QtGui, QtCore, QtSvg
 from ..python2_3 import asUnicode, basestring
+from ..GraphicsScene import GraphicsScene
 import os, re
 LastExportDirectory = None
 
@@ -76,21 +77,21 @@ class Exporter(object):
         self.export(fileName=fileName, **self.fileDialog.opts)
         
     def getScene(self):
-        if isinstance(self.item, QtGui.QGraphicsScene):
+        if isinstance(self.item, GraphicsScene):
             return self.item
         else:
             return self.item.scene()
         
     def getSourceRect(self):
-        if isinstance(self.item, QtGui.QGraphicsScene):
-            w = self.item.views()[0]
+        if isinstance(self.item, GraphicsScene):
+            w = self.item.getViewWidget()
             return w.viewportTransform().inverted()[0].mapRect(w.rect())
         else:
             return self.item.sceneBoundingRect()
         
     def getTargetRect(self):        
-        if isinstance(self.item, QtGui.QGraphicsScene):
-            return self.item.views()[0].rect()
+        if isinstance(self.item, GraphicsScene):
+            return self.item.getViewWidget().rect()
         else:
             return self.item.mapRectToDevice(self.item.boundingRect())
         

--- a/pyqtgraph/exporters/SVGExporter.py
+++ b/pyqtgraph/exporters/SVGExporter.py
@@ -114,9 +114,9 @@ def generateSvg(item, options={}):
     for d in defs:
         defsXml += d.toprettyxml(indent='    ')
     defsXml += "</defs>\n"
-    svgAttributes = f' viewBox ="0 0 {options["width"]} {options["height"]}"'
+    svgAttributes = ' viewBox ="0 0 %f %f"' % (options["width"], options["height"])
     c = options['background']
-    backgroundtag = f'<rect width="100%" height="100%" style="fill:rgba({c.red()}, {c.blue()}, {c.green()}, {c.alpha()/255.0})" />\n'
+    backgroundtag = '<rect width="100%%" height="100%%" style="fill:rgba(%f, %f, %f, %d)" />\n' % (c.red(), c.blue(), c.green(), c.alpha()/255.0)
     return (xmlHeader % svgAttributes) + backgroundtag + defsXml + node.toprettyxml(indent='    ') + "\n</svg>\n"
 
 

--- a/pyqtgraph/exporters/tests/test_svg.py
+++ b/pyqtgraph/exporters/tests/test_svg.py
@@ -33,37 +33,42 @@ def test_plotscene():
 def test_simple():
     tempfilename = tempfile.NamedTemporaryFile(suffix='.svg').name
     print("using %s as a temporary file" % tempfilename)
-    scene = pg.QtGui.QGraphicsScene()
-    #rect = pg.QtGui.QGraphicsRectItem(0, 0, 100, 100)
-    #scene.addItem(rect)
-    #rect.setPos(20,20)
-    #rect.translate(50, 50)
-    #rect.rotate(30)
-    #rect.scale(0.5, 0.5)
     
-    #rect1 = pg.QtGui.QGraphicsRectItem(0, 0, 100, 100)
-    #rect1.setParentItem(rect)
-    #rect1.setFlag(rect1.ItemIgnoresTransformations)
-    #rect1.setPos(20, 20)
-    #rect1.scale(2,2)
-    
-    #el1 = pg.QtGui.QGraphicsEllipseItem(0, 0, 100, 100)
-    #el1.setParentItem(rect1)
-    ##grp = pg.ItemGroup()
-    #grp.setParentItem(rect)
-    #grp.translate(200,0)
-    ##grp.rotate(30)
-    
-    #rect2 = pg.QtGui.QGraphicsRectItem(0, 0, 100, 25)
-    #rect2.setFlag(rect2.ItemClipsChildrenToShape)
-    #rect2.setParentItem(grp)
-    #rect2.setPos(0,25)
-    #rect2.rotate(30)
-    #el = pg.QtGui.QGraphicsEllipseItem(0, 0, 100, 50)
-    #el.translate(10,-5)
-    #el.scale(0.5,2)
+    view = pg.GraphicsView()
+    view.show()
 
-    #el.setParentItem(rect2)
+    scene = view.sceneObj
+
+    rect = pg.QtGui.QGraphicsRectItem(0, 0, 100, 100)
+    scene.addItem(rect)
+    rect.setPos(20,20)
+    rect.translate(50, 50)
+    rect.rotate(30)
+    rect.scale(0.5, 0.5)
+    
+    rect1 = pg.QtGui.QGraphicsRectItem(0, 0, 100, 100)
+    rect1.setParentItem(rect)
+    rect1.setFlag(rect1.ItemIgnoresTransformations)
+    rect1.setPos(20, 20)
+    rect1.scale(2,2)
+    
+    el1 = pg.QtGui.QGraphicsEllipseItem(0, 0, 100, 100)
+    el1.setParentItem(rect1)
+    grp = pg.ItemGroup()
+    grp.setParentItem(rect)
+    grp.translate(200,0)
+    grp.rotate(30)
+    
+    rect2 = pg.QtGui.QGraphicsRectItem(0, 0, 100, 25)
+    rect2.setFlag(rect2.ItemClipsChildrenToShape)
+    rect2.setParentItem(grp)
+    rect2.setPos(0,25)
+    rect2.rotate(30)
+    el = pg.QtGui.QGraphicsEllipseItem(0, 0, 100, 50)
+    el.translate(10,-5)
+    el.scale(0.5,2)
+
+    el.setParentItem(rect2)
 
     grp2 = pg.ItemGroup()
     scene.addItem(grp2)


### PR DESCRIPTION
Fixes #1157

With this PR, the `viewBox` attribute with appropriate width and height is added to the top `svg` tag. Its absence caused trouble visualizing the image on certain browsers, and issues when zooming the image.

Also, the SVG exporter is now storing the background color too.