### PR TITLE
handle case of version string having no '+'

### DIFF
--- a/tools/setupHelpers.py
+++ b/tools/setupHelpers.py
@@ -467,7 +467,7 @@ def getVersionStrings(pkg):
         version = initVersion
         # if git says this is a modified branch, add local version information
         if gitVersion is not None:
-            _, local = gitVersion.split('+')
+            _, _, local = gitVersion.partition('+')
             if local != '':
                 version = version + '+' + local
                 sys.stderr.write("Detected git commit; "


### PR DESCRIPTION
Ran into this issue while testing out another unrelated issue.  I went to check out tag `pyqtgraph-0.11.0` and did `python.setup.py install`  and got the following error:

```
$ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 70, in <module>
    version, forcedVersion, gitVersion, initVersion = helpers.getVersionStrings(pkg='pyqtgraph')
  File "tools/setupHelpers.py", line 470, in getVersionStrings
    _, local = gitVersion.split('+')
ValueError: need more than 1 value to unpack
```

The issue here is that `gitVersion` is reporting the version `0.11.0` with no `+`.  We can work around this by using `str.partition("+")` instead which won't blow up should a `+` not be present.