### PR TITLE
Do not apply transparent background in Qt4

### DIFF
--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -131,9 +131,10 @@ class GraphicsView(QtGui.QGraphicsView):
         self.clickAccepted = False
 
         # Set a transparent background QPalette!
-        palette = self.palette()
-        palette.setColor(QtGui.QPalette.Background, QtCore.Qt.transparent)
-        self.setPalette(palette)
+        if QT_LIB in ["PySide2", "PyQt5"]:
+            palette = self.palette()
+            palette.setColor(QtGui.QPalette.Background, QtCore.Qt.transparent)
+            self.setPalette(palette)
 
     def setAntialiasing(self, aa):
         """Enable or disable default antialiasing.

--- a/pyqtgraph/widgets/tests/test_graphics_view.py
+++ b/pyqtgraph/widgets/tests/test_graphics_view.py
@@ -10,8 +10,10 @@ def test_basics_graphics_view():
     assert background_role == QtGui.QPalette.Background
 
     palette = view.palette()
-    assert palette.isBrushSet(QtGui.QPalette.Active, QtGui.QPalette.Background)
-    assert palette.color(QtGui.QPalette.Background) == QtCore.Qt.transparent
+
+    if pg.Qt.QT_LIB in ["PySide2", "PyQt5"]:
+        assert palette.isBrushSet(QtGui.QPalette.Active, QtGui.QPalette.Background)
+        assert palette.color(QtGui.QPalette.Background) == QtCore.Qt.transparent
     assert view.backgroundBrush().color() == QtGui.QColor(0, 0, 0, 255)
 
     assert view.focusPolicy() == QtCore.Qt.StrongFocus
@@ -37,8 +39,10 @@ def test_basics_graphics_view():
     view.setBackground("w")
     assert view._background == "w"
     palette = view.palette()
-    assert palette.isBrushSet(QtGui.QPalette.Active, QtGui.QPalette.Background)
-    assert palette.color(QtGui.QPalette.Background) == QtCore.Qt.transparent
+    if pg.Qt.QT_LIB in ["PySide2", "PyQt5"]:
+
+        assert palette.isBrushSet(QtGui.QPalette.Active, QtGui.QPalette.Background)
+        assert palette.color(QtGui.QPalette.Background) == QtCore.Qt.transparent
     assert view.backgroundBrush().color() == QtCore.Qt.white
 
     # Set anti aliasing


### PR DESCRIPTION
This makes it so the change in PR #1383 is only applied to when using Qt5.  When using Qt4, this would make non-updating GraphicViews transparent/blank.