### PR TITLE
Use Python 3.9 to Test CI on [Latest] Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Qt Bindings Test Matrix
 
 The following table represents the python environments we test in our CI system.  Our CI system uses Ubuntu 18.04, Windows Server 2019, and macOS 10.15 base images.
 
-| Qt-Bindings    | Python 2.7         | Python 3.6         | Python 3.7         | Python 3.8         |
+| Qt-Bindings    | Python 2.7         | Python 3.6         | Python 3.7         | Python 3.9         |
 | :------------- | :----------------: | :----------------: | :----------------: | :----------------: |
 | PyQt-4         | :white_check_mark: | :x:                | :x:                | :x:                |
 | PySide1        | :white_check_mark: | :x:                | :x:                | :x:                |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.8
+        versionSpec: 3.9
     - script: |
         python -m pip install setuptools wheel
         python setup.py bdist_wheel --universal
@@ -105,7 +105,7 @@ stages:
       vmImage: 'Ubuntu 18.04'
   - template: azure-test-template.yml
     parameters:
-      name: windows
+      name: win
       vmImage: 'windows-2019'
   - template: azure-test-template.yml
     parameters:

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -10,28 +10,28 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      Python27-PyQt4-4.8:
+      Py27-PyQt4-4.8:
         python.version: '2.7'
         qt.bindings: "pyqt=4"
         install.method: "conda"
-      Python27-PySide-4.8:
+      Py27-PySide-4.8:
         python.version: '2.7'
         qt.bindings: "pyside"
         install.method: "conda"
-      Python36-PyQt5-5.9:
+      Py36-PyQt5-5.9:
         python.version: "3.6"
         qt.bindings: "pyqt"
         install.method: "conda"
-      Python37-PySide2-5.13:
+      Py37-PySide2-5.13:
         python.version: "3.7"
         qt.bindings: "pyside2"
         install.method: "conda"
-      Python38-PyQt5-Latest:
-        python.version: '3.8'
+      Py39-PyQt5-Latest:
+        python.version: '3.9'
         qt.bindings: "PyQt5"
         install.method: "pip"
-      Python38-PySide2-Latest:
-        python.version: '3.8'
+      Py39-PySide2-Latest:
+        python.version: '3.9'
         qt.bindings: "PySide2"
         install.method: "pip"     
 

--- a/pyqtgraph/tests/test_reload.py
+++ b/pyqtgraph/tests/test_reload.py
@@ -43,6 +43,8 @@ def remove_cache(mod):
 
 
 def test_reload():
+    """PYTEST_DONT_REWRITE
+    """
     py3 = sys.version_info >= (3,)
 
     # write a module


### PR DESCRIPTION
As Python 3.9 is out, we should likely test that on our CI platform... Only the latest versions of PyQt5/PySide2 are tested against Python 3.9.