### PR TITLE
Hide WidgetParameterItem.defaultBtn if param has no default

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -186,7 +186,7 @@ class WidgetParameterItem(ParameterItem):
         self.defaultBtn.setEnabled(not self.param.valueIsDefault() and self.param.writable())        
         
         # hide / show
-        self.defaultBtn.setVisible(not self.param.readonly())
+        self.defaultBtn.setVisible(self.param.hasDefault() and not self.param.readonly())
 
     def updateDisplayLabel(self, value=None):
         """Update the display label to reflect the value of the parameter."""


### PR DESCRIPTION
Currently the button is both visible and enabled when the parameter has no default. This PR hides it in this case. It could alternatively disable it - I just found this way more visually appealing.