### PR TITLE
Call GraphicsItem.viewTransformChanged()

### DIFF
--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -2,6 +2,7 @@
 from ..Qt import QtGui, QtCore
 from ..Point import Point
 from .GraphicsObject import GraphicsObject
+from .GraphicsItem import GraphicsItem
 from .TextItem import TextItem
 from .ViewBox import ViewBox
 from .. import functions as fn
@@ -431,6 +432,7 @@ class InfiniteLine(GraphicsObject):
         Called whenever the transformation matrix of the view has changed.
         (eg, the view range has changed or the view was resized)
         """
+        GraphicsItem.viewTransformChanged(self)
         self._invalidateCache()
         
     def setName(self, name):

--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -609,6 +609,7 @@ class InfLineLabel(TextItem):
             ev.acceptDrags(QtCore.Qt.LeftButton)
 
     def viewTransformChanged(self):
+        GraphicsItem.viewTransformChanged(self)
         self.updatePosition()
         TextItem.viewTransformChanged(self)
 


### PR DESCRIPTION
Follow up to #1391 got a bug report on slack about infinite lines not extending the height of the view; this was due to some cache handling in GraphicsItem; fix was just to call the inherited viewTransformChanged method from GraphicsItem for InifiniteLine.

I'm wondering if we should take a look at some of the other places we call out `viewTransformChanged` explicitly.

Other places we call it include:

-  ImageItem.py
-  PlotCurveItem.py
-  ROI.py
-  ScatterPlotItem.py
-  TextItem.py
-  TargetItem.py (not currently used much)