### PR TITLE
DataTreeWidget: dict sorting crashfix

### DIFF
--- a/pyqtgraph/widgets/DataTreeWidget.py
+++ b/pyqtgraph/widgets/DataTreeWidget.py
@@ -93,7 +93,10 @@ class DataTreeWidget(QtGui.QTreeWidget):
             if isinstance(data, OrderedDict):
                 childs = data
             else:
-                childs = OrderedDict(sorted(data.items()))
+                try:
+                    childs = OrderedDict(sorted(data.items()))
+                except TypeError: # if sorting falls
+                    childs = OrderedDict(data.items())
         elif isinstance(data, (list, tuple)):
             desc = "length=%d" % len(data)
             childs = OrderedDict(enumerate(data))


### PR DESCRIPTION
Solves issue when DataTreeWidget crashes if some dictionary contains both ints and tuples (yeah, I have such weird stuff). Sorting falls and then it looks like this: 

`File "/packages/python3-3.7.7-2/.self/non-packaged/lib/python3.7/site-packages/pyqtgraph/widgets/DataTreeWidget.py", line 25, in __init__
    self.setData(data)
  File "/packages/python3-3.7.7-2/.self/non-packaged/lib/python3.7/site-packages/pyqtgraph/widgets/DataTreeWidget.py", line 35, in setData
    self.buildTree(data, self.invisibleRootItem(), hideRoot=hideRoot)
  File "/packages/python3-3.7.7-2/.self/non-packaged/lib/python3.7/site-packages/pyqtgraph/widgets/DataTreeWidget.py", line 72, in buildTree
    self.buildTree(data, node, asUnicode(key), path=path+(key,))
  File "/packages/python3-3.7.7-2/.self/non-packaged/lib/python3.7/site-packages/pyqtgraph/widgets/DataTreeWidget.py", line 72, in buildTree
    self.buildTree(data, node, asUnicode(key), path=path+(key,))
  File "/packages/python3-3.7.7-2/.self/non-packaged/lib/python3.7/site-packages/pyqtgraph/widgets/DataTreeWidget.py", line 50, in buildTree
    typeStr, desc, childs, widget = self.parse(data)
  File "/packages/python3-3.7.7-2/.self/non-packaged/lib/python3.7/site-packages/pyqtgraph/widgets/DataTreeWidget.py", line 96, in parse
    childs = OrderedDict(sorted(data.items()))
TypeError: '<' not supported between instances of 'tuple' and 'int'
`