### PR TITLE
Permit entry of non-finite values into float SpinBox

### DIFF
--- a/examples/SpinBox.py
+++ b/examples/SpinBox.py
@@ -39,7 +39,7 @@ spins = [
                 regex='(0x)?(?P<number>[0-9a-fA-F]+)$',
                 evalFunc=lambda s: ast.literal_eval('0x'+s))),
     ("Integer with bounds=[10, 20] and wrapping",
-     pg.SpinBox(value=10, bounds=[10, 20], int=False, minStep=1, step=1, wrapping=True)),
+     pg.SpinBox(value=10, bounds=[10, 20], int=True, minStep=1, step=1, wrapping=True)),
 ]
 
 

--- a/examples/SpinBox.py
+++ b/examples/SpinBox.py
@@ -19,8 +19,8 @@ app = QtGui.QApplication([])
 
 
 spins = [
-    ("Floating-point spin box, min=0, no maximum.", 
-     pg.SpinBox(value=5.0, bounds=[0, None])),
+    ("Floating-point spin box, min=0, no maximum.<br>Non-finite values (nan, inf) are permitted.",
+     pg.SpinBox(value=5.0, bounds=[0, None], finite=False)),
     ("Integer spin box, dec stepping<br>(1-9, 10-90, 100-900, etc), decimals=4", 
      pg.SpinBox(value=10, int=True, dec=True, minStep=1, step=1, decimals=4)),
     ("Float with SI-prefixed units<br>(n, u, m, k, M, etc)", 

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -38,7 +38,7 @@ SI_PREFIXES_ASCII = 'yzafpnum kMGTPEZY'
 SI_PREFIX_EXPONENTS = dict([(SI_PREFIXES[i], (i-8)*3) for i in range(len(SI_PREFIXES))])
 SI_PREFIX_EXPONENTS['u'] = -6
 
-FLOAT_REGEX = re.compile(r'(?P<number>[+-]?((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)\s*((?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>\w.*))?$')
+FLOAT_REGEX = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|(nan)|(inf)))\s*((?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>\w.*))?$')
 INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>.*)$')
 
     

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -38,7 +38,7 @@ SI_PREFIXES_ASCII = 'yzafpnum kMGTPEZY'
 SI_PREFIX_EXPONENTS = dict([(SI_PREFIXES[i], (i-8)*3) for i in range(len(SI_PREFIXES))])
 SI_PREFIX_EXPONENTS['u'] = -6
 
-FLOAT_REGEX = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|(nan)|(inf)))\s*((?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>\w.*))?$')
+FLOAT_REGEX = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|((?i)(nan)|(inf))))\s*((?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>\w.*))?$')
 INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>.*)$')
 
     

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -82,6 +82,7 @@ class SpinBox(QtGui.QAbstractSpinBox):
                             ## if true, minStep must be set in order to cross zero.
             
             'int': False, ## Set True to force value to be integer
+            'finite': True,
             
             'suffix': '',
             'siPrefix': False,   ## Set to True to display numbers with SI prefix (ie, 100pA instead of 1e-10A)
@@ -146,7 +147,9 @@ class SpinBox(QtGui.QAbstractSpinBox):
                        'step' values when dec=True are 0.1, 0.2, 0.5, and 1.0. Default is
                        False.
         minStep        (float) When dec=True, this specifies the minimum allowable step size.
-        int            (bool) if True, the value is forced to integer type. Default is False
+        int            (bool) If True, the value is forced to integer type. Default is False
+        finite         (bool) When False and int=False, infinite values (nan, inf, -inf) are
+                       permitted. Default is True.
         wrapping       (bool) If True and both bounds are not None, spin box has circular behavior.
         decimals       (int) Number of decimal values to display. Default is 6. 
         format         (str) Formatting string used to generate the text shown. Formatting is
@@ -545,10 +548,11 @@ class SpinBox(QtGui.QAbstractSpinBox):
            
         # generate value
         val = self.opts['evalFunc'](val)
-        if self.opts['int']:
-            if not isfinite(val):
-                return False
 
+        if (self.opts['int'] or self.opts['finite']) and not isfinite(val):
+            return False
+
+        if self.opts['int']:
             val = int(fn.siApply(val, siprefix))
         else:
             try:

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from math import isnan, isfinite
+from math import isnan, isinf
 from decimal import Decimal as D  ## Use decimal to avoid accumulating floating-point errors
 import decimal
 import weakref
@@ -339,13 +339,13 @@ class SpinBox(QtGui.QAbstractSpinBox):
             bounds = self.opts['bounds']
             if None not in bounds and self.opts['wrapping'] is True:
                 bounded = False
-                if isfinite(value):
+                if isinf(value):
+                    value = self.val
+                else:
                     # Casting of Decimals to floats required to avoid unexpected behavior of remainder operator
                     value = float(value)
                     l, u = float(bounds[0]), float(bounds[1])
                     value = (value - l) % (u - l) + l
-                else:
-                    value = self.val
             else:
                 if bounds[0] is not None and value < bounds[0]:
                     bounded = False
@@ -396,7 +396,7 @@ class SpinBox(QtGui.QAbstractSpinBox):
         return self.StepUpEnabled | self.StepDownEnabled        
     
     def stepBy(self, n):
-        if not isfinite(self.val):
+        if isinf(self.val) or isnan(self.val):
             return
 
         n = D(int(n))   ## n must be integral number of steps.
@@ -549,7 +549,7 @@ class SpinBox(QtGui.QAbstractSpinBox):
         # generate value
         val = self.opts['evalFunc'](val)
 
-        if (self.opts['int'] or self.opts['finite']) and not isfinite(val):
+        if (self.opts['int'] or self.opts['finite']) and (isinf(val) or isnan(val)):
             return False
 
         if self.opts['int']:


### PR DESCRIPTION
Bounds are enforced for `inf `and `-inf`, but `nan` ignores them. Attempting to step any of these values doesn't do anything.

A previously existing bug is also fixed where the text is not updated properly when out-of-bounds data is entered.