### PR TITLE
Fix small bug in GridItem.py:setTextPen

### DIFF
--- a/pyqtgraph/graphicsItems/GridItem.py
+++ b/pyqtgraph/graphicsItems/GridItem.py
@@ -46,7 +46,7 @@ class GridItem(UIGraphicsItem):
             if args == (None,):
                 self.opts['textPen'] = None
             else:
-                self.opts['textPen'] = fn.mkPen(*args, **kargs)
+                self.opts['textPen'] = fn.mkPen(*args, **kwargs)
 
         self.picture = None
         self.update()


### PR DESCRIPTION
Bug in GridItem.setTextPen() : on line 49 **kargs should be **kwargs. setTextPen does not work (until this simple fix is applied)