### PR TITLE
Fix ExampleApp: Use pg module from directory

### DIFF
--- a/examples/__main__.py
+++ b/examples/__main__.py
@@ -1,15 +1,16 @@
 import sys, os
+
+# Set up path to contain pyqtgraph module when run without installation
+if __name__ == "__main__" and (__package__ is None or __package__==''):
+    parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.insert(0, parent_dir)
+    import examples
+    __package__ = "examples"
+
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
 
 
-
 if __name__ == '__main__':
-    if __package__ is None or __package__ == "":
-        parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        sys.path.insert(0, parent_dir)
-        import examples
-        __package__ = "examples"
-
     from .ExampleApp import main as run
     run()


### PR DESCRIPTION
One should be able to run the example app from the folder without installation of pyqtgraph or when a different pyqtgraph version is installed, e.g. via 
```
pyqtgraph $  python3 examples
```
or 
```
pyqtgraph\examples $  python3 .
```
, which is again possible after this.

Fixes #1431