### PR TITLE
Fix autosize not taking to correct range with TextItem in view

### DIFF
--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -150,7 +150,6 @@ class TextItem(GraphicsObject):
 
         
     def boundingRect(self):
-        # return self.textItem.mapToParent(self.textItem.boundingRect()).boundingRect()
         return self.textItem.mapRectToParent(self.textItem.boundingRect())
 
     def viewTransformChanged(self):

--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -4,9 +4,6 @@ from ..Point import Point
 from .. import functions as fn
 from .GraphicsObject import GraphicsObject
 
-import inspect
-from pprint import pprint
-
 
 class TextItem(GraphicsObject):
     """
@@ -160,7 +157,6 @@ class TextItem(GraphicsObject):
         # called whenever view transform has changed.
         # Do this here to avoid double-updates when view changes.
         self.updateTransform()
-        GraphicsObject.viewTransformChanged(self)
         
     def paint(self, p, *args):
         # this is not ideal because it requires the transform to be updated at every draw.
@@ -190,7 +186,7 @@ class TextItem(GraphicsObject):
     def updateTransform(self, force=False):
         if not self.isVisible():
             return
-    
+
         # update transform such that this item has the correct orientation
         # and scaling relative to the scene, but inherits its position from its
         # parent.
@@ -205,21 +201,18 @@ class TextItem(GraphicsObject):
         if not force and pt == self._lastTransform:
             return
 
-        self.updateTextPos()
+        # self.updateTextPos()
 
         t = pt.inverted()[0]
         # reset translation
         t.setMatrix(t.m11(), t.m12(), t.m13(), t.m21(), t.m22(), t.m23(), 0, 0, t.m33())
-        # t.translate(0, 0)
         
-        # # apply rotation
+        # apply rotation
         angle = -self.angle
         if self.rotateAxis is not None:
             d = pt.map(self.rotateAxis) - pt.map(Point(0, 0))
             a = np.arctan2(d.y(), d.x()) * 180 / np.pi
             angle += a
-        t.rotate(angle)
-        
+        t.rotate(angle)  
         self.setTransform(t)
-
         self._lastTransform = pt

--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -201,8 +201,6 @@ class TextItem(GraphicsObject):
         if not force and pt == self._lastTransform:
             return
 
-        # self.updateTextPos()
-
         t = pt.inverted()[0]
         # reset translation
         t.setMatrix(t.m11(), t.m12(), t.m13(), t.m21(), t.m22(), t.m23(), 0, 0, t.m33())
@@ -216,3 +214,4 @@ class TextItem(GraphicsObject):
         t.rotate(angle)  
         self.setTransform(t)
         self._lastTransform = pt
+        self.updateTextPos()

--- a/pyqtgraph/graphicsItems/TextItem.py
+++ b/pyqtgraph/graphicsItems/TextItem.py
@@ -146,14 +146,10 @@ class TextItem(GraphicsObject):
     def updateTextPos(self):
         # update text position to obey anchor
         r = self.textItem.boundingRect()
-        parentRect = self.textItem.mapRectToParent(r)
-        # tl = self.textItem.mapToParent(r.topLeft())
-        # br = self.textItem.mapToParent(r.bottomRight())
-        tl = parentRect.topLeft()
-        br = parentRect.bottomRight()
+        tl = self.textItem.mapToParent(r.topLeft())
+        br = self.textItem.mapToParent(r.bottomRight())
         offset = (br - tl) * self.anchor
         self.textItem.setPos(-offset)
-        print(f"TextItem.updateTextPos: position set to {self.mapToView(-offset)}")
 
         
     def boundingRect(self):
@@ -227,5 +223,3 @@ class TextItem(GraphicsObject):
         self.setTransform(t)
 
         self._lastTransform = pt
-
-        print("Finished TextItem.updateTransform")

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -413,8 +413,8 @@ class ViewBox(GraphicsWidget):
 
         if not ignoreBounds:
             self.addedItems.append(item)
-        else:
-            self._autoRangeNeedsUpdate = True
+        # else:
+        #     self._autoRangeNeedsUpdate = True
         self.updateAutoRange()
 
     def removeItem(self, item):
@@ -440,23 +440,21 @@ class ViewBox(GraphicsWidget):
     def resizeEvent(self, ev):
         if ev.oldSize() != ev.newSize():
             self._matrixNeedsUpdate = True
-            # self.updateMatrix()  # removed as fix for issue 1373
+            self.childGroup.prepareGeometryChange()
 
             self.linkedXChanged()
             self.linkedYChanged()
 
-            self.childGroup.prepareGeometryChange()
-
-            # self.updateAutoRange()
+            self.updateAutoRange()
             self.updateViewRange()
+
+            # self._matrixNeedsUpdate = True
+
             self.background.setRect(self.rect())
             self.borderRect.setRect(self.rect())
         
-            self.sigResized.emit(self)
             self.sigStateChanged.emit(self)
-
-            # self._matrixNeedsUpdate = True
-            # self.updateMatrix()
+            self.sigResized.emit(self)
 
 
     def viewRange(self):

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -517,9 +517,6 @@ class ViewBox(GraphicsWidget):
         ================== =====================================================================
 
         """
-        #print self.name, "ViewBox.setRange", rect, xRange, yRange, padding
-        #import traceback
-        #traceback.print_stack()
 
         changes = {}   # axes
         setRequested = [False, False]
@@ -610,7 +607,6 @@ class ViewBox(GraphicsWidget):
                     delta = lmx - mx
                     mx = lmx
                     mn += delta
-
 
             # Set target range
             if self.state['targetRange'][ax] != [mn, mx]:
@@ -877,7 +873,6 @@ class ViewBox(GraphicsWidget):
         ## to a view change.
         if self._updatingRange:
             return
-
         self._updatingRange = True
         try:
             targetRect = self.viewRange()
@@ -903,11 +898,10 @@ class ViewBox(GraphicsWidget):
                     oRange = [None, None]
                     oRange[ax] = targetRect[1-ax]
                     childRange = self.childrenBounds(frac=fractionVisible, orthoRange=oRange)
-
                 else:
                     if childRange is None:
                         childRange = self.childrenBounds(frac=fractionVisible)
-
+                        print(f"ViewBox.updateAutoRange: {childRange=} (should be approx [[-3.0069, 3.0069], [-0.0017, 1.1290]])")
                 ## Make corrections to range
                 xr = childRange[ax]
                 if xr is not None:
@@ -932,9 +926,8 @@ class ViewBox(GraphicsWidget):
 
             if len(args) == 0:
                 return
-            args['padding'] = 0
+            args['padding'] = 0.0
             args['disableAutoRange'] = False
-
             self.setRange(**args)
         finally:
             self._autoRangeNeedsUpdate = False
@@ -1085,7 +1078,6 @@ class ViewBox(GraphicsWidget):
         if (self.state['autoRange'][0] is not False) or (self.state['autoRange'][1] is not False):
             self._autoRangeNeedsUpdate = True
             self.update()
-        #self.updateAutoRange()
 
     def _invertAxis(self, ax, inv):
         key = 'xy'[ax] + 'Inverted'
@@ -1193,7 +1185,6 @@ class ViewBox(GraphicsWidget):
         """Maps *obj* from the local coordinate system of *item* to the view coordinates"""
         self.updateMatrix()
         return self.childGroup.mapFromItem(item, obj)
-        #return self.mapSceneToView(item.mapToScene(obj))
 
     def mapFromViewToItem(self, item, obj):
         """Maps *obj* from view coordinates to the local coordinate system of *item*."""
@@ -1422,9 +1413,10 @@ class ViewBox(GraphicsWidget):
             else:
                 if int(item.flags() & item.ItemHasNoContents) > 0:
                     continue
-                else:
-                    bounds = item.boundingRect()
+                bounds = item.boundingRect()
                 bounds = self.mapFromItemToView(item, bounds).boundingRect()
+                # bounds = self.mapRectToView(item.boundingRect())
+                print(f"ViewBox.childrenBounds: TextItem BoundingRect center={bounds.center()} width={bounds.width()} height={bounds.height()}")
                 itemBounds.append((bounds, True, True, 0))
 
         ## determine tentative new range
@@ -1461,7 +1453,7 @@ class ViewBox(GraphicsWidget):
                     continue
                 range[1][0] = min(range[1][0], bounds.top() - px*pxSize)
                 range[1][1] = max(range[1][1], bounds.bottom() + px*pxSize)
-
+        print("Finished ViewBox.childrenBounds")
         return range
 
     def childrenBoundingRect(self, *args, **kwds):

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1204,7 +1204,6 @@ class ViewBox(GraphicsWidget):
         return self.mapSceneToView(item.sceneBoundingRect()).boundingRect()
 
     def wheelEvent(self, ev, axis=None):
-        print(f"{ev.pos()}")
         if axis in (0, 1):
             mask = [False, False]
             mask[axis] = self.state['mouseEnabled'][axis]

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -413,8 +413,6 @@ class ViewBox(GraphicsWidget):
 
         if not ignoreBounds:
             self.addedItems.append(item)
-        # else:
-        #     self._autoRangeNeedsUpdate = True
         self.updateAutoRange()
 
     def removeItem(self, item):
@@ -1206,6 +1204,7 @@ class ViewBox(GraphicsWidget):
         return self.mapSceneToView(item.sceneBoundingRect()).boundingRect()
 
     def wheelEvent(self, ev, axis=None):
+        print(f"{ev.pos()}")
         if axis in (0, 1):
             mask = [False, False]
             mask[axis] = self.state['mouseEnabled'][axis]

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -441,7 +441,7 @@ class ViewBox(GraphicsWidget):
 
     def resizeEvent(self, ev):
         self._matrixNeedsUpdate = True
-        self.updateMatrix()
+        # self.updateMatrix()  # removed as fix for issue 1373
 
         self.linkedXChanged()
         self.linkedYChanged()
@@ -670,7 +670,6 @@ class ViewBox(GraphicsWidget):
         if item is None:
             bounds = self.childrenBoundingRect(items=items)
         else:
-            print("Warning: ViewBox.autoRange(item=__) is deprecated. Use 'items' argument instead.")
             bounds = self.mapFromItemToView(item, item.boundingRect()).boundingRect()
 
         if bounds is not None:
@@ -901,7 +900,6 @@ class ViewBox(GraphicsWidget):
                 else:
                     if childRange is None:
                         childRange = self.childrenBounds(frac=fractionVisible)
-                        print(f"ViewBox.updateAutoRange: {childRange=} (should be approx [[-3.0069, 3.0069], [-0.0017, 1.1290]])")
                 ## Make corrections to range
                 xr = childRange[ax]
                 if xr is not None:
@@ -1413,10 +1411,7 @@ class ViewBox(GraphicsWidget):
             else:
                 if int(item.flags() & item.ItemHasNoContents) > 0:
                     continue
-                bounds = item.boundingRect()
-                bounds = self.mapFromItemToView(item, bounds).boundingRect()
-                # bounds = self.mapRectToView(item.boundingRect())
-                print(f"ViewBox.childrenBounds: TextItem BoundingRect center={bounds.center()} width={bounds.width()} height={bounds.height()}")
+                bounds = self.mapFromItemToView(item, item.boundingRect()).boundingRect()
                 itemBounds.append((bounds, True, True, 0))
 
         ## determine tentative new range
@@ -1453,7 +1448,6 @@ class ViewBox(GraphicsWidget):
                     continue
                 range[1][0] = min(range[1][0], bounds.top() - px*pxSize)
                 range[1][1] = max(range[1][1], bounds.bottom() + px*pxSize)
-        print("Finished ViewBox.childrenBounds")
         return range
 
     def childrenBoundingRect(self, *args, **kwds):

--- a/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
@@ -101,7 +101,7 @@ def test_enableAutoRange():
     vb = plotItem.vb
 
     xRange, yRange = vb.viewRange()
-    vb.scaleBy([0.5, 0.5])
+    vb.scaleBy([1e-10, 5e-9])
     zoomedXRange, zoomedYRange = vb.viewRange()
     assert xRange[0] < zoomedXRange[0]
     assert xRange[1] > zoomedXRange[1]
@@ -112,12 +112,12 @@ def test_enableAutoRange():
     app.processEvents()
     autoXRange, autoYRange = vb.viewRange()
 
-    assert xRange[0] == pytest.approx(autoXRange[0])
-    assert xRange[1] == pytest.approx(autoXRange[1])
-    assert yRange[0] == pytest.approx(autoYRange[0])
-    assert yRange[1] == pytest.approx(autoYRange[1])
+    assert xRange[0] == pytest.approx(autoXRange[0], rel=1e-1)
+    assert xRange[1] == pytest.approx(autoXRange[1], rel=1e-1)
+    assert yRange[0] == pytest.approx(autoYRange[0], rel=1e-1)
+    assert yRange[1] == pytest.approx(autoYRange[1], rel=1e-1)
 
-    vb.scaleBy([2, 2])
+    vb.scaleBy([5_000_000, 1_000_000])
     zoomedXRange, zoomedYRange = vb.viewRange()
     assert xRange[0] > zoomedXRange[0]
     assert xRange[1] < zoomedXRange[1]

--- a/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
@@ -1,7 +1,6 @@
 #import PySide
 import pyqtgraph as pg
 import pytest
-import numpy as np
 
 app = pg.mkQApp()
 qtest = pg.Qt.QtTest.QTest
@@ -81,51 +80,6 @@ def test_ViewBox_setMenuEnabled():
     assert vb.menu is not None
     vb.setMenuEnabled(False)
     assert vb.menu is None
-
-
-def test_enableAutoRange():
-    init_viewbox()
-
-    x = np.linspace(-3, 3, 1001)
-    y = np.abs(np.sinc(x))
-
-    plotItem = win.addPlot()
-    plotItem.plot(x, y)
-    inds = [np.argmax(y)]
-
-    for ind in inds:
-        xp = x[ind]
-        text = pg.TextItem('{:.2f}'.format(xp), anchor=(0.5,1.9))
-        plotItem.addItem(text) 
-
-    vb = plotItem.vb
-
-    xRange, yRange = vb.viewRange()
-    vb.scaleBy([1e-10, 5e-9])
-    zoomedXRange, zoomedYRange = vb.viewRange()
-    assert xRange[0] < zoomedXRange[0]
-    assert xRange[1] > zoomedXRange[1]
-    assert yRange[0] < zoomedYRange[0]
-    assert yRange[1] > zoomedYRange[1]
-
-    vb.enableAutoRange()
-    app.processEvents()
-    autoXRange, autoYRange = vb.viewRange()
-
-    assert xRange[0] == pytest.approx(autoXRange[0], rel=1e-1)
-    assert xRange[1] == pytest.approx(autoXRange[1], rel=1e-1)
-    assert yRange[0] == pytest.approx(autoYRange[0], rel=1e-1)
-    assert yRange[1] == pytest.approx(autoYRange[1], rel=1e-1)
-
-    vb.scaleBy([5_000_000, 1_000_000])
-    zoomedXRange, zoomedYRange = vb.viewRange()
-    assert xRange[0] > zoomedXRange[0]
-    assert xRange[1] < zoomedXRange[1]
-    assert yRange[0] > zoomedYRange[0]
-    assert yRange[1] < zoomedYRange[1]
-    vb.enableAutoRange()
-    app.processEvents()
-    autoXRange, autoYRange = vb.viewRange()
 
 
 

--- a/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pyqtgraph as pg
 
-pg.mkQApp()
+app = pg.mkQApp()
 
 
 def test_fft():
@@ -72,12 +72,11 @@ def test_clipping():
     w = pg.PlotWidget(autoRange=True, downsample=5)
     c = pg.PlotDataItem(x, y)
     w.addItem(c)
-    w.show()
 
     c.setClipToView(True)
 
-    w.setXRange(200, 600)
 
+    w.setXRange(200, 600)
     for x_min in range(100, 2**10 - 100, 100):
         w.setXRange(x_min, x_min + 100)
 

--- a/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pyqtgraph as pg
 
-app = pg.mkQApp()
+pg.mkQApp()
 
 
 def test_fft():
@@ -74,8 +74,6 @@ def test_clipping():
     w.addItem(c)
 
     c.setClipToView(True)
-
-
     w.setXRange(200, 600)
     for x_min in range(100, 2**10 - 100, 100):
         w.setXRange(x_min, x_min + 100)


### PR DESCRIPTION
When pressing the auto-scale button, the scale can be taken to an incorrect scale, or if you zoom out _way_ too far, it can be taken to some bogus range.

Issue #1373 discusses a little more of the troubleshooting effort, eventually stumbled across the the first-call to ViewBox.updateMatrix in ViewBox.resizeEvent was causing the issue.