### PR TITLE
Fix: TickSliderItem method uses function from subclass GradientEditorItem

### DIFF
--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -316,7 +316,6 @@ class TickSliderItem(GraphicsWidget):
         pos.setX(x)
         tick.setPos(pos)
         self.ticks[tick] = val
-        self.updateGradient()
         
     def tickValue(self, tick):
         ## public
@@ -500,6 +499,23 @@ class GradientEditorItem(TickSliderItem):
         #global Gradients
         act = self.sender()
         self.loadPreset(act.name)
+    
+    def setTickValue(self, tick, val):
+        ## public
+        """
+        Set the position (along the slider) of the tick.
+        
+        ==============   ==================================================================
+        **Arguments:**
+        tick             Can be either an integer corresponding to the index of the tick
+                         or a Tick object. Ex: if you had a slider with 3 ticks and you
+                         wanted to change the middle tick, the index would be 1.
+        val              The desired position of the tick. If val is < 0, position will be
+                         set to 0. If val is > 1, position will be set to 1.
+        ==============   ==================================================================
+        """
+        TickSliderItem.setTickValue(self, tick, val)
+        self.updateGradient()
         
     @addGradientListToDocstring()
     def loadPreset(self, name):


### PR DESCRIPTION
This fixes an issue where using `TickSliderItem.setTickValue` fails because it references a `GradientEditorItem` function. Further, since I was on it, the code is now improved do make much more use of signals and slots to avoid code duplication and weak references. This made it possible to reduce the amount of `GradientEditorItem.updateGradient` calls upon `GradientEditorItem` initialization from 34 to 2 in my tests.

Test code to reproduce error:

```python3
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore
import numpy as np

app = pg.mkQApp()

class CustomWidget(pg.GraphicsView):
    def __init__(self, parent=None, *args, **kargs):
        pg.GraphicsView.__init__(self, parent, useOpenGL=False, background=None)

        self.item = pg.TickSliderItem(*args, allowAdd=False, **kargs)
        tick = self.item.addTick(0.5, color="w", movable=False)
        self.item.setTickValue(tick, 0.05)

        self.setCentralItem(self.item)
        self.setFixedHeight(31)


w = CustomWidget()
w.show()

app.exec_()

```

Test code to show that nothing broke:

```python3
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore
import numpy as np

app = pg.mkQApp()

class CustomWidget(pg.GraphicsView):
    def __init__(self, parent=None, *args, **kargs):
        pg.GraphicsView.__init__(self, parent, useOpenGL=False, background=None)

        self.item = pg.GradientEditorItem(*args, **kargs)
        tick = self.item.addTick(0.5)
        self.item.setTickValue(tick, 0.05)

        self.setCentralItem(self.item)
        self.setFixedHeight(31)


w = CustomWidget()
w.show()

app.exec_()
```