### PR TITLE
WIP: Fix: TickSliderItem ignores Tick.removeAllowed

### DIFF
--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -190,7 +190,7 @@ class TickSliderItem(GraphicsWidget):
         pass
     
     def tickClicked(self, tick, ev):
-        if ev.button() == QtCore.Qt.RightButton:
+        if ev.button() == QtCore.Qt.RightButton and tick.removeAllowed:
             self.removeTick(tick)
     
     def widgetLength(self):


### PR DESCRIPTION
This prohibits removing ticks from a `TickSliderItem` if they were set to `tick.removeAllowed=False`.

Test code:
```python3
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore
import numpy as np

app = pg.mkQApp()

class CustomWidget(pg.GraphicsView):
    def __init__(self, parent=None, *args, **kargs):
        pg.GraphicsView.__init__(self, parent, useOpenGL=False, background=None)
        self.item = pg.TickSliderItem(*args, **kargs)

        for pos in (0, 0.5, 1):
            tick = self.item.addTick(pos)
            tick.removeAllowed = False # Possibility 1

        # Possibility 2
        for tick, value in self.item.listTicks():
            tick.removeAllowed = False

        self.setCentralItem(self.item)
        self.setFixedHeight(31)

w = CustomWidget()
w.show()

app.exec_()
```