### PR TITLE
TickSliderItem: Use Tick.removeAllowed

### DIFF
--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -751,7 +751,6 @@ class GradientEditorItem(TickSliderItem):
             color = self.getColor(x)
         t = TickSliderItem.addTick(self, x, color=color, movable=movable)
         t.colorChangeAllowed = True
-        t.removeAllowed = True
         
         if finish:
             self.sigGradientChangeFinished.emit(self)
@@ -854,6 +853,7 @@ class Tick(QtGui.QGraphicsWidget):  ## NOTE: Making this a subclass of GraphicsO
         self.pen = fn.mkPen(pen)
         self.hoverPen = fn.mkPen(255,255,0)
         self.currentPen = self.pen
+        self.removeAllowed = True
         self.pg = QtGui.QPainterPath(QtCore.QPointF(0,0))
         self.pg.lineTo(QtCore.QPointF(-scale/3**0.5, scale))
         self.pg.lineTo(QtCore.QPointF(scale/3**0.5, scale))

--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -190,7 +190,7 @@ class TickSliderItem(GraphicsWidget):
         pass
     
     def tickClicked(self, tick, ev):
-        if ev.button() == QtCore.Qt.RightButton:
+        if ev.button() == QtCore.Qt.RightButton and tick.removeAllowed:
             self.removeTick(tick)
     
     def widgetLength(self):


### PR DESCRIPTION
Previously, `Tick.removeAllowed` was only used in `GradientEditorItem`. This PR makes `removeAllowed` a regular property of `Tick` and enables the use of `removeAllowed` with `TickSliderItem` for a consistent interface.

Test code:
```python3
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore
import numpy as np

app = pg.mkQApp()

class CustomWidget(pg.GraphicsView):
    def __init__(self, parent=None, *args, **kargs):
        pg.GraphicsView.__init__(self, parent, useOpenGL=False, background=None)
        self.item = pg.TickSliderItem(*args, **kargs)

        for pos in (0, 0.5, 1):
            tick = self.item.addTick(pos)
            tick.removeAllowed = False # Possibility 1

        # Possibility 2
        for tick, value in self.item.listTicks():
            tick.removeAllowed = False

        self.setCentralItem(self.item)
        self.setFixedHeight(31)

w = CustomWidget()
w.show()

app.exec_()
```