### PR TITLE
Fix ViewBox axis zoom in RectMode and examples/customPlot.py

### DIFF
--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -23,9 +23,9 @@ class CustomViewBox(pg.ViewBox):
         if ev.button() == QtCore.Qt.RightButton:
             self.autoRange()
     
-    ## reimplement mouseDragEvent to disable axis interaction
+    ## reimplement mouseDragEvent to disable continuous axis zoom
     def mouseDragEvent(self, ev, axis=None):
-        if axis is not None:
+        if axis is not None and ev.button() == QtCore.Qt.RightButton:
             ev.ignore()
         else:
             pg.ViewBox.mouseDragEvent(self, ev, axis=axis)

--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -22,6 +22,13 @@ class CustomViewBox(pg.ViewBox):
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.RightButton:
             self.autoRange()
+    
+    ## reimplement mouseDragEvent to disable axis interaction
+    def mouseDragEvent(self, ev, axis=None):
+        if axis is not None:
+            ev.ignore()
+        else:
+            pg.ViewBox.mouseDragEvent(self, ev, axis=axis)
 
 
 app = pg.mkQApp()

--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -14,6 +14,7 @@ import time
 
 class CustomViewBox(pg.ViewBox):
     def __init__(self, *args, **kwds):
+        kwds['enableMenu'] = False
         pg.ViewBox.__init__(self, *args, **kwds)
         self.setMouseMode(self.RectMode)
         
@@ -21,12 +22,6 @@ class CustomViewBox(pg.ViewBox):
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.RightButton:
             self.autoRange()
-            
-    def mouseDragEvent(self, ev, axis=None):
-        if ev.button() == QtCore.Qt.RightButton:
-            ev.ignore()
-        else:
-            pg.ViewBox.mouseDragEvent(self, ev, axis=axis)
 
 
 app = pg.mkQApp()

--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -22,11 +22,11 @@ class CustomViewBox(pg.ViewBox):
         if ev.button() == QtCore.Qt.RightButton:
             self.autoRange()
             
-    def mouseDragEvent(self, ev):
+    def mouseDragEvent(self, ev, axis=None):
         if ev.button() == QtCore.Qt.RightButton:
             ev.ignore()
         else:
-            pg.ViewBox.mouseDragEvent(self, ev)
+            pg.ViewBox.mouseDragEvent(self, ev, axis=axis)
 
 
 app = pg.mkQApp()

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1267,7 +1267,7 @@ class ViewBox(GraphicsWidget):
 
         ## Scale or translate based on mouse button
         if ev.button() & (QtCore.Qt.LeftButton | QtCore.Qt.MidButton):
-            if self.state['mouseMode'] == ViewBox.RectMode:
+            if self.state['mouseMode'] == ViewBox.RectMode and axis is None:
                 if ev.isFinish():  ## This is the final move in the drag; change the view scale now
                     #print "finish"
                     self.rbScaleBox.hide()


### PR DESCRIPTION
For `ViewBox`, this PR fixes left-click-drag on an axis when the `ViewBox` is in `RectMode`. To try it out, here is a modified version of `customPlot.py`, just left-click-drag on the x or y axis:

```python3
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore, QtGui
import numpy as np
import time

class CustomViewBox(pg.ViewBox):
    def __init__(self, *args, **kwds):
        kwds['enableMenu'] = False
        pg.ViewBox.__init__(self, *args, **kwds)
        self.setMouseMode(self.RectMode)
        
    ## reimplement right-click to zoom out
    def mouseClickEvent(self, ev):
        if ev.button() == QtCore.Qt.RightButton:
            self.autoRange()


app = pg.mkQApp()

axis = pg.DateAxisItem(orientation='bottom')
vb = CustomViewBox()

pw = pg.PlotWidget(viewBox=vb, axisItems={'bottom': axis}, enableMenu=False, title="PlotItem with DateAxisItem and custom ViewBox<br>Menu disabled, mouse behavior changed: left-drag to zoom, right-click to reset zoom")
dates = np.arange(8) * (3600*24*356)
pw.plot(x=dates, y=[1,6,2,4,3,5,6,8], symbol='o')
pw.show()
pw.setWindowTitle('pyqtgraph example: customPlot')

r = pg.PolyLineROI([(0,0), (10, 10)])
pw.addItem(r)

## Start Qt event loop unless running in interactive mode or using pyside.
if __name__ == '__main__':
    import sys
    if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
        QtGui.QApplication.instance().exec_()

```

For `examples/customPlot.py`, this PR
  * updates the method to disable the right-click menu, using `ViewBox.enableMenu`, a feature of PyQtGraph instead of a monkey-patch.
  * shows how to monkey-patch `mouseDragEvent` anyways in case someone wants to e.g. disable continuous zoom via right-click-drag on an axis. This might come in handy e.g. in case of complicated rebinning after zooming

Fixes #1277