### PR TITLE
Fixes for examples\customPlot.py

### DIFF
--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -39,9 +39,9 @@ class CustomTickSliderItem(pg.TickSliderItem):
         self._range = [0,1]
     
     def setTicks(self, ticks):
-        for tick in self.listTicks():
+        for tick, pos in self.listTicks():
             self.removeTick(tick)
-            self.visible_ticks = {}
+        self.visible_ticks = {}
         
         self.all_ticks = ticks
         

--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -39,7 +39,7 @@ class CustomTickSliderItem(pg.TickSliderItem):
         self._range = [0,1]
     
     def setTicks(self, ticks):
-        for tick in tickViewer.listTicks():
+        for tick in self.listTicks():
             self.removeTick(tick)
             self.visible_ticks = {}
         

--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -48,20 +48,27 @@ class CustomTickSliderItem(pg.TickSliderItem):
         self.updateRange(None, self._range)
     
     def updateRange(self, vb, viewRange):
+        origin = self.tickSize/2.
+        length = self.length
+
+        lengthIncludingPadding = length + self.tickSize + 2
+        
         self._range = viewRange
         
         for pos in self.all_ticks:
-            visible = pos >= viewRange[0] and pos <= viewRange[1]
+        
+            if pos not in self.visible_ticks:
+                self.visible_ticks[pos] = self.addTick(pos, movable=False, color="333333")
+            
+            tick = self.visible_ticks[pos]
+            
+            tickValueIncludingPadding = (pos - viewRange[0]) / (viewRange[1] - viewRange[0])
+            tickValue = (tickValueIncludingPadding*lengthIncludingPadding - origin) / length
+            
+            visible = tickValue >= 0 and tickValue <= 1
             
             if visible:
-                if pos not in self.visible_ticks:
-                    self.visible_ticks[pos] = self.addTick(pos, movable=False, color="333333")
-                
-                tick = self.visible_ticks[pos]
-                
-                tickValue = (pos - viewRange[0]) / (viewRange[1] - viewRange[0])
                 self.setTickValue(tick, tickValue)
-            
             elif pos in self.visible_ticks:
                 self.removeTick(self.visible_ticks[pos])
                 del self.visible_ticks[pos]


### PR DESCRIPTION
Fixing three errors:

1. Copy-paste error: I referenced a specific object instead of self, circumventing object orientation.
2. Executing custom function `CustomTickSliderItem.setTicks` more than once resulted in a KeyError.
3. Did not consider padding of `TickSliderItem` for link between `ViewBox` axis limits and tick positions, resulted in ticks positioned slightly off when moved to left or right edge of plot

Errors 1. and 2. were caused because I did only test the custom class `CustomTickSliderItem` in the example, where both was not problematic.

This happened probably because of being happy too early about the implementation of markers being so straight-forward.