### PR TITLE
InfiniteLine caching calls merged (fixes #1450)

### DIFF
--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -249,7 +249,7 @@ class InfiniteLine(GraphicsObject):
 
         if self.p != newPos:
             self.p = newPos
-            self._invalidateCache()
+            self.viewTransformChanged()
             GraphicsObject.setPos(self, Point(self.p))
             self.sigPositionChanged.emit(self)
 
@@ -292,9 +292,6 @@ class InfiniteLine(GraphicsObject):
         if self.span != (mn, mx):
             self.span = (mn, mx)
             self.update()
-
-    def _invalidateCache(self):
-        self._boundingRect = None
 
     def _computeBoundingRect(self):
         #br = UIGraphicsItem.boundingRect(self)
@@ -432,8 +429,8 @@ class InfiniteLine(GraphicsObject):
         Called whenever the transformation matrix of the view has changed.
         (eg, the view range has changed or the view was resized)
         """
+        self._boundingRect = None
         GraphicsItem.viewTransformChanged(self)
-        self._invalidateCache()
         
     def setName(self, name):
         self._name = name


### PR DESCRIPTION
This should fix the `InfiniteLine` problems. Since `viewTransform` caching was added at the `graphicsItem` level, `InfiniteLine` ended up having two different caches and cache cleanup functions, and one of them wasn't called when needed. (Turns out that these lines actually get dragged in the "infinite" direction as well, they just update the view box to draw a different part of the line...) 

This merges both cleanup functions. Seems like `examples/InfiniteLine.py` works as expected now.

