### PR TITLE
Remove ViewBox.childGroup's ItemClipsChildrenToShape flag

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -41,7 +41,6 @@ class ChildGroup(ItemGroup):
 
     def __init__(self, parent):
         ItemGroup.__init__(self, parent)
-        self.setFlag(self.ItemClipsChildrenToShape)
 
         # Used as callback to inform ViewBox when items are added/removed from
         # the group.
@@ -67,12 +66,6 @@ class ChildGroup(ItemGroup):
                 for listener in itemsChangedListeners:
                     listener.itemsChanged()
         return ret
-
-    def shape(self):
-        return self.mapFromParent(self.parentItem().shape())
-
-    def boundingRect(self):
-        return self.mapRectFromParent(self.parentItem().boundingRect())
 
 
 class ViewBox(GraphicsWidget):
@@ -438,7 +431,6 @@ class ViewBox(GraphicsWidget):
     def resizeEvent(self, ev):
         if ev.oldSize() != ev.newSize():
             self._matrixNeedsUpdate = True
-            self.childGroup.prepareGeometryChange()
 
             self.linkedXChanged()
             self.linkedYChanged()


### PR DESCRIPTION
The flag was set on ItemClipsChildrenToShape to solve the issue of #316 "A GraphicsItem object overlaps the ViewBox border line" at Luke Campagnola's suggestion to solve further issues that @espdev had. @campagnola  wisely commented that this approach needs extensive testing.

We tested it. It broke PDF export in Orange (biolab/orange-widget-base#111). :)

A solution to #316 was merged in PR #321, which was refined from the discussion in #316. I am not sure that, given rest of #321, the ItemClipsChildrenToShape was really needed. Even without modifications to ChildGroup I did not see any border problems (but I could replicate them in pre-#321 pyqtgraph).

Removing this flag fixes (and unneeded supporting code) fixes PDF export regression in Orange while borders still seem a-OK.

I tried other solutions, such as calling `childGroup.prepareGeometryChange()` from various places, but nothing worked. Interestingly, as the example below shows, pixmaps render fine in PDF even on master. For example, if I modify PDF export code not to call `setExportMode` (pdf export will then use scatterplot's pixmap atlas), the output is correct but pixelated.

The code below that showcases the problem draws a scatterplot, a curveplot and an image, and exports this to a .png with an `ImageExporter` and to .pdf with a custom `PDFExporter`.

The png looks like this:
<img src="https://user-images.githubusercontent.com/552182/100393033-bb15c500-3038-11eb-9fde-ddad1ca63a2f.png" width="150">

PDFs: Master on left (only shows the background and the image, which is in the correct location). Right, this branch.
<img src="https://user-images.githubusercontent.com/552182/100393325-8e15e200-3039-11eb-9a3a-6bce6d9780f6.png" width="150"> <img src="https://user-images.githubusercontent.com/552182/100393405-cddcc980-3039-11eb-9d35-e7f04f30045b.png" width="150">

```
from pyqtgraph.Qt import QtGui, QtCore
import pyqtgraph as pg
from pyqtgraph.exporters import ImageExporter
from skimage.data import camera

app = QtGui.QApplication([])
view = pg.GraphicsView()
view.resize(500, 500)

glayout = pg.GraphicsLayout()
view.setCentralItem(glayout)
vb1 = pg.ViewBox()
vb1.setBackgroundColor((200, 200, 200, 200))
glayout.addItem(vb1, 0, 0)

vb1.addItem(pg.ScatterPlotItem(x=list(range(100)), y=list(range(100)), pen=(255, 0, 0, 255)))
vb1.addItem(pg.PlotCurveItem(x=[50, 50], y=[0, 100], pen=(0, 255, 0, 255)))
im = pg.ImageItem()
im.setImage(camera().T)
im.setRect(QtCore.QRectF(50, 50, 10, 10))
vb1.addItem(im)

scene = view.scene()
scenerect = scene.sceneRect()  # preserve scene bounding rectangle
viewrect = scene.views()[0].sceneRect()
scene.setSceneRect(viewrect)

exporter = ImageExporter(scene)
exporter.export("scatterplot.png")


from pyqtgraph.exporters.Exporter import Exporter
from pyqtgraph.Qt import QtWidgets


class PDFExporter(Exporter):
    """A pdf exporter for pyqtgraph graphs. Based on pyqtgraph's
     ImageExporter.

     There is a bug in Qt<5.12 that makes Qt wrongly use a cosmetic pen
     (QTBUG-68537). Workaround: do not use completely opaque colors.

     There is also a bug in Qt<5.12 with bold fonts that then remain bold.
     To see it, save the OWNomogram output."""

    def __init__(self, item):
        Exporter.__init__(self, item)
        if isinstance(item, QtWidgets.QGraphicsItem):
            scene = item.scene()
        else:
            scene = item
        bgbrush = scene.views()[0].backgroundBrush()
        bg = bgbrush.color()
        if bgbrush.style() == QtCore.Qt.NoBrush:
            bg.setAlpha(0)
        self.background = bg

    def export(self, filename=None):
        pw = QtGui.QPdfWriter(filename)
        dpi = QtGui.QApplication.desktop().logicalDpiX()
        pw.setResolution(dpi)
        pw.setPageMargins(QtCore.QMarginsF(0, 0, 0, 0))
        pw.setPageSizeMM(QtCore.QSizeF(self.getTargetRect().size()) / dpi * 25.4)
        painter = QtGui.QPainter(pw)
        try:
            self.setExportMode(True, {'antialias': True,
                                      'background': self.background,
                                      'painter': painter})
            painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
            self.getScene().render(painter,
                                   QtCore.QRectF(self.getTargetRect()),
                                   QtCore.QRectF(self.getSourceRect()))
        finally:
            self.setExportMode(False)
        painter.end()

exporter = PDFExporter(scene)
exporter.export("scatterplot.pdf")

view.show()
app.exec()
```
