### PR TITLE
Fix TickSliderItem: Avoid ghost ticks | Improved customPlot.py code

### DIFF
--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -34,16 +34,16 @@ class CustomTickSliderItem(pg.TickSliderItem):
     def __init__(self, *args, **kwds):
         pg.TickSliderItem.__init__(self, *args, **kwds)
         
-        self.all_ticks = []
-        self.visible_ticks = {}
+        self.all_ticks = {}
         self._range = [0,1]
     
     def setTicks(self, ticks):
         for tick, pos in self.listTicks():
             self.removeTick(tick)
-        self.visible_ticks = {}
         
-        self.all_ticks = ticks
+        for pos in ticks:
+            tickItem = self.addTick(pos, movable=False, color="333333")
+            self.all_ticks[pos] = tickItem
         
         self.updateRange(None, self._range)
     
@@ -56,23 +56,16 @@ class CustomTickSliderItem(pg.TickSliderItem):
         self._range = viewRange
         
         for pos in self.all_ticks:
-        
-            if pos not in self.visible_ticks:
-                self.visible_ticks[pos] = self.addTick(pos, movable=False, color="333333")
-            
-            tick = self.visible_ticks[pos]
-            
             tickValueIncludingPadding = (pos - viewRange[0]) / (viewRange[1] - viewRange[0])
             tickValue = (tickValueIncludingPadding*lengthIncludingPadding - origin) / length
             
-            visible = tickValue >= 0 and tickValue <= 1
+            visible = bool(tickValue >= 0 and tickValue <= 1)
             
+            tick = self.all_ticks[pos]
+            tick.setVisible(visible)
+
             if visible:
                 self.setTickValue(tick, tickValue)
-            elif pos in self.visible_ticks:
-                self.removeTick(self.visible_ticks[pos])
-                del self.visible_ticks[pos]
-
 
 app = pg.mkQApp()
 

--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -59,6 +59,7 @@ class CustomTickSliderItem(pg.TickSliderItem):
             tickValueIncludingPadding = (pos - viewRange[0]) / (viewRange[1] - viewRange[0])
             tickValue = (tickValueIncludingPadding*lengthIncludingPadding - origin) / length
             
+            # Convert from np.bool_ to bool for setVisible
             visible = bool(tickValue >= 0 and tickValue <= 1)
             
             tick = self.all_ticks[pos]

--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -342,6 +342,7 @@ class TickSliderItem(GraphicsWidget):
         tick.setPos(pos)
         self.ticks[tick] = val
         
+        self.update()
         self.sigTicksChanged.emit(self)
         self.sigTicksChangeFinished.emit(self)
         


### PR DESCRIPTION
If `TickSliderItem.setTickValue` was called when a full repaint of the `TickSliderItem` was not already scheduled, the tick was visible at the old and the new position. This could e.g. be seen when using the autoscale button in the `customPlot.py`, as seen here, zooming out and using autoscale before the fix using PyQ5 - only three of the markers are real:
![image](https://user-images.githubusercontent.com/31772910/100399250-45b6ee00-3052-11eb-8ad6-905d484d1d12.png)

Further, code from `customPlot.py` is improved to make use of `Tick.setVisible` instead of adding and removing ticks based on their visibility.