### PR TITLE
arrayToPath: revert to old meaning of connect=ndarray parameter

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1529,7 +1529,7 @@ def arrayToQPath(x, y, connect='all'):
             isfinite = np.isfinite(x) & np.isfinite(y)
         arr[2:]['c'] = isfinite
     elif isinstance(connect, np.ndarray):
-        arr[1:-1]['c'] = connect
+        arr[2:-1]['c'] = connect[:-1]
     else:
         raise Exception('connect argument must be "all", "pairs", "finite", or array')
 


### PR DESCRIPTION
The i-th position of that array used to define if points (i) and (i+1) were connected, but in master it defines whether points (i-1) and (i) are connected. This PR reverts to (i) and (i+1) interpretation.

Fixes #1460 (more therein).

A test drawing from test_PlotCurveItem

0.11.0 (as in 0.10.0, as in tests)
![m_connectarray](https://user-images.githubusercontent.com/552182/100451182-446bdc80-30b7-11eb-9aa3-b5fea72124d3.png)

master (different)
![m_connectarray](https://user-images.githubusercontent.com/552182/100451097-18e8f200-30b7-11eb-92fa-87eb7ba432e9.png)

this PR (back to what 0.11.0 draws)
![m_connectarray](https://user-images.githubusercontent.com/552182/100451114-21d9c380-30b7-11eb-9961-b029af74b96f.png)
