### PR TITLE
MAINT: Post 0.11.1 release, drop py2, qt4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,23 @@ heavy leverage of numpy for number crunching, Qt's GraphicsView framework for
 Requirements
 ------------
 
-* Python 3.6+
+pyqtgraph has adopted [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html).
+
+This project supports:
+
+* All minor versions of Python released 42 months prior to the project, and at minimum the two latest minor versions.
+
+* All minor versions of numpy released in the 24 months prior to the project, and at minimum the last three minor versions.
+* All minor versions of Qt 5 currently supported by upstream Qt (Note, Qt 6 support is not yet implemented)
+
+
+Currently this means:
+
+* Python 3.7+
+* Qt 5.12, 5.15
 * Required
   * PyQt5, or PySide2
-  * `numpy`
+  * `numpy` 1.17+
 * Optional
   * `scipy` for image processing
   * `pyopengl` for 3D graphics
@@ -39,8 +52,6 @@ The following table represents the python environments we test in our CI system.
 | PySide2-5.13   | :x:                | :white_check_mark: | :x:                |
 | PyQt5-Latest   | :x:                | :x:                | :white_check_mark: |
 | PySide2-Latest | :x:                | :x:                | :white_check_mark: |
-
-* pyqtgraph has had some incompatibilities with PySide2 versions 5.6-5.11, and we recommend you avoid those versions if possible
 
 Support
 -------

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 PyQtGraph
 =========
 
-A pure-Python graphics library for PyQt/PySide/PyQt5/PySide2
+A pure-Python graphics library for PyQt5/PySide2
 
 Copyright 2020 Luke Campagnola, University of North Carolina at Chapel Hill
 
@@ -19,9 +19,9 @@ heavy leverage of numpy for number crunching, Qt's GraphicsView framework for
 Requirements
 ------------
 
-* Python 2.7, or 3.x
+* Python 3.6+
 * Required
-  * PyQt 4.8+, PySide, PyQt5, or PySide2
+  * PyQt5, or PySide2
   * `numpy`
 * Optional
   * `scipy` for image processing
@@ -33,17 +33,14 @@ Qt Bindings Test Matrix
 
 The following table represents the python environments we test in our CI system.  Our CI system uses Ubuntu 18.04, Windows Server 2019, and macOS 10.15 base images.
 
-| Qt-Bindings    | Python 2.7         | Python 3.6         | Python 3.7         | Python 3.8         |
-| :------------- | :----------------: | :----------------: | :----------------: | :----------------: |
-| PyQt-4         | :white_check_mark: | :x:                | :x:                | :x:                |
-| PySide1        | :white_check_mark: | :x:                | :x:                | :x:                |
-| PyQt5-5.9      | :x:                | :white_check_mark: | :x:                | :x:                |
-| PySide2-5.13   | :x:                | :x:                | :white_check_mark: | :x:                |
-| PyQt5-Latest   | :x:                | :x:                | :x:                | :white_check_mark: |
-| PySide2-Latest | :x:                | :x:                | :x:                | :white_check_mark: |
+| Qt-Bindings    | Python 3.6         | Python 3.7         | Python 3.8         |
+| :------------- | :----------------: | :----------------: | :----------------: |
+| PyQt5-5.9      | :white_check_mark: | :x:                | :x:                |
+| PySide2-5.13   | :x:                | :white_check_mark: | :x:                |
+| PyQt5-Latest   | :x:                | :x:                | :white_check_mark: |
+| PySide2-Latest | :x:                | :x:                | :white_check_mark: |
 
 * pyqtgraph has had some incompatibilities with PySide2 versions 5.6-5.11, and we recommend you avoid those versions if possible
-* on macOS with Python 2.7 and Qt4 bindings (PyQt4 or PySide) the openGL related visualizations do not work reliably
 
 Support
 -------

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -10,14 +10,6 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      Python27-PyQt4-4.8:
-        python.version: '2.7'
-        qt.bindings: "pyqt=4"
-        install.method: "conda"
-      Python27-PySide-4.8:
-        python.version: '2.7'
-        qt.bindings: "pyside"
-        install.method: "conda"
       Python36-PyQt5-5.9:
         python.version: "3.6"
         qt.bindings: "pyqt"

--- a/doc/source/how_to_use.rst
+++ b/doc/source/how_to_use.rst
@@ -51,7 +51,7 @@ For the serious application developer, all of the functionality in pyqtgraph is 
 #. Under "Header file", enter "pyqtgraph".
 #. Click "Add", then click "Promote".
 
-See the designer documentation for more information on promoting widgets. The "VideoSpeedTest" and "ScatterPlotSpeedTest" examples both demonstrate the use of .ui files that are compiled to .py modules using pyuic4 or pyside-uic. The "designerExample" example demonstrates dynamically generating python classes from .ui files (no pyuic4 / pyside-uic needed).
+See the designer documentation for more information on promoting widgets. The "VideoSpeedTest" and "ScatterPlotSpeedTest" examples both demonstrate the use of .ui files that are compiled to .py modules using pyuic5 or pyside-uic. The "designerExample" example demonstrates dynamically generating python classes from .ui files (no pyuic5 / pyside-uic needed).
 
 
 PyQt and PySide
@@ -61,15 +61,15 @@ PyQtGraph supports two popular python wrappers for the Qt library: PyQt and PySi
 APIs and functionality, but for various reasons (discussed elsewhere) you may prefer to use one package or the other. When
 pyqtgraph is first imported, it automatically determines which library to use by making the fillowing checks:
     
-#. If PyQt4 is already imported, use that
-#. Else, if PySide is already imported, use that
-#. Else, attempt to import PyQt4
-#. If that import fails, attempt to import PySide. 
+#. If PyQt5 is already imported, use that
+#. Else, if PySide2 is already imported, use that
+#. Else, attempt to import PyQt5
+#. If that import fails, attempt to import PySide2. 
 
 If you have both libraries installed on your system and you wish to force pyqtgraph to use one or the other, simply
 make sure it is imported before pyqtgraph::
     
-    import PySide  ## this will force pyqtgraph to use PySide instead of PyQt4
+    import PySide2  ## this will force pyqtgraph to use PySide2 instead of PyQt5
     import pyqtgraph as pg
 
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 PyQtGraph depends on:
 
-* Python 3.6+
+* Python 3.7+
 * A Qt library such as PyQt5, or PySide2
 * numpy
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -3,8 +3,8 @@ Installation
 
 PyQtGraph depends on:
 
-* Python 2.7 or Python 3.x
-* A Qt library such as PyQt4, PyQt5, PySide, or PySide2
+* Python 3.6+
+* A Qt library such as PyQt5, or PySide2
 * numpy
 
 The easiest way to meet these dependencies is with ``pip`` or with a scientific

--- a/doc/source/qtcrashcourse.rst
+++ b/doc/source/qtcrashcourse.rst
@@ -17,7 +17,7 @@ PyQtGraph fits into this scheme by providing its own QWidget subclasses to be in
 
 Example::
     
-    from PyQt4 import QtGui  # (the example applies equally well to PySide)
+    from PyQt5 import QtGui  # (the example applies equally well to PySide2)
     import pyqtgraph as pg
         
     ## Always start by initializing Qt (only once per application)
@@ -99,4 +99,3 @@ QTimer, Multi-Threading
 
 Multi-threading vs Multi-processing in Qt
 -----------------------------------------
-

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -4,7 +4,7 @@ PyQtGraph - Scientific Graphics and GUI Library for Python
 www.pyqtgraph.org
 """
 
-__version__ = '0.11.1'
+__version__ = '0.11.1.dev0'
 
 ### import all the goodies and add some helper functions for easy CLI use
 

--- a/setup.py
+++ b/setup.py
@@ -136,10 +136,11 @@ setup(
               'mergetest': helpers.MergeTestCommand,
               'style': helpers.StyleCommand},
     packages=allPackages,
+    python_requires=">=3.7",
     package_dir={'pyqtgraph.examples': 'examples'},  ## install examples along with the rest of the source
     package_data={'pyqtgraph.examples': ['optics/*.gz', 'relativity/presets/*.cfg']},
     install_requires = [
-        'numpy>=1.8.0',
+        'numpy>=1.17.0',
         ],
     **setupOpts
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 DESCRIPTION = """\
-PyQtGraph is a pure-python graphics and GUI library built on PyQt4/PyQt5/PySide/PySide2 and
+PyQtGraph is a pure-python graphics and GUI library built on PyQt5/PySide2 and
 numpy. 
 
 It is intended for use in mathematics / scientific / engineering applications.
@@ -19,8 +19,6 @@ setupOpts = dict(
     author_email='luke.campagnola@gmail.com',
     classifiers = [
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Development Status :: 4 - Beta",
         "Environment :: Other Environment",

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,6 @@ envlist =
     ; qt 5.9.7 (LTS)
     py36-{pyqt5,pyside2}_59_conda
 
-    ; qt 4.8.7
-    py27-{pyqt4,pyside}_conda
-
 [base]
 deps =
     pytest
@@ -37,8 +34,6 @@ deps=
 conda_deps=
     pyside2_59_conda: pyside2=5.9
     pyqt5_59_conda: pyqt=5.9
-    pyqt4_conda: pyqt=4
-    pyside_conda: pyside
 
 conda_channels=
     conda-forge


### PR DESCRIPTION
This focuses on distribution, tests, and docs. This may not be comprehensive, but covers the cases I found by looking and a few greps

Noteably, this does not change any actual internal code yet, to avoid merge conflicts with pending PRs.