### PR TITLE
Use log modulus transform for y axis log scaling

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -236,7 +236,9 @@ class PlotDataItem(GraphicsObject):
     def setLogMode(self, xMode, yMode):
         """
         To enable log scaling for y<0 and y>0, the following formula is used:
-            scaled = sign(y) * log10(abs(y) + eps) \n
+        
+            scaled = sign(y) * log10(abs(y) + eps)
+
         where eps is the smallest unit of y.dtype.
         This allows for handling of 0. values, scaling of large values,
         as well as the typical log scaling of values in the range -1 < x < 1.

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -236,7 +236,7 @@ class PlotDataItem(GraphicsObject):
     def setLogMode(self, xMode, yMode):
         """
         To enable log scaling for y<0 and y>0, the following formula is used:
-            scaled = sign(y) * log10(abs(y) + eps)
+            scaled = sign(y) * log10(abs(y) + eps) \n
         where eps is the smallest unit of y.dtype.
         This allows for handling of 0. values, scaling of large values,
         as well as the typical log scaling of values in the range -1 < x < 1.

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -598,7 +598,7 @@ class PlotDataItem(GraphicsObject):
                 if self.opts['logMode'][0]:
                     x = np.log10(x)
                 if self.opts['logMode'][1]:
-                    y = np.log10(y)
+                    y = np.sign(y) * np.log10(np.abs(y)+1)
 
             ds = self.opts['downsample']
             if not isinstance(ds, int):


### PR DESCRIPTION
Changes the log transform of y variable from: 
    `y = np.log10(y)`
to:
    `y = np.sign(y) * np.log10(np.abs(y)+1)`

This allows log scaling of negative as well as positive values. '0' values in the original array remain 0, at the expense that the transformed values are now approximately log10(y) instead of exactly log10(y).
This is helpful for my use cases, thought it might be for others too.