### PR TITLE
Remove linting check, add pytest test publishing

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-name: analyze pyqtgraph
+name: codeql
 
 on: pull_request
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: test pyqtgraph
+name: main
 
 on: [push, pull_request]
 
@@ -85,7 +85,7 @@ jobs:
         mkdir $SCREENSHOT_DIR
         pytest . -v \
           -n auto \
-          --junitxml=junit/test-results.xml \
+          --junitxml pytest.xml \
           --cov pyqtgraph --cov-report=xml --cov-report=html
       shell: bash
     - name: Upload Screenshots
@@ -99,9 +99,27 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: Unit Test Results (Python ${{ matrix.python-version }} - Qt-Bindings ${{ matrix.qt-lib }} - OS ${{ matrix.os }})
-        path: junit/test-results.xml
+        path: pytest.xml
     env:
       SCREENSHOT_DIR: ./screenshots
+
+  publish-test-results:
+    name: "Publish Unit Test Results"
+    needs: test
+    runs-on: ubuntu-latest
+    if: success() || failure()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.6
+        with:
+          check_name: Unit Test Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: "artifacts/**/pytest.xml"
 
   build-docs:
     name: build docs
@@ -127,22 +145,6 @@ jobs:
           name: html-docs
           path: |
             doc/build/html
-    
-  linting:
-    name: check linting
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-      - name: "Install Dependencies"
-        run: |
-          pip install flake8
-      - name: "Check Linting"
-        run: |
-          python -m flake8 .
 
   build-wheel:
     name: build wheel

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ PyQtGraph
 
 [![PyPi](https://img.shields.io/pypi/v/pyqtgraph.svg)](https://pypi.org/project/pyqtgraph/)
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/pyqtgraph.svg)](https://anaconda.org/conda-forge/pyqtgraph)
-[![Build Status](https://github.com/pyqtgraph/pyqtgraph/workflows/main/badge.svg)](https://github.com/pyqtgraph/pyqtgraph/workflows/main/badge.svg)
-[![CodeQL Status](https://github.com/pyqtgraph/pyqtgraph/workflows/codeql-analysis/badge.svg)](https://github.com/pyqtgraph/pyqtgraph/workflows/codeql-analysis/badge.svg)
+[![Build Status](https://github.com/pyqtgraph/pyqtgraph/workflows/main/badge.svg)](https://github.com/pyqtgraph/pyqtgraph/actions/?query=workflow%3Amain)
+[![CodeQL Status](https://github.com/pyqtgraph/pyqtgraph/workflows/codeql/badge.svg)](https://github.com/pyqtgraph/pyqtgraph/actions/?query=workflow%3Acodeql)
 [![Documentation Status](https://readthedocs.org/projects/pyqtgraph/badge/?version=latest)](https://pyqtgraph.readthedocs.io/en/latest/?badge=latest)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/pyqtgraph/pyqtgraph.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/pyqtgraph/pyqtgraph/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/pyqtgraph/pyqtgraph.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/pyqtgraph/pyqtgraph/context:python)
@@ -78,6 +78,6 @@ Installation Methods
 Documentation
 -------------
 
-The official documentation lives at https://pyqtgraph.readthedocs.io
+The official documentation lives at [pyqtgraph.readthedocs.io](https://pyqtgraph.readthedocs.io)
 
 The easiest way to learn pyqtgraph is to browse through the examples; run `python -m pyqtgraph.examples` to launch the examples application.  


### PR DESCRIPTION
Doing this not from my fork as debugging CI config stuff from a fork can be tricky...

This Pull Request removes the lint-check step (we know it fails, and it will keep failing until we can resolve these issues w/ some automatic formatting tool such as `black`). 

Furthermore, I now publish the unit test results jobs so it's a bit easier to see the results

Made some slight changes to `README.md` as well, fixing broken badge paths/links.