### PR TITLE
minor adjustment on when test runs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,6 @@
 name: codeql
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   analyze:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,12 +115,6 @@ jobs:
         run: |
           cd doc
           make html SPHINXOPTS='-W --keep-going -v'
-      - name: Upload Build Docs
-        uses: actions/upload-artifact@v2
-        with:
-          name: html-docs
-          path: |
-            doc/build/html
 
   build-wheel:
     name: build wheel
@@ -136,9 +130,3 @@ jobs:
         run: |
           python -m pip install setuptools wheel
           python setup.py bdist_wheel
-      - name: Archive pyqtgraph wheel
-        uses: actions/upload-artifact@v2
-        with:
-          name: wheel
-          path: |
-            dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Build Documentation
         run: |
           cd doc
-          make html SPHINXOPTS='-W --keep-going -n -v'
+          make html SPHINXOPTS='-W --keep-going -v'
       - name: Upload Build Docs
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,16 @@
 name: main
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    # always run on push events, but only run on pull_request_target event when pull request pulls from fork repository
+    # for pull requests within the same repository, the pull event is sufficient
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,11 @@
 name: main
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
-    # always run on push events, but only run on pull_request_target event when pull request pulls from fork repository
-    # for pull requests within the same repository, the pull event is sufficient
-    if: >
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -99,32 +94,8 @@ jobs:
         name: Screenshots (Python ${{ matrix.python-version }} - Qt-Bindings ${{ matrix.qt-lib }} - OS ${{ matrix.os }})
         path: $SCREENSHOT_DIR
         if-no-files-found: ignore
-    - name: Upload Unit Test Results
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: Unit Test Results (Python ${{ matrix.python-version }} - Qt-Bindings ${{ matrix.qt-lib }} - OS ${{ matrix.os }})
-        path: pytest.xml
     env:
       SCREENSHOT_DIR: ./screenshots
-
-  publish-test-results:
-    name: "Publish Unit Test Results"
-    needs: test
-    runs-on: ubuntu-latest
-    if: success() || failure()
-
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.6
-        with:
-          check_name: Unit Test Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: "artifacts/**/pytest.xml"
 
   build-docs:
     name: build docs
@@ -143,7 +114,7 @@ jobs:
       - name: Build Documentation
         run: |
           cd doc
-          make html SPHINXOPTS='-W -v'
+          make html SPHINXOPTS='-W --keep-going -n -v'
       - name: Upload Build Docs
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
the publish unit test results action we want doesn't work with `on: pull_request` for reasons described here: https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories

Instead we want to run on `pull_request_target`.