### PR TITLE
setSpan broke LinearRegionItem (#1488)

### DIFF
--- a/pyqtgraph/graphicsItems/LinearRegionItem.py
+++ b/pyqtgraph/graphicsItems/LinearRegionItem.py
@@ -191,8 +191,8 @@ class LinearRegionItem(GraphicsObject):
         self.update()
 
     def boundingRect(self):
-        br = self.viewRect()  # bounds of containing ViewBox mapped to local coords.
-        
+        br = QtCore.QRectF(self.viewRect())  # bounds of containing ViewBox mapped to local coords.
+
         rng = self.getRegion()
         if self.orientation in ('vertical', LinearRegionItem.Vertical):
             br.setLeft(rng[0])


### PR DESCRIPTION
setSpan was calling `setLeft()` etc on a rectangle retrieved from cache, thus modifying the cached one as well. A copy should be made instead.