### PR TITLE
invert QTransform using adjoint() and determinant()

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -2324,26 +2324,32 @@ def isosurface(data, level):
         
     return vertexes, faces
 
-
     
+def _pinv_fallback(tr):
+    arr = np.array([tr.m11(), tr.m12(), tr.m13(),
+                    tr.m21(), tr.m22(), tr.m23(),
+                    tr.m31(), tr.m32(), tr.m33()])
+    arr.shape = (3, 3)
+    pinv = np.linalg.pinv(arr)
+    return QtGui.QTransform(*pinv.ravel().tolist())
+
+
 def invertQTransform(tr):
     """Return a QTransform that is the inverse of *tr*.
-    Rasises an exception if tr is not invertible.
+    A pseudo-inverse is returned if tr is not invertible.
     
     Note that this function is preferred over QTransform.inverted() due to
     bugs in that method. (specifically, Qt has floating-point precision issues
     when determining whether a matrix is invertible)
     """
     try:
-        import numpy.linalg
-        arr = np.array([[tr.m11(), tr.m12(), tr.m13()], [tr.m21(), tr.m22(), tr.m23()], [tr.m31(), tr.m32(), tr.m33()]])
-        inv = numpy.linalg.inv(arr)
-        return QtGui.QTransform(inv[0,0], inv[0,1], inv[0,2], inv[1,0], inv[1,1], inv[1,2], inv[2,0], inv[2,1])
-    except ImportError:
-        inv = tr.inverted()
-        if inv[1] is False:
-            raise Exception("Transform is not invertible.")
-        return inv[0]
+        det = tr.determinant()
+        detr = 1.0 / det    # let singular matrices raise ZeroDivisionError
+        inv = tr.adjoint()
+        inv *= detr
+        return inv
+    except ZeroDivisionError:
+        return _pinv_fallback(tr)
     
 
 def pseudoScatter(data, spacing=None, shuffle=True, bidir=False, method='exact'):

--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -21,7 +21,6 @@ class GraphicsItem(object):
     The GraphicsView system places a lot of emphasis on the notion that the graphics within the scene should be device independent--you should be able to take the same graphics and display them on screens of different resolutions, printers, export to SVG, etc. This is nice in principle, but causes me a lot of headache in practice. It means that I have to circumvent all the device-independent expectations any time I want to operate in pixel coordinates rather than arbitrary scene coordinates. A lot of the code in GraphicsItem is devoted to this task--keeping track of view widgets and device transforms, computing the size and shape of a pixel in local item coordinates, etc. Note that in item coordinates, a pixel does not have to be square or even rectangular, so just asking how to increase a bounding rect by 2px can be a rather complex task.
     """
     _pixelVectorGlobalCache = LRUCache(100, 70)
-    _mapRectFromViewGlobalCache = LRUCache(100, 70)
 
     def __init__(self, register=None):
         if not hasattr(self, '_qtBaseClass'):
@@ -373,21 +372,8 @@ class GraphicsItem(object):
         vt = self.viewTransform()
         if vt is None:
             return None
-
-        cache = self._mapRectFromViewGlobalCache
-        k = (
-            vt.m11(), vt.m12(), vt.m13(),
-            vt.m21(), vt.m22(), vt.m23(),
-            vt.m31(), vt.m32(), vt.m33(),
-        )
-
-        try:
-            inv_vt = cache[k]
-        except KeyError:
-            inv_vt = fn.invertQTransform(vt)
-            cache[k] = inv_vt
-
-        return inv_vt.mapRect(obj)
+        vt = fn.invertQTransform(vt)
+        return vt.mapRect(obj)
 
     def pos(self):
         return Point(self._qtBaseClass.pos(self))


### PR DESCRIPTION
This PR is a result of discussions made in #1418.

It speeds up QTransform inversion using Qt routines adjoint() and determinant() rather than inverted().
The issue with inverted() is that it uses fuzzy floating point to classify matrix types in order to take faster inversion codepaths.

In addition, this PR would make #1216 redundant..
With the speedup in inversion, cache lookup runs slower than always computing the inversion.