### PR TITLE
PlotDataItem now signals on setPos (fix #1494)

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -217,6 +217,13 @@ class PlotDataItem(GraphicsObject):
     def boundingRect(self):
         return QtCore.QRectF()  ## let child items handle this
 
+    def setPos(self, x, y):
+        GraphicsObject.setPos(self, x, y)
+        # to update viewRect:
+        self.viewTransformChanged()
+        # to update displayed point sets, e.g. when clipping (which uses viewRect):
+        self.viewRangeChanged()
+
     def setAlpha(self, alpha, auto):
         if self.opts['alphaHint'] == alpha and self.opts['alphaMode'] == auto:
             return
@@ -552,7 +559,6 @@ class PlotDataItem(GraphicsObject):
         profiler('emit')
 
     def updateItems(self):
-
         curveArgs = {}
         for k,v in [('pen','pen'), ('shadowPen','shadowPen'), ('fillLevel','fillLevel'), ('fillOutline', 'fillOutline'), ('fillBrush', 'brush'), ('antialias', 'antialias'), ('connect', 'connect'), ('stepMode', 'stepMode')]:
             curveArgs[v] = self.opts[k]


### PR DESCRIPTION
Extended `setPos()` of `PlotDataItem` with a couple of signals. This fixes two things:
1. `viewRect` cache wasn't invalidated, which caused #1494 
2. if `clipToView` was on, the clipping frame wasn't updated. For example, modify `examples/scrollingPlots.py` lines 62-63 as below - this first moves the plot in one direction, then reverses, and the line will appear truncated:
```
    if ptr3<=170:
        curve3.setData(data3[:ptr3])
        curve3.setPos(-ptr3, 0)
    if ptr3>180:
        curve3.setPos(-350+ptr3,0)
```