### PR TITLE
Fix git head reference in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,13 @@ jobs:
             qt-version: ""
             numpy-version: ""
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Checkout test-data
+      uses: actions/checkout@v2
+      with:
+        repository: pyqtgraph/test-data
+        path: .pyqtgraph/test-data
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/pyqtgraph/tests/image_testing.py
+++ b/pyqtgraph/tests/image_testing.py
@@ -469,7 +469,10 @@ def getTestDataRepo():
     """
     global testDataTag
 
-    dataPath = os.path.join(os.path.expanduser('~'), '.pyqtgraph', 'test-data')
+    if os.environ["CI"]:
+        dataPath = os.path.join(os.environ["GITHUB_WORKSPACE"], '.pyqtgraph', 'test-data')
+    else:
+        dataPath = os.path.join(os.path.expanduser('~'), '.pyqtgraph', 'test-data')
     gitPath = 'https://github.com/pyqtgraph/test-data'
     gitbase = gitCmdBase(dataPath)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ xvfb_height = 1080
 # use this due to some issues with ndarray reshape errors on CI systems
 xvfb_colordepth = 24
 xvfb_args=-ac +extension GLX +render
-faulthandler_timeout = 15
+faulthandler_timeout = 30
 
 filterwarnings =
     # comfortable skipping these warnings runtime warnings


### PR DESCRIPTION
On CI platforms, there would periodically be errors attempting to grab data from the `test-data` repository.  I suspect this was due to a race condition with running tests in parallel due to pytest-xdist.  The way we get around this is to use the github checkout action to grab the test data before the test starts.

Also during testing, I would trigger a timeout, so decided to up the faulthandler_timeout value to 30.