### PR TITLE
Attempt i18n localization

### DIFF
--- a/pyqtgraph/canvas/Canvas.py
+++ b/pyqtgraph/canvas/Canvas.py
@@ -16,6 +16,7 @@ import gc
 from .CanvasManager import CanvasManager
 from .CanvasItem import CanvasItem, GroupCanvasItem
 
+translate = QtCore.QCoreApplication.translate
 
 class Canvas(QtGui.QWidget):
     
@@ -78,7 +79,7 @@ class Canvas(QtGui.QWidget):
             self.ui.redirectCombo.setHostName(self.registeredName)
             
         self.menu = QtGui.QMenu()
-        remAct = QtGui.QAction("Remove item", self.menu)
+        remAct = QtGui.QAction(translate("Context Menu", "Remove item"), self.menu)
         remAct.triggered.connect(self.removeClicked)
         self.menu.addAction(remAct)
         self.menu.remAct = remAct

--- a/pyqtgraph/canvas/CanvasItem.py
+++ b/pyqtgraph/canvas/CanvasItem.py
@@ -9,6 +9,8 @@ ui_template = importlib.import_module(
 
 from .. import debug
 
+translate = QtCore.QCoreApplication.translate
+
 class SelectBox(ROI):
     def __init__(self, scalable=False, rotatable=True):
         #QtGui.QGraphicsRectItem.__init__(self, 0, 0, size[0], size[1])
@@ -61,7 +63,7 @@ class CanvasItem(QtCore.QObject):
         self.layout.setContentsMargins(0,0,0,0)
         self.ctrl.setLayout(self.layout)
         
-        self.alphaLabel = QtGui.QLabel("Alpha")
+        self.alphaLabel = QtGui.QLabel(translate("CanvasItem", "Alpha"))
         self.alphaSlider = QtGui.QSlider()
         self.alphaSlider.setMaximum(1023)
         self.alphaSlider.setOrientation(QtCore.Qt.Horizontal)

--- a/pyqtgraph/exporters/CSVExporter.py
+++ b/pyqtgraph/exporters/CSVExporter.py
@@ -5,18 +5,20 @@ from ..parametertree import Parameter
 from .. import PlotItem
 from ..python2_3 import asUnicode
 
+translate = QtCore.QCoreApplication.translate
+
 __all__ = ['CSVExporter']
     
     
 class CSVExporter(Exporter):
-    Name = "CSV from plot data"
+    Name = translate("Exporter", "CSV from plot data")
     windows = []
     def __init__(self, item):
         Exporter.__init__(self, item)
         self.params = Parameter(name='params', type='group', children=[
-            {'name': 'separator', 'type': 'list', 'value': 'comma', 'values': ['comma', 'tab']},
-            {'name': 'precision', 'type': 'int', 'value': 10, 'limits': [0, None]},
-            {'name': 'columnMode', 'type': 'list', 'values': ['(x,y) per plot', '(x,y,y,y) for all plots']}
+            {'name': translate("Exporter", 'separator'), 'type': 'list', 'value': 'comma', 'values': ['comma', 'tab']},
+            {'name': translate("Exporter", 'precision'), 'type': 'int', 'value': 10, 'limits': [0, None]},
+            {'name': translate("Exporter", 'columnMode'), 'type': 'list', 'values': ['(x,y) per plot', '(x,y,y,y) for all plots']}
         ])
         
     def parameters(self):

--- a/pyqtgraph/exporters/HDF5Exporter.py
+++ b/pyqtgraph/exporters/HDF5Exporter.py
@@ -9,20 +9,22 @@ try:
     HAVE_HDF5 = True
 except ImportError:
     HAVE_HDF5 = False
-    
+
+translate = QtCore.QCoreApplication.translate
+
 __all__ = ['HDF5Exporter']
 
     
 class HDF5Exporter(Exporter):
-    Name = "HDF5 Export: plot (x,y)"
+    Name = translate("Exporter", "HDF5 Export: plot (x,y)")
     windows = []
     allowCopy = False
 
     def __init__(self, item):
         Exporter.__init__(self, item)
         self.params = Parameter(name='params', type='group', children=[
-            {'name': 'Name', 'type': 'str', 'value': 'Export',},
-            {'name': 'columnMode', 'type': 'list', 'values': ['(x,y) per plot', '(x,y,y,y) for all plots']},
+            {'name': translate("Exporter", 'Name'), 'type': 'str', 'value': 'Export',},
+            {'name': translate("Exporter", 'columnMode'), 'type': 'list', 'values': ['(x,y) per plot', '(x,y,y,y) for all plots']},
         ])
         
     def parameters(self):
@@ -39,11 +41,11 @@ class HDF5Exporter(Exporter):
         if fileName is None:
             self.fileSaveDialog(filter=["*.h5", "*.hdf", "*.hd5"])
             return
-        dsname = self.params['Name']
+        dsname = self.params[translate("Exporter", 'Name')]
         fd = h5py.File(fileName, 'a') # forces append to file... 'w' doesn't seem to "delete/overwrite"
         data = []
 
-        appendAllX = self.params['columnMode'] == '(x,y) per plot'
+        appendAllX = self.params[translate("Exporter", 'columnMode')] == '(x,y) per plot'
         # Check if the arrays are ragged
         len_first = len(self.item.curves[0].getData()[0]) if self.item.curves[0] else None
         ragged = any(len(i.getData()[0]) != len_first for i in self.item.curves)

--- a/pyqtgraph/exporters/ImageExporter.py
+++ b/pyqtgraph/exporters/ImageExporter.py
@@ -8,7 +8,7 @@ translate = QtCore.QCoreApplication.translate
 __all__ = ['ImageExporter']
 
 class ImageExporter(Exporter):
-    Name = "Image File (PNG, TIF, JPG, ...)"
+    Name = f"{translate('Exporter', 'Image File')} (PNG, TIF, JPG, ...)"
     allowCopy = True
     
     def __init__(self, item):

--- a/pyqtgraph/exporters/ImageExporter.py
+++ b/pyqtgraph/exporters/ImageExporter.py
@@ -4,6 +4,7 @@ from ..Qt import QtGui, QtCore, QtSvg, QT_LIB
 from .. import functions as fn
 import numpy as np
 
+translate = QtCore.QCoreApplication.translate
 __all__ = ['ImageExporter']
 
 class ImageExporter(Exporter):
@@ -23,24 +24,24 @@ class ImageExporter(Exporter):
             bg.setAlpha(0)
             
         self.params = Parameter(name='params', type='group', children=[
-            {'name': 'width', 'type': 'int', 'value': int(tr.width()), 'limits': (0, None)},
-            {'name': 'height', 'type': 'int', 'value': int(tr.height()), 'limits': (0, None)},
-            {'name': 'antialias', 'type': 'bool', 'value': True},
-            {'name': 'background', 'type': 'color', 'value': bg},
-            {'name': 'invertValue', 'type': 'bool', 'value': False}
+            {'name': translate("Exporter", 'width'), 'type': 'int', 'value': int(tr.width()), 'limits': (0, None)},
+            {'name': translate("Exporter", 'height'), 'type': 'int', 'value': int(tr.height()), 'limits': (0, None)},
+            {'name': translate("Exporter", 'antialias'), 'type': 'bool', 'value': True},
+            {'name': translate("Exporter", 'background'), 'type': 'color', 'value': bg},
+            {'name': translate("Exporter", 'invertValue'), 'type': 'bool', 'value': False}
         ])
-        self.params.param('width').sigValueChanged.connect(self.widthChanged)
-        self.params.param('height').sigValueChanged.connect(self.heightChanged)
+        self.params.param(translate("Exporter", 'width')).sigValueChanged.connect(self.widthChanged)
+        self.params.param(translate("Exporter", 'height')).sigValueChanged.connect(self.heightChanged)
         
     def widthChanged(self):
         sr = self.getSourceRect()
         ar = float(sr.height()) / sr.width()
-        self.params.param('height').setValue(int(self.params['width'] * ar), blockSignal=self.heightChanged)
+        self.params.param(translate("Exporter", 'height')).setValue(int(self.params[translate("Exporter", 'width')] * ar), blockSignal=self.heightChanged)
         
     def heightChanged(self):
         sr = self.getSourceRect()
         ar = float(sr.width()) / sr.height()
-        self.params.param('width').setValue(int(self.params['height'] * ar), blockSignal=self.widthChanged)
+        self.params.param(translate("Exporter", 'width')).setValue(int(self.params[translate("Exporter", 'height')] * ar), blockSignal=self.widthChanged)
         
     def parameters(self):
         return self.params
@@ -61,8 +62,8 @@ class ImageExporter(Exporter):
             self.fileSaveDialog(filter=filter)
             return
 
-        w = int(self.params['width'])
-        h = int(self.params['height'])
+        w = int(self.params[translate("Exporter", 'width')])
+        h = int(self.params[translate("Exporter", 'height')])
         if w == 0 or h == 0:
             raise Exception("Cannot export image with size=0 (requested "
                             "export size is %dx%d)" % (w, h))
@@ -71,7 +72,7 @@ class ImageExporter(Exporter):
         sourceRect = self.getSourceRect()
 
         bg = np.empty((h, w, 4), dtype=np.ubyte)
-        color = self.params['background']
+        color = self.params[translate("Exporter", 'background')]
         bg[:,:,0] = color.blue()
         bg[:,:,1] = color.green()
         bg[:,:,2] = color.red()
@@ -89,8 +90,12 @@ class ImageExporter(Exporter):
         painter = QtGui.QPainter(self.png)
         #dtr = painter.deviceTransform()
         try:
-            self.setExportMode(True, {'antialias': self.params['antialias'], 'background': self.params['background'], 'painter': painter, 'resolutionScale': resolutionScale})
-            painter.setRenderHint(QtGui.QPainter.Antialiasing, self.params['antialias'])
+            self.setExportMode(True, {
+                'antialias': self.params[translate("Exporter", 'antialias')],
+                'background': self.params[translate("Exporter", 'background')],
+                'painter': painter,
+                'resolutionScale': resolutionScale})
+            painter.setRenderHint(QtGui.QPainter.Antialiasing, self.params[translate("Exporter", 'antialias')])
             self.getScene().render(painter, QtCore.QRectF(targetRect), QtCore.QRectF(sourceRect))
         finally:
             self.setExportMode(False)

--- a/pyqtgraph/exporters/Matplotlib.py
+++ b/pyqtgraph/exporters/Matplotlib.py
@@ -4,6 +4,8 @@ from .Exporter import Exporter
 from .. import PlotItem
 from .. import functions as fn
 
+translate = QtCore.QCoreApplication.translate
+
 __all__ = ['MatplotlibExporter']
 
 """
@@ -30,7 +32,7 @@ publication. Fonts are not vectorized (outlined), and window colors are white.
 """
     
 class MatplotlibExporter(Exporter):
-    Name = "Matplotlib Window"
+    Name = translate('Exporter', "Matplotlib Window")
     windows = []
 
     def __init__(self, item):

--- a/pyqtgraph/exporters/PrintExporter.py
+++ b/pyqtgraph/exporters/PrintExporter.py
@@ -3,6 +3,8 @@ from ..parametertree import Parameter
 from ..Qt import QtGui, QtCore, QtSvg
 import re
 
+translate = QtCore.QCoreApplication.translate
+
 __all__ = ['PrintExporter']  
 #__all__ = []   ## Printer is disabled for now--does not work very well.
 
@@ -12,8 +14,8 @@ class PrintExporter(Exporter):
         Exporter.__init__(self, item)
         tr = self.getTargetRect()
         self.params = Parameter(name='params', type='group', children=[
-            {'name': 'width', 'type': 'float', 'value': 0.1, 'limits': (0, None), 'suffix': 'm', 'siPrefix': True},
-            {'name': 'height', 'type': 'float', 'value': (0.1 * tr.height()) / tr.width(), 'limits': (0, None), 'suffix': 'm', 'siPrefix': True},
+            {'name': translate("Exporter", 'width'), 'type': 'float', 'value': 0.1, 'limits': (0, None), 'suffix': 'm', 'siPrefix': True},
+            {'name': translate("Exporter", 'height'), 'type': 'float', 'value': (0.1 * tr.height()) / tr.width(), 'limits': (0, None), 'suffix': 'm', 'siPrefix': True},
         ])
         self.params.param('width').sigValueChanged.connect(self.widthChanged)
         self.params.param('height').sigValueChanged.connect(self.heightChanged)
@@ -21,12 +23,12 @@ class PrintExporter(Exporter):
     def widthChanged(self):
         sr = self.getSourceRect()
         ar = sr.height() / sr.width()
-        self.params.param('height').setValue(self.params['width'] * ar, blockSignal=self.heightChanged)
+        self.params.param(translate("Exporter", 'height')).setValue(self.params[translate("Exporter", 'width')] * ar, blockSignal=self.heightChanged)
         
     def heightChanged(self):
         sr = self.getSourceRect()
         ar = sr.width() / sr.height()
-        self.params.param('width').setValue(self.params['height'] * ar, blockSignal=self.widthChanged)
+        self.params.param(translate("Exporter", 'width')).setValue(self.params[translate("Exporter", 'height')] * ar, blockSignal=self.widthChanged)
         
     def parameters(self):
         return self.params
@@ -34,7 +36,7 @@ class PrintExporter(Exporter):
     def export(self, fileName=None):
         printer = QtGui.QPrinter(QtGui.QPrinter.HighResolution)
         dialog = QtGui.QPrintDialog(printer)
-        dialog.setWindowTitle("Print Document")
+        dialog.setWindowTitle(translate('Exporter', "Print Document"))
         if dialog.exec_() != QtGui.QDialog.Accepted:
             return
             

--- a/pyqtgraph/exporters/SVGExporter.py
+++ b/pyqtgraph/exporters/SVGExporter.py
@@ -56,7 +56,7 @@ class SVGExporter(Exporter):
     
     def export(self, fileName=None, toBytes=False, copy=False):
         if toBytes is False and copy is False and fileName is None:
-            self.fileSaveDialog(filter=f"{translate('Exporter', 'Scalable Vector Graphics)'} (*.svg)")
+            self.fileSaveDialog(filter=f"{translate('Exporter', 'Scalable Vector Graphics')} (*.svg)")
             return
         
         ## Qt's SVG generator is not complete. (notably, it lacks clipping)

--- a/pyqtgraph/exporters/SVGExporter.py
+++ b/pyqtgraph/exporters/SVGExporter.py
@@ -8,11 +8,12 @@ import re
 import xml.dom.minidom as xml
 import numpy as np
 
+translate = QtCore.QCoreApplication.translate
 
 __all__ = ['SVGExporter']
 
 class SVGExporter(Exporter):
-    Name = "Scalable Vector Graphics (SVG)"
+    Name = translate("Exporter", "Scalable Vector Graphics (SVG)")
     allowCopy=True
     
     def __init__(self, item):
@@ -29,42 +30,42 @@ class SVGExporter(Exporter):
             bg.setAlpha(0)
 
         self.params = Parameter(name='params', type='group', children=[
-            {'name': 'background', 'type': 'color', 'value': bg},
-            {'name': 'width', 'type': 'float', 'value': tr.width(), 'limits': (0, None)},
-            {'name': 'height', 'type': 'float', 'value': tr.height(), 'limits': (0, None)},
+            {'name': translate("Exporter", 'background'), 'type': 'color', 'value': bg},
+            {'name': translate("Exporter", 'width'), 'type': 'float', 'value': tr.width(), 'limits': (0, None)},
+            {'name': translate("Exporter", 'height'), 'type': 'float', 'value': tr.height(), 'limits': (0, None)},
             #{'name': 'viewbox clipping', 'type': 'bool', 'value': True},
             #{'name': 'normalize coordinates', 'type': 'bool', 'value': True},
-            {'name': 'scaling stroke', 'type': 'bool', 'value': False, 'tip': "If False, strokes are non-scaling, "
+            {'name': translate("Exporter", 'scaling stroke'), 'type': 'bool', 'value': False, 'tip': "If False, strokes are non-scaling, "
              "which means that they appear the same width on screen regardless of how they are scaled or how the view is zoomed."},
         ])
-        self.params.param('width').sigValueChanged.connect(self.widthChanged)
-        self.params.param('height').sigValueChanged.connect(self.heightChanged)
+        self.params.param(translate("Exporter", 'width')).sigValueChanged.connect(self.widthChanged)
+        self.params.param(translate("Exporter", 'height')).sigValueChanged.connect(self.heightChanged)
 
     def widthChanged(self):
         sr = self.getSourceRect()
         ar = sr.height() / sr.width()
-        self.params.param('height').setValue(self.params['width'] * ar, blockSignal=self.heightChanged)
+        self.params.param(translate("Exporter", 'height')).setValue(self.params[translate("Exporter", 'width')] * ar, blockSignal=self.heightChanged)
         
     def heightChanged(self):
         sr = self.getSourceRect()
         ar = sr.width() / sr.height()
-        self.params.param('width').setValue(self.params['height'] * ar, blockSignal=self.widthChanged)
+        self.params.param(translate("Exporter", 'width')).setValue(self.params[translate("Exporter", 'height')] * ar, blockSignal=self.widthChanged)
         
     def parameters(self):
         return self.params
     
     def export(self, fileName=None, toBytes=False, copy=False):
         if toBytes is False and copy is False and fileName is None:
-            self.fileSaveDialog(filter="Scalable Vector Graphics (*.svg)")
+            self.fileSaveDialog(filter=f"{translate('Exporter', 'Scalable Vector Graphics)'} (*.svg)")
             return
         
         ## Qt's SVG generator is not complete. (notably, it lacks clipping)
         ## Instead, we will use Qt to generate SVG for each item independently,
         ## then manually reconstruct the entire document.
         options = {ch.name():ch.value() for ch in self.params.children()}
-        options['background'] = self.params['background']
-        options['width'] = self.params['width']
-        options['height'] = self.params['height']
+        options['background'] = self.params[translate("Exporter", 'background')]
+        options['width'] = self.params[translate("Exporter", 'width')]
+        options['height'] = self.params[translate("Exporter", 'height')]
         xml = generateSvg(self.item, options)
         
         if toBytes:

--- a/pyqtgraph/flowchart/FlowchartGraphicsView.py
+++ b/pyqtgraph/flowchart/FlowchartGraphicsView.py
@@ -4,6 +4,7 @@ from ..widgets.GraphicsView import GraphicsView
 from ..GraphicsScene import GraphicsScene
 from ..graphicsItems.ViewBox import ViewBox
 
+translate = QtCore.QCoreApplication.translate
 
 class FlowchartGraphicsView(GraphicsView):
     
@@ -37,5 +38,5 @@ class FlowchartViewBox(ViewBox):
     def getContextMenus(self, ev):
         ## called by scene to add menus on to someone else's context menu
         menu = self.widget.buildMenu(ev.scenePos())
-        menu.setTitle("Add node")
+        menu.setTitle(translate("Context Menu", "Add node"))
         return [menu, ViewBox.getMenu(self, ev)]

--- a/pyqtgraph/flowchart/Node.py
+++ b/pyqtgraph/flowchart/Node.py
@@ -8,6 +8,8 @@ from ..debug import *
 import numpy as np
 
 
+translate = QtCore.QCoreApplication.translate
+
 def strDict(d):
     return dict([(str(k), v) for k, v in d.items()])
 
@@ -639,14 +641,14 @@ class NodeGraphicsItem(GraphicsObject):
         
     def buildMenu(self):
         self.menu = QtGui.QMenu()
-        self.menu.setTitle("Node")
-        a = self.menu.addAction("Add input", self.addInputFromMenu)
+        self.menu.setTitle(translate("Context Menu", "Node"))
+        a = self.menu.addAction(translate("Context Menu","Add input"), self.addInputFromMenu)
         if not self.node._allowAddInput:
             a.setEnabled(False)
-        a = self.menu.addAction("Add output", self.addOutputFromMenu)
+        a = self.menu.addAction(translate("Context Menu", "Add output"), self.addOutputFromMenu)
         if not self.node._allowAddOutput:
             a.setEnabled(False)
-        a = self.menu.addAction("Remove node", self.node.close)
+        a = self.menu.addAction(translate("Context Menu", "Remove node"), self.node.close)
         if not self.node._allowRemove:
             a.setEnabled(False)
         

--- a/pyqtgraph/flowchart/Terminal.py
+++ b/pyqtgraph/flowchart/Terminal.py
@@ -5,6 +5,7 @@ from ..graphicsItems.GraphicsObject import GraphicsObject
 from .. import functions as fn
 from ..Point import Point
 
+translate = QtCore.QCoreApplication.translate
 
 class Terminal(object):
     def __init__(self, node, name, io, optional=False, multi=False, pos=None, renamable=False, removable=False, multiable=False, bypass=None):
@@ -373,14 +374,14 @@ class TerminalGraphicsItem(GraphicsObject):
     def getMenu(self):
         if self.menu is None:
             self.menu = QtGui.QMenu()
-            self.menu.setTitle("Terminal")
-            remAct = QtGui.QAction("Remove terminal", self.menu)
+            self.menu.setTitle(translate("Context Menu", "Terminal"))
+            remAct = QtGui.QAction(translate("Context Menu", "Remove terminal"), self.menu)
             remAct.triggered.connect(self.removeSelf)
             self.menu.addAction(remAct)
             self.menu.remAct = remAct
             if not self.term.isRemovable():
                 remAct.setEnabled(False)
-            multiAct = QtGui.QAction("Multi-value", self.menu)
+            multiAct = QtGui.QAction(translate("Context Menu", "Multi-value"), self.menu)
             multiAct.setCheckable(True)
             multiAct.setChecked(self.term.isMultiValue())
             multiAct.setEnabled(self.term.isMultiable())

--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -10,6 +10,7 @@ from ..widgets.SpinBox import SpinBox
 from ..pgcollections import OrderedDict
 from ..colormap import ColorMap
 
+translate = QtCore.QCoreApplication.translate
 
 __all__ = ['TickSliderItem', 'GradientEditorItem']
 
@@ -442,10 +443,10 @@ class GradientEditorItem(TickSliderItem):
         
         self.setMaxDim(self.rectSize + self.tickSize)
         
-        self.rgbAction = QtGui.QAction('RGB', self)
+        self.rgbAction = QtGui.QAction(translate("GradiantEditorItem", 'RGB'), self)
         self.rgbAction.setCheckable(True)
         self.rgbAction.triggered.connect(lambda: self.setColorMode('rgb'))
-        self.hsvAction = QtGui.QAction('HSV', self)
+        self.hsvAction = QtGui.QAction(translate("GradiantEditorItem", 'HSV'), self)
         self.hsvAction.setCheckable(True)
         self.hsvAction.triggered.connect(lambda: self.setColorMode('hsv'))
             
@@ -949,11 +950,11 @@ class TickMenu(QtGui.QMenu):
         self.tick = weakref.ref(tick)
         self.sliderItem = weakref.ref(sliderItem)
         
-        self.removeAct = self.addAction("Remove Tick", lambda: self.sliderItem().removeTick(tick))
+        self.removeAct = self.addAction(translate("GradientEditorItem", "Remove Tick"), lambda: self.sliderItem().removeTick(tick))
         if (not self.tick().removeAllowed) or len(self.sliderItem().ticks) < 3:
             self.removeAct.setEnabled(False)
             
-        positionMenu = self.addMenu("Set Position")
+        positionMenu = self.addMenu(translate("GradientEditorItem", "Set Position"))
         w = QtGui.QWidget()
         l = QtGui.QGridLayout()
         w.setLayout(l)
@@ -964,7 +965,7 @@ class TickMenu(QtGui.QMenu):
         #self.dataPosSpin = SpinBox(value=dataVal)
         #self.dataPosSpin.setOpts(decimals=3, siPrefix=True)
                 
-        l.addWidget(QtGui.QLabel("Position:"), 0,0)
+        l.addWidget(QtGui.QLabel(f"{translate('GradiantEditorItem', 'Position')}:"), 0,0)
         l.addWidget(self.fracPosSpin, 0, 1)
         #l.addWidget(QtGui.QLabel("Position (data units):"), 1, 0)
         #l.addWidget(self.dataPosSpin, 1,1)
@@ -979,7 +980,7 @@ class TickMenu(QtGui.QMenu):
         self.fracPosSpin.sigValueChanging.connect(self.fractionalValueChanged)
         #self.dataPosSpin.valueChanged.connect(self.dataValueChanged)
         
-        colorAct = self.addAction("Set Color", lambda: self.sliderItem().raiseColorDialog(self.tick()))
+        colorAct = self.addAction(translate("Context Menu", "Set Color"), lambda: self.sliderItem().raiseColorDialog(self.tick()))
         if not self.tick().colorChangeAllowed:
             colorAct.setEnabled(False)
 

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -17,6 +17,8 @@ except ImportError:
     # fallback for python < 3.3
     from collections import Callable
 
+translate = QtCore.QCoreApplication.translate
+
 __all__ = ['ImageItem']
 
 
@@ -634,8 +636,8 @@ class ImageItem(GraphicsObject):
             if not self.removable:
                 return None
             self.menu = QtGui.QMenu()
-            self.menu.setTitle("Image")
-            remAct = QtGui.QAction("Remove image", self.menu)
+            self.menu.setTitle(translate("ImageItem", "Image"))
+            remAct = QtGui.QAction(translate("ImageItem", "Remove image"), self.menu)
             remAct.triggered.connect(self.removeClicked)
             self.menu.addAction(remAct)
             self.menu.remAct = remAct

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -19,6 +19,8 @@ from .. InfiniteLine import InfiniteLine
 from ...WidgetGroup import WidgetGroup
 from ...python2_3 import basestring
 
+translate = QtCore.QCoreApplication.translate
+
 import importlib
 ui_template = importlib.import_module(
     f'.plotConfigTemplate_{QT_LIB.lower()}', package=__package__)
@@ -189,18 +191,18 @@ class PlotItem(GraphicsWidget):
         dv = QtGui.QDoubleValidator(self)
         
         menuItems = [
-            ('Transforms', c.transformGroup),
-            ('Downsample', c.decimateGroup),
-            ('Average', c.averageGroup),
-            ('Alpha', c.alphaGroup),
-            ('Grid', c.gridGroup),
-            ('Points', c.pointsGroup),
+            (translate("PlotItem", 'Transforms'), c.transformGroup),
+            (translate("PlotItem", 'Downsample'), c.decimateGroup),
+            (translate("PlotItem", 'Average'), c.averageGroup),
+            (translate("PlotItem", 'Alpha'), c.alphaGroup),
+            (translate("PlotItem", 'Grid'), c.gridGroup),
+            (translate("PlotItem", 'Points'), c.pointsGroup),
         ]
         
         
         self.ctrlMenu = QtGui.QMenu()
         
-        self.ctrlMenu.setTitle('Plot Options')
+        self.ctrlMenu.setTitle(translate("PlotItem", 'Plot Options'))
         self.subMenus = []
         for name, grp in menuItems:
             sm = QtGui.QMenu(name)

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -23,6 +23,8 @@ from .GraphicsObject import GraphicsObject
 from .UIGraphicsItem import UIGraphicsItem
 from .. import getConfigOption
 
+translate = QtCore.QCoreApplication.translate
+
 __all__ = [
     'ROI', 
     'TestROI', 'RectROI', 'EllipseROI', 'CircleROI', 'PolygonROI', 
@@ -770,8 +772,8 @@ class ROI(GraphicsObject):
     def getMenu(self):
         if self.menu is None:
             self.menu = QtGui.QMenu()
-            self.menu.setTitle("ROI")
-            remAct = QtGui.QAction("Remove ROI", self.menu)
+            self.menu.setTitle(translate("ROI", "ROI"))
+            remAct = QtGui.QAction(translate("ROI", "Remove ROI"), self.menu)
             remAct.triggered.connect(self.removeClicked)
             self.menu.addAction(remAct)
             self.menu.remAct = remAct
@@ -1368,8 +1370,8 @@ class Handle(UIGraphicsItem):
                 
     def buildMenu(self):
         menu = QtGui.QMenu()
-        menu.setTitle("Handle")
-        self.removeAction = menu.addAction("Remove handle", self.removeClicked) 
+        menu.setTitle(translate("ROI", "Handle"))
+        self.removeAction = menu.addAction(translate("ROI", "Remove handle"), self.removeClicked) 
         return menu
         
     def getMenu(self):

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -9,6 +9,7 @@ ui_template = importlib.import_module(
 
 import weakref 
 
+translate = QtCore.QCoreApplication.translate
 class ViewBoxMenu(QtGui.QMenu):
     def __init__(self, view):
         QtGui.QMenu.__init__(self)
@@ -63,15 +64,15 @@ class ViewBoxMenu(QtGui.QMenu):
         #self.setExportMethods(view.exportMethods)
         #self.addMenu(self.export)
         
-        self.leftMenu = QtGui.QMenu("Mouse Mode")
+        self.leftMenu = QtGui.QMenu(translate("ViewBox", "Mouse Mode"))
         group = QtGui.QActionGroup(self)
         
         # This does not work! QAction _must_ be initialized with a permanent 
         # object as the parent or else it may be collected prematurely.
         #pan = self.leftMenu.addAction("3 button", self.set3ButtonMode)
         #zoom = self.leftMenu.addAction("1 button", self.set1ButtonMode)
-        pan = QtGui.QAction("3 button", self.leftMenu)
-        zoom = QtGui.QAction("1 button", self.leftMenu)
+        pan = QtGui.QAction(translate("ViewBox", "3 button"), self.leftMenu)
+        zoom = QtGui.QAction(translate("ViewBox", "1 button"), self.leftMenu)
         self.leftMenu.addAction(pan)
         self.leftMenu.addAction(zoom)
         pan.triggered.connect(self.set3ButtonMode)

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -18,8 +18,8 @@ class ViewBoxMenu(QtGui.QMenu):
         self.valid = False  ## tells us whether the ui needs to be updated
         self.viewMap = weakref.WeakValueDictionary()  ## weakrefs to all views listed in the link combos
 
-        self.setTitle("ViewBox options")
-        self.viewAll = QtGui.QAction("View All", self)
+        self.setTitle(translate("ViewBox", "ViewBox options"))
+        self.viewAll = QtGui.QAction(translate("ViewBox", "View All"), self)
         self.viewAll.triggered.connect(self.autoRange)
         self.addAction(self.viewAll)
         
@@ -29,7 +29,7 @@ class ViewBoxMenu(QtGui.QMenu):
         self.dv = QtGui.QDoubleValidator(self)
         for axis in 'XY':
             m = QtGui.QMenu()
-            m.setTitle("%s Axis" % axis)
+            m.setTitle(f"{axis} {translate('ViewBox', 'axis')}")
             w = QtGui.QWidget()
             ui = ui_template.Ui_Form()
             ui.setupUi(w)

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -37,6 +37,7 @@ try:
 except ImportError:
     from numpy import nanmin, nanmax
 
+translate = QtCore.QCoreApplication.translate
 
 class PlotROI(ROI):
     def __init__(self, size):
@@ -817,11 +818,11 @@ class ImageView(QtGui.QWidget):
         
     def buildMenu(self):
         self.menu = QtGui.QMenu()
-        self.normAction = QtGui.QAction("Normalization", self.menu)
+        self.normAction = QtGui.QAction(translate("ImageView", "Normalization"), self.menu)
         self.normAction.setCheckable(True)
         self.normAction.toggled.connect(self.normToggled)
         self.menu.addAction(self.normAction)
-        self.exportAction = QtGui.QAction("Export", self.menu)
+        self.exportAction = QtGui.QAction(translate("ImageView", "Export"), self.menu)
         self.exportAction.triggered.connect(self.exportClicked)
         self.menu.addAction(self.exportAction)
         

--- a/pyqtgraph/parametertree/ParameterItem.py
+++ b/pyqtgraph/parametertree/ParameterItem.py
@@ -2,6 +2,8 @@ from ..Qt import QtGui, QtCore
 from ..python2_3 import asUnicode
 import os, weakref, re
 
+translate = QtCore.QCoreApplication.translate
+
 class ParameterItem(QtGui.QTreeWidgetItem):
     """
     Abstract ParameterTree item. 
@@ -111,9 +113,9 @@ class ParameterItem(QtGui.QTreeWidgetItem):
         self.contextMenu = QtGui.QMenu() # Put in global name space to prevent garbage collection
         self.contextMenu.addSeparator()
         if opts.get('renamable', False):
-            self.contextMenu.addAction('Rename').triggered.connect(self.editName)
+            self.contextMenu.addAction(translate("ParameterItem", 'Rename')).triggered.connect(self.editName)
         if opts.get('removable', False):
-            self.contextMenu.addAction("Remove").triggered.connect(self.requestRemove)
+            self.contextMenu.addAction(translate("ParameterItem", "Remove")).triggered.connect(self.requestRemove)
         
         # context menu
         context = opts.get('context', None)

--- a/pyqtgraph/widgets/TableWidget.py
+++ b/pyqtgraph/widgets/TableWidget.py
@@ -4,6 +4,7 @@ from ..Qt import QtGui, QtCore
 from ..python2_3 import asUnicode, basestring
 from .. import metaarray
 
+translate = QtCore.QCoreApplication.translate
 
 __all__ = ['TableWidget']
 
@@ -74,10 +75,10 @@ class TableWidget(QtGui.QTableWidget):
         self.itemChanged.connect(self.handleItemChanged)
         
         self.contextMenu = QtGui.QMenu()
-        self.contextMenu.addAction('Copy Selection').triggered.connect(self.copySel)
-        self.contextMenu.addAction('Copy All').triggered.connect(self.copyAll)
-        self.contextMenu.addAction('Save Selection').triggered.connect(self.saveSel)
-        self.contextMenu.addAction('Save All').triggered.connect(self.saveAll)
+        self.contextMenu.addAction(translate("TableWidget", 'Copy Selection')).triggered.connect(self.copySel)
+        self.contextMenu.addAction(translate("TableWidget", 'Copy All')).triggered.connect(self.copyAll)
+        self.contextMenu.addAction(translate("TableWidget", 'Save Selection')).triggered.connect(self.saveSel)
+        self.contextMenu.addAction(translate("TableWidget", 'Save All')).triggered.connect(self.saveAll)
         
     def clear(self):
         """Clear all contents from the table."""
@@ -350,7 +351,12 @@ class TableWidget(QtGui.QTableWidget):
         self.save(self.serialize(useSelection=False))
 
     def save(self, data):
-        fileName = QtGui.QFileDialog.getSaveFileName(self, "Save As..", "", "Tab-separated values (*.tsv)")
+        fileName = QtGui.QFileDialog.getSaveFileName(
+            self,
+            f"{translate('TableWidget', 'Save As')}...",
+            "",
+            f"{translate('TableWidget', 'Tab-separated values')} (*.tsv)"
+        )
         if isinstance(fileName, tuple):
             fileName = fileName[0]  # Qt4/5 API difference
         if fileName == '':


### PR DESCRIPTION
Fixes #649 

This PR is a _very_ early attempt to try and implement i18n localization to various strings that pyqtgraph shows to the user.  At the initial draft of this PR, this includes context menus in ImageView, ImageItem, ViewBox and PlotItem, as well as the Image Exporter and SVG Exporter.  Given that I do not have a system with a different localization, or know what the process here is, I could use some assistance to test the functionality here.

The process as shown in the PyQt5 docs here seems to indicate the following:

https://www.riverbankcomputing.com/static/Docs/PyQt5/i18n.html

* run `pylupdate5` to create a `.ts` file on a per-language basis
* a translator updates the `.ts` file with the relevant translations
* run `lrelease` on the `.ts` files.  In my case `lrelease` was not bundled with the PyQt5 distribution, but was part of the homebrew Qt package, can I could run it via `/usr/local/opt/qt/bin/lrelease`

More information on running `lrelease` can be found here: https://doc.qt.io/qt-5/linguist-manager.html#using-lrelease

