### PR TITLE
fix RemoteSpeedTest shutdown errors

### DIFF
--- a/examples/RemoteSpeedTest.py
+++ b/examples/RemoteSpeedTest.py
@@ -24,6 +24,8 @@ pg.setConfigOptions(antialias=True)  ## this will be expensive for the local plo
 view.pg.setConfigOptions(antialias=True)  ## prettier plots at no cost to the main process! 
 view.setWindowTitle('pyqtgraph example: RemoteSpeedTest')
 
+app.aboutToQuit.connect(view.close)
+
 label = QtGui.QLabel()
 rcheck = QtGui.QCheckBox('plot remote')
 rcheck.setChecked(True)

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -70,10 +70,6 @@ conditionalExamples = {
         False,
         reason="Test is being problematic on CI machines"
     ),
-    "RemoteGraphicsView.py": exceptionCondition(
-        not(platform.system() == "Darwin"),
-        reason="FileNotFoundError for pyqtgraph_shmem_* file"
-    ),
     "ProgressDialog.py": exceptionCondition(
         not(platform.system() == "Linux"),
         reason="QXcbConnection: XCB error"


### PR DESCRIPTION
This PR fixes shutdown errors encountered in RemoteSpeedTest.py when executed locally.
It also fixes Darwin errors when running RemoteGraphicsView.py on the CI.

The fixes made are however not sufficient to allow enabling of RemoteSpeedTest.py on the CI due to forced termination done by test_examples.py