### PR TITLE
Infiniteline emits clicked signal event

### DIFF
--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -25,12 +25,14 @@ class InfiniteLine(GraphicsObject):
     sigDragged(self)
     sigPositionChangeFinished(self)
     sigPositionChanged(self)
+    sigclicked(self, ev)
     =============================== ===================================================
     """
 
     sigDragged = QtCore.Signal(object)
     sigPositionChangeFinished = QtCore.Signal(object)
     sigPositionChanged = QtCore.Signal(object)
+    sigClicked = QtCore.Signal(object, object)
 
     def __init__(self, pos=None, angle=90, pen=None, movable=False, bounds=None,
                  hoverPen=None, label=None, labelOpts=None, span=(0, 1), markers=None, 
@@ -400,6 +402,7 @@ class InfiniteLine(GraphicsObject):
                 self.sigPositionChangeFinished.emit(self)
 
     def mouseClickEvent(self, ev):
+        self.sigClicked.emit(self, ev)
         if self.moving and ev.button() == QtCore.Qt.RightButton:
             ev.accept()
             self.setPos(self.startPosition)


### PR DESCRIPTION
Supersedes #334 ... after looking over that PR, decided that instead of emitting a number of different signals, we should emit the event.  The other signals that were created as part of that PR should really be handled via inheritance, which is sort of the Qt way.