### PR TITLE
switch to use of QOpenGLWidget in GraphicsView.py

### DIFF
--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -354,7 +354,8 @@ if QT_LIB in [PYQT6, PYSIDE6]:
     # We're using Qt6 which has a different structure so we're going to use a shim to
     # recreate the Qt5 structure
 
-    QtWidgets.QOpenGLWidget = QtOpenGLWidgets.QOpenGLWidget
+    if not isinstance(QtOpenGLWidgets, FailedImport):
+        QtWidgets.QOpenGLWidget = QtOpenGLWidgets.QOpenGLWidget
 
 
 # Common to PySide, PySide2 and PySide6

--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -212,10 +212,6 @@ elif QT_LIB == PYQT5:
     except ImportError as err:
         QtSvg = FailedImport(err)
     try:
-        from PyQt5 import QtOpenGL
-    except ImportError as err:
-        QtOpenGL = FailedImport(err)
-    try:
         from PyQt5 import QtTest
         QtTest.QTest.qWaitForWindowShown = QtTest.QTest.qWaitForWindowExposed
     except ImportError as err:
@@ -249,10 +245,6 @@ elif QT_LIB == PYSIDE2:
         from PySide2 import QtSvg
     except ImportError as err:
         QtSvg = FailedImport(err)
-    try:
-        from PySide2 import QtOpenGL
-    except ImportError as err:
-        QtOpenGL = FailedImport(err)
     try:
         from PySide2 import QtTest
         QtTest.QTest.qWaitForWindowShown = QtTest.QTest.qWaitForWindowExposed

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -1,14 +1,6 @@
 # -*- coding: utf-8 -*-
 from ..Qt import QtCore, QtGui, QtWidgets
-try:
-    from ..Qt import QtOpenGL
-    HAVE_LEGACY_OPENGL = hasattr(QtOpenGL, 'QGLWidget')
-except:
-    HAVE_LEGACY_OPENGL = False
-try:
-    HAVE_OPENGL = hasattr(QtWidgets, 'QOpenGLWidget')
-except:
-    HAVE_OPENGL = False
+HAVE_OPENGL = hasattr(QtWidgets, 'QOpenGLWidget')
 
 import warnings
 import numpy as np
@@ -488,8 +480,7 @@ class PlotCurveItem(GraphicsObject):
             return
 
         if getConfigOption('enableExperimental'):
-            if (HAVE_LEGACY_OPENGL and isinstance(widget, QtOpenGL.QGLWidget)) or \
-                    (HAVE_OPENGL and isinstance(widget, QtWidgets.QOpenGLWidget)):
+            if HAVE_OPENGL and isinstance(widget, QtWidgets.QOpenGLWidget):
                 self.paintGL(p, opt, widget)
                 return
 

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
-from ..Qt import QtGui, QtCore
+from ..Qt import QtCore, QtGui, QtWidgets
 try:
     from ..Qt import QtOpenGL
-    HAVE_OPENGL = True
+    HAVE_LEGACY_OPENGL = hasattr(QtOpenGL, 'QGLWidget')
+except:
+    HAVE_LEGACY_OPENGL = False
+try:
+    HAVE_OPENGL = hasattr(QtWidgets, 'QOpenGLWidget')
 except:
     HAVE_OPENGL = False
 
@@ -483,10 +487,11 @@ class PlotCurveItem(GraphicsObject):
         if self.xData is None or len(self.xData) == 0:
             return
 
-        if HAVE_OPENGL and getConfigOption('enableExperimental') and \
-                hasattr(QtOpenGL, 'QGLWidget') and isinstance(widget, QtOpenGL.QGLWidget):
-            self.paintGL(p, opt, widget)
-            return
+        if getConfigOption('enableExperimental'):
+            if (HAVE_LEGACY_OPENGL and isinstance(widget, QtOpenGL.QGLWidget)) or \
+                    (HAVE_OPENGL and isinstance(widget, QtWidgets.QOpenGLWidget)):
+                self.paintGL(p, opt, widget)
+                return
 
         x = None
         y = None

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -483,7 +483,8 @@ class PlotCurveItem(GraphicsObject):
         if self.xData is None or len(self.xData) == 0:
             return
 
-        if HAVE_OPENGL and getConfigOption('enableExperimental') and isinstance(widget, QtOpenGL.QGLWidget):
+        if HAVE_OPENGL and getConfigOption('enableExperimental') and \
+                hasattr(QtOpenGL, 'QGLWidget') and isinstance(widget, QtOpenGL.QGLWidget):
             self.paintGL(p, opt, widget)
             return
 

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -171,7 +171,7 @@ class GraphicsView(QtGui.QGraphicsView):
         if b:
             widget_name = ''
             try:
-                if getConfigOption('enableExperimental'):
+                if getConfigOption('enableExperimental') and QT_LIB in ['PyQt5', 'PySide2']:
                     # legacy QGLWidget has been dropped in Qt6.
                     # however, this library's enableExperimental drawing code in PlotCurveItem.py
                     # is broken when using QOpenGLWidget.

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -169,22 +169,11 @@ class GraphicsView(QtGui.QGraphicsView):
 
     def useOpenGL(self, b=True):
         if b:
-            widget_name = ''
-            try:
-                if getConfigOption('enableExperimental') and QT_LIB in ['PyQt5', 'PySide2']:
-                    # legacy QGLWidget has been dropped in Qt6.
-                    # however, this library's enableExperimental drawing code in PlotCurveItem.py
-                    # is broken when using QOpenGLWidget.
-                    widget_name = 'QGLWidget'
-                    from ..Qt import QtOpenGL
-                    GLWidget = QtOpenGL.QGLWidget
-                else:
-                    widget_name = 'QOpenGLWidget'
-                    GLWidget = getattr(QtWidgets, 'QOpenGLWidget')
-            except:
-                raise Exception(f"Requested to use OpenGL with QGraphicsView, but {widget_name} is not available.")
+            HAVE_OPENGL = hasattr(QtWidgets, 'QOpenGLWidget')
+            if not HAVE_OPENGL:
+                raise Exception("Requested to use OpenGL with QGraphicsView, but QOpenGLWidget is not available.")
 
-            v = GLWidget()
+            v = QtWidgets.QOpenGLWidget()
         else:
             v = QtGui.QWidget()
             


### PR DESCRIPTION
For Qt5, this switches from use of legacy QGLWidget to QOpenGLWidget.
For Qt6, this enables the option of using OpenGL, also using QOpenGLWidget.

Experimental plotting in PlotCurveItem gets broken by this switch and I do not know how to fix it, so we allow Qt5 users to opt back to using QGLWidget with the enableExperimental option.

There is some discussion here about issues with switching from QGLWidget to QOpenGLWidget when using them as a viewport.
https://stackoverflow.com/questions/31658176/using-qopenglwidget-with-qgraphicsview-viewport-not-updating