### PR TITLE
Support suffix for int parameters

### DIFF
--- a/examples/SpinBox.py
+++ b/examples/SpinBox.py
@@ -34,6 +34,8 @@ spins = [
     ("Float with custom formatting", 
      pg.SpinBox(value=23.07, format='${value:0.02f}',
                 regex='\$?(?P<number>(-?\d+(\.\d+)?)|(-?\.\d+))$')),
+    ("Int with suffix",
+     pg.SpinBox(value=999, step=1, int=True, suffix="V")),
     ("Int with custom formatting", 
      pg.SpinBox(value=4567, step=1, int=True, bounds=[0,None], format='0x{value:X}', 
                 regex='(0x)?(?P<number>[0-9a-fA-F]+)$',

--- a/examples/parametertree.py
+++ b/examples/parametertree.py
@@ -81,6 +81,7 @@ params = [
     {'name': 'Numerical Parameter Options', 'type': 'group', 'children': [
         {'name': 'Units + SI prefix', 'type': 'float', 'value': 1.2e-6, 'step': 1e-6, 'siPrefix': True, 'suffix': 'V'},
         {'name': 'Limits (min=7;max=15)', 'type': 'int', 'value': 11, 'limits': (7, 15), 'default': -6},
+        {'name': 'Int suffix', 'type': 'int', 'value': 9, 'suffix': 'V'},
         {'name': 'DEC stepping', 'type': 'float', 'value': 1.2e6, 'dec': True, 'step': 1, 'siPrefix': True, 'suffix': 'Hz'},
         
     ]},

--- a/pyqtgraph/parametertree/parameterTypes.py
+++ b/pyqtgraph/parametertree/parameterTypes.py
@@ -105,7 +105,6 @@ class WidgetParameterItem(ParameterItem):
             if t == 'int':
                 defs['int'] = True
                 defs['minStep'] = 1.0
-                defs['format'] = '{value:d}'
             for k in defs:
                 if k in opts:
                     defs[k] = opts[k]

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -225,6 +225,9 @@ class SpinBox(QtGui.QAbstractSpinBox):
                 if ms < 1:
                     ms = 1
                 self.opts['minStep'] = ms
+
+            if 'format' not in opts:
+                self.opts['format'] = asUnicode("{value:d}{suffixGap}{suffix}")
         
         if 'delay' in opts:
             self.proxy.setDelay(opts['delay'])

--- a/pyqtgraph/widgets/tests/test_spinbox.py
+++ b/pyqtgraph/widgets/tests/test_spinbox.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pyqtgraph as pg
 pg.mkQApp()
 
@@ -14,7 +15,7 @@ def test_spinbox_formatting():
         (100, '100', dict()),
         (1000000, '1e+06', dict()),
         (1000, '1e+03', dict(decimals=2)),
-        (1000000, '1e+06', dict(int=True, decimals=6)),
+        (1000000, '1000000 V', dict(int=True, suffix='V')),
         (12345678955, '12345678955', dict(int=True, decimals=100)),
         (1.45e-9, '1.45e-09 A', dict(int=False, decimals=6, suffix='A', siPrefix=False)),
         (1.45e-9, '1.45 nA', dict(int=False, decimals=6, suffix='A', siPrefix=True)),
@@ -24,7 +25,7 @@ def test_spinbox_formatting():
     ]
     
     for (value, text, opts) in conds:
-        sb.setOpts(**opts)
+        sb = pg.SpinBox(**opts)
         sb.setValue(value)
         assert sb.value() == value
         assert pg.asUnicode(sb.text()) == text

--- a/pyqtgraph/widgets/tests/test_spinbox.py
+++ b/pyqtgraph/widgets/tests/test_spinbox.py
@@ -1,42 +1,44 @@
 # -*- coding: utf-8 -*-
+import pytest
 import pyqtgraph as pg
+
 pg.mkQApp()
 
 
-def test_spinbox_formatting():
+def test_SpinBox_defaults():
     sb = pg.SpinBox()
     assert sb.opts['decimals'] == 6
     assert sb.opts['int'] is False
-    
-    # table  of test conditions:
-    # value, text, options
-    conds = [
-        (0, '0', dict(suffix='', siPrefix=False, dec=False, int=False)),
-        (100, '100', dict()),
-        (1000000, '1e+06', dict()),
-        (1000, '1e+03', dict(decimals=2)),
-        (1000000, '1000000 V', dict(int=True, suffix='V')),
-        (12345678955, '12345678955', dict(int=True, decimals=100)),
-        (1.45e-9, '1.45e-09 A', dict(int=False, decimals=6, suffix='A', siPrefix=False)),
-        (1.45e-9, '1.45 nA', dict(int=False, decimals=6, suffix='A', siPrefix=True)),
-        (1.45, '1.45 PSI', dict(int=False, decimals=6, suffix='PSI', siPrefix=True)),
-        (1.45e-3, '1.45 mPSI', dict(int=False, decimals=6, suffix='PSI', siPrefix=True)),
-        (-2500.3427, '$-2500.34', dict(int=False, format='${value:0.02f}')),
-    ]
-    
-    for (value, text, opts) in conds:
-        sb = pg.SpinBox(**opts)
-        sb.setValue(value)
-        assert sb.value() == value
-        assert pg.asUnicode(sb.text()) == text
 
-        # test setting value
-        if not opts.get('int', False):
-            suf = sb.opts['suffix']
-            sb.lineEdit().setText('0.1' + suf)
-            sb.editingFinishedEvent()
-            assert sb.value() == 0.1
-            if suf != '':
-                sb.lineEdit().setText('0.1 m' + suf)
-                sb.editingFinishedEvent()
-                assert sb.value() == 0.1e-3
+
+@pytest.mark.parametrize("value,expected_text,opts", [
+    (0, '0', dict(suffix='', siPrefix=False, dec=False, int=False)),
+    (100, '100', dict()),
+    (1000000, '1e+06', dict()),
+    (1000, '1e+03', dict(decimals=2)),
+    (1000000, '1000000 V', dict(int=True, suffix='V')),
+    (12345678955, '12345678955', dict(int=True, decimals=100)),
+    (1.45e-9, '1.45e-09 A', dict(int=False, decimals=6, suffix='A', siPrefix=False)),
+    (1.45e-9, '1.45 nA', dict(int=False, decimals=6, suffix='A', siPrefix=True)),
+    (1.45, '1.45 PSI', dict(int=False, decimals=6, suffix='PSI', siPrefix=True)),
+    (1.45e-3, '1.45 mPSI', dict(int=False, decimals=6, suffix='PSI', siPrefix=True)),
+    (-2500.3427, '$-2500.34', dict(int=False, format='${value:0.02f}')),
+])
+def test_SpinBox_formatting(value, expected_text, opts):
+    sb = pg.SpinBox(**opts)
+    sb.setValue(value)
+
+    assert sb.value() == value
+    assert pg.asUnicode(sb.text()) == expected_text
+
+
+@pytest.mark.parametrize("suffix", ["", "V"])
+def test_SpinBox_gui_set_value(suffix):
+    sb = pg.SpinBox(suffix=suffix)
+    sb.lineEdit().setText('0.1' + suffix)
+    sb.editingFinishedEvent()
+    assert sb.value() == 0.1
+    if suffix != '':
+        sb.lineEdit().setText('0.1 m' + suffix)
+        sb.editingFinishedEvent()
+        assert sb.value() == 0.1e-3


### PR DESCRIPTION
Follow-up from #1524. Changes here up for discussion.

Technically this could be seen as a breaking change for `SpinBox`. `siPrefix` now has no effect for `SpinBox` in "int mode". Previously, `SpinBox` in int mode forces the underlying value to be an int, but it shows you a scaled representation in accordance with the `siPrefix`.

The alternative here would be to just let the scaled formatting happen and the parameter value is still an integer. I could see that being somewhat confusing when you ask for an int parameter though. Maybe that's an argument for specifying the format string on the parameter side instead.