### PR TITLE
get test_ref_cycles to pass

### DIFF
--- a/pyqtgraph/graphicsItems/tests/test_GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_GraphicsItem.py
@@ -1,4 +1,3 @@
-import gc
 import weakref
 try:
     import faulthandler
@@ -16,7 +15,6 @@ def test_getViewWidget():
     view.addItem(item)
     assert item.getViewWidget() is view
     del view
-    gc.collect()
     assert vref() is None
     assert item.getViewWidget() is None
 
@@ -30,7 +28,6 @@ def test_getViewWidget_deleted():
     obj = pg.QtGui.QWidget()
     view.setParent(obj)
     del obj
-    gc.collect()
 
     assert not pg.Qt.isQObjectAlive(view)
     assert item.getViewWidget() is None

--- a/pyqtgraph/tests/test_ref_cycles.py
+++ b/pyqtgraph/tests/test_ref_cycles.py
@@ -6,7 +6,6 @@ Test for unwanted reference cycles
 import pyqtgraph as pg
 import numpy as np
 import weakref
-import pytest
 app = pg.mkQApp()
 
 def assert_alldead(refs):

--- a/pyqtgraph/tests/test_ref_cycles.py
+++ b/pyqtgraph/tests/test_ref_cycles.py
@@ -5,12 +5,10 @@ Test for unwanted reference cycles
 """
 import pyqtgraph as pg
 import numpy as np
-import gc, weakref
+import weakref
 import pytest
 app = pg.mkQApp()
 
-skipreason = ('This test is failing on pyside and pyside2 for an unknown reason.')
-                 
 def assert_alldead(refs):
     for ref in refs:
         assert ref() is None
@@ -37,7 +35,6 @@ def mkrefs(*objs):
     return [weakref.ref(obj) for obj in allObjs.values()]
 
 
-@pytest.mark.skipif(pg.Qt.QT_LIB in {'PySide'}, reason=skipreason)
 def test_PlotWidget():
     def mkobjs(*args, **kwds):
         w = pg.PlotWidget(*args, **kwds)
@@ -55,7 +52,6 @@ def test_PlotWidget():
     for i in range(5):
         assert_alldead(mkobjs())
     
-@pytest.mark.skipif(pg.Qt.QT_LIB in {'PySide', 'PySide2', 'PySide6'}, reason=skipreason)
 def test_ImageView():
     def mkobjs():
         iv = pg.ImageView()
@@ -63,12 +59,11 @@ def test_ImageView():
         iv.setImage(data)
         
         return mkrefs(iv, iv.imageItem, iv.view, iv.ui.histogram, data)
+
     for i in range(5):
-        gc.collect()
         assert_alldead(mkobjs())
 
 
-@pytest.mark.skipif(pg.Qt.QT_LIB in {'PySide'}, reason=skipreason)
 def test_GraphicsWindow():
     def mkobjs():
         w = pg.GraphicsWindow()

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -407,18 +407,3 @@ class GraphicsView(QtGui.QGraphicsView):
         
     def dragEnterEvent(self, ev):
         ev.ignore()  ## not sure why, but for some reason this class likes to consume drag events
-
-    def _del(self):
-        try:
-            if self.parentWidget() is None and self.isVisible():
-                msg = "Visible window deleted. To prevent this, store a reference to the window object."
-                try:
-                    warnings.warn(msg, RuntimeWarning, stacklevel=2)
-                except TypeError:
-                    # warnings module not available during interpreter shutdown
-                    pass
-        except RuntimeError:
-            pass
-
-if sys.version_info[0] == 3 and sys.version_info[1] >= 4:
-    GraphicsView.__del__ = GraphicsView._del

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -8,7 +8,6 @@ Distributed under MIT/X11 license. See license.txt for more information.
 from ..Qt import QtCore, QtGui, QtWidgets, QT_LIB
 from ..Point import Point
 import sys, os
-import warnings
 from .FileDialog import FileDialog
 from ..GraphicsScene import GraphicsScene
 import numpy as np


### PR DESCRIPTION
The workaround applied in 08c0de768bc205a720eeebf171cbe4919b346015 seems to be no longer needed for the current support matrix and was the cause for PySide2 and PySide6 failing one of the ref_cycles test.