### PR TITLE
use qWaitForWindowExposed instead of qWaitForWindowShown

### DIFF
--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -232,7 +232,6 @@ elif QT_LIB == PYQT6:
         QtOpenGLWidgets = FailedImport(err)
     try:
         from PyQt6 import QtTest
-        QtTest.QTest.qWaitForWindowShown = QtTest.QTest.qWaitForWindowExposed
     except ImportError as err:
         QtTest = FailedImport(err)
 
@@ -273,7 +272,6 @@ elif QT_LIB == PYSIDE6:
         QtOpenGLWidgets = FailedImport(err)
     try:
         from PySide6 import QtTest
-        QtTest.QTest.qWaitForWindowShown = QtTest.QTest.qWaitForWindowExposed
     except ImportError as err:
         QtTest = FailedImport(err)
 

--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -213,7 +213,6 @@ elif QT_LIB == PYQT5:
         QtSvg = FailedImport(err)
     try:
         from PyQt5 import QtTest
-        QtTest.QTest.qWaitForWindowShown = QtTest.QTest.qWaitForWindowExposed
     except ImportError as err:
         QtTest = FailedImport(err)
 
@@ -246,7 +245,6 @@ elif QT_LIB == PYSIDE2:
         QtSvg = FailedImport(err)
     try:
         from PySide2 import QtTest
-        QtTest.QTest.qWaitForWindowShown = QtTest.QTest.qWaitForWindowExposed
     except ImportError as err:
         QtTest = FailedImport(err)
 

--- a/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/tests/test_ViewBox.py
@@ -27,7 +27,7 @@ def init_viewbox():
     vb.setRange(xRange=[0, 10], yRange=[0, 10], padding=0)
     
     # required to make mapFromView work properly.
-    qtest.qWaitForWindowShown(win)
+    qtest.qWaitForWindowExposed(win)
     
     g = pg.GridItem()
     vb.addItem(g)

--- a/pyqtgraph/graphicsItems/tests/test_ImageItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_ImageItem.py
@@ -28,7 +28,7 @@ def test_ImageItem(transpose=False):
     data[3, :10] = dmax + 13
     img.setImage(data)
     
-    QtTest.QTest.qWaitForWindowShown(w)
+    QtTest.QTest.qWaitForWindowExposed(w)
     time.sleep(0.1)
     app.processEvents()
     assertImageApproved(w, 'imageitem/init', 'Init image item. View is auto-scaled, image axis 0 marked by 1 line, axis 1 is marked by 2 lines. Origin in bottom-left.')

--- a/pyqtgraph/graphicsItems/tests/test_InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/tests/test_InfiniteLine.py
@@ -16,7 +16,7 @@ def test_InfiniteLine():
     plt.resize(600, 600)
 
     # seemingly arbitrary requirements; might need longer wait time for some platforms..
-    QtTest.QTest.qWaitForWindowShown(plt)
+    QtTest.QTest.qWaitForWindowExposed(plt)
     QtTest.QTest.qWait(100)
 
     vline = plt.addLine(x=1)

--- a/pyqtgraph/graphicsItems/tests/test_NonUniformImage.py
+++ b/pyqtgraph/graphicsItems/tests/test_NonUniformImage.py
@@ -70,7 +70,7 @@ def test_NonUniformImage_lut():
     h = image.getHistogram()
     lut.plot.setData(*h)
 
-    QtTest.QTest.qWaitForWindowShown(window)
+    QtTest.QTest.qWaitForWindowExposed(window)
     QtTest.QTest.qWait(100)
 
     assertImageApproved(window, 'nonuniform_image/lut-3x3')
@@ -98,7 +98,7 @@ def test_NonUniformImage_colormap():
 
     viewbox.addItem(image)
 
-    QtTest.QTest.qWaitForWindowShown(window)
+    QtTest.QTest.qWaitForWindowExposed(window)
     QtTest.QTest.qWait(100)
 
     assertImageApproved(window, 'nonuniform_image/colormap-3x3')

--- a/pyqtgraph/graphicsItems/tests/test_ROI.py
+++ b/pyqtgraph/graphicsItems/tests/test_ROI.py
@@ -174,7 +174,7 @@ def test_PolyLineROI():
     plt.scene().minDragTime = 0  # let us simulate mouse drags very quickly.
 
     # seemingly arbitrary requirements; might need longer wait time for some platforms..
-    QtTest.QTest.qWaitForWindowShown(plt)
+    QtTest.QTest.qWaitForWindowExposed(plt)
     QtTest.QTest.qWait(100)
     
     for r, name in rois:

--- a/pyqtgraph/tests/ui_testing.py
+++ b/pyqtgraph/tests/ui_testing.py
@@ -10,8 +10,8 @@ def resizeWindow(win, w, h, timeout=2.0):
     """
     QtGui.QApplication.processEvents()
     # Sometimes the window size will switch multiple times before settling
-    # on its final size. Adding qWaitForWindowShown seems to help with this.
-    QtTest.QTest.qWaitForWindowShown(win)
+    # on its final size. Adding qWaitForWindowExposed seems to help with this.
+    QtTest.QTest.qWaitForWindowExposed(win)
     win.resize(w, h)
     start = time.time()
     while True:


### PR DESCRIPTION
qWaitForWindowShown has been obsolete since Qt 5.6

In view of the comments in #1533  and #1535, the shim is left behind for Qt5 but removed for Qt6.
However, can this particular shim really be considered part of pyqtgraph's public API given that it is only used in pyqtgraph's unit tests?
