### PR TITLE
Guard against key events when there's no time axis in ImageView

### DIFF
--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -429,7 +429,10 @@ class ImageView(QtGui.QWidget):
         self.setParent(None)
         
     def keyPressEvent(self, ev):
-        #print ev.key()
+        if not self.hasTimeAxis():
+            super().keyPressEvent(ev)
+            return
+
         if ev.key() == QtCore.Qt.Key_Space:
             if self.playRate == 0:
                 self.play()
@@ -454,6 +457,10 @@ class ImageView(QtGui.QWidget):
             super().keyPressEvent(ev)
 
     def keyReleaseEvent(self, ev):
+        if not self.hasTimeAxis():
+            super().keyReleaseEvent(ev)
+            return
+
         if ev.key() in [QtCore.Qt.Key_Space, QtCore.Qt.Key_Home, QtCore.Qt.Key_End]:
             ev.accept()
         elif ev.key() in self.noRepeatKeys:
@@ -756,7 +763,7 @@ class ImageView(QtGui.QWidget):
             
     def timeIndex(self, slider):
         ## Return the time and frame index indicated by a slider
-        if self.image is None:
+        if not self.hasTimeAxis():
             return (0,0)
         
         t = slider.value()


### PR DESCRIPTION
Fixes #1545. `ImageView` should be robust to GUI interaction when there's no data and/or no time axis.

This is kind of the minimal change to fix the issue. If `ImageView` is ever extended to take other keyboard shortcuts (either internally or in a user's subclass), there are still potentially codepaths that would throw an exception, such as `setCurrentIndex`. It may be worth peppering in a few more of these checks.