### PR TITLE
remove ProgressDialog from CI test

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -70,10 +70,6 @@ conditionalExamples = {
         False,
         reason="Test is being problematic on CI machines"
     ),
-    "ProgressDialog.py": exceptionCondition(
-        not(platform.system() == "Linux"),
-        reason="QXcbConnection: XCB error"
-    ),
     'GLVolumeItem.py': exceptionCondition(
         not(platform.system() == "Darwin" and
             tuple(map(int, platform.mac_ver()[0].split("."))) >= (10, 16) and 

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -108,7 +108,6 @@ others = dict([
     ('DateAxisItem_QtDesigner', 'DateAxisItem_QtDesigner.py'),
     ('GraphicsScene', 'GraphicsScene.py'),
     ('MouseSelection', 'MouseSelection.py'),
-    ('ProgressDialog', 'ProgressDialog.py'),
 ])
 
 
@@ -117,4 +116,9 @@ trivial = dict([
     ('SimplePlot', 'SimplePlot.py'),    # Plotting.py
     ('LogPlotTest', 'LogPlotTest.py'),  # Plotting.py
     ('ViewLimits', 'ViewLimits.py'),    # ViewBoxFeatures.py
+])
+
+# examples that are not suitable for CI testing
+skiptest = dict([
+    ('ProgressDialog', 'ProgressDialog.py'),    # modal dialog
 ])

--- a/pyqtgraph/exporters/SVGExporter.py
+++ b/pyqtgraph/exporters/SVGExporter.py
@@ -199,7 +199,7 @@ def _generateItemSvg(item, nodes=None, root=None, options={}):
         svg = QtSvg.QSvgGenerator()
         svg.setOutputDevice(buf)
         dpi = QtGui.QGuiApplication.primaryScreen().logicalDotsPerInchX()
-        svg.setResolution(dpi)
+        svg.setResolution(int(dpi))
 
         p = QtGui.QPainter()
         p.begin(svg)

--- a/pyqtgraph/tests/image_testing.py
+++ b/pyqtgraph/tests/image_testing.py
@@ -603,7 +603,7 @@ def runSubprocess(command, return_code=False, **kwargs):
     if p.returncode != 0:
         print(output)
         err_fun = sp.CalledProcessError.__init__
-        if 'output' in inspect.getargspec(err_fun).args:
+        if 'output' in inspect.getfullargspec(err_fun).args:
             raise sp.CalledProcessError(p.returncode, command, output)
         else:
             raise sp.CalledProcessError(p.returncode, command)


### PR DESCRIPTION
It is not suitable as it creates a modal dialog. On MacOS, this triggers the CI 30 sec timeout.