### PR TITLE
PyQt6 6.0.1 QEvent.Type needs to be explicitly deserialized

### DIFF
--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -250,8 +250,8 @@ class Renderer(GraphicsView):
 
     def deserialize_mouse_event(self, mouse_event):
         typ, pos, gpos, btn, btns, mods = mouse_event
+        typ = QtCore.QEvent.Type(typ)
         if QT_LIB != 'PyQt6':
-            typ = QtCore.QEvent.Type(typ)
             btn = QtCore.Qt.MouseButton(btn)
             btns = QtCore.Qt.MouseButtons(btns)
             mods = QtCore.Qt.KeyboardModifiers(mods)


### PR DESCRIPTION
in PyQt6 6.0.0, QEvent.Type was automatically pickled / unpickled.

in PyQt6 6.0.1, QEvent.Type is now pickled to be an int, so needs to be
recreated back explicitly (like the other bindings)

this change is backwards compatible with PyQt6 6.0.0