### PR TITLE
Avoid More Users of QTransform.inverted()

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -8,7 +8,6 @@ import weakref
 import operator
 from ..util.lru_cache import LRUCache
 
-
 class GraphicsItem(object):
     """
     **Bases:** :class:`object`
@@ -374,6 +373,42 @@ class GraphicsItem(object):
             return None
         vt = fn.invertQTransform(vt)
         return vt.mapRect(obj)
+
+    def mapRectFromParent(self, obj):
+    # QRectF QGraphicsItem::mapRectFromParent(const QRectF &rect) const
+    # {
+    #     // COMBINE
+    #     if (!d_ptr->transformData)
+    #         return rect.translated(-d_ptr->pos);
+    #     return d_ptr->transformToParent().inverted().mapRect(rect);
+    # }
+
+    # inline QTransform QGraphicsItemPrivate::transformToParent() const
+    # {
+    #     QTransform matrix;
+    #     combineTransformToParent(&matrix);
+    #     return matrix;
+    # }
+
+    # void QGraphicsItemPrivate::combineTransformToParent(QTransform *x, const QTransform *viewTransform) const
+    # {
+    #     // COMBINE
+    #     if (viewTransform && itemIsUntransformable()) {
+    #         *x = q_ptr->deviceTransform(*viewTransform);
+    #     } else {
+    #         if (transformData)
+    #             *x *= transformData->computedFullTransform();
+    #         if (!pos.isNull())
+    #             *x *= QTransform::fromTranslate(pos.x(), pos.y());
+    #     }
+    # }
+        vt = QtGui.QTransform()
+        if not self.pos().isNull():
+            vt *= QtGui.QTransform.fromTranslate(self.pos().x(), self.pos().y())
+
+        ivt = fn.invertQTransform(vt)
+        return  ivt.mapRect(obj)
+
 
     def pos(self):
         return Point(self._qtBaseClass.pos(self))

--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -409,6 +409,26 @@ class GraphicsItem(object):
         ivt = fn.invertQTransform(vt)
         return  ivt.mapRect(obj)
 
+    def mapRectFromScene(self, obj):
+        print("QGraphicsItem.mapRectFromScene called")
+        return super().mapRectFromScene(obj)
+
+    def mapFromParent(self, obj):
+        print("QGraphicsItem.mapFromParent called")
+        return super().mapFromParent(obj)
+    
+    def mapFromScene(self, point):
+    # QPointF QGraphicsItem::mapFromScene(const QPointF &point) const
+    # {
+    #     if (d_ptr->hasTranslateOnlySceneTransform())
+    #         return QPointF(point.x() - d_ptr->sceneTransform.dx(), point.y() - d_ptr->sceneTransform.dy());
+    #     return d_ptr->sceneTransform.inverted().map(point);
+    # }
+        # if self.hasTranslateOnlySceneTransform():
+        #     return QtCore.QPointF(point.x() - self.sceneTransform.dx(), point.y() - self.sceneTransform.dy())
+        st = self.sceneTransform()
+        ist = fn.invertQTransform(st)
+        return ist.map(point)
 
     def pos(self):
         return Point(self._qtBaseClass.pos(self))


### PR DESCRIPTION
This PR aims to implement `GraphicsItem` mapping methods that avoid the use of `QTransform.inverted()` and use `pyqtgraph.functions.invertQTransform`.

I have implemented `mapRectFromParent` as was requested in #1537 _but_ I make no claim to how well it actually works or it solving any issues.  Using the test data provided in #1556 (thanks @NilsNemitz ) the plot still disappears on me.

I put the relevant Qt methods commented out for someone to verify that I'm reading the C code correctly (this is likely _not_ the case).

I'm going to go about implementing some of the other mapping methods.  Those of you that have an interest in this feature, I encourage you to test out this PR.

Tagging @markotoplak and @NilsNemitz 