### PR TITLE
Fix Small Heights in ErrorBarItem

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -662,6 +662,35 @@ def affineSlice(data, shape, origin, vectors, axes, order=1, returnCoords=False,
         return output
 
 
+def interweaveArrays(*args):
+    """
+    Parameters
+    ----------
+
+    args : numpy.ndarray
+           series of 1D numpy arrays of the same length and dtype
+    
+    Returns
+    -------
+    numpy.ndarray
+        A numpy array with all the input numpy arrays interwoven
+
+    Examples
+    --------
+
+    >>> result = interweaveArrays(numpy.ndarray([0, 2, 4]), numpy.ndarray([1, 3, 5]))
+    >>> result
+    array([0, 1, 2, 3, 4, 5])
+    """
+
+    size = sum(x.size for x in args)
+    result = np.empty((size,), dtype=args[0].dtype)
+    n = len(args)
+    for index, array in enumerate(args):
+        result[index::n] = array
+    return result
+
+
 def interpolateArray(data, x, default=0.0, order=1):
     """
     N-dimensional interpolation similar to scipy.ndimage.map_coordinates.

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -67,9 +67,6 @@ class ErrorBarItem(GraphicsObject):
         
         beam = self.opts['beam']
         
-        ys = np.column_stack((y, y)).flatten()
-        xs = np.column_stack((x, x)).flatten()
-        
         height, top, bottom = self.opts['height'], self.opts['top'], self.opts['bottom']
         if height is not None or top is not None or bottom is not None:
             ## draw vertical error bars
@@ -86,10 +83,8 @@ class ErrorBarItem(GraphicsObject):
                 else:
                     y2 = y + top
 
-            y1_y2 = np.column_stack((y1, y2)).flatten()
-            y2s = np.column_stack((y2, y2)).flatten()
-            y1s = np.column_stack((y1, y1)).flatten()
-            
+            xs = fn.interweaveArrays(x, x)
+            y1_y2 = fn.interweaveArrays(y1, y2)
             verticalLines = fn.arrayToQPath(xs, y1_y2, connect="pairs")
             p.addPath(verticalLines)
 
@@ -97,12 +92,14 @@ class ErrorBarItem(GraphicsObject):
                 x1 = x - beam/2.
                 x2 = x + beam/2.
 
-                x1_x2 = np.column_stack((x2, x1)).flatten()
+                x1_x2 = fn.interweaveArrays(x1, x2)
                 if height is not None or top is not None:
+                    y2s = fn.interweaveArrays(y2, y2)
                     topEnds = fn.arrayToQPath(x1_x2, y2s, connect="pairs")
                     p.addPath(topEnds)
 
                 if height is not None or bottom is not None:
+                    y1s = fn.interweaveArrays(y1, y1)
                     bottomEnds = fn.arrayToQPath(x1_x2, y1s, connect="pairs")
                     p.addPath(bottomEnds)
 
@@ -122,23 +119,22 @@ class ErrorBarItem(GraphicsObject):
                 else:
                     x2 = x + right
             
-            x1_x2 = np.column_stack((x1, x2)).flatten()
-            x2s = np.column_stack((x2, x2)).flatten()
-            x1s = np.column_stack((x1, x1)).flatten()
-
+            ys = fn.interweaveArrays(y, y)
+            x1_x2 = fn.interweaveArrays(x1, x2)
             ends = fn.arrayToQPath(x1_x2, ys, connect='pairs')
             p.addPath(ends)
 
             if beam is not None and beam > 0:
                 y1 = y - beam/2.
                 y2 = y + beam/2.
-                y1_y2 = np.column_stack((y1, y2)).flatten()
-
+                y1_y2 = fn.interweaveArrays(y1, y2)
                 if width is not None or right is not None:
+                    x2s = fn.interweaveArrays(x2, x2)
                     rightEnds = fn.arrayToQPath(x2s, y1_y2, connect="pairs")
                     p.addPath(rightEnds)
 
                 if width is not None or left is not None:
+                    x1s = fn.interweaveArrays(x1, x1)
                     leftEnds = fn.arrayToQPath(x1s, y1_y2, connect="pairs")
                     p.addPath(leftEnds)
                     

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -90,31 +90,22 @@ class ErrorBarItem(GraphicsObject):
             y2s = np.column_stack((y2, y2)).flatten()
             y1s = np.column_stack((y1, y1)).flatten()
             
+            verticalLines = fn.arrayToQPath(xs, y1_y2, connect="pairs")
+            p.addPath(verticalLines)
 
-            partial = fn.arrayToQPath(xs, y1_y2, connect="pairs")
-            p.connectPath(partial)
-            # for i in range(len(x)):
-            #     p.moveTo(x[i], y1[i])
-            #     p.lineTo(x[i], y2[i])
-                
             if beam is not None and beam > 0:
                 x1 = x - beam/2.
                 x2 = x + beam/2.
 
-                x1_x2 = np.column_stack((x1, x2)).flatten()
+                x1_x2 = np.column_stack((x2, x1)).flatten()
                 if height is not None or top is not None:
-                    # partial = fn.arrayToQPath(x1_x2[:-1], y2s[:-1], connect="pairs")
-                    # p.connectPath(partial)
-                    for i in range(len(x)):
-                        p.moveTo(x1[i], y2[i])
-                        p.lineTo(x2[i], y2[i])
+                    tops = fn.arrayToQPath(x1_x2, y2s, connect="pairs")
+                    p.addPath(tops)
+
                 if height is not None or bottom is not None:
-                    # partial = fn.arrayToQPath(x1_x2, y1s, connect="pairs")
-                    # p.connectPath(partial)
-                    for i in range(len(x)):
-                        p.moveTo(x1[i], y1[i])
-                        p.lineTo(x2[i], y1[i])
-        
+                    partial = fn.arrayToQPath(x1_x2, y1s, connect="pairs")
+                    p.addPath(partial)
+
         width, right, left = self.opts['width'], self.opts['right'], self.opts['left']
         if width is not None or right is not None or left is not None:
             ## draw vertical error bars
@@ -136,11 +127,8 @@ class ErrorBarItem(GraphicsObject):
             x1s = np.column_stack((x1, x1)).flatten()
 
             ends = fn.arrayToQPath(x1_x2, ys, connect='pairs')
-            p.connectPath(ends)
-            # for i in range(len(x)):
-            #     p.moveTo(x1[i], y[i])
-            #     p.lineTo(x2[i], y[i])
-                
+            p.addPath(ends)
+
             if beam is not None and beam > 0:
                 y1 = y - beam/2.
                 y2 = y + beam/2.
@@ -148,16 +136,11 @@ class ErrorBarItem(GraphicsObject):
 
                 if width is not None or right is not None:
                     partial = fn.arrayToQPath(x2s, y1_y2, connect="pairs")
-                    p.connectPath(partial)
-                    # for i in range(len(x)):
-                        # p.moveTo(x2[i], y1[i])
-                        # p.lineTo(x2[i], y2[i])
+                    p.addPath(partial)
+
                 if width is not None or left is not None:
                     partial = fn.arrayToQPath(x1s, y1_y2, connect="pairs")
-                    p.connectPath(partial)
-                    # for i in range(len(x)):
-                    #     p.moveTo(x1[i], y1[i])
-                    #     p.lineTo(x1[i], y2[i])
+                    p.addPath(partial)
                     
         self.path = p
         self.prepareGeometryChange()

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -99,12 +99,12 @@ class ErrorBarItem(GraphicsObject):
 
                 x1_x2 = np.column_stack((x2, x1)).flatten()
                 if height is not None or top is not None:
-                    tops = fn.arrayToQPath(x1_x2, y2s, connect="pairs")
-                    p.addPath(tops)
+                    topEnds = fn.arrayToQPath(x1_x2, y2s, connect="pairs")
+                    p.addPath(topEnds)
 
                 if height is not None or bottom is not None:
-                    partial = fn.arrayToQPath(x1_x2, y1s, connect="pairs")
-                    p.addPath(partial)
+                    bottomEnds = fn.arrayToQPath(x1_x2, y1s, connect="pairs")
+                    p.addPath(bottomEnds)
 
         width, right, left = self.opts['width'], self.opts['right'], self.opts['left']
         if width is not None or right is not None or left is not None:
@@ -135,12 +135,12 @@ class ErrorBarItem(GraphicsObject):
                 y1_y2 = np.column_stack((y1, y2)).flatten()
 
                 if width is not None or right is not None:
-                    partial = fn.arrayToQPath(x2s, y1_y2, connect="pairs")
-                    p.addPath(partial)
+                    rightEnds = fn.arrayToQPath(x2s, y1_y2, connect="pairs")
+                    p.addPath(rightEnds)
 
                 if width is not None or left is not None:
-                    partial = fn.arrayToQPath(x1s, y1_y2, connect="pairs")
-                    p.addPath(partial)
+                    leftEnds = fn.arrayToQPath(x1s, y1_y2, connect="pairs")
+                    p.addPath(leftEnds)
                     
         self.path = p
         self.prepareGeometryChange()

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -2,6 +2,7 @@ from ..Qt import QtGui, QtCore
 from .GraphicsObject import GraphicsObject
 from .. import getConfigOption
 from .. import functions as fn
+import numpy as np
 
 __all__ = ['ErrorBarItem']
 
@@ -66,6 +67,8 @@ class ErrorBarItem(GraphicsObject):
         
         beam = self.opts['beam']
         
+        ys = np.column_stack((y, y)).flatten()
+        xs = np.column_stack((x, x)).flatten()
         
         height, top, bottom = self.opts['height'], self.opts['top'], self.opts['bottom']
         if height is not None or top is not None or bottom is not None:
@@ -82,19 +85,32 @@ class ErrorBarItem(GraphicsObject):
                     y2 = y
                 else:
                     y2 = y + top
+
+            y1_y2 = np.column_stack((y1, y2)).flatten()
+            y2s = np.column_stack((y2, y2)).flatten()
+            y1s = np.column_stack((y1, y1)).flatten()
             
-            for i in range(len(x)):
-                p.moveTo(x[i], y1[i])
-                p.lineTo(x[i], y2[i])
+
+            partial = fn.arrayToQPath(xs, y1_y2, connect="pairs")
+            p.connectPath(partial)
+            # for i in range(len(x)):
+            #     p.moveTo(x[i], y1[i])
+            #     p.lineTo(x[i], y2[i])
                 
             if beam is not None and beam > 0:
                 x1 = x - beam/2.
                 x2 = x + beam/2.
+
+                x1_x2 = np.column_stack((x1, x2)).flatten()
                 if height is not None or top is not None:
+                    # partial = fn.arrayToQPath(x1_x2[:-1], y2s[:-1], connect="pairs")
+                    # p.connectPath(partial)
                     for i in range(len(x)):
                         p.moveTo(x1[i], y2[i])
                         p.lineTo(x2[i], y2[i])
                 if height is not None or bottom is not None:
+                    # partial = fn.arrayToQPath(x1_x2, y1s, connect="pairs")
+                    # p.connectPath(partial)
                     for i in range(len(x)):
                         p.moveTo(x1[i], y1[i])
                         p.lineTo(x2[i], y1[i])
@@ -115,21 +131,33 @@ class ErrorBarItem(GraphicsObject):
                 else:
                     x2 = x + right
             
-            for i in range(len(x)):
-                p.moveTo(x1[i], y[i])
-                p.lineTo(x2[i], y[i])
+            x1_x2 = np.column_stack((x1, x2)).flatten()
+            x2s = np.column_stack((x2, x2)).flatten()
+            x1s = np.column_stack((x1, x1)).flatten()
+
+            ends = fn.arrayToQPath(x1_x2, ys, connect='pairs')
+            p.connectPath(ends)
+            # for i in range(len(x)):
+            #     p.moveTo(x1[i], y[i])
+            #     p.lineTo(x2[i], y[i])
                 
             if beam is not None and beam > 0:
                 y1 = y - beam/2.
                 y2 = y + beam/2.
+                y1_y2 = np.column_stack((y1, y2)).flatten()
+
                 if width is not None or right is not None:
-                    for i in range(len(x)):
-                        p.moveTo(x2[i], y1[i])
-                        p.lineTo(x2[i], y2[i])
+                    partial = fn.arrayToQPath(x2s, y1_y2, connect="pairs")
+                    p.connectPath(partial)
+                    # for i in range(len(x)):
+                        # p.moveTo(x2[i], y1[i])
+                        # p.lineTo(x2[i], y2[i])
                 if width is not None or left is not None:
-                    for i in range(len(x)):
-                        p.moveTo(x1[i], y1[i])
-                        p.lineTo(x1[i], y2[i])
+                    partial = fn.arrayToQPath(x1s, y1_y2, connect="pairs")
+                    p.connectPath(partial)
+                    # for i in range(len(x)):
+                    #     p.moveTo(x1[i], y1[i])
+                    #     p.lineTo(x1[i], y2[i])
                     
         self.path = p
         self.prepareGeometryChange()


### PR DESCRIPTION
Fixes #1149

I'm implementing a fix that @ixjlyons observed seemed to work when displaying values smaller than 1e-12; he noticed that when using `functions.arrayToQPath` instead of `QPainterPath.moveTo` and `QPainterPath.lineTo` the problem seemed to go away.  

So somehow this gets us around https://bugreports.qt.io/browse/QTBUG-75630

Leaving in draft pull request form for right now as there are still some `QPainterPath.moveTo` / `QPainterPath.lineTo` calls in the paint method that I want to do away with.