### PR TITLE
restrict PyQt6 QEvent.type() monkey patching to 6.0.0

### DIFF
--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -387,10 +387,7 @@ if QT_LIB == PYQT6:
 
     # PyQt6 6.0.0 has a bug where it can't handle certain Type values returned
     # by the Qt library.
-    try:
-        # 213 is a known failing value
-        QtCore.QEvent.Type(213)
-    except ValueError:
+    if QtCore.PYQT_VERSION == 0x60000:
         def new_method(self, old_method=QtCore.QEvent.type):
             try:
                 typ = old_method(self)

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -113,12 +113,6 @@ class SpinBox(QtGui.QAbstractSpinBox):
         
         self.editingFinished.connect(self.editingFinishedEvent)
 
-    def event(self, ev):
-        ret = super().event(ev)
-        if ev.type() == QtCore.QEvent.KeyPress and ev.key() == QtCore.Qt.Key_Return:
-            ret = True  ## For some reason, spinbox pretends to ignore return key press
-        return ret
-        
     def setOpts(self, **opts):
         """Set options affecting the behavior of the SpinBox.
         


### PR DESCRIPTION
The bug that this workaround was for has been fixed in PyQt6 6.0.1.

However our feature test for the bug was faulty and triggers positive
for PyQt6 6.0.1. In other words, we would be needlessly monkey patching
where it wasn't needed.

Moving forward, do we maintain workarounds for older patch level versions of PyQt6? We already have the current workarounds, so it's a matter of restricting it to particular versions. However, if new issues surface with 6.0.0, wouldn't we just tell users to use the newer version rather than implement another workaround?