### PR TITLE
Cache scatter-plot items by hashable properties

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -224,7 +224,7 @@ class SymbolAtlas(object):
                     squareness=1.0 if n == 0 else 2 * w * h / (w**2 + h**2))
 
     def _keys(self, styles):
-        return [(id(symbol), size, id(pen), id(brush)) for symbol, size, pen, brush in styles]
+        return [(symbol, size, (pen.style(), pen.capStyle(), pen.joinStyle()), (brush.color().rgba(), brush.style())) for symbol, size, pen, brush in styles]
 
     def _itemData(self, keys):
         for key in keys:

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -224,7 +224,14 @@ class SymbolAtlas(object):
                     squareness=1.0 if n == 0 else 2 * w * h / (w**2 + h**2))
 
     def _keys(self, styles):
-        return [(symbol, size, (pen.style(), pen.capStyle(), pen.joinStyle()), (brush.color().rgba(), brush.style())) for symbol, size, pen, brush in styles]
+        return [
+            (
+                symbol if isinstance(symbol, (str, int)) else f"{symbol.boundingRect()} + {symbol.elementCount()} elements",
+                size,
+                (pen.style(), pen.capStyle(), pen.joinStyle()),
+                (brush.color().rgba(), brush.style())
+            ) for symbol, size, pen, brush in styles
+        ]
 
     def _itemData(self, keys):
         for key in keys:


### PR DESCRIPTION
This fixes an issue that the great folks at ephyviewer encountered:  https://github.com/NeuralEnsemble/ephyviewer/issues/132

In an effort to speed up the `ScatterPlotItem`, we attempted to cache things like the Pen, Brush, and the Symbol.  Turns out, caching by `id(object)` wasn't the greatest, as those id numbers can be reused; and you get an interesting effect that was documented in the linked issue.

I want to thank @jpgill86 for helping me reproduce the issue and for @lidstrom83 for pointing me in the right direction for where to look.