### PR TITLE
remove app.deleteLater() from tests

### DIFF
--- a/pyqtgraph/widgets/tests/test_graphics_view.py
+++ b/pyqtgraph/widgets/tests/test_graphics_view.py
@@ -86,6 +86,3 @@ def test_basics_graphics_view():
     assert view.currentItem is None
     assert view.sceneObj is None
     assert view.closed is True
-
-    del view
-    app.deleteLater()


### PR DESCRIPTION
Multiple tests are executed by pytest with the same Python process. Deleting QApplication is likely to cause a crash.

Refer to comments in #1396