### PR TITLE
Flowchart documentation fix

### DIFF
--- a/doc/source/flowchart/index.rst
+++ b/doc/source/flowchart/index.rst
@@ -40,7 +40,7 @@ In the example above, each terminal is defined by a dictionary of options which 
 
 Once the flowchart is created, add its control widget to your application::
     
-    ctrl = fc.ctrlWidget()
+    ctrl = fc.widget()
     myLayout.addWidget(ctrl)  ## read Qt docs on QWidget and layouts for more information
 
 The control widget provides several features:


### PR DESCRIPTION
the widget() method should be used to display the flowchart in a window rather than the ctrlWidget().