### PR TITLE
Handle case of 0-d array in infinite line setPos

### DIFF
--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -225,7 +225,7 @@ class InfiniteLine(GraphicsObject):
 
     def setPos(self, pos):
 
-        if type(pos) in [list, tuple, np.ndarray]:
+        if isinstance(pos, (list, tuple, np.ndarray)) and not np.ndim(pos) == 0:
             newPos = list(pos)
         elif isinstance(pos, QtCore.QPointF):
             newPos = [pos.x(), pos.y()]


### PR DESCRIPTION
Fixes a small regression found in my app introduced by #1310.

Basically a 0-d array should be treated as a scalar, it works downstream of this check, but since the check added ndarray it got caught trying to make a list, which is not allowed for 0-d.

np.ndim works for any array like, which will be what is passed, since the isinstance check runs first. (and indeed even if it was run on a QPointF instance, it just returns 0).

this will also make it work with subclasses, which the direct type check will not