### PR TITLE
Change image tests to not rely on non-const QImage

### DIFF
--- a/pyqtgraph/tests/image_testing.py
+++ b/pyqtgraph/tests/image_testing.py
@@ -137,12 +137,14 @@ def assertImageApproved(image, standardFile, message=None, **kwargs):
         QtGui.QApplication.processEvents()
 
         graphstate = scenegraphState(w, standardFile)
-        image = np.zeros((w.height(), w.width(), 4), dtype=np.ubyte)
-        qimg = fn.makeQImage(image, alpha=True, copy=False, transpose=False)
+        qimg = QtGui.QImage(w.size(), QtGui.QImage.Format.Format_ARGB32)
+        qimg.fill(QtCore.Qt.GlobalColor.transparent)
         painter = QtGui.QPainter(qimg)
         w.render(painter)
         painter.end()
         
+        image = fn.imageToArray(qimg, copy=False, transpose=False)
+
         # transpose BGRA to RGBA
         image = image[..., [2, 1, 0, 3]]
 


### PR DESCRIPTION
During an attempt at refactoring in #1223, it was found that PyQt bindings would fail the CI image comparison tests.
The CI image comparison tests also failed when PyQt6 was updated to 6.0.1, as reported in #1550.

Note that the failures were not due to the images being different but due to ```image_testing.py::assertImageApproved``` relying on QImage being non-const. This PR removes this unnecessary assumption.

The changes to ```functions.py``` is an unrelated change to allow images larger than 2GB for PyQt5 5.15.

