### PR TITLE
Add deprecation warnings, Use non-deprecated upstream methods

### DIFF
--- a/examples/VideoSpeedTest.py
+++ b/examples/VideoSpeedTest.py
@@ -149,7 +149,7 @@ def mkData():
                 scale = 1024
                 mx = 2**16
             elif cacheKey[0] == 'float':
-                dt = xp.float
+                dt = xp.float32
                 loc = 1.0
                 scale = 0.1
                 mx = 1.0

--- a/examples/relativity/relativity.py
+++ b/examples/relativity/relativity.py
@@ -131,7 +131,7 @@ class RelativityGUI(QtGui.QWidget):
     def setAnimation(self, a):
         if a:
             self.lastAnimTime = pg.ptime.time()
-            self.animTimer.start(self.animDt*1000)
+            self.animTimer.start(int(self.animDt*1000))
         else:
             self.animTimer.stop()
             
@@ -654,15 +654,6 @@ class Animation(pg.ItemGroup):
             item = ClockItem(cl)
             self.addItem(item)
             self.items[name] = item
-            
-        #self.timer = timer
-        #self.timer.timeout.connect(self.step)
-        
-    #def run(self, run):
-        #if not run:
-            #self.timer.stop()
-        #else:
-            #self.timer.start(self.dt)
         
     def restart(self):
         for cl in self.items.values():

--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -290,6 +290,59 @@ else:
 if QT_LIB in [PYQT5, PYQT6, PYSIDE2, PYSIDE6]:
     # We're using Qt5 which has a different structure so we're going to use a shim to
     # recreate the Qt4 structure
+
+    if QT_LIB in [PYQT5, PYSIDE2]:
+        __QGraphicsItem_scale = QtWidgets.QGraphicsItem.scale	
+
+        def scale(self, *args):
+            warnings.warn(
+                "Deprecated Qt API, will be removed in 0.13.0.",
+                DeprecationWarning, stacklevel=2
+            )
+            if args:	
+                sx, sy = args	
+                tr = self.transform()	
+                tr.scale(sx, sy)	
+                self.setTransform(tr)	
+            else:	
+                return __QGraphicsItem_scale(self)
+        QtWidgets.QGraphicsItem.scale = scale	
+
+        def rotate(self, angle):
+            warnings.warn(
+                "Deprecated Qt API, will be removed in 0.13.0.",
+                DeprecationWarning, stacklevel=2
+            )
+            tr = self.transform()	
+            tr.rotate(angle)	
+            self.setTransform(tr)	
+        QtWidgets.QGraphicsItem.rotate = rotate	
+
+        def translate(self, dx, dy):
+            warnings.warn(
+                "Deprecated Qt API, will be removed in 0.13.0.",
+                DeprecationWarning, stacklevel=2
+            )
+            tr = self.transform()	
+            tr.translate(dx, dy)	
+            self.setTransform(tr)	
+        QtWidgets.QGraphicsItem.translate = translate	
+
+        def setMargin(self, i):
+            warnings.warn(
+                "Deprecated Qt API, will be removed in 0.13.0.",
+                DeprecationWarning, stacklevel=2
+            )
+            self.setContentsMargins(i, i, i, i)	
+        QtWidgets.QGridLayout.setMargin = setMargin	
+
+        def setResizeMode(self, *args):
+            warnings.warn(
+                "Deprecated Qt API, will be removed in 0.13.0.",
+                DeprecationWarning, stacklevel=2
+            )
+            self.setSectionResizeMode(*args)
+        QtWidgets.QHeaderView.setResizeMode = setResizeMode	
     
     # Import all QtWidgets objects into QtGui
     for o in dir(QtWidgets):

--- a/pyqtgraph/SRTTransform.py
+++ b/pyqtgraph/SRTTransform.py
@@ -2,7 +2,7 @@
 from .Qt import QtCore, QtGui
 from .Point import Point
 import numpy as np
-
+import warnings
 
 class SRTTransform(QtGui.QTransform):
     """Transform that can always be represented as a combination of 3 matrices: scale * rotate * translate
@@ -35,7 +35,11 @@ class SRTTransform(QtGui.QTransform):
         return self._state['scale']
         
     def getAngle(self):  
-        ## deprecated; for backward compatibility
+        warnings.warn(
+            'SRTTransform.getAngle() is deprecated, use SRTTransform.getRotation() instead'
+            'will be removed in 0.13',
+            DeprecationWarning, stacklevel=2
+        )
         return self.getRotation()
         
     def getRotation(self):

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -384,29 +384,18 @@ def exit():
     os._exit(0)
     
 
-
 ## Convenience functions for command-line use
-
 plots = []
 images = []
 QAPP = None
 
 def plot(*args, **kargs):
     """
-    Create and return a :class:`PlotWindow <pyqtgraph.PlotWindow>` 
-    (this is just a window with :class:`PlotWidget <pyqtgraph.PlotWidget>` inside), plot data in it.
+    Create and return a :class:`PlotWidget <pyqtgraph.PlotWinPlotWidgetdow>` 
     Accepts a *title* argument to set the title of the window.
     All other arguments are used to plot data. (see :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>`)
     """
-    mkQApp()
-    #if 'title' in kargs:
-        #w = PlotWindow(title=kargs['title'])
-        #del kargs['title']
-    #else:
-        #w = PlotWindow()
-    #if len(args)+len(kargs) > 0:
-        #w.plot(*args, **kargs)
-        
+    mkQApp()      
     pwArgList = ['title', 'labels', 'name', 'left', 'right', 'top', 'bottom', 'background']
     pwArgs = {}
     dataArgs = {}
@@ -415,44 +404,32 @@ def plot(*args, **kargs):
             pwArgs[k] = kargs[k]
         else:
             dataArgs[k] = kargs[k]
-        
-    w = PlotWindow(**pwArgs)
-    w.sigClosed.connect(_plotWindowClosed)
+    windowTitle = pwArgs.pop("title", "PlotWidget")
+    w = PlotWidget(**pwArgs)
+    w.setWindowTitle(windowTitle)
     if len(args) > 0 or len(dataArgs) > 0:
         w.plot(*args, **dataArgs)
     plots.append(w)
     w.show()
     return w
 
-def _plotWindowClosed(w):
-    w.close()
-    try:
-        plots.remove(w)
-    except ValueError:
-        pass
-
 def image(*args, **kargs):
     """
-    Create and return an :class:`ImageWindow <pyqtgraph.ImageWindow>` 
-    (this is just a window with :class:`ImageView <pyqtgraph.ImageView>` widget inside), show image data inside.
+    Create and return an :class:`ImageView <pyqtgraph.ImageView>` 
     Will show 2D or 3D image data.
     Accepts a *title* argument to set the title of the window.
     All other arguments are used to show data. (see :func:`ImageView.setImage() <pyqtgraph.ImageView.setImage>`)
     """
     mkQApp()
-    w = ImageWindow(*args, **kargs)
-    w.sigClosed.connect(_imageWindowClosed)
+    w = ImageView()
+    windowTitle = kargs.pop("title", "ImageView")
+    w.setWindowTitle(windowTitle)
+    w.setImage(*args, **kargs)
     images.append(w)
     w.show()
     return w
 show = image  ## for backward compatibility
 
-def _imageWindowClosed(w):
-    w.close()
-    try:
-        images.remove(w)
-    except ValueError:
-        pass
 
 def dbg(*args, **kwds):
     """

--- a/pyqtgraph/exporters/tests/test_svg.py
+++ b/pyqtgraph/exporters/tests/test_svg.py
@@ -14,7 +14,7 @@ def test_plotscene():
     tempfilename = tempfile.NamedTemporaryFile(suffix='.svg').name
     print("using %s as a temporary file" % tempfilename)
     pg.setConfigOption('foreground', (0,0,0))
-    w = pg.GraphicsWindow()
+    w = pg.GraphicsLayoutWidget()
     w.show()        
     p1 = w.addPlot()
     p2 = w.addPlot()

--- a/pyqtgraph/flowchart/Node.py
+++ b/pyqtgraph/flowchart/Node.py
@@ -6,7 +6,7 @@ from .Terminal import *
 from ..pgcollections import OrderedDict
 from ..debug import *
 import numpy as np
-
+import warnings
 
 translate = QtCore.QCoreApplication.translate
 
@@ -191,6 +191,12 @@ class Node(QtCore.QObject):
     ## this is just bad planning. Causes too many bugs.
     def __getattr__(self, attr):
         """Return the terminal with the given name"""
+        warnings.warn(
+            "Use of note.terminalName is deprecated, use node['terminalName'] instead"
+            "Will be removed from 0.13.0",
+            DeprecationWarning, stacklevel=2
+        )
+        
         if attr not in self.terminals:
             raise AttributeError(attr)
         else:

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -262,7 +262,7 @@ def mkColor(*args):
                 a = int(c[6:8], 16)
         elif isinstance(args[0], QtGui.QColor):
             return QtGui.QColor(args[0])
-        elif isinstance(args[0], float):
+        elif np.issubdtype(type(args[0]), np.floating):
             r = g = b = int(args[0] * 255)
             a = 255
         elif hasattr(args[0], '__len__'):
@@ -275,7 +275,7 @@ def mkColor(*args):
                 return intColor(*args[0])
             else:
                 raise TypeError(err)
-        elif type(args[0]) == int:
+        elif np.issubdtype(type(args[0]), np.integer):
             return intColor(args[0])
         else:
             raise TypeError(err)

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1129,7 +1129,7 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False, output=None
             raise Exception('levels argument is required for float input types')
     if not isinstance(levels, xp.ndarray):
         levels = xp.array(levels)
-    levels = levels.astype(xp.float)
+    levels = levels.astype(xp.float32)
     if levels.ndim == 1:
         if levels.shape[0] != 2:
             raise Exception('levels argument must have length 2')

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -9,6 +9,7 @@ import weakref
 from .. import functions as fn
 from .. import getConfigOption
 from .GraphicsWidget import GraphicsWidget
+import warnings
 
 __all__ = ['AxisItem']
 class AxisItem(GraphicsWidget):
@@ -459,6 +460,12 @@ class AxisItem(GraphicsWidget):
         """
         # Deprecated usage, kept for backward compatibility
         if scale is None:
+            warnings.warn(
+                'AxisItem.setScale(None) is deprecated, will be removed in 0.13.0'
+                'instead use AxisItem.enableAutoSIPrefix(bool) to enable/disable'
+                'SI prefix scaling',                
+                DeprecationWarning, stacklevel=2
+            )
             scale = 1.0
             self.enableAutoSIPrefix(True)
 

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -108,7 +108,7 @@ class TickSpec:
     def skipFactor(self, minSpc):
         if self.autoSkip is None or minSpc < self.spacing:
             return 1
-        factors = np.array(self.autoSkip, dtype=np.float)
+        factors = np.array(self.autoSkip, dtype=np.float64)
         while True:
             for f in factors:
                 spc = self.spacing * f

--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -39,7 +39,7 @@ class GraphicsItem(object):
         self._cachedView = None
         if register is not None and register:
             warnings.warn(
-                "'register' argument is deprecated and does nothing",
+                "'register' argument is deprecated and does nothing, will be removed in 0.13",
                 DeprecationWarning, stacklevel=2
             )
 

--- a/pyqtgraph/graphicsItems/GridItem.py
+++ b/pyqtgraph/graphicsItems/GridItem.py
@@ -171,10 +171,8 @@ class GridItem(UIGraphicsItem):
                     linePen.setCosmetic(False)
                     if ax == 0:
                         linePen.setWidthF(self.pixelWidth())
-                        #print "ax 0 height", self.pixelHeight()
                     else:
                         linePen.setWidthF(self.pixelHeight())
-                        #print "ax 1 width", self.pixelWidth()
                     p.setPen(linePen)
                     p1 = np.array([0.,0.])
                     p2 = np.array([0.,0.])
@@ -195,7 +193,6 @@ class GridItem(UIGraphicsItem):
                             y = p1[1] + unit[1]
                         texts.append((QtCore.QPointF(x, y), "%g"%p1[ax]))
         tr = self.deviceTransform()
-        #tr.scale(1.5, 1.5)
         p.setWorldTransform(fn.invertQTransform(tr))
 
         if textPen is not None and len(texts) > 0:

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -9,6 +9,7 @@ from .ScatterPlotItem import ScatterPlotItem
 from .. import functions as fn
 from .. import debug as debug
 from .. import getConfigOption
+import warnings
 
 
 class PlotDataItem(GraphicsObject):
@@ -438,10 +439,20 @@ class PlotDataItem(GraphicsObject):
         """
         #self.clear()
         if kargs.get("stepMode", None) is True:
-            import warnings
             warnings.warn(
                 'stepMode=True is deprecated, use stepMode="center" instead',
                 DeprecationWarning, stacklevel=3
+            )
+        if 'decimate' in kargs.keys():
+            warnings.warn(
+                'decimate kwarg has been deprecated, it has no effect',
+                DeprecationWarning, stacklevel=2
+            )
+        
+        if 'identical' in kargs.keys():
+            warnings.warn(
+                'identical kwarg has been deprecated, it has no effect',
+                DeprecationWarning, stacklevel=2
             )
         profiler = debug.Profiler()
         y = None

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -510,7 +510,11 @@ class PlotItem(GraphicsWidget):
         """
         Enable auto-scaling. The plot will continuously scale to fit the boundaries of its data.
         """
-        print("Warning: enableAutoScale is deprecated. Use enableAutoRange(axis, enable) instead.")
+        warnings.warn(
+            'PlotItem.enableAutoScale is deprecated, and will be removed in 0.13'
+            'Use PlotItem.enableAutoRange(axis, enable) instead',
+            DeprecationWarning, stacklevel=2
+        )
         self.vb.enableAutoRange(self.vb.XYAxes)
 
     def addItem(self, item, *args, **kargs):
@@ -567,7 +571,11 @@ class PlotItem(GraphicsWidget):
             self.legend.addItem(item, name=name)            
 
     def addDataItem(self, item, *args):
-        print("PlotItem.addDataItem is deprecated. Use addItem instead.")
+        warnings.warn(
+            'PlotItem.addDataItem is deprecated and will be removed in 0.13. '
+            'Use PlotItem.addItem instead',
+            DeprecationWarning, stacklevel=2
+        )    
         self.addItem(item, *args)
         
     def listDataItems(self):
@@ -576,7 +584,12 @@ class PlotItem(GraphicsWidget):
         return self.dataItems[:]
         
     def addCurve(self, c, params=None):
-        print("PlotItem.addCurve is deprecated. Use addItem instead.")
+        warnings.warn(
+            'PlotItem.addCurve is deprecated and will be removed in 0.13. '
+            'Use PlotItem.addItem instead.',
+            DeprecationWarning, stacklevel=2
+        )    
+
         self.addItem(c, params)
 
     def addLine(self, x=None, y=None, z=None, **kwds):
@@ -1163,7 +1176,11 @@ class PlotItem(GraphicsWidget):
         self.showAxis(axis, False)
             
     def showScale(self, *args, **kargs):
-        print("Deprecated. use showAxis() instead")
+        warnings.warn(
+            'PlotItem.showScale has been deprecated and will be removed in 0.13. '
+            'Use PlotItem.showAxis() instead',
+            DeprecationWarning, stacklevel=2
+        )    
         return self.showAxis(*args, **kargs)
             
     def hideButtons(self):

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -22,6 +22,7 @@ from .. import functions as fn
 from .GraphicsObject import GraphicsObject
 from .UIGraphicsItem import UIGraphicsItem
 from .. import getConfigOption
+import warnings
 
 translate = QtCore.QCoreApplication.translate
 
@@ -1890,16 +1891,20 @@ class CircleROI(EllipseROI):
 
 
 class PolygonROI(ROI):
-    ## deprecated. Use PloyLineROI instead.
-    
+   
     def __init__(self, positions, pos=None, **args):
+        warnings.warn(
+            'PolygonROI has been deprecated, will be removed in 0.13'
+            'use PolyLineROI instead',
+            DeprecationWarning, stacklevel=2
+        )
+
         if pos is None:
             pos = [0,0]
         ROI.__init__(self, pos, [1,1], **args)
         for p in positions:
             self.addFreeHandle(p)
         self.setZValue(1000)
-        print("Warning: PolygonROI is deprecated. Use PolyLineROI instead.")
             
     def listPoints(self):
         return [p['item'].pos() for p in self.handles]

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -119,7 +119,8 @@ def renderSymbol(symbol, size, pen, brush, device=None):
 
 def makeSymbolPixmap(size, pen, brush, symbol):
     warnings.warn(
-        "This is an internal function that is no longer being used.",
+        "This is an internal function that is no longer being used. "
+        "Will be removed in 0.13",
         DeprecationWarning, stacklevel=2
     )
     img = renderSymbol(symbol, size, pen, brush)
@@ -462,7 +463,6 @@ class ScatterPlotItem(GraphicsObject):
         *hoverSize*            A single size to use for hovered spots. Set to -1 to keep size unchanged. Default is -1.
         *hoverPen*             A single pen to use for hovered spots. Set to None to keep pen unchanged. Default is None.
         *hoverBrush*           A single brush to use for hovered spots. Set to None to keep brush unchanged. Default is None.
-        *identical*            *Deprecated*. This functionality is handled automatically now.
         *antialias*            Whether to draw symbols with antialiasing. Note that if pxMode is True, symbols are
                                always rendered with antialiasing (since the rendered symbols can be cached, this
                                incurs very little performance cost)
@@ -474,7 +474,8 @@ class ScatterPlotItem(GraphicsObject):
         """
         if 'identical' in kargs:
             warnings.warn(
-                "The *identical* functionality is handled automatically now.",
+                "The *identical* functionality is handled automatically now. "
+                "Will be removed in 0.13.",
                 DeprecationWarning, stacklevel=2
             )
         oldData = self.data  ## this causes cached pixmaps to be preserved while new data is registered.
@@ -614,7 +615,8 @@ class ScatterPlotItem(GraphicsObject):
 
     def setPoints(self, *args, **kargs):
         warnings.warn(
-            "Use setData instead.",
+            "ScatterPlotItem.setPoints is deprecated, use ScatterPlotItem.setData "
+            "instead.  Will be removed in 0.13",
             DeprecationWarning, stacklevel=2
         )
         return self.setData(*args, **kargs)
@@ -863,7 +865,8 @@ class ScatterPlotItem(GraphicsObject):
 
     def getSpotOpts(self, recs, scale=1.0):
         warnings.warn(
-            "This is an internal method that is no longer being used.",
+            "This is an internal method that is no longer being used.  Will be "
+            "removed in 0.13",
             DeprecationWarning, stacklevel=2
         )
         if recs.ndim == 0:
@@ -892,7 +895,8 @@ class ScatterPlotItem(GraphicsObject):
 
     def measureSpotSizes(self, dataSet):
         warnings.warn(
-            "This is an internal method that is no longer being used.",
+            "This is an internal method that is no longer being used. "
+            "Will be removed in 0.13.",
             DeprecationWarning, stacklevel=2
         )
         for size, pen in zip(*self._style(['size', 'pen'], data=dataSet)):
@@ -998,7 +1002,8 @@ class ScatterPlotItem(GraphicsObject):
 
     def mapPointsToDevice(self, pts):
         warnings.warn(
-            "This is an internal method that is no longer being used.",
+            "This is an internal method that is no longer being used. "
+            "Will be removed in 0.13",
             DeprecationWarning, stacklevel=2
         )
         # Map point locations to device
@@ -1014,7 +1019,8 @@ class ScatterPlotItem(GraphicsObject):
 
     def getViewMask(self, pts):
         warnings.warn(
-            "This is an internal method that is no longer being used.",
+            "This is an internal method that is no longer being used. "
+            "Will be removed in 0.13",
             DeprecationWarning, stacklevel=2
         )
         # Return bool mask indicating all points that are within viewbox

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1237,7 +1237,7 @@ class ViewBox(GraphicsWidget):
         dif = dif * -1
 
         ## Ignore axes if mouse is disabled
-        mouseEnabled = np.array(self.state['mouseEnabled'], dtype=np.float)
+        mouseEnabled = np.array(self.state['mouseEnabled'], dtype=np.float64)
         mask = mouseEnabled.copy()
         if axis is not None:
             mask[1-axis] = 0.0

--- a/pyqtgraph/graphicsItems/tests/test_ImageItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_ImageItem.py
@@ -10,11 +10,11 @@ app = pg.mkQApp()
 
 def test_ImageItem(transpose=False):
     
-    w = pg.GraphicsWindow()    
+    w = pg.GraphicsLayoutWidget()
+    w.show()
     view = pg.ViewBox()
     w.setCentralWidget(view)
     w.resize(200, 200)
-    w.show()
     img = TransposedImageItem(border=0.5, transpose=transpose)
 
     view.addItem(img)

--- a/pyqtgraph/graphicsItems/tests/test_ImageItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_ImageItem.py
@@ -134,7 +134,6 @@ def test_ImageItem_axisorder():
         pg.setConfigOptions(imageAxisOrder=origMode)
 
 
-@pytest.mark.skipif(pg.Qt.QT_LIB=='PySide', reason="pyside does not have qWait")
 def test_dividebyzero():
     import pyqtgraph as pg
     im = pg.image(pg.np.random.normal(size=(100,100)))

--- a/pyqtgraph/graphicsItems/tests/test_NonUniformImage.py
+++ b/pyqtgraph/graphicsItems/tests/test_NonUniformImage.py
@@ -48,7 +48,7 @@ def test_NonUniformImage_data_dimensions():
 
 def test_NonUniformImage_lut():
 
-    window = pg.GraphicsWindow()
+    window = pg.GraphicsLayoutWidget()
     viewbox = pg.ViewBox()
     window.setCentralWidget(viewbox)
     window.resize(200, 200)
@@ -78,7 +78,7 @@ def test_NonUniformImage_lut():
 
 def test_NonUniformImage_colormap():
 
-    window = pg.GraphicsWindow()
+    window = pg.GraphicsLayoutWidget()
     viewbox = pg.ViewBox()
     window.setCentralWidget(viewbox)
     window.resize(200, 200)

--- a/pyqtgraph/graphicsItems/tests/test_PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_PlotCurveItem.py
@@ -4,10 +4,11 @@ from pyqtgraph.tests import assertImageApproved
 
 
 def test_PlotCurveItem():
-    p = pg.GraphicsWindow()
-    p.ci.layout.setContentsMargins(4, 4, 4, 4)  # default margins vary by platform
-    v = p.addViewBox()
+    p = pg.GraphicsLayoutWidget()
     p.resize(200, 150)
+    p.ci.setContentsMargins(4, 4, 4, 4)  # default margins vary by platform
+    p.show()
+    v = p.addViewBox()
     data = np.array([1,4,2,3,np.inf,5,7,6,-np.inf,8,10,9,np.nan,-1,-2,0])
     c = pg.PlotCurveItem(data)
     v.addItem(c)

--- a/pyqtgraph/graphicsWindows.py
+++ b/pyqtgraph/graphicsWindows.py
@@ -11,6 +11,7 @@ from .widgets.PlotWidget import *
 from .imageview import *
 from .widgets.GraphicsLayoutWidget import GraphicsLayoutWidget
 from .widgets.GraphicsView import GraphicsView
+import warnings
 
 
 class GraphicsWindow(GraphicsLayoutWidget):
@@ -21,6 +22,11 @@ class GraphicsWindow(GraphicsLayoutWidget):
     is intended for use from the interactive python prompt.
     """
     def __init__(self, title=None, size=(800,600), **kargs):
+        warnings.warn(
+            'GraphicsWindow is deprecated, use GraphicsLayoutWidget instead,'
+            'will be removed in 0.13',
+            DeprecationWarning, stacklevel=2
+        )
         mkQApp()
         GraphicsLayoutWidget.__init__(self, **kargs)
         self.resize(*size)
@@ -34,6 +40,10 @@ class TabWindow(QtGui.QMainWindow):
     (deprecated)
     """
     def __init__(self, title=None, size=(800,600)):
+        warnings.warn(
+            'TabWindow is deprecated, will be removed in 0.13',
+            DeprecationWarning, stacklevel=2
+        )
         mkQApp()
         QtGui.QMainWindow.__init__(self)
         self.resize(*size)
@@ -54,6 +64,11 @@ class PlotWindow(PlotWidget):
     (deprecated; use :class:`~pyqtgraph.PlotWidget` instead)
     """
     def __init__(self, title=None, **kargs):
+        warnings.warn(
+            'PlotWindow is deprecated, use PlotWidget instead,'
+            'will be removed in 0.13',
+            DeprecationWarning, stacklevel=2
+        )    
         mkQApp()
         self.win = QtGui.QMainWindow()
         PlotWidget.__init__(self, **kargs)
@@ -76,6 +91,11 @@ class ImageWindow(ImageView):
     (deprecated; use :class:`~pyqtgraph.ImageView` instead)
     """
     def __init__(self, *args, **kargs):
+        warnings.warn(
+            'ImageWindow is deprecated, use ImageView instead'
+            'will be removed in 0.13',
+            DeprecationWarning, stacklevel=2
+        ) 
         mkQApp()
         self.win = QtGui.QMainWindow()
         self.win.resize(800,600)

--- a/pyqtgraph/metaarray/MetaArray.py
+++ b/pyqtgraph/metaarray/MetaArray.py
@@ -14,6 +14,7 @@ import types, copy, threading, os, re
 import pickle
 import numpy as np
 from ..python2_3 import basestring
+import warnings
 
 
 ## By default, the library will use HDF5 when writing files.
@@ -320,7 +321,11 @@ class MetaArray(object):
             return self.asarray().astype(dtype)
             
     def view(self, typ):
-        ## deprecated; kept for backward compatibility
+        warnings.warn(
+            'MetaArray.view is deprecated and will be removed in 0.13. '
+            'Use MetaArray.asarray() instead.',
+            DeprecationWarning, stacklevel=2
+        )    
         if typ is np.ndarray:
             return self.asarray()
         else:

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -4,7 +4,7 @@ import OpenGL.GL.framebufferobjects as glfbo
 import numpy as np
 from .. import Vector
 from .. import functions as fn
-
+import warnings
 ##Vector = QtGui.QVector3D
 
 ShareWidget = None
@@ -359,7 +359,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         *relative*      String that determines the direction of dx,dy,dz. 
                         If "global", then the global coordinate system is used.
                         If "view", then the z axis is aligned with the view
-                        direction, and x and y axes are inthe plane of the
+                        direction, and x and y axes are in the plane of the
                         view: +x points right, +y points up. 
                         If "view-upright", then x is in the global xy plane and
                         points to the right side of the view, y is in the
@@ -374,8 +374,13 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         False (global). These values are deprecated but still recognized.
         """
         # for backward compatibility:
+        if isinstance(relative, bool):
+            warnings.warn(
+                "'relative' as a boolean is deprecated, and will not be recognized in 0.13. "
+                "Acceptable values are 'global', 'view', or 'view-upright'",
+                DeprecationWarning, stacklevel=2
+            )    
         relative = {True: "view-upright", False: "global"}.get(relative, relative)
-        
         if relative == 'global':
             self.opts['center'] += QtGui.QVector3D(dx, dy, dz)
         elif relative == 'view-upright':

--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -5,6 +5,7 @@ import os, weakref, re
 from ..pgcollections import OrderedDict
 from ..python2_3 import asUnicode, basestring
 from .ParameterItem import ParameterItem
+import warnings
 
 PARAM_TYPES = {}
 PARAM_NAMES = {}
@@ -703,7 +704,11 @@ class Parameter(QtCore.QObject):
     def __getattr__(self, attr):
         ## Leaving this undocumented because I might like to remove it in the future..
         #print type(self), attr
-        
+        warnings.warn(
+            'Use of Parameter.subParam is deprecated and will be removed in 0.13 '
+            'Use Parameter.param(name) instead.',
+            DeprecationWarning, stacklevel=2
+        )          
         if 'names' not in self.__dict__:
             raise AttributeError(attr)
         if attr in self.names:

--- a/pyqtgraph/parametertree/tests/test_parametertypes.py
+++ b/pyqtgraph/parametertree/tests/test_parametertypes.py
@@ -44,8 +44,8 @@ def test_types():
     tree.setParameters(param)
 
     all_objs = {
-        'int0': 0, 'int':7, 'float': -0.35, 'bigfloat': 1e129, 'npfloat': np.float(5), 
-        'npint': np.int(5),'npinf': np.inf, 'npnan': np.nan, 'bool': True, 
+        'int0': 0, 'int':7, 'float': -0.35, 'bigfloat': 1e129, 'npfloat': np.float64(5), 
+        'npint': np.int64(5),'npinf': np.inf, 'npnan': np.nan, 'bool': True, 
         'complex': 5+3j, 'str': 'xxx', 'unicode': asUnicode('µ'), 
         'list': [1,2,3], 'dict': {'1': 2}, 'color': pg.mkColor('k'), 
         'brush': pg.mkBrush('k'), 'pen': pg.mkPen('k'), 'none': None

--- a/pyqtgraph/tests/test_functions.py
+++ b/pyqtgraph/tests/test_functions.py
@@ -340,9 +340,7 @@ def test_makeARGB():
 def test_eq():
     eq = pg.functions.eq
     
-    zeros = [0, 0.0, np.float(0), np.int(0)]
-    if sys.version[0] < '3':
-        zeros.append(long(0))
+    zeros = [0, 0.0, np.float64(0), np.float32(0), np.int32(0), np.int64(0)]
     for i,x in enumerate(zeros):
         for y in zeros[i:]:
             assert eq(x, y)

--- a/pyqtgraph/tests/test_ref_cycles.py
+++ b/pyqtgraph/tests/test_ref_cycles.py
@@ -6,6 +6,7 @@ Test for unwanted reference cycles
 import pyqtgraph as pg
 import numpy as np
 import weakref
+import warnings
 app = pg.mkQApp()
 
 def assert_alldead(refs):
@@ -36,7 +37,9 @@ def mkrefs(*objs):
 
 def test_PlotWidget():
     def mkobjs(*args, **kwds):
-        w = pg.PlotWidget(*args, **kwds)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            w = pg.PlotWidget(*args, **kwds)
         data = pg.np.array([1,5,2,4,3])
         c = w.plot(data, name='stuff')
         w.addLegend()
@@ -50,7 +53,19 @@ def test_PlotWidget():
     
     for i in range(5):
         assert_alldead(mkobjs())
+
+def test_GraphicsWindow():
+    def mkobjs():
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            w = pg.GraphicsWindow()
+        p1 = w.addPlot()
+        v1 = w.addViewBox()
+        return mkrefs(w, p1, v1)
     
+    for i in range(5):
+        assert_alldead(mkobjs())
+
 def test_ImageView():
     def mkobjs():
         iv = pg.ImageView()
@@ -63,15 +78,7 @@ def test_ImageView():
         assert_alldead(mkobjs())
 
 
-def test_GraphicsWindow():
-    def mkobjs():
-        w = pg.GraphicsWindow()
-        p1 = w.addPlot()
-        v1 = w.addViewBox()
-        return mkrefs(w, p1, v1)
-    
-    for i in range(5):
-        assert_alldead(mkobjs())
+
 
     
     

--- a/pyqtgraph/tests/test_reload.py
+++ b/pyqtgraph/tests/test_reload.py
@@ -43,10 +43,13 @@ def remove_cache(mod):
         shutil.rmtree(cachedir)
 
 @pytest.mark.skipif(
-    ((pg.Qt.QT_LIB == "PySide2" and pg.Qt.PySide2.__version__.startswith("5.15"))
-     or (pg.Qt.QT_LIB == "PySide6"))
-    and sys.version_info > (3, 9),
-    reason="Unknown Issue")
+    (
+        (pg.Qt.QT_LIB == "PySide2" and pg.Qt.QtVersion.startswith("5.15"))
+        or (pg.Qt.QT_LIB == "PySide6")
+    ) and (sys.version_info > (3, 9))
+    or (sys.version_info >= (3, 10)),
+    reason="Unknown Issue"
+)
 def test_reload():
     py3 = sys.version_info >= (3,)
 

--- a/pyqtgraph/widgets/JoystickButton.py
+++ b/pyqtgraph/widgets/JoystickButton.py
@@ -11,7 +11,7 @@ class JoystickButton(QtGui.QPushButton):
         self.radius = 200
         self.setCheckable(True)
         self.state = None
-        self.setState(0,0)
+        self.setState(0, 0)
         self.setFixedWidth(50)
         self.setFixedHeight(50)
         
@@ -42,21 +42,24 @@ class JoystickButton(QtGui.QPushButton):
     def setState(self, *xy):
         xy = list(xy)
         d = (xy[0]**2 + xy[1]**2)**0.5
-        nxy = [0,0]
+        nxy = [0, 0]
         for i in [0,1]:
             if xy[i] == 0:
                 nxy[i] = 0
             else:
-                nxy[i] = xy[i]/d
+                nxy[i] = xy[i] / d
         
         if d > self.radius:
             d = self.radius
-        d = (d/self.radius)**2
-        xy = [nxy[0]*d, nxy[1]*d]
+        d = (d / self.radius) ** 2
+        xy = [nxy[0] * d, nxy[1] * d]
         
-        w2 = self.width()/2.
-        h2 = self.height()/2
-        self.spotPos = QtCore.QPoint(w2*(1+xy[0]), h2*(1-xy[1]))
+        w2 = self.width() / 2
+        h2 = self.height() / 2
+        self.spotPos = QtCore.QPoint(
+            int(w2 * (1 + xy[0])),
+            int(h2 * (1 - xy[1]))
+        )
         self.update()
         if self.state == xy:
             return
@@ -67,7 +70,12 @@ class JoystickButton(QtGui.QPushButton):
         super().paintEvent(ev)
         p = QtGui.QPainter(self)
         p.setBrush(QtGui.QBrush(QtGui.QColor(0,0,0)))
-        p.drawEllipse(self.spotPos.x()-3,self.spotPos.y()-3,6,6)
+        p.drawEllipse(
+            self.spotPos.x() - 3,
+            self.spotPos.y() - 3,
+            6,
+            6
+        )
         
     def resizeEvent(self, ev):
         self.setState(*self.state)

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -77,7 +77,6 @@ class SpinBox(QtGui.QAbstractSpinBox):
             'step': D('0.01'),  ## if 'dec' is false, the spinBox steps by 'step' every time
                                 ## if 'dec' is True, the step size is relative to the value
                                 ## 'step' needs to be an integral divisor of ten, ie 'step'*n=10 for some integer value of n (but only if dec is True)
-            'log': False,   # deprecated
             'dec': False,   ## if true, does decimal stepping. ie from 1-10 it steps by 'step', from 10 to 100 it steps by 10*'step', etc. 
                             ## if true, minStep must be set in order to cross zero.
             
@@ -402,13 +401,6 @@ class SpinBox(QtGui.QAbstractSpinBox):
         val = self.val
         
         for i in range(int(abs(n))):
-            
-            if self.opts['log']:
-                raise Exception("Log mode no longer supported.")
-            #    step = abs(val) * self.opts['step']
-            #    if 'minStep' in self.opts:
-            #        step = max(step, self.opts['minStep'])
-            #    val += step * s
             if self.opts['dec']:
                 if val == 0:
                     step = self.opts['minStep']


### PR DESCRIPTION
In many portions of the codebase, there are commented out sections about methods or classes, or key-word arguments being deprecated, but they do not emit actual deprecation warnings.

This PR makes it so the use of deprecated methods emit deprecation warnings.  Furthermore, the code-base, examples and test-suite have been altered so that the deprecated methods are not used (exception in the test suite, where some tests test those explicitly).

This PR also restore the public API bits whose removal caused #1535  (restored, but added a deprecation warning).

Furthermore, thanks to @swt2c we got a heads up on issues involving Python 3.10, this PR addresses those as well.

Fixes #1535 
Fixes #1571 