### PR TITLE
Pin sphinx version to avoid buggy sphinx.ext.viewcode

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 pyside2
 numpy
 pyopengl
-sphinx
-sphinx_rtd_theme
+sphinx==3.4.3
+sphinx_rtd_theme==0.5.1


### PR DESCRIPTION
I'm watching sphinx releases so I'll see when 3.5.1 comes out and update accordingly