### PR TITLE
RawImageWidget.py : fix port to QOpenGLWidget

### DIFF
--- a/pyqtgraph/widgets/RawImageWidget.py
+++ b/pyqtgraph/widgets/RawImageWidget.py
@@ -134,6 +134,8 @@ if HAVE_OPENGL:
             glDisable(GL_TEXTURE_2D)
 
         def paintGL(self):
+            glClear(GL_COLOR_BUFFER_BIT)
+
             if self.image is None:
                 if self.opts is None:
                     return
@@ -144,9 +146,6 @@ if HAVE_OPENGL:
             if not self.uploaded:
                 self.uploadTexture()
 
-            dpr = self.devicePixelRatio()
-            vp = (0, 0, int(self.width() * dpr), int(self.height() * dpr))
-            glViewport(*vp)
             glEnable(GL_TEXTURE_2D)
             glBindTexture(GL_TEXTURE_2D, self.texture)
             glColor4f(1, 1, 1, 1)


### PR DESCRIPTION
There are some minor differences between QGLWidget and QOpenGLWidget that were not addressed during the port to QOpenGLWidget.

Qt5 docs specify differences between QGLWidget and QOpenGLWidget:
https://doc.qt.io/qt-5/qopenglwidget.html#relation-to-qglwidget
```...when invoking paintGL().  QOpenGLWidget sets up the viewport via glViewport(). It does not perform any clearing.```
```...it is important to call glClear() as early as possible in paintGL()...```

need someone to test that hi-dpi continues to work without any need to call glViewport()

```python
import scipy.misc
import pyqtgraph as pg
from pyqtgraph.widgets.RawImageWidget import RawImageWidget, RawImageGLWidget

pg.setConfigOptions(imageAxisOrder='row-major')

data = scipy.misc.face()

app = pg.mkQApp()
win = pg.Qt.QtWidgets.QMainWindow()
wgt = RawImageGLWidget()
wgt.setImage(data)
win.setCentralWidget(wgt)
win.resize(800, 600)
win.show()
app.exec_()
```
