### PR TITLE
Remove references to self from lambdas

### DIFF
--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -446,10 +446,10 @@ class GradientEditorItem(TickSliderItem):
         
         self.rgbAction = QtGui.QAction(translate("GradiantEditorItem", 'RGB'), self)
         self.rgbAction.setCheckable(True)
-        self.rgbAction.triggered.connect(self.setColorModeToRGB)
+        self.rgbAction.triggered.connect(self._setColorModeToRGB)
         self.hsvAction = QtGui.QAction(translate("GradiantEditorItem", 'HSV'), self)
         self.hsvAction.setCheckable(True)
-        self.hsvAction.triggered.connect(self.setColorModeToHSV)
+        self.hsvAction.triggered.connect(self._setColorModeToHSV)
             
         self.menu = QtGui.QMenu()
         
@@ -493,7 +493,7 @@ class GradientEditorItem(TickSliderItem):
         self.updateGradient()
         self.linkedGradients = {}
         
-        self.sigTicksChanged.connect(self.updateGradientIgnoreArgs)
+        self.sigTicksChanged.connect(self._updateGradientIgnoreArgs)
         self.sigTicksChangeFinished.connect(self.sigGradientChangeFinished.emit)
 
     def showTicks(self, show=True):
@@ -567,10 +567,10 @@ class GradientEditorItem(TickSliderItem):
         self.sigTicksChanged.emit(self)
         self.sigGradientChangeFinished.emit(self)
 
-    def setColorModeToRGB(self):
+    def _setColorModeToRGB(self):
         self.setColorMode("rgb")
 
-    def setColorModeToHSV(self):
+    def _setColorModeToHSV(self):
         self.setColorMode("hsv")
 
     def colorMap(self):
@@ -591,7 +591,7 @@ class GradientEditorItem(TickSliderItem):
         self.gradRect.setBrush(QtGui.QBrush(self.gradient))
         self.sigGradientChanged.emit(self)
 
-    def updateGradientIgnoreArgs(self, *args, **kwargs):
+    def _updateGradientIgnoreArgs(self, *args, **kwargs):
         self.updateGradient()
 
     def setLength(self, newLen):

--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -446,10 +446,10 @@ class GradientEditorItem(TickSliderItem):
         
         self.rgbAction = QtGui.QAction(translate("GradiantEditorItem", 'RGB'), self)
         self.rgbAction.setCheckable(True)
-        self.rgbAction.triggered.connect(lambda: self.setColorMode('rgb'))
+        self.rgbAction.triggered.connect(self.setColorModeToRGB)
         self.hsvAction = QtGui.QAction(translate("GradiantEditorItem", 'HSV'), self)
         self.hsvAction.setCheckable(True)
-        self.hsvAction.triggered.connect(lambda: self.setColorMode('hsv'))
+        self.hsvAction.triggered.connect(self.setColorModeToHSV)
             
         self.menu = QtGui.QMenu()
         
@@ -493,7 +493,7 @@ class GradientEditorItem(TickSliderItem):
         self.updateGradient()
         self.linkedGradients = {}
         
-        self.sigTicksChanged.connect(lambda *args, **kwargs: self.updateGradient())
+        self.sigTicksChanged.connect(self.updateGradientIgnoreArgs)
         self.sigTicksChangeFinished.connect(self.sigGradientChangeFinished.emit)
 
     def showTicks(self, show=True):
@@ -566,7 +566,13 @@ class GradientEditorItem(TickSliderItem):
         
         self.sigTicksChanged.emit(self)
         self.sigGradientChangeFinished.emit(self)
-        
+
+    def setColorModeToRGB(self):
+        self.setColorMode("rgb")
+
+    def setColorModeToHSV(self):
+        self.setColorMode("hsv")
+
     def colorMap(self):
         """Return a ColorMap object representing the current state of the editor."""
         if self.colorMode == 'hsv':
@@ -584,7 +590,10 @@ class GradientEditorItem(TickSliderItem):
         self.gradient = self.getGradient()
         self.gradRect.setBrush(QtGui.QBrush(self.gradient))
         self.sigGradientChanged.emit(self)
-        
+
+    def updateGradientIgnoreArgs(self, *args, **kwargs):
+        self.updateGradient()
+
     def setLength(self, newLen):
         #private (but maybe public)
         TickSliderItem.setLength(self, newLen)

--- a/pyqtgraph/graphicsItems/LinearRegionItem.py
+++ b/pyqtgraph/graphicsItems/LinearRegionItem.py
@@ -110,8 +110,8 @@ class LinearRegionItem(GraphicsObject):
         for l in self.lines:
             l.setParentItem(self)
             l.sigPositionChangeFinished.connect(self.lineMoveFinished)
-        self.lines[0].sigPositionChanged.connect(self.line0Moved)
-        self.lines[1].sigPositionChanged.connect(self.line1Moved)
+        self.lines[0].sigPositionChanged.connect(self._line0Moved)
+        self.lines[1].sigPositionChanged.connect(self._line1Moved)
             
         if brush is None:
             brush = QtGui.QBrush(QtGui.QColor(0, 0, 255, 50))
@@ -242,10 +242,10 @@ class LinearRegionItem(GraphicsObject):
         self.prepareGeometryChange()
         self.sigRegionChanged.emit(self)
 
-    def line0Moved(self):
+    def _line0Moved(self):
         self.lineMoved(0)
 
-    def line1Moved(self):
+    def _line1Moved(self):
         self.lineMoved(1)
 
     def lineMoveFinished(self):

--- a/pyqtgraph/graphicsItems/LinearRegionItem.py
+++ b/pyqtgraph/graphicsItems/LinearRegionItem.py
@@ -110,8 +110,8 @@ class LinearRegionItem(GraphicsObject):
         for l in self.lines:
             l.setParentItem(self)
             l.sigPositionChangeFinished.connect(self.lineMoveFinished)
-        self.lines[0].sigPositionChanged.connect(lambda: self.lineMoved(0))
-        self.lines[1].sigPositionChanged.connect(lambda: self.lineMoved(1))
+        self.lines[0].sigPositionChanged.connect(self.line0Moved)
+        self.lines[1].sigPositionChanged.connect(self.line1Moved)
             
         if brush is None:
             brush = QtGui.QBrush(QtGui.QColor(0, 0, 255, 50))
@@ -241,7 +241,13 @@ class LinearRegionItem(GraphicsObject):
         
         self.prepareGeometryChange()
         self.sigRegionChanged.emit(self)
-            
+
+    def line0Moved(self):
+        self.lineMoved(0)
+
+    def line1Moved(self):
+        self.lineMoved(1)
+
     def lineMoveFinished(self):
         self.sigRegionChangeFinished.emit(self)
 

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -785,8 +785,11 @@ class ROI(GraphicsObject):
 
     def removeClicked(self):
         ## Send remove event only after we have exited the menu event handler
-        QtCore.QTimer.singleShot(0, lambda: self.sigRemoveRequested.emit(self))
-        
+        QtCore.QTimer.singleShot(0, self.emitRemoveRequest)
+
+    def emitRemoveRequest(self):
+        self.sigRemoveRequested.emit(self)
+
     def mouseDragEvent(self, ev):
         self.mouseDragHandler.mouseDragEvent(ev)
 

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -785,9 +785,9 @@ class ROI(GraphicsObject):
 
     def removeClicked(self):
         ## Send remove event only after we have exited the menu event handler
-        QtCore.QTimer.singleShot(0, self.emitRemoveRequest)
+        QtCore.QTimer.singleShot(0, self._emitRemoveRequest)
 
-    def emitRemoveRequest(self):
+    def _emitRemoveRequest(self):
         self.sigRemoveRequested.emit(self)
 
     def mouseDragEvent(self, ev):

--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -203,15 +203,15 @@ class Parameter(QtCore.QObject):
             self.opts['default'] = None
     
         ## Connect all state changed signals to the general sigStateChanged
-        self.sigValueChanged.connect(self.emitValueChanged)
-        self.sigChildAdded.connect(self.emitChildAddedChanged)
-        self.sigChildRemoved.connect(self.emitChildRemovedChanged)
-        self.sigParentChanged.connect(self.emitParentChanged)
-        self.sigLimitsChanged.connect(self.emitLimitsChanged)
-        self.sigDefaultChanged.connect(self.emitDefaultChanged)
-        self.sigNameChanged.connect(self.emitNameChanged)
-        self.sigOptionsChanged.connect(self.emitOptionsChanged)
-        self.sigContextMenu.connect(self.emitContextMenuChanged)
+        self.sigValueChanged.connect(self._emitValueChanged)
+        self.sigChildAdded.connect(self._emitChildAddedChanged)
+        self.sigChildRemoved.connect(self._emitChildRemovedChanged)
+        self.sigParentChanged.connect(self._emitParentChanged)
+        self.sigLimitsChanged.connect(self._emitLimitsChanged)
+        self.sigDefaultChanged.connect(self._emitDefaultChanged)
+        self.sigNameChanged.connect(self._emitNameChanged)
+        self.sigOptionsChanged.connect(self._emitOptionsChanged)
+        self.sigContextMenu.connect(self._emitContextMenuChanged)
 
         
         #self.watchParam(self)  ## emit treechange signals if our own state changes
@@ -511,31 +511,31 @@ class Parameter(QtCore.QObject):
         self.treeStateChanges.append((self, changeDesc, data))
         self.emitTreeChanges()
 
-    def emitValueChanged(self, param, data):
+    def _emitValueChanged(self, param, data):
         self.emitStateChanged("value", data)
 
-    def emitChildAddedChanged(self, param, *data):
+    def _emitChildAddedChanged(self, param, *data):
         self.emitStateChanged("childAdded", data)
 
-    def emitChildRemovedChanged(self, param, data):
+    def _emitChildRemovedChanged(self, param, data):
         self.emitStateChanged("childRemoved", data)
 
-    def emitParentChanged(self, param, data):
+    def _emitParentChanged(self, param, data):
         self.emitStateChanged("parent", data)
 
-    def emitLimitsChanged(self, param, data):
+    def _emitLimitsChanged(self, param, data):
         self.emitStateChanged("limits", data)
 
-    def emitDefaultChanged(self, param, data):
+    def _emitDefaultChanged(self, param, data):
         self.emitStateChanged("default", data)
 
-    def emitNameChanged(self, param, data):
+    def _emitNameChanged(self, param, data):
         self.emitStateChanged("name", data)
 
-    def emitOptionsChanged(self, param, data):
+    def _emitOptionsChanged(self, param, data):
         self.emitStateChanged("options", data)
 
-    def emitContextMenuChanged(self, param, data):
+    def _emitContextMenuChanged(self, param, data):
         self.emitStateChanged("contextMenu", data)
 
     def makeTreeItem(self, depth):

--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -517,7 +517,7 @@ class Parameter(QtCore.QObject):
     def emitChildAddedChanged(self, param, *data):
         self.emitStateChanged("childAdded", data)
 
-    def emitchildRemovedChanged(self, param, data):
+    def emitChildRemovedChanged(self, param, data):
         self.emitStateChanged("childRemoved", data)
 
     def emitParentChanged(self, param, data):

--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -203,15 +203,15 @@ class Parameter(QtCore.QObject):
             self.opts['default'] = None
     
         ## Connect all state changed signals to the general sigStateChanged
-        self.sigValueChanged.connect(lambda param, data: self.emitStateChanged('value', data))
-        self.sigChildAdded.connect(lambda param, *data: self.emitStateChanged('childAdded', data))
-        self.sigChildRemoved.connect(lambda param, data: self.emitStateChanged('childRemoved', data))
-        self.sigParentChanged.connect(lambda param, data: self.emitStateChanged('parent', data))
-        self.sigLimitsChanged.connect(lambda param, data: self.emitStateChanged('limits', data))
-        self.sigDefaultChanged.connect(lambda param, data: self.emitStateChanged('default', data))
-        self.sigNameChanged.connect(lambda param, data: self.emitStateChanged('name', data))
-        self.sigOptionsChanged.connect(lambda param, data: self.emitStateChanged('options', data))
-        self.sigContextMenu.connect(lambda param, data: self.emitStateChanged('contextMenu', data))
+        self.sigValueChanged.connect(self.emitValueChanged)
+        self.sigChildAdded.connect(self.emitChildAddedChanged)
+        self.sigChildRemoved.connect(self.emitChildRemovedChanged)
+        self.sigParentChanged.connect(self.emitParentChanged)
+        self.sigLimitsChanged.connect(self.emitLimitsChanged)
+        self.sigDefaultChanged.connect(self.emitDefaultChanged)
+        self.sigNameChanged.connect(self.emitNameChanged)
+        self.sigOptionsChanged.connect(self.emitOptionsChanged)
+        self.sigContextMenu.connect(self.emitContextMenuChanged)
 
         
         #self.watchParam(self)  ## emit treechange signals if our own state changes
@@ -510,6 +510,33 @@ class Parameter(QtCore.QObject):
         #self.treeStateChanged(self, changeDesc, data)
         self.treeStateChanges.append((self, changeDesc, data))
         self.emitTreeChanges()
+
+    def emitValueChanged(self, param, data):
+        self.emitStateChanged("value", data)
+
+    def emitChildAddedChanged(self, param, *data):
+        self.emitStateChanged("childAdded", data)
+
+    def emitchildRemovedChanged(self, param, data):
+        self.emitStateChanged("childRemoved", data)
+
+    def emitParentChanged(self, param, data):
+        self.emitStateChanged("parent", data)
+
+    def emitLimitsChanged(self, param, data):
+        self.emitStateChanged("limits", data)
+
+    def emitDefaultChanged(self, param, data):
+        self.emitStateChanged("default", data)
+
+    def emitNameChanged(self, param, data):
+        self.emitStateChanged("name", data)
+
+    def emitOptionsChanged(self, param, data):
+        self.emitStateChanged("options", data)
+
+    def emitContextMenuChanged(self, param, data):
+        self.emitStateChanged("contextMenu", data)
 
     def makeTreeItem(self, depth):
         """


### PR DESCRIPTION
Lambdas used as signal responders which reference `self` prevent GC of said object. Instance methods do not suffer the same problem. I wasn't sure if the `QTimer` one needed to be fixed, but it doesn't hurt to be safe.

I couldn't solve `pyqtgraph.WidgetGroup.WidgetGroup.mkChangeCallback`, though. That case can't be rewritten as an instance method, and it needs to remain associated with `self`, so it can't be a static function. Maybe it would be sufficient to add the appropriate `disconnect` somehow? But what would that look like? If anyone has ideas, I'm willing to take another stab at this one.