### PR TITLE
Optimize makeARGB for ubyte images

### DIFF
--- a/examples/VideoSpeedTest.py
+++ b/examples/VideoSpeedTest.py
@@ -165,16 +165,22 @@ def mkData():
                 mx = 1.0
             else:
                 raise ValueError(f"unable to handle dtype: {cacheKey[0]}")
-            
+
+            chan_shape = (width, height)
             if ui.rgbCheck.isChecked():
-                data = xp.random.normal(size=(frames,width,height,3), loc=loc, scale=scale)
-                data = pg.gaussianFilter(data, (0, 6, 6, 0))
+                frame_shape = chan_shape + (3,)
             else:
-                data = xp.random.normal(size=(frames,width,height), loc=loc, scale=scale)
-                data = pg.gaussianFilter(data, (0, 6, 6))
-            if cacheKey[0] != 'float':
-                data = xp.clip(data, 0, mx)
-            data = data.astype(dt)
+                frame_shape = chan_shape
+            data = xp.empty((frames,) + frame_shape, dtype=dt)
+            view = data.reshape((-1,) + chan_shape)
+            for idx in range(view.shape[0]):
+                subdata = xp.random.normal(loc=loc, scale=scale, size=chan_shape)
+                # note: gaussian filtering has been removed as it slows down array
+                #       creation greatly.
+                if cacheKey[0] != 'float':
+                    xp.clip(subdata, 0, mx, out=subdata)
+                view[idx] = subdata
+
             data[:, 10, 10:50] = mx
             data[:, 9:12, 48] = mx
             data[:, 8:13, 47] = mx

--- a/examples/VideoSpeedTest.py
+++ b/examples/VideoSpeedTest.py
@@ -157,7 +157,7 @@ def mkData():
                 dt = xp.uint16
                 loc = 4096
                 scale = 1024
-                mx = 2**16
+                mx = 2**16 - 1
             elif cacheKey[0] == 'float':
                 dt = xp.float32
                 loc = 1.0

--- a/examples/VideoSpeedTest.py
+++ b/examples/VideoSpeedTest.py
@@ -18,6 +18,8 @@ import pyqtgraph as pg
 import pyqtgraph.ptime as ptime
 from pyqtgraph.Qt import QtGui, QtCore, QT_LIB
 
+pg.setConfigOption('imageAxisOrder', 'row-major')
+
 import importlib
 ui_template = importlib.import_module(f'VideoTemplate_{QT_LIB.lower()}')
 
@@ -166,7 +168,7 @@ def mkData():
             else:
                 raise ValueError(f"unable to handle dtype: {cacheKey[0]}")
 
-            chan_shape = (width, height)
+            chan_shape = (height, width)
             if ui.rgbCheck.isChecked():
                 frame_shape = chan_shape + (3,)
             else:
@@ -181,9 +183,9 @@ def mkData():
                     xp.clip(subdata, 0, mx, out=subdata)
                 view[idx] = subdata
 
-            data[:, 10, 10:50] = mx
-            data[:, 9:12, 48] = mx
-            data[:, 8:13, 47] = mx
+            data[:, 10:50, 10] = mx
+            data[:, 48, 9:12] = mx
+            data[:, 47, 8:13] = mx
             cache = {cacheKey: data} # clear to save memory (but keep one to prevent unnecessary regeneration)
 
         data = cache[cacheKey]


### PR DESCRIPTION
This PR optimizes the channel reordering portion of makeARGB by using the conversion routines of QImage.

It only optimizes for row major ubyte images and defers to the original code for the rest. Improvement in fps is measurable with VideoSpeedTest 

Would such a PR that optimizes for specific data types be acceptable?
Tagging @outofculture 