### PR TITLE
PyQt6 install sys.excepthook

### DIFF
--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -196,17 +196,6 @@ elif QT_LIB == PYQT5:
     # recreate the Qt4 structure for Qt5
     from PyQt5 import QtGui, QtCore, QtWidgets, uic
     
-    # PyQt5, starting in v5.5, calls qAbort when an exception is raised inside
-    # a slot. To maintain backward compatibility (and sanity for interactive
-    # users), we install a global exception hook to override this behavior.
-    ver = QtCore.PYQT_VERSION_STR.split('.')
-    if int(ver[1]) >= 5:
-        if sys.excepthook == sys.__excepthook__:
-            sys_excepthook = sys.excepthook
-            def pyqt5_qabort_override(*args, **kwds):
-                return sys_excepthook(*args, **kwds)
-            sys.excepthook = pyqt5_qabort_override
-    
     try:
         from PyQt5 import QtSvg
     except ImportError as err:
@@ -377,9 +366,18 @@ if QT_LIB in [PYSIDE, PYSIDE2, PYSIDE6]:
             QtTest.QTest.qWait = qWait
 
 
-# Common to PyQt4, PyQt5 and PyQt6
-if QT_LIB in [PYQT4, PYQT5, PYQT6]:
+# Common to PyQt5 and PyQt6
+if QT_LIB in [PYQT5, PYQT6]:
     QtVersion = QtCore.QT_VERSION_STR
+
+    # PyQt, starting in v5.5, calls qAbort when an exception is raised inside
+    # a slot. To maintain backward compatibility (and sanity for interactive
+    # users), we install a global exception hook to override this behavior.
+    if sys.excepthook == sys.__excepthook__:
+        sys_excepthook = sys.excepthook
+        def pyqt_qabort_override(*args, **kwds):
+            return sys_excepthook(*args, **kwds)
+        sys.excepthook = pyqt_qabort_override
     
     try:
         sip = importlib.import_module(QT_LIB + '.sip')


### PR DESCRIPTION
https://github.com/pyqtgraph/pyqtgraph/pull/1605#issuecomment-788784635
https://github.com/pijyoi/pyqtgraph/runs/1853387168?check_suite_focus=true

The PyQt6 run failures in the link above are all:
```
AttributeError: 'NoneType' object has no attribute 'color'
Fatal Python error: Aborted
```

Disregarding why the slot is being executed in the first place, the errors show that PyQt6, like PyQt5, aborts the process upon an uncaught Exception inside a slot. This PR installs the PyQt5 sys.excepthook also for PyQt6.

The other commits take the opportunity to remove more Qt4 from Qt.py.