### PR TITLE
combine levels and lut only if both are present

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -419,21 +419,18 @@ class ImageItem(GraphicsObject):
         # if the image data is a small int, then we can combine levels + lut
         # into a single lut for better performance
         levels = self.levels
-        if levels is not None and levels.ndim == 1 and image.dtype in (self._xp.ubyte, self._xp.uint16):
+        if levels is not None and lut is not None and levels.ndim == 1 and \
+                image.dtype in (self._xp.ubyte, self._xp.uint16):
             if self._effectiveLut is None:
                 eflsize = 2**(image.itemsize*8)
                 ind = self._xp.arange(eflsize)
                 minlev, maxlev = levels
                 levdiff = maxlev - minlev
                 levdiff = 1 if levdiff == 0 else levdiff  # don't allow division by 0
-                if lut is None:
-                    efflut = fn.rescaleData(ind, scale=255./levdiff,
-                                            offset=minlev, dtype=self._xp.ubyte)
-                else:
-                    lutdtype = self._xp.min_scalar_type(lut.shape[0] - 1)
-                    efflut = fn.rescaleData(ind, scale=(lut.shape[0]-1)/levdiff,
-                                            offset=minlev, dtype=lutdtype, clip=(0, lut.shape[0]-1))
-                    efflut = lut[efflut]
+                lutdtype = self._xp.min_scalar_type(lut.shape[0] - 1)
+                efflut = fn.rescaleData(ind, scale=(lut.shape[0]-1)/levdiff,
+                                        offset=minlev, dtype=lutdtype, clip=(0, lut.shape[0]-1))
+                efflut = lut[efflut]
 
                 self._effectiveLut = efflut
             lut = self._effectiveLut


### PR DESCRIPTION
This PR does a partial fix for #1590.

Previously, if ```levels``` was present but ```lut``` was not, ```levels``` would be converted into ```lut```.
i.e. levels and ~lut --> ~levels and lut 
However, since makeARGB _always_ applies levels, this becomes a pessimization.
i.e. both levels and lut are now applied.

This PR changes it to become: levels and lut --> ~levels and lut

With this fix, in the (perhaps common) use case where the user does not provide a lut, the pessimization will no longer get triggered.