### PR TITLE
PlotDataItem: Fix view range <-> dynamic range limit pathology and switch to np.umath.clip

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -671,8 +671,8 @@ class PlotDataItem(GraphicsObject):
                         # workaround for slowdown from numpy deprecation issues in 1.17 to 1.20+
                         # x0 = np.clip(int((range.left()-x[0])/dx) - 1*ds, 0, len(x)-1)
                         # x1 = np.clip(int((range.right()-x[0])/dx) + 2*ds, 0, len(x)-1)
-                        x0 = np.core.umath.clip(int((range.left()-x[0])/dx) - 1*ds, 0, len(x)-1)
-                        x1 = np.core.umath.clip(int((range.right()-x[0])/dx) + 2*ds, 0, len(x)-1)
+                        x0 = fn.clip_array(int((range.left()-x[0])/dx) - 1*ds, 0, len(x)-1)
+                        x1 = fn.clip_array(int((range.right()-x[0])/dx) + 2*ds, 0, len(x)-1)
 
                         # if data has been clipped too strongly (in case of non-uniform
                         # spacing of x-values), refine the clipping region as required
@@ -680,10 +680,12 @@ class PlotDataItem(GraphicsObject):
                         # best case performance: O(1)
                         if x[x0] > range.left():
                             x0 = np.searchsorted(x, range.left()) - 1*ds
-                            x0 = np.core.umath.clip(x0, 0, len(x)) # workaround
+                            x0 = fn.clip_array(x0, 0, len(x)) # workaround
+                            # x0 = np.clip(x0, 0, len(x))
                         if x[x1] < range.right():
                             x1 = np.searchsorted(x, range.right()) + 2*ds
-                            x1 = np.core.umath.clip(x1, 0, len(x)) # workaround
+                            x1 = fn.clip_array(x1, 0, len(x))
+                            # x1 = np.clip(x1, 0, len(x))
                         x = x[x0:x1]
                         y = y[x0:x1]
 
@@ -740,7 +742,7 @@ class PlotDataItem(GraphicsObject):
                                         # print('in-place:', end='')
                                         # workaround for slowdown from numpy deprecation issues in 1.17 to 1.20+ :
                                         # np.clip(self.yDisp, out=self.yDisp, a_min=min_val, a_max=max_val)
-                                        np.core.umath.clip(self.yDisp, min_val, max_val, out=self.yDisp)
+                                        fn.clip_array(self.yDisp, min_val, max_val, out=self.yDisp)
                                         x = self.xDisp
                                         y = self.yDisp
                                     else:
@@ -748,7 +750,7 @@ class PlotDataItem(GraphicsObject):
                                         # print('alloc:', end='')
                                         # workaround for slowdown from numpy deprecation issues in 1.17 to 1.20+ :
                                         # y = np.clip(y, a_min=min_val, a_max=max_val)
-                                        y = np.core.umath.clip(y, min_val, max_val)
+                                        y = fn.clip_array(y, min_val, max_val)
                                     # print('{:.1e}<->{:.1e}'.format( min_val, max_val ))
                                     self._drlLastClip = (min_val, max_val)
 

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -668,8 +668,11 @@ class PlotDataItem(GraphicsObject):
                         # clip to visible region extended by downsampling value, assuming
                         # uniform spacing of x-values, has O(1) performance
                         dx = float(x[-1]-x[0]) / (len(x)-1)
-                        x0 = np.clip(int((range.left()-x[0])/dx) - 1*ds, 0, len(x)-1)
-                        x1 = np.clip(int((range.right()-x[0])/dx) + 2*ds, 0, len(x)-1)
+                        # workaround for slowdown from numpy deprecation issues in 1.17 to 1.20+
+                        # x0 = np.clip(int((range.left()-x[0])/dx) - 1*ds, 0, len(x)-1)
+                        # x1 = np.clip(int((range.right()-x[0])/dx) + 2*ds, 0, len(x)-1)
+                        x0 = np.core.umath.clip(int((range.left()-x[0])/dx) - 1*ds, 0, len(x)-1)
+                        x1 = np.core.umath.clip(int((range.right()-x[0])/dx) + 2*ds, 0, len(x)-1)
 
                         # if data has been clipped too strongly (in case of non-uniform
                         # spacing of x-values), refine the clipping region as required
@@ -677,10 +680,10 @@ class PlotDataItem(GraphicsObject):
                         # best case performance: O(1)
                         if x[x0] > range.left():
                             x0 = np.searchsorted(x, range.left()) - 1*ds
-                            x0 = np.clip(x0, a_min=0, a_max=len(x))
+                            x0 = np.core.umath.clip(x0, 0, len(x)) # workaround
                         if x[x1] < range.right():
                             x1 = np.searchsorted(x, range.right()) + 2*ds
-                            x1 = np.clip(x1, a_min=0, a_max=len(x))
+                            x1 = np.core.umath.clip(x1, 0, len(x)) # workaround
                         x = x[x0:x1]
                         y = y[x0:x1]
 
@@ -712,11 +715,15 @@ class PlotDataItem(GraphicsObject):
                         limit = self.opts['dynamicRangeLimit']
                         hyst  = self.opts['dynamicRangeHyst']
                         # never clip data if it fits into +/- (extended) limit * view height
-                        if data_range.height() > 2 * hyst * limit * view_height:
+                        if ( # note that "bottom" is the larger number, and "top" is the smaller one.
+                            not data_range.bottom() < view_range.top()     # never clip if all data is too small to see
+                            and not data_range.top() > view_range.bottom() # never clip if all data is too large to see
+                            and data_range.height() > 2 * hyst * limit * view_height
+                        ):
                             # check if cached display data can be reused:
                             if self.yDisp is not None: # top is minimum value, bottom is maximum value
                                 # how many multiples of the current view height does the clipped plot extend to the top and bottom?
-                                top_exc =-(self._drlLastClip[0]-view_range.bottom()) / view_height 
+                                top_exc =-(self._drlLastClip[0]-view_range.bottom()) / view_height
                                 bot_exc = (self._drlLastClip[1]-view_range.top()   ) / view_height
                                 # print(top_exc, bot_exc, hyst)
                                 if (    top_exc >= limit / hyst and top_exc <= limit * hyst
@@ -726,18 +733,22 @@ class PlotDataItem(GraphicsObject):
                                     y = self.yDisp
                                 else:
                                     min_val = view_range.bottom() - limit * view_height
-                                    max_val = view_range.top()    + limit * view_height                                    
+                                    max_val = view_range.top()    + limit * view_height
                                     if(     min_val >= self._drlLastClip[0]
                                         and max_val <= self._drlLastClip[1] ):
                                         # if we need to clip further, we can work in-place on the output buffer
                                         # print('in-place:', end='')
-                                        np.clip(self.yDisp, out=self.yDisp, a_min=min_val, a_max=max_val)
+                                        # workaround for slowdown from numpy deprecation issues in 1.17 to 1.20+ :
+                                        # np.clip(self.yDisp, out=self.yDisp, a_min=min_val, a_max=max_val)
+                                        np.core.umath.clip(self.yDisp, min_val, max_val, out=self.yDisp)
                                         x = self.xDisp
                                         y = self.yDisp
                                     else:
                                         # otherwise we need to recopy from the full data
                                         # print('alloc:', end='')
-                                        y = np.clip(y, a_min=min_val, a_max=max_val)
+                                        # workaround for slowdown from numpy deprecation issues in 1.17 to 1.20+ :
+                                        # y = np.clip(y, a_min=min_val, a_max=max_val)
+                                        y = np.core.umath.clip(y, min_val, max_val)
                                     # print('{:.1e}<->{:.1e}'.format( min_val, max_val ))
                                     self._drlLastClip = (min_val, max_val)
 


### PR DESCRIPTION
Issue #1634 brought to light an issue with the current code that does dynamic range limiting in `PlotDataItem` (see #1140):

If all data is far above (or below) the screen, then it will all be clipped to the same value.
If auto-range is active, it will then center the view on the constant-valued clipped data, and set the view height to the minimum allowed.

Data will then be re-clipped according to the updated view, but since the view height is very small, the data will be clipped aggressively again. For far-away data, all clipped values will again be identical.

This process then repeats, with the center of the view range shifting towards the true data by approximately 1E6 every loop.
If the input data is all >1E10, this process takes an amusingly long time.

The solution is simple:
Never clip data when it is all off to the top or bottom, which we can judge from pre-existing information.
Then auto-range will jump to the proper range in one step, as intended. 
This also happens to be an optimization, since it saves calculation when nothing is visible.


The PR also switches `np.clip()` for `np.umath.clip()` throughout PlotDataItem.
This works around a problem with code overhead in numpy's main clip function, as discussed in  #1632 .
