### PR TITLE
Fix transformations in GradientLegend

### DIFF
--- a/pyqtgraph/graphicsItems/GradientLegend.py
+++ b/pyqtgraph/graphicsItems/GradientLegend.py
@@ -6,7 +6,7 @@ __all__ = ['GradientLegend']
 
 class GradientLegend(UIGraphicsItem):
     """
-    Draws a color gradient rectangle along with text labels denoting the value at specific 
+    Draws a color gradient rectangle along with text labels denoting the value at specific
     points along the gradient.
     """
     
@@ -50,6 +50,9 @@ class GradientLegend(UIGraphicsItem):
         if unit[0] is None:  
             return
         
+        ## Have to scale painter so that text and gradients are correct size and not upside down
+        p.scale(unit[0], -unit[1])
+
         ## determine max width of all labels
         labelWidth = 0
         labelHeight = 0
@@ -58,57 +61,56 @@ class GradientLegend(UIGraphicsItem):
             labelWidth = max(labelWidth, b.width())
             labelHeight = max(labelHeight, b.height())
             
-        labelWidth *= unit[0]
-        labelHeight *= unit[1]
-        
         textPadding = 2  # in px
         
+        xR = rect.right()  / unit[0]
+        xL = rect.left()   / unit[0]
+        yB = -(rect.top()    / unit[1])
+        yT = -(rect.bottom() / unit[1])
+        
+        # coordinates describe edges of text and bar, additional margins will be added for background
         if self.offset[0] < 0:
-            x3 = rect.right() + unit[0] * self.offset[0]
-            x2 = x3 - labelWidth - unit[0]*textPadding*2
-            x1 = x2 - unit[0] * self.size[0]
+            x3 = xR + self.offset[0] # right edge from right edge of view, offset is negative!
+            x2 = x3 - labelWidth - 2*textPadding # right side of color bar
+            x1 = x2 - self.size[0]               # left side of color bar
         else:
-            x1 = rect.left() + unit[0] * self.offset[0]
-            x2 = x1 + unit[0] * self.size[0]
-            x3 = x2 + labelWidth + unit[0]*textPadding*2
+            x1 = xL + self.offset[0] # left edge from left edge of view
+            x2 = x1 + self.size[0]
+            x3 = x2 + labelWidth + 2*textPadding # leave room for 2x textpadding between bar and text
         if self.offset[1] < 0:
-            y2 = rect.top() - unit[1] * self.offset[1]
-            y1 = y2 + unit[1] * self.size[1]
+            y2 = yB + self.offset[1] # bottom edge from bottom of view, offset is negative!
+            y1 = y2 - self.size[1]
         else:
-            y1 = rect.bottom() - unit[1] * self.offset[1]
-            y2 = y1 - unit[1] * self.size[1]
+            y1 = yT + self.offset[1] # top edge from top of view
+            y2 = y1 + self.size[1]
         self.b = [x1,x2,x3,y1,y2,labelWidth]
-            
+
         ## Draw background
         p.setPen(self.pen)
         p.setBrush(QtGui.QBrush(QtGui.QColor(255,255,255,100)))
         rect = QtCore.QRectF(
-            QtCore.QPointF(x1 - unit[0]*textPadding, y1 + labelHeight/2 + unit[1]*textPadding), 
-            QtCore.QPointF(x3, y2 - labelHeight/2 - unit[1]*textPadding)
+            QtCore.QPointF(x1 - textPadding, y1-labelHeight/2 - textPadding), # extra left/top padding 
+            QtCore.QPointF(x3 + textPadding, y2+labelHeight/2 + textPadding)  # extra bottom/right padding
         )
         p.drawRect(rect)
-        
-        
-        ## Have to scale painter so that text and gradients are correct size. Bleh.
-        p.scale(unit[0], unit[1])
-        
-        ## Draw color bar
-        self.gradient.setStart(0, y1/unit[1])
-        self.gradient.setFinalStop(0, y2/unit[1])
-        p.setBrush(self.gradient)
-        rect = QtCore.QRectF(
-            QtCore.QPointF(x1/unit[0], y1/unit[1]), 
-            QtCore.QPointF(x2/unit[0], y2/unit[1])
-        )
-        p.drawRect(rect)
-        
-        
+
         ## draw labels
         p.setPen(QtGui.QPen(QtGui.QColor(0,0,0)))
-        tx = x2 + unit[0]*textPadding
-        lh = labelHeight/unit[1]
+        tx = x2 + 2 * textPadding # margin between bar and text
+        lh = labelHeight
+        lw = labelWidth
         for k in self.labels:
+            print(k, self.labels[k])
             y = y1 + self.labels[k] * (y2-y1)
-            p.drawText(QtCore.QRectF(tx/unit[0], y/unit[1] - lh/2.0, 1000, lh), QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter, str(k))
-        
-        
+            print('text x/y:',tx,'/',y)
+            p.drawText(QtCore.QRectF(tx, y - lh/2, lw, lh), QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter, str(k))
+
+        ## Draw color bar
+        self.gradient.setStart(0, y1)
+        self.gradient.setFinalStop(0, y2)
+        p.setBrush(self.gradient)
+        rect = QtCore.QRectF(
+            QtCore.QPointF(x1, y1), 
+            QtCore.QPointF(x2, y2)
+        )
+        p.drawRect(rect)

--- a/pyqtgraph/graphicsItems/GradientLegend.py
+++ b/pyqtgraph/graphicsItems/GradientLegend.py
@@ -94,17 +94,6 @@ class GradientLegend(UIGraphicsItem):
         )
         p.drawRect(rect)
 
-        ## draw labels
-        p.setPen(QtGui.QPen(QtGui.QColor(0,0,0)))
-        tx = x2 + 2 * textPadding # margin between bar and text
-        lh = labelHeight
-        lw = labelWidth
-        for k in self.labels:
-            print(k, self.labels[k])
-            y = y1 + self.labels[k] * (y2-y1)
-            print('text x/y:',tx,'/',y)
-            p.drawText(QtCore.QRectF(tx, y - lh/2, lw, lh), QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter, str(k))
-
         ## Draw color bar
         self.gradient.setStart(0, y1)
         self.gradient.setFinalStop(0, y2)
@@ -114,3 +103,12 @@ class GradientLegend(UIGraphicsItem):
             QtCore.QPointF(x2, y2)
         )
         p.drawRect(rect)
+
+        ## draw labels
+        p.setPen(QtGui.QPen(QtGui.QColor(0,0,0)))
+        tx = x2 + 2 * textPadding # margin between bar and text
+        lh = labelHeight
+        lw = labelWidth
+        for k in self.labels:
+            y = y1 + self.labels[k] * (y2-y1)
+            p.drawText(QtCore.QRectF(tx, y - lh/2, lw, lh), QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter, str(k))


### PR DESCRIPTION
I am not entirely sure what is going wrong in the coordinate transformations of the GradientLegend item, causing it to plot upside down in #1591. I suspect that this has always plotted upside down.

This PR tries to tidy up the calculations a little, sticks to screen coordinates for everything, and flips the painter scale upside down. Then everything seems to plot in the expected position and direction on my system. If there is an *additional* reason for things to appear upside down, this should at least make it a little easier to fix.

closes #1591