### PR TITLE
Add Deprecation Warning to Hex Strings That Do Not Start With "#" in mkColor

### DIFF
--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -42,7 +42,7 @@ class CustomTickSliderItem(pg.TickSliderItem):
             self.removeTick(tick)
         
         for pos in ticks:
-            tickItem = self.addTick(pos, movable=False, color="333333")
+            tickItem = self.addTick(pos, movable=False, color="#333333")
             self.all_ticks[pos] = tickItem
         
         self.updateRange(None, self._range)

--- a/examples/parametertree.py
+++ b/examples/parametertree.py
@@ -69,7 +69,7 @@ params = [
         {'name': 'List', 'type': 'list', 'values': [1,2,3], 'value': 2},
         {'name': 'Named List', 'type': 'list', 'values': {"one": 1, "two": "twosies", "three": [3,3,3]}, 'value': 2},
         {'name': 'Boolean', 'type': 'bool', 'value': True, 'tip': "This is a checkbox"},
-        {'name': 'Color', 'type': 'color', 'value': "FF0", 'tip': "This is a color button"},
+        {'name': 'Color', 'type': 'color', 'value': "#FF0", 'tip': "This is a color button"},
         {'name': 'Gradient', 'type': 'colormap'},
         {'name': 'Subgroup', 'type': 'group', 'children': [
             {'name': 'Sub-param 1', 'type': 'int', 'value': 10},

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -223,10 +223,10 @@ def mkColor(*args):
      float           greyscale, 0.0-1.0
      int             see :func:`intColor() <pyqtgraph.intColor>`
      (int, hues)     see :func:`intColor() <pyqtgraph.intColor>`
-     "RGB"           hexadecimal strings; deprecated if they don't start
-     "RGBA"          with "#"
-     "RRGGBB"       
-     "RRGGBBAA"     
+     "#RGB"          hexadecimal strings prefixed with '#'
+     "#RGBA"         previously allowed use without prefix is deprecated and 
+     "#RRGGBB"       will be removed in 0.13
+     "#RRGGBBAA"     
      QColor          QColor instance; makes a copy.
     ================ ================================================
     """
@@ -244,7 +244,7 @@ def mkColor(*args):
             else:
                 warnings.warn(
                     "Parsing of hex strings that do not start with '#' is"
-                    "deprecated support will be removed in 0.13",
+                    "deprecated and support will be removed in 0.13",
                     DeprecationWarning, stacklevel=2
                 )
             if len(c) == 3:

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -213,7 +213,8 @@ class Color(QtGui.QColor):
     
 def mkColor(*args):
     """
-    Convenience function for constructing QColor from a variety of argument types. Accepted arguments are:
+    Convenience function for constructing QColor from a variety of argument 
+    types. Accepted arguments are:
     
     ================ ================================================
      'c'             one of: r, g, b, c, m, y, k, w                      
@@ -222,8 +223,8 @@ def mkColor(*args):
      float           greyscale, 0.0-1.0
      int             see :func:`intColor() <pyqtgraph.intColor>`
      (int, hues)     see :func:`intColor() <pyqtgraph.intColor>`
-     "RGB"           hexadecimal strings; may begin with '#'
-     "RGBA"          
+     "RGB"           hexadecimal strings; deprecated if they don't start
+     "RGBA"          with "#"
      "RRGGBB"       
      "RRGGBBAA"     
      QColor          QColor instance; makes a copy.
@@ -233,13 +234,19 @@ def mkColor(*args):
     if len(args) == 1:
         if isinstance(args[0], basestring):
             c = args[0]
-            if c[0] == '#':
-                c = c[1:]
             if len(c) == 1:
                 try:
                     return Colors[c]
                 except KeyError:
                     raise ValueError('No color named "%s"' % c)
+            if c[0] == '#':
+                c = c[1:]
+            else:
+                warnings.warn(
+                    "Parsing of hex strings that do not start with '#' is"
+                    "deprecated support will be removed in 0.13",
+                    DeprecationWarning, stacklevel=2
+                )
             if len(c) == 3:
                 r = int(c[0]*2, 16)
                 g = int(c[1]*2, 16)

--- a/pyqtgraph/graphicsItems/LabelItem.py
+++ b/pyqtgraph/graphicsItems/LabelItem.py
@@ -39,7 +39,7 @@ class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
 
         ==================== ==============================
         **Style Arguments:**
-        color                (str) example: 'CCFF00'
+        color                (str) example: '#CCFF00'
         size                 (str) example: '8pt'
         bold                 (bool)
         italic               (bool)

--- a/pyqtgraph/parametertree/tests/test_parametertypes.py
+++ b/pyqtgraph/parametertree/tests/test_parametertypes.py
@@ -46,7 +46,7 @@ def test_types():
     all_objs = {
         'int0': 0, 'int':7, 'float': -0.35, 'bigfloat': 1e129, 'npfloat': np.float64(5), 
         'npint': np.int64(5),'npinf': np.inf, 'npnan': np.nan, 'bool': True, 
-        'complex': 5+3j, 'str': 'xxx', 'unicode': asUnicode('µ'), 
+        'complex': 5+3j, 'str': '#xxx', 'unicode': asUnicode('µ'), 
         'list': [1,2,3], 'dict': {'1': 2}, 'color': pg.mkColor('k'), 
         'brush': pg.mkBrush('k'), 'pen': pg.mkPen('k'), 'none': None
     }


### PR DESCRIPTION
@NilsNemitz `https://i.imgur.com/uyKgrYk.gif`

`mkColor` supports a wide variety of inputs to generate `QColor` objects.  One of the currently supported features is providing a hexadecimal value for RGB/RGBA via hex-string, from the docs 

```
     "RGB"           hexadecimal strings; may begin with '#'
     "RGBA"          
     "RRGGBB"       
     "RRGGBBAA"     
```

As we try and support more color-names, it will be more difficult to distinguish between color names and hexadecimal color codes; so we are going to stop supporting that.

Given this is a public API change, we're going to go through a deprecation phase, and won't actually remove this functionality until the next minor or major release is rolled over.

