### PR TITLE
Remove unhelpful warnings

### DIFF
--- a/doc/source/config_options.rst
+++ b/doc/source/config_options.rst
@@ -26,8 +26,6 @@ imageAxisOrder     str                 'col-major'        For 'row-major', image
                                                           change in the future.
 editorCommand      str or None         None               Command used to invoke code editor from ConsoleWidget.
 exitCleanup        bool                True               Attempt to work around some exit crash bugs in PyQt and PySide.
-useWeave           bool                False              Use weave to speed up some operations, if it is available.
-weaveDebug         bool                False              Print full error message if weave compile fails.
 useOpenGL          bool                False              Enable OpenGL in GraphicsView. This can have unpredictable effects on stability
                                                           and performance.
 useCupy            bool                False              Use cupy to perform calculations on the GPU. Only currently applies to

--- a/doc/source/config_options.rst
+++ b/doc/source/config_options.rst
@@ -26,8 +26,7 @@ imageAxisOrder     str                 'col-major'        For 'row-major', image
                                                           change in the future.
 editorCommand      str or None         None               Command used to invoke code editor from ConsoleWidget.
 exitCleanup        bool                True               Attempt to work around some exit crash bugs in PyQt and PySide.
-useOpenGL          bool                False              Enable OpenGL in GraphicsView. This can have unpredictable effects on stability
-                                                          and performance.
+useOpenGL          bool                False              Enable OpenGL in GraphicsView.
 useCupy            bool                False              Use cupy to perform calculations on the GPU. Only currently applies to
                                                           ImageItem and its associated functions.
 enableExperimental bool                False              Enable experimental features (the curious can search for this key in the code).

--- a/doc/source/images.rst
+++ b/doc/source/images.rst
@@ -21,6 +21,6 @@ There are a few other methods for displaying images as well:
 * Instances of :class:`~pyqtgraph.ImageItem` can be used inside a :class:`ViewBox <pyqtgraph.ViewBox>` or :class:`GraphicsView <pyqtgraph.GraphicsView>`.
 * For higher performance, use :class:`~pyqtgraph.RawImageWidget`.
 
-Any of these classes are acceptable for displaying video by calling setImage() to display a new frame. To increase performance, the image processing system uses scipy.weave to produce compiled libraries. If your computer has a compiler available, weave will automatically attempt to build the libraries it needs on demand. If this fails, then the slower pure-python methods will be used instead. 
+Any of these classes are acceptable for displaying video by calling setImage() to display a new frame.
 
 For more information, see the classes listed above and the 'VideoSpeedTest', 'ImageItem', 'ImageView', and 'HistogramLUT' :ref:`examples`.

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -36,8 +36,6 @@ if 'linux' in sys.platform:  ## linux has numerous bugs in opengl implementation
     useOpenGL = False
 elif 'darwin' in sys.platform: ## openGL can have a major impact on mac, but also has serious bugs
     useOpenGL = False
-    if QtGui.QApplication.instance() is not None:
-        print('Warning: QApplication was created before pyqtgraph was imported; there may be problems.')
 else:
     useOpenGL = False  ## on windows there's a more even performance / bugginess tradeoff. 
                 

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -47,7 +47,6 @@ CONFIG_OPTIONS = {
     'background': 'k',        ## default background for GraphicsWidget
     'antialias': False,
     'editorCommand': None,  ## command used to invoke code editor from ConsoleWidgets
-    'useWeave': False,       ## Use weave to speed up some operations, if it is available
     'weaveDebug': False,    ## Print full error message if weave compile fails
     'exitCleanup': True,    ## Attempt to work around some exit crash bugs in PyQt and PySide
     'enableExperimental': False, ## Enable experimental features (the curious can search for this key in the code)

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -47,7 +47,6 @@ CONFIG_OPTIONS = {
     'background': 'k',        ## default background for GraphicsWidget
     'antialias': False,
     'editorCommand': None,  ## command used to invoke code editor from ConsoleWidgets
-    'weaveDebug': False,    ## Print full error message if weave compile fails
     'exitCleanup': True,    ## Attempt to work around some exit crash bugs in PyQt and PySide
     'enableExperimental': False, ## Enable experimental features (the curious can search for this key in the code)
     'crashWarning': False,  # If True, print warnings about situations that may result in a crash


### PR DESCRIPTION
One of the comments from #1620 was regarding the wording in the docs relating to `useOpenGL`; while the wording did give a warning, it was not particularly helpful.  We either support that option, or we don't, so that was removed.

References to `weave` have been removed since that hasn't been in the library forever.

Fixes #1623 by removing another unhelpful warning as well.