### PR TITLE
GraphItem: handle empty adjaceny array

### DIFF
--- a/pyqtgraph/graphicsItems/GraphItem.py
+++ b/pyqtgraph/graphicsItems/GraphItem.py
@@ -55,7 +55,9 @@ class GraphItem(GraphicsObject):
         """
         if 'adj' in kwds:
             self.adjacency = kwds.pop('adj')
-            if self.adjacency is not None and self.adjacency.dtype.kind not in 'iu':
+            if hasattr(self.adjacency, '__len__') and len(self.adjacency) == 0:
+                self.adjacency = None
+            elif self.adjacency is not None and self.adjacency.dtype.kind not in 'iu':
                 raise Exception("adjacency must be None or an array of either int or unsigned type.")
             self._update()
         if 'pos' in kwds:
@@ -140,8 +142,3 @@ class GraphItem(GraphicsObject):
     
     def pixelPadding(self):
         return self.scatter.pixelPadding()
-        
-        
-        
-        
-


### PR DESCRIPTION
Looking over the issue tracker, I came across #228.

GraphItem lets you set connections between points by a list of "adjacencies".
When this list is empty, the logical behavior would be not to draw any connections.
Instead, an exception is raised, requesting data to be supplied in a specific format... Which seems to be hard or impossible to satisfy for an empty list.

The PR adds a simple check for an empty list and converts it into `None`, which is the accepted way to specify no connections.
That should save the user the need to sanitize any programmatically generated list of adjacencies.

Testing code:
```python
from PyQt5 import QtCore, QtGui
from PyQt5.QtWidgets import QWidget, QApplication, QMainWindow
import numpy as np
import pyqtgraph as pg
import sys

class TestApp(QMainWindow):
    def __init__(self):
        super().__init__()

        self.resize(500,500)
        glw = pg.GraphicsLayoutWidget(self)
        v = glw.addViewBox()
        v.setAspectLocked()
        g = pg.GraphItem()
        v.addItem(g)
                
        ## Define the list of points
        pos = np.array([ [0,0], [10,0], [0,10], [10,10], [5,5], [15,5] ])
            
        ## Define the set of connections in the graph
        # adj = np.array([ [0,1], [1,3], [3,2], [2,0], [1,5], [3,5] ])
        adj = []
            
        ## Define the symbol to use for each node (this is optional)
        symbols = ['o','o','o','o','t','+']

        ## Define the line style for each connection (this is optional)
        lines = np.array([
            (255,  0,  0,255, 1), (255,  0,255,255, 2),
            (255,  0,255,255, 3), (255,255,  0,255, 2),
            (255,  0,  0,255, 1), (255,255,255,255, 4)
            ], dtype=[('red',np.ubyte),('green',np.ubyte),('blue',np.ubyte),('alpha',np.ubyte),('width',float)])
        
        g.setData(pos=pos, adj=adj, pen=lines, size=1, symbol=symbols, pxMode=False)

if __name__ == "__main__":
    app = QApplication(sys.argv)
    ui = TestApp()
    ui.show()
    app.exec_()
```
Closes #228.