### PR TITLE
implement rescaleData_blocked

### DIFF
--- a/pyqtgraph/tests/test_functions.py
+++ b/pyqtgraph/tests/test_functions.py
@@ -127,7 +127,7 @@ def test_subArray():
     assert np.all(bb == cc)
     
     
-def test_rescaleData():
+def helper_rescaleData(rescale_func):
     dtypes = map(np.dtype, ('ubyte', 'uint16', 'byte', 'int16', 'int', 'float'))
     for dtype1 in dtypes:
         for dtype2 in dtypes:
@@ -139,12 +139,20 @@ def test_rescaleData():
                 else:
                     lim = (-np.inf, np.inf)
                 s1 = np.clip(float(scale) * (data-float(offset)), *lim).astype(dtype2)
-                s2 = pg.rescaleData(data, scale, offset, dtype2)
+                s2 = rescale_func(data, scale, offset, dtype2)
                 assert s1.dtype == s2.dtype
                 if dtype2.kind in 'iu':
                     assert np.all(s1 == s2)
                 else:
                     assert np.allclose(s1, s2)
+
+
+def test_rescaleData():
+    helper_rescaleData(pg.rescaleData)
+
+
+def test_rescaleData_blocked():
+    helper_rescaleData(pg.rescaleData_blocked)
 
 
 def makeARGB(*args, **kwds):

--- a/pyqtgraph/tests/test_functions.py
+++ b/pyqtgraph/tests/test_functions.py
@@ -151,8 +151,8 @@ def test_rescaleData():
     helper_rescaleData(pg.rescaleData)
 
 
-def test_rescaleData_blocked():
-    helper_rescaleData(pg.rescaleData_blocked)
+def test_rescaleData_nditer():
+    helper_rescaleData(pg.rescaleData_nditer)
 
 
 def makeARGB(*args, **kwds):

--- a/pyqtgraph/tests/test_functions.py
+++ b/pyqtgraph/tests/test_functions.py
@@ -127,7 +127,7 @@ def test_subArray():
     assert np.all(bb == cc)
     
     
-def helper_rescaleData(rescale_func):
+def test_rescaleData():
     dtypes = map(np.dtype, ('ubyte', 'uint16', 'byte', 'int16', 'int', 'float'))
     for dtype1 in dtypes:
         for dtype2 in dtypes:
@@ -139,20 +139,12 @@ def helper_rescaleData(rescale_func):
                 else:
                     lim = (-np.inf, np.inf)
                 s1 = np.clip(float(scale) * (data-float(offset)), *lim).astype(dtype2)
-                s2 = rescale_func(data, scale, offset, dtype2)
+                s2 = pg.rescaleData(data, scale, offset, dtype2)
                 assert s1.dtype == s2.dtype
                 if dtype2.kind in 'iu':
                     assert np.all(s1 == s2)
                 else:
                     assert np.allclose(s1, s2)
-
-
-def test_rescaleData():
-    helper_rescaleData(pg.rescaleData)
-
-
-def test_rescaleData_nditer():
-    helper_rescaleData(pg.rescaleData_nditer)
 
 
 def makeARGB(*args, **kwds):


### PR DESCRIPTION
This PR continues the rescaleData_blocked() function implementation spun off from #1617.
A standalone test file depending only on numpy has been put temporarily in benchmarks/time_rescale.py.

Some improvements have been made to the benchmarking script:
1) tests both uint8 and float32
2) ensures that there are values outside _both_ clipping bounds
   * this exercises any branch prediction that may be taking place

A slowdown in the fits_int32 codepath was found
1) for int32 data types, the clip limits provided to the clip function should be integer-valued. otherwise, it will be slower, particularly so on Windows. Probably different versions of the ufunc get selected based on its input arguments.

From https://github.com/pyqtgraph/pyqtgraph/pull/1641#issuecomment-803448357, it was found that:
1) on Linux, numpy 1.20 runs faster than 1.17, probably due to SIMD implemented on 1.20.
2) on macOS, numpy 1.20 and 1.17 are equally fast
3) using umath.minimum(umath.maximum()) instead of umath.clip() is only an improvement on Windows. It is in fact a pessimization to use it on Linux and macOS. (For Linux, rescaleData_blocked() already takes umath.clip() codepath) 
These findings have not been incorporated yet, pending more verification.
