### PR TITLE
Do not use clip_array on scalars (use clip_scalar instead)

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -998,6 +998,9 @@ def solveBilinearTransform(points1, points2):
     
     return matrix
 
+def clip_scalar(val, vmin, vmax):
+    """ convenience function to avoid using np.clip for scalar values """
+    return vmin if val < vmin else vmax if val > vmax else val
 
 def clip_array(arr, vmin, vmax, out=None):
     # replacement for np.clip due to regression in

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -679,8 +679,8 @@ class PlotDataItem(GraphicsObject):
                         # workaround for slowdown from numpy deprecation issues in 1.17 to 1.20+
                         # x0 = np.clip(int((range.left()-x[0])/dx) - 1*ds, 0, len(x)-1)
                         # x1 = np.clip(int((range.right()-x[0])/dx) + 2*ds, 0, len(x)-1)
-                        x0 = fn.clip_array(int((range.left()-x[0])/dx) - 1*ds, 0, len(x)-1)
-                        x1 = fn.clip_array(int((range.right()-x[0])/dx) + 2*ds, 0, len(x)-1)
+                        x0 = fn.clip_scalar(int((range.left()-x[0])/dx) - 1*ds, 0, len(x)-1)
+                        x1 = fn.clip_scalar(int((range.right()-x[0])/dx) + 2*ds, 0, len(x)-1)
 
                         # if data has been clipped too strongly (in case of non-uniform
                         # spacing of x-values), refine the clipping region as required
@@ -688,11 +688,11 @@ class PlotDataItem(GraphicsObject):
                         # best case performance: O(1)
                         if x[x0] > range.left():
                             x0 = np.searchsorted(x, range.left()) - 1*ds
-                            x0 = fn.clip_array(x0, 0, len(x)) # workaround
+                            x0 = fn.clip_scalar(x0, 0, len(x)) # workaround
                             # x0 = np.clip(x0, 0, len(x))
                         if x[x1] < range.right():
                             x1 = np.searchsorted(x, range.right()) + 2*ds
-                            x1 = fn.clip_array(x1, 0, len(x))
+                            x1 = fn.clip_scalar(x1, 0, len(x))
                             # x1 = np.clip(x1, 0, len(x))
                         x = x[x0:x1]
                         y = y[x0:x1]


### PR DESCRIPTION
As discussed in #1641, the replacement for `np.clip()` in PlotDataitem now accidentally uses @pijyoi 's `functions.clip_array()` method to limit the range of scalar variables. Although the tests for clipToView pass, indicating that this actually seems to work, this is not intended... and not fast either.

This PR adds a `functions.clip_scalar(val, vmin, vmax)` function and uses that in the clipToView part of PlotDataItem.
The appeal is to have less ambiguity than using np.clip for everything, as well as generally better performance:

Direct python comparisons are about 100x faster than the current `np.clip()` on Windows:
```python
>>> timeit('clip_scalar( random.random(), -0.1, 0.1)', number=10000000, globals=globals())
2.789680599999997
>>> timeit('np.clip( random.random(), -0.1, 0.1)', number=10000000, globals=globals())
217.01810209999996 
```

If None or an array is passed to this function, it fails right away with a pretty clear error message, so I think handling that explicitly is not needed here? 