### PR TITLE
Fix to accidentally disabled style updates in PlotDataItem

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -242,7 +242,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['fftMode'] = mode
         self.xDisp = self.yDisp = None
-        self.updateItems()
+        self.updateItems(update_style=False)
         self.informViewBoundsChanged()
 
     def setLogMode(self, xMode, yMode):
@@ -260,7 +260,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['logMode'] = [xMode, yMode]
         self.xDisp = self.yDisp = None
-        self.updateItems()
+        self.updateItems(update_style=False)
         self.informViewBoundsChanged()
 
 
@@ -269,7 +269,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['derivativeMode'] = mode
         self.xDisp = self.yDisp = None
-        self.updateItems()
+        self.updateItems(update_style=False)
         self.informViewBoundsChanged()
 
     def setPhasemapMode(self, mode):
@@ -277,7 +277,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['phasemapMode'] = mode
         self.xDisp = self.yDisp = None
-        self.updateItems()
+        self.updateItems(update_style=False)
         self.informViewBoundsChanged()
 
     def setPointMode(self, mode):
@@ -297,7 +297,7 @@ class PlotDataItem(GraphicsObject):
         #for c in self.curves:
             #c.setPen(pen)
         #self.update()
-        self.updateItems()
+        self.updateItems(update_style=True)
 
     def setShadowPen(self, *args, **kargs):
         """
@@ -312,14 +312,14 @@ class PlotDataItem(GraphicsObject):
         #for c in self.curves:
             #c.setPen(pen)
         #self.update()
-        self.updateItems()
+        self.updateItems(update_style=True)
 
     def setFillBrush(self, *args, **kargs):
         brush = fn.mkBrush(*args, **kargs)
         if self.opts['fillBrush'] == brush:
             return
         self.opts['fillBrush'] = brush
-        self.updateItems()
+        self.updateItems(update_style=True)
 
     def setBrush(self, *args, **kargs):
         return self.setFillBrush(*args, **kargs)
@@ -328,14 +328,14 @@ class PlotDataItem(GraphicsObject):
         if self.opts['fillLevel'] == level:
             return
         self.opts['fillLevel'] = level
-        self.updateItems()
+        self.updateItems(update_style=True)
 
     def setSymbol(self, symbol):
         if self.opts['symbol'] == symbol:
             return
         self.opts['symbol'] = symbol
         #self.scatter.setSymbol(symbol)
-        self.updateItems()
+        self.updateItems(update_style=True)
 
     def setSymbolPen(self, *args, **kargs):
         pen = fn.mkPen(*args, **kargs)
@@ -343,7 +343,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['symbolPen'] = pen
         #self.scatter.setSymbolPen(pen)
-        self.updateItems()
+        self.updateItems(update_style=True)
 
     def setSymbolBrush(self, *args, **kargs):
         brush = fn.mkBrush(*args, **kargs)
@@ -351,7 +351,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['symbolBrush'] = brush
         #self.scatter.setSymbolBrush(brush)
-        self.updateItems()
+        self.updateItems(update_style=True)
 
 
     def setSymbolSize(self, size):
@@ -359,7 +359,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['symbolSize'] = size
         #self.scatter.setSymbolSize(symbolSize)
-        self.updateItems()
+        self.updateItems(update_style=True)
 
     def setDownsampling(self, ds=None, auto=None, method=None):
         """
@@ -396,14 +396,14 @@ class PlotDataItem(GraphicsObject):
 
         if changed:
             self.xDisp = self.yDisp = None
-            self.updateItems()
+            self.updateItems(update_style=False)
 
     def setClipToView(self, clip):
         if self.opts['clipToView'] == clip:
             return
         self.opts['clipToView'] = clip
         self.xDisp = self.yDisp = None
-        self.updateItems()
+        self.updateItems(update_style=False)
 
     def setDynamicRangeLimit(self, limit=1e06, hysteresis=3.):
         """
@@ -431,7 +431,7 @@ class PlotDataItem(GraphicsObject):
             return # avoid update if there is no change
         self.opts['dynamicRangeLimit'] = limit # can be None
         self.xDisp = self.yDisp = None
-        self.updateItems()
+        self.updateItems(update_style=False)
 
     def setData(self, *args, **kargs):
         """
@@ -587,7 +587,7 @@ class PlotDataItem(GraphicsObject):
         self.sigPlotChanged.emit(self)
         profiler('emit')
 
-    def updateItems(self, update_style=False):
+    def updateItems(self, update_style=True):
         curveArgs = {}
         scatterArgs = {}
         if update_style: # repeat style arguments only when changed
@@ -872,10 +872,10 @@ class PlotDataItem(GraphicsObject):
             or self.opts['autoDownsample']
         ):
             self.xDisp = self.yDisp = None
-            self.updateItems()
+            self.updateItems(update_style=False)
         elif self.opts['dynamicRangeLimit'] is not None:
-            # do not discard cached display data
-            self.updateItems()
+            # update, but do not discard cached display data
+            self.updateItems(update_style=False)
 
     def _fourierTransform(self, x, y):
         ## Perform fourier transform. If x values are not sampled uniformly,

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -242,7 +242,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['fftMode'] = mode
         self.xDisp = self.yDisp = None
-        self.updateItems(update_style=False)
+        self.updateItems(styleUpdate=False)
         self.informViewBoundsChanged()
 
     def setLogMode(self, xMode, yMode):
@@ -260,7 +260,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['logMode'] = [xMode, yMode]
         self.xDisp = self.yDisp = None
-        self.updateItems(update_style=False)
+        self.updateItems(styleUpdate=False)
         self.informViewBoundsChanged()
 
 
@@ -269,7 +269,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['derivativeMode'] = mode
         self.xDisp = self.yDisp = None
-        self.updateItems(update_style=False)
+        self.updateItems(styleUpdate=False)
         self.informViewBoundsChanged()
 
     def setPhasemapMode(self, mode):
@@ -277,7 +277,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['phasemapMode'] = mode
         self.xDisp = self.yDisp = None
-        self.updateItems(update_style=False)
+        self.updateItems(styleUpdate=False)
         self.informViewBoundsChanged()
 
     def setPointMode(self, mode):
@@ -297,7 +297,7 @@ class PlotDataItem(GraphicsObject):
         #for c in self.curves:
             #c.setPen(pen)
         #self.update()
-        self.updateItems(update_style=True)
+        self.updateItems(styleUpdate=True)
 
     def setShadowPen(self, *args, **kargs):
         """
@@ -312,14 +312,14 @@ class PlotDataItem(GraphicsObject):
         #for c in self.curves:
             #c.setPen(pen)
         #self.update()
-        self.updateItems(update_style=True)
+        self.updateItems(styleUpdate=True)
 
     def setFillBrush(self, *args, **kargs):
         brush = fn.mkBrush(*args, **kargs)
         if self.opts['fillBrush'] == brush:
             return
         self.opts['fillBrush'] = brush
-        self.updateItems(update_style=True)
+        self.updateItems(styleUpdate=True)
 
     def setBrush(self, *args, **kargs):
         return self.setFillBrush(*args, **kargs)
@@ -328,14 +328,14 @@ class PlotDataItem(GraphicsObject):
         if self.opts['fillLevel'] == level:
             return
         self.opts['fillLevel'] = level
-        self.updateItems(update_style=True)
+        self.updateItems(styleUpdate=True)
 
     def setSymbol(self, symbol):
         if self.opts['symbol'] == symbol:
             return
         self.opts['symbol'] = symbol
         #self.scatter.setSymbol(symbol)
-        self.updateItems(update_style=True)
+        self.updateItems(styleUpdate=True)
 
     def setSymbolPen(self, *args, **kargs):
         pen = fn.mkPen(*args, **kargs)
@@ -343,7 +343,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['symbolPen'] = pen
         #self.scatter.setSymbolPen(pen)
-        self.updateItems(update_style=True)
+        self.updateItems(styleUpdate=True)
 
     def setSymbolBrush(self, *args, **kargs):
         brush = fn.mkBrush(*args, **kargs)
@@ -351,7 +351,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['symbolBrush'] = brush
         #self.scatter.setSymbolBrush(brush)
-        self.updateItems(update_style=True)
+        self.updateItems(styleUpdate=True)
 
 
     def setSymbolSize(self, size):
@@ -359,7 +359,7 @@ class PlotDataItem(GraphicsObject):
             return
         self.opts['symbolSize'] = size
         #self.scatter.setSymbolSize(symbolSize)
-        self.updateItems(update_style=True)
+        self.updateItems(styleUpdate=True)
 
     def setDownsampling(self, ds=None, auto=None, method=None):
         """
@@ -396,14 +396,14 @@ class PlotDataItem(GraphicsObject):
 
         if changed:
             self.xDisp = self.yDisp = None
-            self.updateItems(update_style=False)
+            self.updateItems(styleUpdate=False)
 
     def setClipToView(self, clip):
         if self.opts['clipToView'] == clip:
             return
         self.opts['clipToView'] = clip
         self.xDisp = self.yDisp = None
-        self.updateItems(update_style=False)
+        self.updateItems(styleUpdate=False)
 
     def setDynamicRangeLimit(self, limit=1e06, hysteresis=3.):
         """
@@ -431,7 +431,7 @@ class PlotDataItem(GraphicsObject):
             return # avoid update if there is no change
         self.opts['dynamicRangeLimit'] = limit # can be None
         self.xDisp = self.yDisp = None
-        self.updateItems(update_style=False)
+        self.updateItems(styleUpdate=False)
 
     def setData(self, *args, **kargs):
         """
@@ -575,7 +575,7 @@ class PlotDataItem(GraphicsObject):
         self.yDisp = None
         profiler('set data')
 
-        self.updateItems( update_style = self._styleWasChanged )
+        self.updateItems( styleUpdate = self._styleWasChanged )
         self._styleWasChanged = False # items have been updated
         profiler('update items')
 
@@ -587,10 +587,10 @@ class PlotDataItem(GraphicsObject):
         self.sigPlotChanged.emit(self)
         profiler('emit')
 
-    def updateItems(self, update_style=True):
+    def updateItems(self, styleUpdate=True):
         curveArgs = {}
         scatterArgs = {}
-        if update_style: # repeat style arguments only when changed
+        if styleUpdate: # repeat style arguments only when changed
             for k,v in [('pen','pen'), ('shadowPen','shadowPen'), ('fillLevel','fillLevel'), ('fillOutline', 'fillOutline'), ('fillBrush', 'brush'), ('antialias', 'antialias'), ('connect', 'connect'), ('stepMode', 'stepMode')]:
                 if k in self.opts:
                     curveArgs[v] = self.opts[k]
@@ -872,10 +872,10 @@ class PlotDataItem(GraphicsObject):
             or self.opts['autoDownsample']
         ):
             self.xDisp = self.yDisp = None
-            self.updateItems(update_style=False)
+            self.updateItems(styleUpdate=False)
         elif self.opts['dynamicRangeLimit'] is not None:
             # update, but do not discard cached display data
-            self.updateItems(update_style=False)
+            self.updateItems(styleUpdate=False)
 
     def _fourierTransform(self, x, y):
         ## Perform fourier transform. If x values are not sampled uniformly,

--- a/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
 
 pg.mkQApp()
 
@@ -59,6 +60,35 @@ def test_setData():
     pdi.setData([],[])
     assert pdi.xData is None
     assert pdi.yData is None
+
+def test_opts():
+    # test that curve and scatter plot properties get updated from PlotDataItem methods
+    y = list(np.random.normal(size=100))
+    x = np.linspace(5, 10, 100)
+    pdi = pg.PlotDataItem(x, y)
+    pen = QtGui.QPen( QtGui.QColor('#FF0000') )
+    pen2 = QtGui.QPen( QtGui.QColor('#FFFF00') )
+    brush = QtGui.QBrush( QtGui.QColor('#00FF00'))
+    brush2 = QtGui.QBrush( QtGui.QColor('#00FFFF'))
+    float_value = 1.0 + 20*np.random.random()
+    pen2.setWidth( int(float_value) )
+    pdi.setPen(pen)
+    pdi.setShadowPen(pen2)
+    pdi.setFillLevel( float_value )
+    pdi.setFillBrush(brush2)
+
+    pdi.setSymbolPen(pen)
+    pdi.setSymbolBrush(brush)
+    pdi.setSymbol('t')
+    pdi.setSymbolSize( float_value )
+    assert pdi.curve.opts['pen'] == pen
+    assert pdi.curve.opts['shadowPen'] == pen2
+    assert pdi.curve.opts['fillLevel'] == float_value
+    assert pdi.curve.opts['brush'] == brush2
+    assert pdi.scatter.opts['pen'] == pen
+    assert pdi.scatter.opts['brush'] == brush
+    assert pdi.scatter.opts['symbol'] == 't'
+    assert pdi.scatter.opts['size'] == float_value
 
 def test_clear():
     y = list(np.random.normal(size=100))

--- a/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
@@ -73,21 +73,21 @@ def test_opts():
     float_value = 1.0 + 20*np.random.random()
     pen2.setWidth( int(float_value) )
     pdi.setPen(pen)
-    pdi.setShadowPen(pen2)
-    pdi.setFillLevel( float_value )
-    pdi.setFillBrush(brush2)
-
-    pdi.setSymbolPen(pen)
-    pdi.setSymbolBrush(brush)
-    pdi.setSymbol('t')
-    pdi.setSymbolSize( float_value )
     assert pdi.curve.opts['pen'] == pen
+    pdi.setShadowPen(pen2)
     assert pdi.curve.opts['shadowPen'] == pen2
+    pdi.setFillLevel( float_value )
     assert pdi.curve.opts['fillLevel'] == float_value
+    pdi.setFillBrush(brush2)
     assert pdi.curve.opts['brush'] == brush2
-    assert pdi.scatter.opts['pen'] == pen
-    assert pdi.scatter.opts['brush'] == brush
+
+    pdi.setSymbol('t')
     assert pdi.scatter.opts['symbol'] == 't'
+    pdi.setSymbolPen(pen)
+    assert pdi.scatter.opts['pen'] == pen
+    pdi.setSymbolBrush(brush)
+    assert pdi.scatter.opts['brush'] == brush
+    pdi.setSymbolSize( float_value )
     assert pdi.scatter.opts['size'] == float_value
 
 def test_clear():


### PR DESCRIPTION
#1652 points out that PR #1619 broke most of the style update methods in PlotDataItem, such as `setPen()`.

The error was that `def updateItems(self, update_style=False):` disabled the propagation of pen, brush etc. settings from PlotDataItem to PlotCurveItem and ScatterPlotItem *unless explicitly requested*. This request only occurred when the style properties were set through the `setData()` method. I have now gone through the individual methods and added an explicit setting of update_style=True / False to each update, so that changes to e.g. log mode do not update the pens/brushes, but calls to setPen, setShadowPen etc. do.

Since most of out example code sets the colors on initialization or through `setData()`, this problem was not obvious in the tests. I added a set of tests that check that the properties correctly arrive with the ScatterPlotItem and PlotCurveItem associated with the PlotDataItem.

Closes #1652, I hope.