### PR TITLE
added cast to int so that QSplitter.setSizes works on Python 3.10

### DIFF
--- a/pyqtgraph/canvas/Canvas.py
+++ b/pyqtgraph/canvas/Canvas.py
@@ -113,7 +113,7 @@ class Canvas(QtGui.QWidget):
         
         if not self.sizeApplied:
             self.sizeApplied = True
-            s = min(self.width(), max(100, min(200, self.width()*0.25)))
+            s = int( min(self.width(), max(100, min(200, self.width()//4))) )
             s2 = self.width()-s
             self.ui.splitter.setSizes([s2, s])
     

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -563,7 +563,7 @@ class ImageView(QtGui.QWidget):
             self.roi.show()
             #self.ui.roiPlot.show()
             self.ui.roiPlot.setMouseEnabled(True, True)
-            self.ui.splitter.setSizes([self.height()*0.6, self.height()*0.4])
+            self.ui.splitter.setSizes([int(self.height()*0.6), int(self.height()*0.4)])
             self.ui.splitter.handle(1).setEnabled(True)
             self.roiCurve.show()
             self.roiChanged()


### PR DESCRIPTION
While I am not set up to test on 3.10, the error message in #1657 seems quite specific:
`TypeError: index 0 has type 'float' but 'int' is expected`

This adds a cast to int to the parameters in the `QSplitter.setSizes()` call in question.
That might be enough to fix this issue and it doesn't break any other tests.