### PR TITLE
revert style change reduction in PlotDataItem

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -542,7 +542,6 @@ class PlotDataItem(GraphicsObject):
             if k in kargs:
                 self.opts[k] = kargs[k]
                 self._styleWasChanged = True
-
         #curveArgs = {}
         #for k in ['pen', 'shadowPen', 'fillLevel', 'brush']:
             #if k in kargs:
@@ -588,8 +587,14 @@ class PlotDataItem(GraphicsObject):
         profiler('emit')
 
     def updateItems(self, styleUpdate=True):
+        # override styleUpdate request and always enforce update until we have a better solution for
+        # - ScatterPlotItem losing per-point style information
+        # - PlotDataItem performing multiple unnecessary setData call on initialization
+        styleUpdate=True
+        
         curveArgs = {}
         scatterArgs = {}
+
         if styleUpdate: # repeat style arguments only when changed
             for k,v in [('pen','pen'), ('shadowPen','shadowPen'), ('fillLevel','fillLevel'), ('fillOutline', 'fillOutline'), ('fillBrush', 'brush'), ('antialias', 'antialias'), ('connect', 'connect'), ('stepMode', 'stepMode')]:
                 if k in self.opts:


### PR DESCRIPTION
I had a look at #1652, the failure of list-wise style definitions through PlotDataItem.

The problem is that
- PlotDataItem does multiple calls to set the data of the underlying ScatterPlotItem, of which only the first one applies the style information.
- It seems that ScatterPlotItem does not retain the per-point styling information on a call to , even if the data is not changed.

The only immediate solution I have is to revert to always transmitting the full style information.
This PR does that, and in the example given in  #1652, I do see the colors as intended then.

A proper fix will need closer inspection into why there are redundant `setData()` calls to ScatterPlotItem, which seems less than ideal.