### PR TITLE
make ImageItem combine levels + lut not be a pessimization

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -424,18 +424,31 @@ class ImageItem(GraphicsObject):
         while True:
             if image.dtype not in (self._xp.ubyte, self._xp.uint16):
                 break
-            if lut is None:
-                # no lut to combine
-                break
-            if levels is None:
-                # remove degenerate case
-                info = numpy.iinfo(image.dtype)
-                levels = info.min, info.max
-                levels = self._xp.asarray(levels)
-            # here, both levels and lut are present
-            if levels.ndim != 1:
+            if levels is not None and levels.ndim != 1:
                 # can't handle this case
                 break
+
+            info = numpy.iinfo(image.dtype)
+            if image.dtype == self._xp.ubyte:
+                if levels is not None and levels[0] == info.min and levels[1] == info.max:
+                    # degenerate case, equivalent to not specifying levels
+                    levels = None
+            else:   # uint16
+                if levels is None:
+                    # degenerate case, always specify levels to force conversion to lut
+                    levels = info.min, info.max
+
+            if levels is None:
+                if lut is None:
+                    # fast path for uint8
+                    break
+                else:
+                    # ensure that makeARGB() bypasses apply levels
+                    scale = lut.shape[0] - 1
+                    break
+
+            # here, levels is present
+            # convert to lut only
 
             if self._effectiveLut is None:
                 eflsize = 2**(image.itemsize*8)
@@ -443,10 +456,14 @@ class ImageItem(GraphicsObject):
                 minlev, maxlev = levels
                 levdiff = maxlev - minlev
                 levdiff = 1 if levdiff == 0 else levdiff  # don't allow division by 0
-                lutdtype = self._xp.min_scalar_type(lut.shape[0] - 1)
-                efflut = fn.rescaleData(ind, scale=(lut.shape[0]-1)/levdiff,
-                                        offset=minlev, dtype=lutdtype, clip=(0, lut.shape[0]-1))
-                efflut = lut[efflut]
+                if lut is None:
+                    efflut = fn.rescaleData(ind, scale=255./levdiff,
+                                            offset=minlev, dtype=self._xp.ubyte)
+                else:
+                    lutdtype = self._xp.min_scalar_type(lut.shape[0] - 1)
+                    efflut = fn.rescaleData(ind, scale=(lut.shape[0]-1)/levdiff,
+                                            offset=minlev, dtype=lutdtype, clip=(0, lut.shape[0]-1))
+                    efflut = lut[efflut]
 
                 self._effectiveLut = efflut
             lut = self._effectiveLut


### PR DESCRIPTION
This PR continues #1630 in trying to fix the pessimization identified in #1590

Cases tested with PYQTGRAPHPROFILE=functions.makeARGB:
1) VideoSpeedTest.py --size=3072x3072 --levels=0,255
   * both levels and lut bypassed (fastest path)
2) VideoSpeedTest.py --size=3072x3072 --levels=50,200
   * levels applied, lut bypassed
3) VideoSpeedTest.py --size=3072x3072 --lut
   * levels bypassed, lut applied (was previously both applied)
4) VideoSpeedTest.py --size=3072x3072 --levels=50,200 --lut
   * levels bypassed, lut applied (was previously both applied)
5) VideoSpeedTest.py --dtype=uint16 --size=3072x3072 --levels=0,65535
   * levels applied, lut bypassed
6) VideoSpeedTest.py --dtype=uint16 --size=3072x3072 --levels=100,10000
   * levels applied, lut bypassed
7) VideoSpeedTest.py --dtype=uint16 --size=3072x3072 --lut
   * levels bypassed, lut applied (was previously both applied)
8) VideoSpeedTest.py --dtype=uint16 --size=3072x3072 --levels=100,10000 --lut
   * levels bypassed, lut applied (was previously both applied)
 
#1630 fixed cases 1,2,5,6
This PR fixes cases 3,4,7,8

It would good to take a look at #792 and #793 to get context on what this PR is working around.
What this PR does is to explicitly supply a ```scale``` argument with a specific value to ```makeARGB()``` such that ```makeARGB()``` does not use its own default. This causes rescaling to be bypassed, which was the intention of combining levels + lut in the first place.