### PR TITLE
DateAxisItem: Account for daylight saving time

### DIFF
--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -222,7 +222,9 @@ class DateAxisItem(AxisItem):
 
         super(DateAxisItem, self).__init__(orientation, **kwargs)
         # Set the zoom level to use depending on the time density on the axis
-        self.utcOffset = utcOffset or get_utc_offset()
+        if utcOffset is None:
+            utcOffset = get_utc_offset()
+        self.utcOffset = utcOffset
         
         self.zoomLevels = OrderedDict([
             (np.inf,      YEAR_MONTH_ZOOM_LEVEL),

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -186,7 +186,7 @@ MS_ZOOM_LEVEL = ZoomLevel([
 ], "99:99:99")
 
 
-def get_utc_offset():
+def getOffsetFromUtc():
     """Retrieve the utc offset respecting the daylight saving time"""
     ts = time.localtime()
     if ts.tm_isdst:
@@ -223,7 +223,7 @@ class DateAxisItem(AxisItem):
         super(DateAxisItem, self).__init__(orientation, **kwargs)
         # Set the zoom level to use depending on the time density on the axis
         if utcOffset is None:
-            utcOffset = get_utc_offset()
+            utcOffset = getOffsetFromUtc()
         self.utcOffset = utcOffset
         
         self.zoomLevels = OrderedDict([

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -185,6 +185,17 @@ MS_ZOOM_LEVEL = ZoomLevel([
              autoSkip=[1, 5, 10, 25])
 ], "99:99:99")
 
+
+def get_utc_offset():
+    """Retrieve the utc offset respecting the daylight saving time"""
+    ts = time.localtime()
+    if ts.tm_isdst:
+        utc_offset = time.altzone
+    else:
+        utc_offset = time.timezone
+    return utc_offset
+
+
 class DateAxisItem(AxisItem):
     """
     **Bases:** :class:`AxisItem <pyqtgraph.AxisItem>`
@@ -200,7 +211,7 @@ class DateAxisItem(AxisItem):
 
     """
 
-    def __init__(self, orientation='bottom', utcOffset=time.timezone, **kwargs):
+    def __init__(self, orientation='bottom', utcOffset=None, **kwargs):
         """
         Create a new DateAxisItem.
         
@@ -211,7 +222,7 @@ class DateAxisItem(AxisItem):
 
         super(DateAxisItem, self).__init__(orientation, **kwargs)
         # Set the zoom level to use depending on the time density on the axis
-        self.utcOffset = utcOffset
+        self.utcOffset = utcOffset or get_utc_offset()
         
         self.zoomLevels = OrderedDict([
             (np.inf,      YEAR_MONTH_ZOOM_LEVEL),


### PR DESCRIPTION
This should fix the initial setting of the _utcOffset_ to respect the daylight saving time. According to the official docs it is recommended to use `tm_zone results from localtime() to obtain timezone information.`





