### PR TITLE
add usage of numba (for rescale)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Install Dependencies
       run: |
         pip install --upgrade pip
-        pip install ${{ matrix.qt-version }} numpy${{ matrix.numpy-version }} scipy pyopengl h5py matplotlib
+        pip install ${{ matrix.qt-version }} numpy${{ matrix.numpy-version }} scipy pyopengl h5py matplotlib numba
         pip install .
         pip install pytest pytest-cov pytest-xdist coverage
     - name: "Install Linux VirtualDisplay"

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -56,6 +56,7 @@ CONFIG_OPTIONS = {
                                  # The default is 'col-major' for backward compatibility, but this may
                                  # change in the future.
     'useCupy': False,  # When True, attempt to use cupy ( currently only with ImageItem and related functions )
+    'useNumba': False, # When True, use numba
 } 
 
 

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1124,7 +1124,8 @@ def rescaleData(data, scale, offset, dtype=None, clip=None):
         return data_out.astype(out_dtype, copy=False)
 
     numba_fn = getNumbaFunctions()
-    if numba_fn and out_dtype in (np.uint8, np.uint16):
+    if numba_fn and clip is not None:
+        # if we got here by makeARGB(), clip will not be None at this point
         return numba_fn.rescaleData(data, scale, offset, out_dtype, clip)
 
     return _rescaleData_nditer(data, scale, offset, work_dtype, out_dtype, clip)

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -17,6 +17,7 @@ import math
 
 import numpy as np
 from .util.cupy_helper import getCupy
+from .util.numba_helper import getNumbaFunctions
 
 from . import debug, reload
 from .Qt import QtGui, QtCore, QT_LIB, QtVersion
@@ -1121,8 +1122,12 @@ def rescaleData(data, scale, offset, dtype=None, clip=None):
 
         # don't copy if no change in dtype
         return data_out.astype(out_dtype, copy=False)
-    else:
-        return _rescaleData_nditer(data, scale, offset, work_dtype, out_dtype, clip)
+
+    numba_fn = getNumbaFunctions()
+    if numba_fn:
+        return numba_fn.rescaleData(data, scale, offset, out_dtype, clip)
+
+    return _rescaleData_nditer(data, scale, offset, work_dtype, out_dtype, clip)
 
 
 def applyLookupTable(data, lut):

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1124,7 +1124,7 @@ def rescaleData(data, scale, offset, dtype=None, clip=None):
         return data_out.astype(out_dtype, copy=False)
 
     numba_fn = getNumbaFunctions()
-    if numba_fn:
+    if numba_fn and out_dtype in (np.uint8, np.uint16):
         return numba_fn.rescaleData(data, scale, offset, out_dtype, clip)
 
     return _rescaleData_nditer(data, scale, offset, work_dtype, out_dtype, clip)

--- a/pyqtgraph/functions_numba.py
+++ b/pyqtgraph/functions_numba.py
@@ -1,0 +1,23 @@
+import numpy as np
+import numba
+
+@numba.guvectorize(
+    '(n),(),(),(),()->(n)', nopython=True)
+def rescale_clip(xx, scale, offset, vmin, vmax, yy):
+    for i in range(xx.size):
+        val = (xx[i] - offset) * scale
+        yy[i] = min(max(val, vmin), vmax)
+
+@numba.guvectorize(
+    '(n),(),()->(n)', nopython=True)
+def rescale_noclip(xx, scale, offset, yy):
+    for i in range(xx.size):
+        yy[i] = (xx[i] - offset) * scale
+
+
+def rescaleData(data, scale, offset, dtype, clip):
+    data_out = np.empty_like(data, dtype=dtype)
+    if clip is None:
+        return rescale_noclip(data, scale, offset, out=data_out)
+    else:
+        return rescale_clip(data, scale, offset, clip[0], clip[1], out=data_out)

--- a/pyqtgraph/functions_numba.py
+++ b/pyqtgraph/functions_numba.py
@@ -14,7 +14,7 @@ def rescaleData(data, scale, offset, dtype, clip):
     func = rescale_functions.get(key)
     if func is None:
         func = numba.guvectorize(
-            f'{key[0]}[:],f8,f8,f8,f8,{key[1]}[:]',
+            [f'{key[0]}[:],f8,f8,f8,f8,{key[1]}[:]'],
             '(n),(),(),(),()->(n)',
             nopython=True)(rescale_clip_source)
         rescale_functions[key] = func

--- a/pyqtgraph/functions_numba.py
+++ b/pyqtgraph/functions_numba.py
@@ -3,21 +3,41 @@ import numba
 
 @numba.guvectorize(
     '(n),(),(),(),()->(n)', nopython=True)
-def rescale_clip(xx, scale, offset, vmin, vmax, yy):
+def rescale_clip_uint8(xx, scale, offset, vmin, vmax, yy):
     for i in range(xx.size):
         val = (xx[i] - offset) * scale
         yy[i] = min(max(val, vmin), vmax)
 
 @numba.guvectorize(
     '(n),(),()->(n)', nopython=True)
-def rescale_noclip(xx, scale, offset, yy):
+def rescale_noclip_uint8(xx, scale, offset, yy):
+    for i in range(xx.size):
+        yy[i] = (xx[i] - offset) * scale
+
+@numba.guvectorize(
+    '(n),(),(),(),()->(n)', nopython=True)
+def rescale_clip_uint16(xx, scale, offset, vmin, vmax, yy):
+    for i in range(xx.size):
+        val = (xx[i] - offset) * scale
+        yy[i] = min(max(val, vmin), vmax)
+
+@numba.guvectorize(
+    '(n),(),()->(n)', nopython=True)
+def rescale_noclip_uint16(xx, scale, offset, yy):
     for i in range(xx.size):
         yy[i] = (xx[i] - offset) * scale
 
 
 def rescaleData(data, scale, offset, dtype, clip):
     data_out = np.empty_like(data, dtype=dtype)
-    if clip is None:
-        return rescale_noclip(data, scale, offset, out=data_out)
+    if dtype == np.uint8:
+        if clip is None:
+            rescale_noclip_uint8(data, scale, offset, out=data_out)
+        else:
+            rescale_clip_uint8(data, scale, offset, clip[0], clip[1], out=data_out)
     else:
-        return rescale_clip(data, scale, offset, clip[0], clip[1], out=data_out)
+        if clip is None:
+            rescale_noclip_uint16(data, scale, offset, out=data_out)
+        else:
+            rescale_clip_uint16(data, scale, offset, clip[0], clip[1], out=data_out)
+    return data_out

--- a/pyqtgraph/tests/test_makeARGB.py
+++ b/pyqtgraph/tests/test_makeARGB.py
@@ -4319,12 +4319,13 @@ def test_cupy_makeARGB_against_generated_references():
 
 
 def test_numba_makeARGB_against_generated_references():
-    try:
-        import numba
-    except ImportError:
-        pytest.skip("Numba unavailable to test")
-
     oldcfg = getConfigOption("useNumba")
+    if not oldcfg:
+        try:
+            import numba
+        except ImportError:
+            pytest.skip("Numba unavailable to test")
+
     setConfigOption("useNumba", not oldcfg)
     test_makeARGB_against_generated_references()
     setConfigOption("useNumba", oldcfg)

--- a/pyqtgraph/tests/test_makeARGB.py
+++ b/pyqtgraph/tests/test_makeARGB.py
@@ -4291,9 +4291,11 @@ def test_makeARGB_against_generated_references():
 
 
 def test_cupy_makeARGB_against_generated_references():
+    oldcfg = getConfigOption("useCupy")
     setConfigOption("useCupy", True)
     cp = getCupy()
     if cp is None:
+        setConfigOption("useCupy", oldcfg)
         pytest.skip("CuPy unavailable to test")
 
     def assert_cupy_correct(data, key, levels, lut, scale, use_rgba):
@@ -4316,6 +4318,7 @@ def test_cupy_makeARGB_against_generated_references():
             ).all(), f"Incorrect _makeARGB({key!r}) output! Expected:\n{expectation!r}\n  Got:\n{output!r}"
 
     _do_something_for_every_combo(assert_cupy_correct)
+    setConfigOption("useCupy", oldcfg)
 
 
 def test_numba_makeARGB_against_generated_references():

--- a/pyqtgraph/tests/test_makeARGB.py
+++ b/pyqtgraph/tests/test_makeARGB.py
@@ -4291,11 +4291,9 @@ def test_makeARGB_against_generated_references():
 
 
 def test_cupy_makeARGB_against_generated_references():
-    oldcfg = getConfigOption("useCupy")
     setConfigOption("useCupy", True)
     cp = getCupy()
     if cp is None:
-        setConfigOption("useCupy", oldcfg)
         pytest.skip("CuPy unavailable to test")
 
     def assert_cupy_correct(data, key, levels, lut, scale, use_rgba):
@@ -4318,21 +4316,25 @@ def test_cupy_makeARGB_against_generated_references():
             ).all(), f"Incorrect _makeARGB({key!r}) output! Expected:\n{expectation!r}\n  Got:\n{output!r}"
 
     _do_something_for_every_combo(assert_cupy_correct)
-    setConfigOption("useCupy", oldcfg)
 
 
 @pytest.mark.filterwarnings("ignore:invalid value encountered")
 def test_numba_makeARGB_against_generated_references():
-    oldcfg = getConfigOption("useNumba")
-    if not oldcfg:
+    oldcfg_numba = getConfigOption("useNumba")
+    if not oldcfg_numba:
         try:
             import numba
         except ImportError:
             pytest.skip("Numba unavailable to test")
 
-    setConfigOption("useNumba", not oldcfg)
+    # useCupy needs to be set to False because it takes
+    # precedence over useNumba in rescaleData
+    oldcfg_cupy = getConfigOption("useCupy")
+    setConfigOption("useCupy", False)
+    setConfigOption("useNumba", not oldcfg_numba)
     test_makeARGB_against_generated_references()
-    setConfigOption("useNumba", oldcfg)
+    setConfigOption("useNumba", oldcfg_numba)
+    setConfigOption("useCupy", oldcfg_cupy)
 
 
 def test_makeARGB_with_human_readable_code():

--- a/pyqtgraph/tests/test_makeARGB.py
+++ b/pyqtgraph/tests/test_makeARGB.py
@@ -4,7 +4,7 @@ import pytest
 import sys
 from typing import Dict, Any, Union, Type
 
-from pyqtgraph import getCupy, setConfigOption
+from pyqtgraph import getCupy, getConfigOption, setConfigOption
 from pyqtgraph.functions import makeARGB as real_makeARGB
 
 IN_2D_INT8 = np.array([[173, 48, 122, 41], [210, 192, 0, 5], [104, 56, 102, 115], [78, 19, 255, 6]], dtype=np.uint8)
@@ -4316,6 +4316,18 @@ def test_cupy_makeARGB_against_generated_references():
             ).all(), f"Incorrect _makeARGB({key!r}) output! Expected:\n{expectation!r}\n  Got:\n{output!r}"
 
     _do_something_for_every_combo(assert_cupy_correct)
+
+
+def test_numba_makeARGB_against_generated_references():
+    try:
+        import numba
+    except ImportError:
+        pytest.skip("Numba unavailable to test")
+
+    oldcfg = getConfigOption("useNumba")
+    setConfigOption("useNumba", not oldcfg)
+    test_makeARGB_against_generated_references()
+    setConfigOption("useNumba", oldcfg)
 
 
 def test_makeARGB_with_human_readable_code():

--- a/pyqtgraph/tests/test_makeARGB.py
+++ b/pyqtgraph/tests/test_makeARGB.py
@@ -4321,6 +4321,7 @@ def test_cupy_makeARGB_against_generated_references():
     setConfigOption("useCupy", oldcfg)
 
 
+@pytest.mark.filterwarnings("ignore:invalid value encountered")
 def test_numba_makeARGB_against_generated_references():
     oldcfg = getConfigOption("useNumba")
     if not oldcfg:

--- a/pyqtgraph/util/numba_helper.py
+++ b/pyqtgraph/util/numba_helper.py
@@ -10,10 +10,6 @@ def getNumbaFunctions():
             warn("numba library could not be loaded, but 'useNumba' is set.")
             return None
 
-        if numba.version_info.full < (0, 53):
-            warn(f"pyqtgraph requires numba version >= 0.53  (your version is {numba.version_info.string})")
-            return None
-
         from .. import functions_numba
         return functions_numba
     else:

--- a/pyqtgraph/util/numba_helper.py
+++ b/pyqtgraph/util/numba_helper.py
@@ -1,0 +1,20 @@
+from warnings import warn
+
+from .. import getConfigOption
+
+def getNumbaFunctions():
+    if getConfigOption("useNumba"):
+        try:
+            import numba
+        except ImportError:
+            warn("numba library could not be loaded, but 'useNumba' is set.")
+            return None
+
+        if numba.version_info.full < (0, 53):
+            warn(f"pyqtgraph requires numba version >= 0.53  (your version is {numba.version_info.string})")
+            return None
+
+        from .. import functions_numba
+        return functions_numba
+    else:
+        return None


### PR DESCRIPTION
This PR adds optional usage of numba to pyqtgraph as permitted by #1253.
As a working example, a numba implementation for rescaleData() is included.
A fairly new version >= 0.53 of numba is required for the dynamic guvectorize functionality. As it happens, version 0.53 is the first version with a Python 3.9 wheel.

Benchmarking code with timings obtained on the same machine
```python
import time
import argparse
import numpy as np
import pyqtgraph as pg
from pyqtgraph.functions import rescaleData

parser = argparse.ArgumentParser()
parser.add_argument('--numba', action='store_true')
args = parser.parse_args()

if args.numba:
    try:
        pg.setConfigOptions(useNumba=True)
        import pyqtgraph.functions_numba
    except KeyError:
        pass

shape = 3072, 3072
data_uint8 = np.random.randint(256, size=shape, dtype=np.uint8)
data_float32 = np.random.random(shape).astype(np.float32)
niters = 20

if args.numba:
    # force the JIT
    rescaleData(data_uint8, 1.0, 0.0, dtype=np.uint8)
    rescaleData(data_float32, 1.0, 0.0, dtype=np.uint8)

for data in [data_uint8, data_float32]:
    for alpha in [0.1, 0.25]:
        if data.dtype.kind == 'u':
            minval, maxval = alpha * 255, (1 - alpha) * 255
        else:
            minval, maxval = alpha, 1 - alpha
        scale = 255 / (maxval - minval)
        offset = minval
        params = data, scale, offset, np.uint8

        t0 = time.perf_counter()
        for _ in range(niters):
            output = rescaleData(*params)
        t1 = time.perf_counter()
        print(data.dtype, alpha, '{:.6f}'.format((t1 - t0) / niters))

if args.numba:
    print(pyqtgraph.functions_numba.rescale_clip.types)
    print(pyqtgraph.functions_numba.rescale_noclip.types)
```


|    | Windows numpy 1.20.2 | Windows numba | WSL2 numpy 1.20.2 | WSL2 numba |
|--| -- | -- | -- |--|
|uint8 0.1   | 0.029979 | 0.007479 | 0.010434 | 0.006391 |
|uint8 0.25  | 0.030011 | 0.007832 | 0.010233 | 0.006176 |
|float32 0.1 | 0.044040 | 0.008983 | 0.011722 | 0.006383 |
|float32 0.25| 0.073928 | 0.008264 | 0.011681 | 0.006399 |

Windows platform benefits the most from the use of numba here.
Linux platform already has fairly good performance with numpy 1.20