### PR TITLE
avoid numpy scalar overflow

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1046,7 +1046,9 @@ def _rescaleData_nditer(data_in, scale, offset, work_dtype, out_dtype, clip):
         # casting to an int32 will lose the fractional part, therefore the
         # output dtype must be an integer kind.
         lim_in = np.iinfo(data_in.dtype)
-        dst_bounds = scale * (lim_in.min - offset), scale * (lim_in.max - offset)
+        # convert numpy scalar to python scalar to avoid overflow warnings
+        lo = offset.item(0) if isinstance(offset, np.number) else offset
+        dst_bounds = scale * (lim_in.min - lo), scale * (lim_in.max - lo)
         if dst_bounds[1] < dst_bounds[0]:
             dst_bounds = dst_bounds[1], dst_bounds[0]
         lim32 = np.iinfo(np.int32)


### PR DESCRIPTION
the "offset" argument passed into rescaleData() is typically an element
of an ndarray, i.e. it comes from the lower bound value of the "levels"
ndarray. as such, arithmetic operations on it can overflow.

this triggers a runtime warning in the test suite.

the workaround is to convert it to a Python (integer) scalar.