### PR TITLE
add PyQt6 6.1 forwards compatibility

### DIFF
--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -376,6 +376,15 @@ if QT_LIB == PYQT6:
         QtCore.QEvent.type = new_method
         del new_method
 
+    # PyQt6 6.1 renames some enums and flags to be in line with the other bindings.
+    # "Alignment" and "Orientations" are PyQt6 6.0 and are used in the generated
+    # ui files. Pending a regeneration of the template files, which would mean a
+    # drop in support for PyQt6 6.0, provide the old names for PyQt6 6.1.
+    # This is strictly a temporary private shim. Do not depend on it in your code.
+    if hasattr(QtCore.Qt, 'AlignmentFlag') and not hasattr(QtCore.Qt, 'Alignment'):
+        QtCore.Qt.Alignment = QtCore.Qt.AlignmentFlag
+    if hasattr(QtCore.Qt, 'Orientation') and not hasattr(QtCore.Qt, 'Orientations'):
+        QtCore.Qt.Orientations = QtCore.Qt.Orientation
 
 # USE_XXX variables are deprecated
 USE_PYSIDE = QT_LIB == PYSIDE

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -826,10 +826,17 @@ class ROI(GraphicsObject):
         """
         return True
 
-    def movePoint(self, handle, pos, modifiers=QtCore.Qt.KeyboardModifiers(0), finish=True, coords='parent'):
+    def movePoint(self, handle, pos, modifiers=None, finish=True, coords='parent'):
         ## called by Handles when they are moved. 
         ## pos is the new position of the handle in scene coords, as requested by the handle.
-        
+        if modifiers is None:
+            try:
+                # this works for PyQt6 6.1 and other bindings
+                modifiers = QtCore.Qt.KeyboardModifier.NoModifier
+            except AttributeError:
+                # this works for PyQt6 6.0 and other bindings
+                modifiers = QtCore.Qt.KeyboardModifiers(0)
+
         newState = self.stateCopy()
         index = self.indexOfHandle(handle)
         h = self.handles[index]
@@ -1454,7 +1461,14 @@ class Handle(UIGraphicsItem):
             self.currentPen = self.hoverPen
             self.movePoint(pos, ev.modifiers(), finish=False)
 
-    def movePoint(self, pos, modifiers=QtCore.Qt.KeyboardModifiers(0), finish=True):
+    def movePoint(self, pos, modifiers=None, finish=True):
+        if modifiers is None:
+            try:
+                # this works for PyQt6 6.1 and other bindings
+                modifiers = QtCore.Qt.KeyboardModifier.NoModifier
+            except AttributeError:
+                # this works for PyQt6 6.0 and other bindings
+                modifiers = QtCore.Qt.KeyboardModifiers(0)
         for r in self.rois:
             if not r.checkPointMove(self, pos, modifiers):
                 return

--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -259,9 +259,10 @@ class Renderer(GraphicsView):
 
     def deserialize_wheel_event(self, wheel_event):
         pos, gpos, pixelDelta, angleDelta, btns, mods, phase, inverted = wheel_event
-        btns = QtCore.Qt.MouseButtons(btns)
-        mods = QtCore.Qt.KeyboardModifiers(mods)
-        phase = QtCore.Qt.ScrollPhase(phase)
+        if QT_LIB != 'PyQt6':
+            btns = QtCore.Qt.MouseButtons(btns)
+            mods = QtCore.Qt.KeyboardModifiers(mods)
+            phase = QtCore.Qt.ScrollPhase(phase)
         return QtGui.QWheelEvent(pos, gpos, pixelDelta, angleDelta, btns, mods, phase, inverted)
 
     def mousePressEvent(self, mouse_event):


### PR DESCRIPTION
This addresses #1692 to provide forwards compatibility to PyQt6 6.1.

It adds a temporary shim for the renamed enums such that when PyQt6 6.1 is released, it will run on the ui files generated using PyQt6 6.0. Only forwards-compatibility is provided. Backwards-compatibility is deliberately not provided.

The decision by pyqtgraph library to drop PyQt6 6.0 support would coincide with the regeneration of the ui files using PyQt6 6.1 (and also removal of the temporary shim.)