### PR TITLE
Remove infiniteline from others in examples

### DIFF
--- a/examples/utils.py
+++ b/examples/utils.py
@@ -97,7 +97,6 @@ others = dict([
     ('MultiplePlotAxes', 'MultiplePlotAxes.py'),
     ('ROItypes', 'ROItypes.py'),
     ('ScaleBar', 'ScaleBar.py'),
-    ('InfiniteLine', 'InfiniteLine.py'),
     ('ViewBox', 'ViewBox.py'),
     ('GradientEditor', 'GradientEditor.py'),
     ('GLBarGraphItem', 'GLBarGraphItem.py'),


### PR DESCRIPTION
Since merging #1318 `InfiniteLine.py` is listed both in the Example App under "Graphics Items" section, and under the `others` dictionary.  This PR removes the entry from the `others` dictionary.

Thanks @pijyoi for noticing that this.