### PR TITLE
run pyqtgraph tests before examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Run Tests
       run: |
         mkdir $SCREENSHOT_DIR
-        pytest . -v \
+        pytest pyqtgraph examples -v \
           -n auto \
           --junitxml pytest.xml \
           --cov pyqtgraph --cov-report=xml --cov-report=html


### PR DESCRIPTION
Recently, the CI has been failing frequently, crashing on Linux / Python 3.8 / PySide2 at ```test_ref_cycles.py::test_ImageView()```. This appears to be a case of being at the wrong place at the wrong time, i.e. automatic garbage collection got triggered around that point.

By arranging to have the pyqtgraph tests run before the examples, this particular crash seems to have gone away.
