### PR TITLE
Expose the `clickable` property of `PlotDataItem`. (#519)

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -208,6 +208,7 @@ class PlotDataItem(GraphicsObject):
 
             'data': None,
         }
+        self.setCurveClickable(kargs.get('clickable', False))
         self.setData(*args, **kargs)
 
     def implements(self, interface=None):
@@ -218,6 +219,12 @@ class PlotDataItem(GraphicsObject):
 
     def name(self):
         return self.opts.get('name', None)
+
+    def setCurveClickable(self, s, width=None):
+        self.curve.setClickable(s, width)
+
+    def curveClickable(self):
+        return self.curve.clickable
 
     def boundingRect(self):
         return QtCore.QRectF()  ## let child items handle this


### PR DESCRIPTION
* Fix the `clickable` property of `PlotDataItem`.

Currently if you attempt to set the `clickable` property of a PlotDataItem,
this property is silently ignored. The expected behavior is to set the
`clickable` property of the underlying PlotCurveItem.

* Use setCurvesClickable and curvesClickable instead

* curve is singular