### PR TITLE
small TargetItem fixes

### DIFF
--- a/examples/InfiniteLine.py
+++ b/examples/InfiniteLine.py
@@ -32,13 +32,7 @@ p1.addItem(inf1)
 p1.addItem(inf2)
 p1.addItem(inf3)
 
-targetItem1 = pg.TargetItem(
-    label=True,
-    symbol="crosshair",
-    labelOpts={
-        "angle": 0
-    }
-)
+targetItem1 = pg.TargetItem()
 
 targetItem2 = pg.TargetItem(
     pos=(30, 5),
@@ -47,10 +41,10 @@ targetItem2 = pg.TargetItem(
     symbol="star",
     pen="#F4511E",
     labelOpts={
-        "angle": 45,
         "offset": QtCore.QPoint(15, 15)
     }
 )
+targetItem2.label().setAngle(45)
 
 targetItem3 = pg.TargetItem(
     pos=(10, 10),

--- a/examples/InfiniteLine.py
+++ b/examples/InfiniteLine.py
@@ -37,9 +37,9 @@ targetItem1 = pg.TargetItem()
 targetItem2 = pg.TargetItem(
     pos=(30, 5),
     size=20,
-    label="vert={1:0.2f}",
     symbol="star",
     pen="#F4511E",
+    label="vert={1:0.2f}",
     labelOpts={
         "offset": QtCore.QPoint(15, 15)
     }
@@ -49,16 +49,19 @@ targetItem2.label().setAngle(45)
 targetItem3 = pg.TargetItem(
     pos=(10, 10),
     size=10,
-    label="Third Label",
-    symbol="x", 
+    symbol="x",
     pen="#00ACC1",
-    labelOpts={
+)
+targetItem3.setLabel(
+    "Third Label",
+    {
         "anchor": QtCore.QPointF(0.5, 0.5),
         "offset": QtCore.QPointF(30, 0),
         "color": "#558B2F",
         "rotateAxis": (0, 1)
     }
 )
+
 
 def callableFunction(x, y):
     return f"Square Values: ({x**2:.4f}, {y**2:.4f})"

--- a/pyqtgraph/graphicsItems/TargetItem.py
+++ b/pyqtgraph/graphicsItems/TargetItem.py
@@ -393,11 +393,6 @@ class TargetLabel(TextItem):
         anchor=(0, 0.5),
         **kwargs,
     ):
-        super().__init__(anchor=anchor, **kwargs)
-        self.setParentItem(target)
-        self.target = target
-        self.setFormat(text)
-
         if isinstance(offset, Point):
             self.offset = offset
         elif isinstance(offset, (tuple, list)):
@@ -406,6 +401,12 @@ class TargetLabel(TextItem):
             self.offset = Point(offset.x(), offset.y())
         else:
             raise TypeError("Offset parameter is the wrong data type")
+
+        super().__init__(anchor=anchor, **kwargs)
+        self.setParentItem(target)
+        self.target = target
+        self.setFormat(text)
+
         self.target.sigPositionChanged.connect(self.valueChanged)
         self.valueChanged()
 

--- a/pyqtgraph/graphicsItems/TargetItem.py
+++ b/pyqtgraph/graphicsItems/TargetItem.py
@@ -354,7 +354,7 @@ class TargetItem(UIGraphicsItem):
             DeprecationWarning,
             stacklevel=2,
         )
-        if self.label() is not None and angle != self.label().angle():
+        if self.label() is not None and angle != self.label().angle:
             self.label().setAngle(angle)
         return None
 


### PR DESCRIPTION
Playing around with TargetItem more, I found a couple of errors:

```
    |  Traceback (most recent call last):
    |    File "/home/martin/src/acq4/acq4/acq4/devices/Pipette/pipette.py", line 500, in __init__
    |      self.target.setLabelAngle(dev.yawAngle())
    |    File "/home/martin/src/acq4/pyqtgraph/pyqtgraph/graphicsItems/TargetItem.py", line 357, in setLabelAngle
    |      if self.label() is not None and angle != self.label().angle():
    |  TypeError: 'int' object is not callable
    |==============================<<
```

Which is deprecated, so no biggie, but we may as well fix it.

This next one I couldn't make an isolated test of, but the fix was just reorganizing the `__init__` method:

```
Traceback (most recent call last):
  File "/home/martin/src/acq4/pyqtgraph/pyqtgraph/graphicsItems/GraphicsObject.py", line 23, in itemChange
    self.parentChanged()
  File "/home/martin/src/acq4/pyqtgraph/pyqtgraph/graphicsItems/GraphicsItem.py", line 472, in parentChanged
    self._updateView()
  File "/home/martin/src/acq4/pyqtgraph/pyqtgraph/graphicsItems/GraphicsItem.py", line 529, in _updateView
    self.viewTransformChanged()
  File "/home/martin/src/acq4/pyqtgraph/pyqtgraph/graphicsItems/TargetItem.py", line 452, in viewTransformChanged
    self.offset.x() * viewPixelSize[0], self.offset.y() * viewPixelSize[1]
AttributeError: 'TargetLabel' object has no attribute 'offset'
```

I tweaked the example, too, just to exercise the class a little.

**Edited** to not have quite so much irrelevant stack.