### PR TITLE
Update pytest and tox configs, fix misc warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,29 +120,9 @@ jobs:
     env:
       SCREENSHOT_DIR: ./screenshots
 
-  build-docs:
-    name: build docs
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-      - name: Install Dependencies
-        run: |
-          cd doc
-          python -m pip install -r requirements.txt
-      - name: Build Documentation
-        run: |
-          cd doc
-          make html SPHINXOPTS='-W --keep-going -v'
-
   build-wheel:
     name: build wheel
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python 3.9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,19 +24,19 @@ jobs:
           - python-version: "3.8"
             qt-lib: "pyqt"
             qt-version: "PyQt5~=5.15.0"
-            numpy-version: "~=1.19.0"
+            numpy-version: "~=1.20.0"
           - python-version: "3.8"
             qt-lib: "pyside"
             qt-version: "PySide2~=5.15.0"
-            numpy-version: "~=1.19.0"
+            numpy-version: "~=1.20.0"
           - python-version: "3.9"
             qt-lib: "pyqt"
             qt-version: "PyQt6"
-            numpy-version: "~=1.19.0"
+            numpy-version: "~=1.20.0"
           - python-version: "3.9"
             qt-lib: "pyside"
             qt-version: "PySide6"
-            numpy-version: "~=1.19.0"
+            numpy-version: "~=1.20.0"
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -55,11 +55,14 @@ The following table represents the python environments we test in our CI system.
 | Qt-Bindings    | Python 3.7         | Python 3.8         | Python 3.9         |
 | :------------- | :----------------: | :----------------: | :----------------: |
 | PySide2-5.12   | :white_check_mark: | :x:                | :x:                |
-| PyQt5-5.12     | :white_check_mark: | :x:                | :x:                |
-| PySide2-5.15   | :x:                | :white_check_mark: | :x:                |
-| PyQt5-5.15     | :x:                | :white_check_mark: | :x:                |
-| PySide6-6.0    | :x:                | :x:                | :white_check_mark: |
-| PyQt6-6.0      | :x:                | :x:                | :white_check_mark: |
+| PyQt5-5.12     | :white_check_mark: |                    | :x:                |
+| PySide2-5.15   |                    | :white_check_mark: |                    |
+| PyQt5-5.15     |                    | :white_check_mark: |                    |
+| PySide6-6.0    |                    |                    | :white_check_mark: |
+| PyQt6-6.0      |                    |                    | :white_check_mark: |
+
+* :x: - Not compatible
+* :white_check_mark: - Tested
 
 Support
 -------

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -58,7 +58,7 @@ installedFrontends = sorted([
 
 darwin_opengl_broken = (platform.system() == "Darwin" and
             tuple(map(int, platform.mac_ver()[0].split("."))) >= (10, 16) and
-            (sys.version_info <= (3, 8, 7) or (3, 9) <= sys.version_info < (3, 9, 1)))
+            sys.version_info < (3, 9, 1))
 
 darwin_opengl_reason = ("pyopenGL cannot find openGL library on big sur: "
                         "https://github.com/python/cpython/pull/21241")

--- a/pyqtgraph/debug.py
+++ b/pyqtgraph/debug.py
@@ -5,14 +5,21 @@ Copyright 2010  Luke Campagnola
 Distributed under MIT/X11 license. See license.txt for more information.
 """
 
+
 from __future__ import print_function
 
 import sys, traceback, time, gc, re, types, weakref, inspect, os, cProfile, threading
+import warnings
 from . import ptime
 from numpy import ndarray
-from .Qt import QtCore, QtGui
-from .util.mutex import Mutex
+from .Qt import QtCore, QT_LIB
 from .util import cprint
+if sys.version.startswith("3.8") and QT_LIB == "PySide2":
+    from .Qt import PySide2
+    if tuple(map(int, PySide2.__version__.split("."))) < (5, 14):
+        warnings.warn("Due to PYSIDE-1140, ThreadChase and ThreadColor won't work")
+from .util.mutex import Mutex
+
 
 __ftraceDepth = 0
 def ftrace(func):

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -2266,7 +2266,7 @@ class LineSegmentROI(ROI):
         Since this pulls 1D data from a 2D coordinate system, the return value 
         will have ndim = data.ndim-1
         
-        See :meth:`~pytqgraph.ROI.getArrayRegion` for a description of the
+        See :meth:`~pyqtgraph.ROI.getArrayRegion` for a description of the
         arguments.
         """
         imgPts = [self.mapToItem(img, h.pos()) for h in self.endpoints]
@@ -2384,7 +2384,7 @@ class RulerROI(LineSegmentROI):
 
 
 class TriangleROI(ROI):
-    """
+    r"""
     Equilateral triangle ROI subclass with one scale handle and one rotation handle.
     Arguments
     pos            (length-2 sequence) The position of the ROI's origin.

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -800,7 +800,7 @@ class ROI(GraphicsObject):
         if ev.button() == QtCore.Qt.RightButton and self.contextMenuEnabled():
             self.raiseContextMenu(ev)
             ev.accept()
-        elif ev.button() & self.acceptedMouseButtons():
+        elif ev.button() in self.acceptedMouseButtons():
             ev.accept()
             self.sigClicked.emit(self, ev)
         else:

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1243,7 +1243,7 @@ class ViewBox(GraphicsWidget):
             mask[1-axis] = 0.0
 
         ## Scale or translate based on mouse button
-        if ev.button() & (QtCore.Qt.LeftButton | QtCore.Qt.MiddleButton):
+        if ev.button() in [QtCore.Qt.LeftButton, QtCore.Qt.MiddleButton]:
             if self.state['mouseMode'] == ViewBox.RectMode and axis is None:
                 if ev.isFinish():  ## This is the final move in the drag; change the view scale now
                     #print "finish"

--- a/pyqtgraph/tests/test_makeARGB.py
+++ b/pyqtgraph/tests/test_makeARGB.py
@@ -4290,12 +4290,10 @@ def test_makeARGB_against_generated_references():
     _do_something_for_every_combo(assert_correct)
 
 
+@pytest.mark.skipif(getCupy() is None, reason="CuPy unavailable to test")
 def test_cupy_makeARGB_against_generated_references():
     setConfigOption("useCupy", True)
     cp = getCupy()
-    if cp is None:
-        pytest.skip("CuPy unavailable to test")
-
     def assert_cupy_correct(data, key, levels, lut, scale, use_rgba):
         data = cp.asarray(data)
         if lut is not None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,15 +7,15 @@ xvfb_args=-ac +extension GLX +render
 faulthandler_timeout = 30
 
 filterwarnings =
+    # re-enable standard library warnings
+    once::DeprecationWarning
+    once::PendingDeprecationWarning
     # comfortable skipping these warnings runtime warnings
     # https://stackoverflow.com/questions/40845304/runtimewarning-numpy-dtype-size-changed-may-indicate-binary-incompatibility
     ignore:numpy.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning
-    # Warnings generated from PyQt5.9
+    # pyside2_512 specific issue
     ignore:This method will be removed in future versions.  Use 'tree.iter\(\)' or 'list\(tree.iter\(\)\)' instead.:PendingDeprecationWarning
-    ignore:.*'U' mode is deprecated.*:DeprecationWarning
-    # py36/pyside2_512 specific issue
-    ignore:split\(\) requires a non-empty pattern match\.:FutureWarning
     # pyqtgraph specific warning we want to ignore during testing
     ignore:Visible window deleted. To prevent this, store a reference to the window object.
-    # xvfb warnings
+    # xvfb warnings on non-linux systems
     ignore:Unknown config option:pytest.PytestConfigWarning

--- a/tox.ini
+++ b/tox.ini
@@ -1,43 +1,37 @@
 [tox]
 envlist = 
-    ; qt latest
-    py{37,38}-{pyqt5,pyside2}_latest
+    ; qt 5.15.x
+    py{37,38,39}-{pyqt5,pyside2}_515
 
-    ; qt 5.12.x (LTS) 
-    py{36,37}-{pyqt5,pyside2}_512
+    ; qt 5.12.x
+    py{37}-{pyqt5,pyside2}_512
+    ; py38-pyside2_512 doesn't work due to PYSIDE-1140
+    py38-pyqt5_512 
 
-    ; qt 5.9.7 (LTS)
-    py36-{pyqt5,pyside2}_59_conda
+    ; qt 6
+    py{37,38,39}-{pyqt6,pyside6}
 
 [base]
 deps =
     pytest
+    pytest-xdist
     numpy
     scipy
     pyopengl
-    flake8
-    coverage
+    h5py
 
 [testenv]
-passenv = DISPLAY XAUTHORITY
+passenv = DISPLAY XAUTHORITY, PYTHON_VERSION
 setenv = PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command
 deps=
     {[base]deps}
-    pytest-cov
-    h5py
-    pyside2_512: pyside2>=5.12,<5.13
-    pyqt5_512: pyqt5>=5.12,<5.13
-    pyside2_latest: pyside2
-    pyqt5_latest: pyqt5
-
-conda_deps=
-    pyside2_59_conda: pyside2=5.9
-    pyqt5_59_conda: pyqt=5.9
-
-conda_channels=
-    conda-forge
-    free
+    pyside2_512: pyside2==5.12.6
+    pyqt5_512: pyqt5==5.12.3
+    pyside2_515: pyside2
+    pyqt5_515: pyqt5
+    pyqt6: pyqt6
+    pyside6: pyside6
 
 commands=
     python -c "import pyqtgraph as pg; pg.systemInfo()"
-    pytest {posargs:} 
+    pytest -n auto {posargs:} 


### PR DESCRIPTION
`pytest.ini` was updated to show standard library warnings involving Deprecations,  and some warnings were removed that were emitted from older bindings we no longer support.

The pyopenGL tests that had to be skipped on macOS Big Sur, I had to rework the conditional statement (I had assumed the bug that was causing the issue would be fixed with later versions of Python 3.8, but that did not happen).

`tox.ini` got fairly far out of date; updated it so `conda` is no longer necessary (config is a lot simpler now without Qt4).

On some configs, using `ev.button() & QtCore.Qt.LeftButton` would throw a warning about implicit integer conversion is being deprecated, so those methods were removed.

Only thing here that surprised me is due to [PYSIDE-1140](https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1140?filter=allissues) PyQtGraph won't work with Python 3.8 and PySide2 < 5.14.

Also fixed a warning in ROI.py for invalid escape sequence, and a typo in the docstring.