### PR TITLE
Set fixed data ordering for ColorBarItem

### DIFF
--- a/pyqtgraph/graphicsItems/ColorBarItem.py
+++ b/pyqtgraph/graphicsItems/ColorBarItem.py
@@ -98,7 +98,7 @@ class ColorBarItem(PlotItem):
         self.axis.unlinkFromView()
         self.axis.setRange( self.values[0], self.values[1] )
 
-        self.bar = ImageItem()
+        self.bar = ImageItem(axisOrder='col-major')
         if self.horizontal:
             self.bar.setImage( np.linspace(0, 1, 256).reshape( (-1,1) ) )
             if label is not None: self.getAxis('bottom').setLabel(label)


### PR DESCRIPTION
#1720 points out that ColorBarItem assumes 'col-major' data ordering for drawing its gradient bar.

If the user sets `pg.setConfigOption('imageAxisOrder', 'row-major')`, the gradient plots orthogonal to the intended direction, and only color 0 is visible. As suggested by @pijyoi , initializing ColorBarItem's internal ImageItem as `axisOrder='col-major'` fixes this problem.

Closes #1720 .