### PR TITLE
fix ExampleApp crash on PowerShell

### DIFF
--- a/examples/ExampleApp.py
+++ b/examples/ExampleApp.py
@@ -360,15 +360,7 @@ class ExampleLoader(QtGui.QMainWindow):
             fn = self.currentFile()
             if fn is None:
                 return
-            if sys.platform.startswith('win'):
-                args = [os.P_NOWAIT, sys.executable, '"'+sys.executable+'"', '"' + fn + '"']
-            else:
-                args = [os.P_NOWAIT, sys.executable, sys.executable, fn]
-            if env is None:
-                os.spawnl(*args)
-            else:
-                args.append(env)
-                os.spawnle(*args)
+            subprocess.Popen([sys.executable, fn], env=env)
 
     def showFile(self):
         fn = self.currentFile()


### PR DESCRIPTION
When the ExampleApp is launched from Windows PowerShell, selecting a binding other than the default and then launching an example may cause a crash of the ExampleApp itself. This may have to do with spawnle being documented as not thread-safe on Windows. https://docs.python.org/3/library/os.html#os.spawnle

This PR fixes it by replacing use of os.spawn* with subprocess.Popen, as suggested by the Python docs.
It also simplifies the code.