### PR TITLE
be hidpi-aware for remote rendering

### DIFF
--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -211,7 +211,10 @@ class Renderer(GraphicsView):
             ## make sure shm is large enough and get its address
             if self.width() == 0 or self.height() == 0:
                 return
-            size = self.width() * self.height() * 4
+            dpr = self.devicePixelRatioF()
+            iwidth = int(self.width() * dpr)
+            iheight = int(self.height() * dpr)
+            size = iwidth * iheight * 4
             if size > self.shm.size():
                 if sys.platform.startswith('win'):
                     ## windows says "WindowsError: [Error 87] the parameter is incorrect" if we try to resize the mmap
@@ -240,13 +243,14 @@ class Renderer(GraphicsView):
                 # PySide2, PySide6
                 img_ptr = self.shm
 
-            self.img = QtGui.QImage(img_ptr, self.width(), self.height(), QtGui.QImage.Format_ARGB32)
+            self.img = QtGui.QImage(img_ptr, iwidth, iheight, QtGui.QImage.Format_ARGB32)
+            self.img.setDevicePixelRatio(dpr)
 
             self.img.fill(0xffffffff)
             p = QtGui.QPainter(self.img)
             self.render(p, self.viewRect(), self.rect())
             p.end()
-            self.sceneRendered.emit((self.width(), self.height(), self.shm.size(), self.shmFileName()))
+            self.sceneRendered.emit((iwidth, iheight, self.shm.size(), self.shmFileName()))
 
     def deserialize_mouse_event(self, mouse_event):
         typ, pos, gpos, btn, btns, mods = mouse_event


### PR DESCRIPTION
Get and set device pixel ratio for remote rendering.
Should address the low resolution issue (but not the font issue) mentioned in #1731.

Using examples\RemoteGraphicsView.py:
before:
![before](https://user-images.githubusercontent.com/2657027/115693291-5f0a5f00-a392-11eb-8c38-933bb01b0ed1.png)
after:
![after](https://user-images.githubusercontent.com/2657027/115693333-66316d00-a392-11eb-8d90-fa86549d4fb4.png)
