### PR TITLE
use Format_RGB32 when using QImage as paint device

### DIFF
--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -80,17 +80,14 @@ class RemoteGraphicsView(QtGui.QWidget):
                 self.shm = mmap.mmap(-1, size, self.shmtag) ## can't use tmpfile on windows because the file can only be opened once.
             else:
                 self.shm = mmap.mmap(self.shmFile.fileno(), size, mmap.MAP_SHARED, mmap.PROT_READ)
-        self.shm.seek(0)
-        data = self.shm.read(w*h*4)
-        self._img = QtGui.QImage(data, w, h, QtGui.QImage.Format_ARGB32)
-        self._img.data = data  # data must be kept alive or PySide 1.2.1 (and probably earlier) will crash.
+        self._img = QtGui.QImage(self.shm, w, h, QtGui.QImage.Format.Format_RGB32).copy()
         self.update()
         
     def paintEvent(self, ev):
         if self._img is None:
             return
         p = QtGui.QPainter(self)
-        p.drawImage(self.rect(), self._img, QtCore.QRect(0, 0, self._img.width(), self._img.height()))
+        p.drawImage(self.rect(), self._img, self._img.rect())
         p.end()
 
     def serialize_mouse_enum(self, *args):
@@ -243,7 +240,7 @@ class Renderer(GraphicsView):
                 # PySide2, PySide6
                 img_ptr = self.shm
 
-            self.img = QtGui.QImage(img_ptr, iwidth, iheight, QtGui.QImage.Format_ARGB32)
+            self.img = QtGui.QImage(img_ptr, iwidth, iheight, QtGui.QImage.Format.Format_RGB32)
             self.img.setDevicePixelRatio(dpr)
 
             self.img.fill(0xffffffff)


### PR DESCRIPTION
This allows sub-pixel font antialiasing to take place.
This addresses the font issue mentioned in #1731.

Qt docs https://doc.qt.io/qt-5/qimage.html#Format-enum say:
"Rendering is best optimized to the Format_RGB32 and Format_ARGB32_Premultiplied formats"

Before (top is the remote render, bottom is the local render):
![before](https://user-images.githubusercontent.com/2657027/115860094-9c8aed00-a463-11eb-823c-64e96c1623c7.png)
After (top is the remote render, bottom is the local render): 
![after](https://user-images.githubusercontent.com/2657027/115860103-9e54b080-a463-11eb-9376-2ec7436d7b3f.png)

One thing that I noticed is that the remote render is brighter than the local render. This includes the plot, not just the text. And this is the case even before this PR.