### PR TITLE
fix: cprint of remote output needs decode()

### DIFF
--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -489,12 +489,12 @@ class FileForwarder(threading.Thread):
             while not self.finish.is_set():
                 line = self.input.readline()
                 with self.lock:
-                    cprint.cout(self.color, line, -1)
+                    cprint.cout(self.color, line.decode('utf8'), -1)
         elif self.output == 'stderr' and self.color is not False:
             while not self.finish.is_set():
                 line = self.input.readline()
                 with self.lock:
-                    cprint.cerr(self.color, line, -1)
+                    cprint.cerr(self.color, line.decode('utf8'), -1)
         else:
             if isinstance(self.output, str):
                 self.output = getattr(sys, self.output)


### PR DESCRIPTION
To trigger the bug that this PR fixes, under Windows OS, run examples/RemoteGraphicsView.py after editing ```debug=False``` to ```debug=True```.
Debug output from the remote end will raise an exception and hang the remote end.

Local end debug output is colorized in white.
Remote end debug output is colorized in green.

This bug affects Windows OS only as the FileForwarder class is only used on Windows.