### PR TITLE
fix bug when plotting boolean arrays

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -639,9 +639,9 @@ class PlotDataItem(GraphicsObject):
             y = self.yData
 
             if y.dtype == np.bool:
-                y = y.astype(int)
+                y = y.astype(np.uint8)
             if x.dtype == np.bool:
-                x = x.astype(int)
+                x = x.astype(np.uint8)
 
             if self.opts['fftMode']:
                 x,y = self._fourierTransform(x, y)

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -638,6 +638,11 @@ class PlotDataItem(GraphicsObject):
             x = self.xData
             y = self.yData
 
+            if y.dtype == np.bool:
+                y = y.astype(int)
+            if x.dtype == np.bool:
+                x = x.astype(int)
+
             if self.opts['fftMode']:
                 x,y = self._fourierTransform(x, y)
                 # Ignore the first bin for fft data if we have a logx scale

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -638,9 +638,9 @@ class PlotDataItem(GraphicsObject):
             x = self.xData
             y = self.yData
 
-            if y.dtype == np.bool:
+            if y.dtype == bool:
                 y = y.astype(np.uint8)
-            if x.dtype == np.bool:
+            if x.dtype == bool:
                 x = x.astype(np.uint8)
 
             if self.opts['fftMode']:

--- a/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
@@ -1,8 +1,19 @@
+# -*- coding: utf-8 -*-
 import numpy as np
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtGui
 
 pg.mkQApp()
+
+
+def test_bool():
+    truths = np.random.randint(0, 2, size=(100,)).astype(np.bool)
+    pdi = pg.PlotDataItem(truths)
+    bounds = pdi.dataBounds(1)
+    assert isinstance(bounds[0], np.integer)
+    assert isinstance(bounds[1], np.integer)
+    xdata, ydata = pdi.getData()
+    assert ydata.dtype == np.integer
 
 
 def test_fft():

--- a/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_PlotDataItem.py
@@ -7,13 +7,13 @@ pg.mkQApp()
 
 
 def test_bool():
-    truths = np.random.randint(0, 2, size=(100,)).astype(np.bool)
+    truths = np.random.randint(0, 2, size=(100,)).astype(bool)
     pdi = pg.PlotDataItem(truths)
     bounds = pdi.dataBounds(1)
-    assert isinstance(bounds[0], np.integer)
-    assert isinstance(bounds[1], np.integer)
+    assert isinstance(bounds[0], np.uint8)
+    assert isinstance(bounds[1], np.uint8)
     xdata, ydata = pdi.getData()
-    assert ydata.dtype == np.integer
+    assert ydata.dtype == np.uint8
 
 
 def test_fft():


### PR DESCRIPTION
Just converts them in `DataPlotItem.getData`. Adds a test.