### PR TITLE
Enable nit-picky mode in documentation and fix associated warnings

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,7 +10,7 @@ BUILDDIR      = build
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -n -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest
 

--- a/doc/listmissing.py
+++ b/doc/listmissing.py
@@ -7,8 +7,8 @@ dirs = [
 
 path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
 for a, b in dirs:
-     rst = [os.path.splitext(x)[0].lower() for x in os.listdir(os.path.join(path, 'documentation', 'source', a))]
-     py = [os.path.splitext(x)[0].lower() for x in os.listdir(os.path.join(path, b))]
+     rst = [os.path.splitext(x)[0].lower() for x in os.listdir(os.path.join(path, 'doc', 'source', a))]
+     py = [os.path.splitext(x)[0].lower() for x in os.listdir(os.path.join(path, "pyqtgraph", b))]
      print(a)
      for x in set(py) - set(rst):
          print( "    ", x)

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,6 @@
 sphinx==5.1.1
 PyQt6==6.3.1
-sphinx_rtd_theme
+sphinx-rtd-theme
+sphinx-qt-documentation
 numpy
 pyopengl

--- a/doc/source/3dgraphics/index.rst
+++ b/doc/source/3dgraphics/index.rst
@@ -2,7 +2,7 @@ PyQtGraph's 3D Graphics System
 ==============================
 
 The 3D graphics system in pyqtgraph is composed of a :class:`view widget <pyqtgraph.opengl.GLViewWidget>` and 
-several graphics items (all subclasses of :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`) which 
+several graphics items (all subclasses of :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem.GLGraphicsItem>`) which 
 can be added to a view widget.
 
 **Note 1:** pyqtgraph.opengl is based on the deprecated OpenGL fixed-function pipeline. Although it is

--- a/doc/source/apireference.rst
+++ b/doc/source/apireference.rst
@@ -17,3 +17,4 @@ Contents:
     graphicsscene/index
     flowchart/index
     point
+    transform3d

--- a/doc/source/apireference.rst
+++ b/doc/source/apireference.rst
@@ -16,3 +16,4 @@ Contents:
     dockarea
     graphicsscene/index
     flowchart/index
+    point

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,7 +30,13 @@ import pyqtgraph
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.napoleon', 'sphinx_qt_documentation']
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx_qt_documentation",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -41,7 +47,6 @@ source_suffix = '.rst'
 # Set Qt Documentation Variable
 qt_documentation = "Qt6"
 
-extensions += ["sphinx.ext.intersphinx"]
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/doc/stable/', None)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,9 +10,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import time
-import sys
 import os
+import sys
+import time
 from datetime import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -30,13 +30,27 @@ import pyqtgraph
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.napoleon']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.napoleon', 'sphinx_qt_documentation']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
+
+# Set Qt Documentation Variable
+qt_documentation = "Qt6"
+
+extensions += ["sphinx.ext.intersphinx"]
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'numpy': ('https://numpy.org/doc/stable/', None)
+}
+
+napoleon_preprocess_types = True
+napoleon_type_aliases = {
+    "callable": ":class:`collections.abc.Callable`"
+}
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -47,6 +47,10 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable/', None)
 }
 
+nitpick_ignore_regex = [
+    ("py:class", r"re\.Pattern"),  # doesn't seem to be a good ref in python docs
+]
+
 napoleon_preprocess_types = True
 napoleon_type_aliases = {
     "callable": ":class:`collections.abc.Callable`",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -49,7 +49,10 @@ intersphinx_mapping = {
 
 napoleon_preprocess_types = True
 napoleon_type_aliases = {
-    "callable": ":class:`collections.abc.Callable`"
+    "callable": ":class:`collections.abc.Callable`",
+    "np.ndarray": ":class:`numpy.ndarray`",
+    'array_like': ':term:`array_like`',
+    'color_like': ':func:`pyqtgraph.mkColor`'
 }
 
 # The encoding of source files.

--- a/doc/source/config_options.rst
+++ b/doc/source/config_options.rst
@@ -49,4 +49,6 @@ segmentedLineMode  str                 'auto'             For 'on', lines are al
 
 .. autofunction:: pyqtgraph.setConfigOptions
 
+.. autofunction:: pyqtgraph.setConfigOption
+
 .. autofunction:: pyqtgraph.getConfigOption

--- a/doc/source/flowchart/index.rst
+++ b/doc/source/flowchart/index.rst
@@ -161,7 +161,7 @@ control panel. A minimal Node subclass looks like::
 Some nodes implement fairly complex control widgets, but most nodes follow a simple 
 form-like pattern: a list of parameter names and a single value (represented as spin 
 box, check box, etc..) for each parameter. To make this easier, the 
-:class:`CtrlNode <pyqtgraph.flowchart.library.common.CtrlNode>` subclass allows you 
+``pyqtgraph.flowchart.library.common.CtrlNode`` subclass allows you 
 to instead define a simple data structure that CtrlNode will use to automatically 
 generate the control widget. This is used in  many of the built-in library nodes 
 (especially the filters).

--- a/doc/source/flowchart/index.rst
+++ b/doc/source/flowchart/index.rst
@@ -1,14 +1,32 @@
 Visual Programming with Flowcharts
 ==================================
 
-PyQtGraph's flowcharts provide a visual programming environment similar in concept to LabView--functional modules are added to a flowchart and connected by wires to define a more complex and arbitrarily configurable algorithm. A small number of predefined modules (called Nodes) are included with pyqtgraph, but most flowchart developers will want to define their own library of Nodes. At their core, the Nodes are little more than 1) a python function 2) a list of input/output terminals, and 3) an optional widget providing a control panel for the Node. Nodes may transmit/receive any type of Python object via their terminals.
+PyQtGraph's flowcharts provide a visual programming environment similar in concept to 
+LabView--functional modules are added to a flowchart and connected by wires to define 
+a more complex and arbitrarily configurable algorithm. A small number of predefined 
+modules (called Nodes) are included with pyqtgraph, but most flowchart developers will 
+want to define their own library of Nodes. At their core, the Nodes are little more 
+than 1) a python function 2) a list of input/output terminals, and 3) an optional 
+widget providing a control panel for the Node. Nodes may transmit/receive any type of 
+Python object via their terminals.
 
-One major limitation of flowcharts is that there is no mechanism for looping within a flowchart. (however individual Nodes may contain loops (they may contain any Python code at all), and an entire flowchart may be executed from within a loop). 
+One major limitation of flowcharts is that there is no mechanism for looping within a 
+flowchart. (however individual Nodes may contain loops (they may contain any Python 
+code at all), and an entire flowchart may be executed from within a loop). 
 
 There are two distinct modes of executing the code in a flowchart:
     
-1. Provide data to the input terminals of the flowchart. This method is slower and will provide a graphical representation of the data as it passes through the flowchart. This is useful for debugging as it allows the user to inspect the data at each terminal and see where exceptions occurred within the flowchart.
-2. Call :func:`Flowchart.process() <pyqtgraph.flowchart.Flowchart.process>`. This method does not update the displayed state of the flowchart and only retains the state of each terminal as long as it is needed. Additionally, Nodes which do not contribute to the output values of the flowchart (such as plotting nodes) are ignored. This mode allows for faster processing of large data sets and avoids memory issues which can occur if too much data is present in the flowchart at once (e.g., when processing image data through several stages). 
+1. Provide data to the input terminals of the flowchart. This method is slower and 
+will provide a graphical representation of the data as it passes through the 
+flowchart. This is useful for debugging as it allows the user to inspect the data 
+at each terminal and see where exceptions occurred within the flowchart.
+2. Call :func:`Flowchart.process() <pyqtgraph.flowchart.Flowchart.process>`. This 
+method does not update the displayed state of the flowchart and only retains the 
+state of each terminal as long as it is needed. Additionally, Nodes which do not 
+contribute to the output values of the flowchart (such as plotting nodes) are 
+ignored. This mode allows for faster processing of large data sets and avoids memory 
+issues which can occur if too much data is present in the flowchart at once (e.g., 
+when processing image data through several stages). 
 
 See the flowchart example for more information.
 
@@ -24,9 +42,15 @@ API Reference:
 Basic Use
 ---------
 
-Flowcharts are most useful in situations where you have a processing stage in your application that you would like to be arbitrarily configurable by the user. Rather than giving a pre-defined algorithm with parameters for the user to tweak, you supply a set of pre-defined functions and allow the user to arrange and connect these functions how they like. A very common example is the use of filter networks in audio / video processing applications.
+Flowcharts are most useful in situations where you have a processing stage in your 
+application that you would like to be arbitrarily configurable by the user. Rather 
+than giving a pre-defined algorithm with parameters for the user to tweak, you supply 
+a set of pre-defined functions and allow the user to arrange and connect these 
+functions how they like. A very common example is the use of filter networks in 
+audio / video processing applications.
 
-To begin, you must decide what the input and output variables will be for your flowchart. Create a flowchart with one terminal defined for each variable::
+To begin, you must decide what the input and output variables will be for your 
+flowchart. Create a flowchart with one terminal defined for each variable::
     
     ## This example creates just a single input and a single output.
     ## Flowcharts may define any number of terminals, though.
@@ -36,7 +60,11 @@ To begin, you must decide what the input and output variables will be for your f
         'nameOfOutputTerminal': {'io': 'out'}    
     })
     
-In the example above, each terminal is defined by a dictionary of options which define the behavior of that terminal (see :func:`Terminal.__init__() <pyqtgraph.flowchart.Terminal.__init__>` for more information and options). Note that Terminals are not typed; any python object may be passed from one Terminal to another.
+In the example above, each terminal is defined by a dictionary of options which define 
+the behavior of that terminal (see 
+:func:`Terminal.__init__() <pyqtgraph.flowchart.Terminal.__init__>` for more 
+information and options). Note that Terminals are not typed; any python object may be 
+passed from one Terminal to another.
 
 Once the flowchart is created, add its control widget to your application::
     
@@ -50,36 +78,60 @@ The control widget provides several features:
 * Provides access to the flowchart design window via the 'flowchart' button
 * Interface for saving / restoring flowcharts to disk.
 
-At this point your user has the ability to generate flowcharts based on the built-in node library. It is recommended to provide a default set of flowcharts for your users to build from.
+At this point your user has the ability to generate flowcharts based on the built-in 
+node library. It is recommended to provide a default set of flowcharts for your users 
+to build from.
 
-All that remains is to process data through the flowchart. As noted above, there are two ways to do this:
+All that remains is to process data through the flowchart. As noted above, there are 
+two ways to do this:
 
 .. _processing methods:
 
-1. Set the values of input terminals with :func:`Flowchart.setInput() <pyqtgraph.flowchart.Flowchart.setInput>`, then read the values of output terminals with :func:`Flowchart.output() <pyqtgraph.flowchart.Flowchart.output>`::
-    
+1. Set the values of input terminals with 
+   :func:`Flowchart.setInput() <pyqtgraph.flowchart.Flowchart.setInput>`, then read 
+   the values of output terminals with 
+   :func:`Flowchart.output() <pyqtgraph.flowchart.Flowchart.output>`::
+
        fc.setInput(nameOfInputTerminal=newValue)
        output = fc.output()  # returns {terminalName:value}
-       
-   This method updates all of the values displayed in the flowchart design window, allowing the user to inspect values at all terminals in the flowchart and indicating the location of errors that occurred during processing.
+
+   This method updates all of the values displayed in the flowchart design window, 
+   allowing the user to inspect values at all terminals in the flowchart and 
+   indicating the location of errors that occurred during processing.
 2. Call :func:`Flowchart.process() <pyqtgraph.flowchart.Flowchart.process>`::
-    
+
        output = fc.process(nameOfInputTerminal=newValue)
-       
-   This method processes data without updating any of the displayed terminal values. Additionally, all :func:`Node.process() <pyqtgraph.flowchart.Node.process>` methods are called with display=False to request that they not invoke any custom display code. This allows data to be processed both more quickly and with a smaller memory footprint, but errors that occur during Flowchart.process() will be more difficult for the user to diagnose. It is thus recommended to use this method for batch processing through flowcharts that have already been tested and debugged with method 1.
+
+   This method processes data without updating any of the displayed terminal values. 
+   Additionally, all :func:`Node.process() <pyqtgraph.flowchart.Node.process>` methods 
+   are called with display=False to request that they not invoke any custom display 
+   code. This allows data to be processed both more quickly and with a smaller memory 
+   footprint, but errors that occur during Flowchart.process() will be more difficult 
+   for the user to diagnose. It is thus recommended to use this method for batch 
+   processing through flowcharts that have already been tested and debugged with 
+   method 1.
 
 Implementing Custom Nodes
 -------------------------
 
-PyQtGraph includes a small library of built-in flowchart nodes. This library is intended to cover some of the most commonly-used functions as well as provide examples for some more exotic Node types. Most applications that use the flowchart system will find the built-in library insufficient and will thus need to implement custom Node classes. 
+PyQtGraph includes a small library of built-in flowchart nodes. This library is 
+intended to cover some of the most commonly-used functions as well as provide examples 
+for some more exotic Node types. Most applications that use the flowchart system will 
+find the built-in library insufficient and will thus need to implement custom Node 
+classes. 
 
 A node subclass implements at least:
-    
-1) A list of input / output terminals and their properties
-2) A :func:`process() <pyqtgraph.flowchart.Node.process>` function which takes the names of input terminals as keyword arguments and returns a dict with the names of output terminals as keys.
 
-Optionally, a Node subclass can implement the :func:`ctrlWidget() <pyqtgraph.flowchart.Node.ctrlWidget>` method, which must return a QWidget (usually containing other widgets) that will be displayed in the flowchart control panel. A minimal Node subclass looks like::
-    
+1) A list of input / output terminals and their properties
+2) A :func:`process() <pyqtgraph.flowchart.Node.process>` function which takes the 
+   names of input terminals as keyword arguments and returns a dict with the names of 
+   output terminals as keys.
+
+Optionally, a Node subclass can implement the 
+:func:`ctrlWidget() <pyqtgraph.flowchart.Node.ctrlWidget>` method, which must return 
+a QWidget (usually containing other widgets) that will be displayed in the flowchart 
+control panel. A minimal Node subclass looks like::
+
     class SpecialFunctionNode(Node):
         """SpecialFunction: short description
         
@@ -106,16 +158,28 @@ Optionally, a Node subclass can implement the :func:`ctrlWidget() <pyqtgraph.flo
         def ctrlWidget(self):  # this method is optional
             return someQWidget
 
-Some nodes implement fairly complex control widgets, but most nodes follow a simple form-like pattern: a list of parameter names and a single value (represented as spin box, check box, etc..) for each parameter. To make this easier, the :class:`~pyqtgraph.flowchart.library.common.CtrlNode` subclass allows you to instead define a simple data structure that CtrlNode will use to automatically generate the control widget. This is used in  many of the built-in library nodes (especially the filters).
+Some nodes implement fairly complex control widgets, but most nodes follow a simple 
+form-like pattern: a list of parameter names and a single value (represented as spin 
+box, check box, etc..) for each parameter. To make this easier, the 
+:class:`CtrlNode <pyqtgraph.flowchart.library.common.CtrlNode>` subclass allows you 
+to instead define a simple data structure that CtrlNode will use to automatically 
+generate the control widget. This is used in  many of the built-in library nodes 
+(especially the filters).
 
-There are many other optional parameters for nodes and terminals -- whether the user is allowed to add/remove/rename terminals, whether one terminal may be connected to many others or just one, etc. See the documentation on the :class:`~pyqtgraph.flowchart.Node` and :class:`~pyqtgraph.flowchart.Terminal` classes for more details.
+There are many other optional parameters for nodes and terminals -- whether the user 
+is allowed to add/remove/rename terminals, whether one terminal may be connected to 
+many others or just one, etc. See the documentation on the 
+:class:`~pyqtgraph.flowchart.Node` and :class:`~pyqtgraph.flowchart.Terminal` 
+classes for more details.
 
-After implementing a new Node subclass, you will most likely want to register the class so that it appears in the menu of Nodes the user can select from::
+After implementing a new Node subclass, you will most likely want to register the 
+class so that it appears in the menu of Nodes the user can select from::
     
     import pyqtgraph.flowchart.library as fclib
     fclib.registerNodeType(SpecialFunctionNode, [('Category', 'Sub-Category')])
     
-The second argument to registerNodeType is a list of tuples, with each tuple describing a menu location in which SpecialFunctionNode should appear.
+The second argument to registerNodeType is a list of tuples, with each tuple 
+describing a menu location in which SpecialFunctionNode should appear.
     
 See the FlowchartCustomNode example for more information.
 
@@ -123,13 +187,23 @@ See the FlowchartCustomNode example for more information.
 Debugging Custom Nodes
 ^^^^^^^^^^^^^^^^^^^^^^
 
-When designing flowcharts or custom Nodes, it is important to set the input of the flowchart with data that at least has the same types and structure as the data you intend to process (see `processing methods`_ #1 above). When you use :func:`Flowchart.setInput() <pyqtgraph.flowchart.Flowchart.setInput>`, the flowchart displays visual feedback in its design window that can tell you what data is present at any terminal and whether there were errors in processing. Nodes that generated errors are displayed with a red border. If you select a Node, its input and output values will be displayed as well as the exception that occurred while the node was processing, if any.
+When designing flowcharts or custom Nodes, it is important to set the input of the 
+flowchart with data that at least has the same types and structure as the data you 
+intend to process (see `processing methods`_ #1 above). When you use 
+:func:`Flowchart.setInput() <pyqtgraph.flowchart.Flowchart.setInput>`, the flowchart 
+displays visual feedback in its design window that can tell you what data is present 
+at any terminal and whether there were errors in processing. Nodes that generated 
+errors are displayed with a red border. If you select a Node, its input and output 
+values will be displayed as well as the exception that occurred while the node was 
+processing, if any.
 
 
 Using Nodes Without Flowcharts
 ------------------------------
 
-Flowchart Nodes implement a very useful generalization in data processing by combining a function with a GUI for configuring that function. This generalization is useful even outside the context of a flowchart. For example::
+Flowchart Nodes implement a very useful generalization in data processing by combining 
+a function with a GUI for configuring that function. This generalization is useful 
+even outside the context of a flowchart. For example::
     
     ## We defined a useful filter Node for use in flowcharts, but would like to 
     ## re-use its processing code and GUI without having a flowchart present.

--- a/doc/source/graphicsItems/infiniteline.rst
+++ b/doc/source/graphicsItems/infiniteline.rst
@@ -5,3 +5,8 @@ InfiniteLine
     :members:
 
     .. automethod:: pyqtgraph.InfiniteLine.__init__
+
+.. autoclass:: pyqtgraph.InfLineLabel
+    :members:
+
+    .. automethod:: pyqtgraph.InfLineLabel.__init__

--- a/doc/source/parametertree/parametertypes.rst
+++ b/doc/source/parametertree/parametertypes.rst
@@ -102,3 +102,6 @@ ParameterItems
 
 .. autoclass:: TextParameterItem
    :members:
+
+.. autoclass:: WidgetParameterItem
+   :members:

--- a/doc/source/plotting.rst
+++ b/doc/source/plotting.rst
@@ -3,12 +3,12 @@ Plotting in pyqtgraph
 
 There are a few basic ways to plot data in pyqtgraph: 
 
-===================================================================     ==================================================
+===================================================================     =====================================================
 :func:`pyqtgraph.plot`                                                  Create a new plot window showing your data
-:func:`PlotWidget.plot() <pyqtgraph.PlotWidget.plot>`                   Add a new set of data to an existing plot widget
 :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>`                       Add a new set of data to an existing plot widget
+``PlotWidget.plot()``                                                   Calls :func:`PlotItem.plot <pyqtgraph.PlotItem.plot>`
 :func:`GraphicsLayout.addPlot() <pyqtgraph.GraphicsLayout.addPlot>`     Add a new plot to a grid of plots
-===================================================================     ==================================================
+===================================================================     =====================================================
 
 All of these will accept the same basic arguments which control how the plot data is interpreted and displayed:
     

--- a/doc/source/point.rst
+++ b/doc/source/point.rst
@@ -1,0 +1,17 @@
+Point
+=====
+
+.. automodule:: pyqtgraph.Point
+    :members:
+
+    .. automethod:: pyqtgraph.Point.length
+
+    .. automethod:: pyqtgraph.Point.norm
+
+    .. automethod:: pyqtgraph.Point.angle
+
+    .. automethod:: pyqtgraph.Point.dot
+
+    .. automethod:: pyqtgraph.Point.cross
+
+    .. automethod:: pyqtgraph.Point.proj

--- a/doc/source/prototyping.rst
+++ b/doc/source/prototyping.rst
@@ -21,6 +21,8 @@ PyQtGraph's flowcharts provide a visual programming environment similar in conce
 See the `flowchart documentation <flowchart>`_ and the flowchart examples for more information.
 
 
+.. _Canvas:
+
 Graphical Canvas
 ----------------
 

--- a/doc/source/transform3d.rst
+++ b/doc/source/transform3d.rst
@@ -1,0 +1,5 @@
+Transform3D
+===========
+
+.. automodule:: pyqtgraph.Transform3D
+    :members:

--- a/doc/source/widgets/colormapwidget.rst
+++ b/doc/source/widgets/colormapwidget.rst
@@ -6,7 +6,9 @@ ColorMapWidget
 
     .. automethod:: pyqtgraph.ColorMapWidget.__init__
 
-    .. automethod:: pyqtgraph.widgets.ColorMapWidget.ColorMapParameter.setFields
+    .. automethod:: pyqtgraph.ColorMapParameter.setFields
 
-    .. automethod:: pyqtgraph.widgets.ColorMapWidget.ColorMapParameter.map
-    
+    .. automethod:: pyqtgraph.ColorMapParameter.map
+
+.. autoclass:: pyqtgraph.widgets.ColorMapWidget.ColorMapParameter
+    :members:

--- a/doc/source/widgets/consolewidget.rst
+++ b/doc/source/widgets/consolewidget.rst
@@ -4,3 +4,4 @@ ConsoleWidget
 .. autoclass:: pyqtgraph.console.ConsoleWidget
     :members:
     
+    .. automethod:: pyqtgraph.console.ConsoleWidget.__init__

--- a/doc/source/widgets/index.rst
+++ b/doc/source/widgets/index.rst
@@ -38,3 +38,4 @@ Contents:
     pathbutton
     valuelabel
     busycursor
+    rawimagewidget

--- a/doc/source/widgets/rawimagewidget.rst
+++ b/doc/source/widgets/rawimagewidget.rst
@@ -1,0 +1,9 @@
+RawImageWidget
+==============
+
+.. autoclass:: pyqtgraph.RawImageWidget
+    :members:
+
+    .. automethod:: pyqtgraph.widgets.RawImageWidget.RawImageWidget.__init__
+
+    .. automethod:: pyqtgraph.widgets.RawImageWidget.RawImageWidget.setImage

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -34,7 +34,7 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
     sigMouseClicked(event) Emitted when the mouse is clicked over the scene. Use ev.pos() to
                            get the click position relative to the item that was clicked on,
                            or ev.scenePos() to get the click position in scene coordinates.
-                           See :class:`pyqtgraph.GraphicsScene.MouseClickEvent`.                        
+                           See :class:`pyqtgraph.GraphicsScene.mouseEvents.MouseClickEvent`.                        
     sigMouseMoved(pos)     Emitted when the mouse cursor moves over the scene. The position
                            is given in scene coordinates.
     sigMouseHover(items)   Emitted when the mouse is moved over the scene. Items is a list

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -278,6 +278,7 @@ from .widgets.MultiPlotWidget import *
 from .widgets.PathButton import *
 from .widgets.PlotWidget import *
 from .widgets.ProgressDialog import *
+from .widgets.RawImageWidget import *
 from .widgets.RemoteGraphicsView import RemoteGraphicsView
 from .widgets.ScatterPlotWidget import *
 from .widgets.SpinBox import *

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -393,7 +393,7 @@ QAPP = None
 
 def plot(*args, **kargs):
     """
-    Create and return a :class:`PlotWidget <pyqtgraph.PlotWinPlotWidgetdow>` 
+    Create and return a :class:`PlotWidget <pyqtgraph.PlotWidget>` 
     Accepts a *title* argument to set the title of the window.
     All other arguments are used to plot data. (see :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>`)
     """

--- a/pyqtgraph/colormap.py
+++ b/pyqtgraph/colormap.py
@@ -378,9 +378,10 @@ class ColorMap(object):
         
         Parameters
         ----------
-        pos: array_like of float in range 0 to 1, or None
+        pos: array_like of float, optional
             Assigned positions of specified colors. `None` sets equal spacing.
-        color: array_like of colors
+            Values need to be in range 0.0-1.0.
+        color: array_like of color_like
             List of colors, interpreted via :func:`mkColor() <pyqtgraph.mkColor>`.
         mapping: str or int, optional
             Controls how values outside the 0 to 1 range are mapped to colors.
@@ -481,16 +482,18 @@ class ColorMap(object):
         
         Parameters
         ----------
-        start : float (0.0 to 1.0)
+        start : float
                 Starting value that defines the 0.0 value of the new color map.
-        span  : float (-1.0 to 1.0)
-                span of the extracted region. The orignal color map will be trated as cyclical
-                if the extracted interval exceeds the 0.0 to 1.0 range. 
+                Possible value between 0.0 to 1.0
+        span  : float
+                Span of the extracted region. The original color map will be 
+                treated as cyclical if the extracted interval exceeds the 
+                0.0 to 1.0 range.  Possible values between -1.0 to 1.0.
         """
         pos, col = self.getStops( mode=ColorMap.FLOAT )
         start = clip_scalar(start, 0.0, 1.0)
         span  = clip_scalar(span, -1.0, 1.0)
-        
+
         if span == 0.0:
             raise ValueError("'length' needs to be non-zero")
         stop = (start + span)
@@ -561,14 +564,14 @@ class ColorMap(object):
 
         Returns
         -------
-        array of color.dtype
+        np.ndarray of {``ColorMap.BYTE``, ``ColorMap.FLOAT``, QColor}
             for `ColorMap.BYTE` or `ColorMap.FLOAT`:
 
             RGB values for each `data` value, arranged in the same shape as `data`.
-        list of QColor objects
+        list of QColor
             for `ColorMap.QCOLOR`:
 
-            Colors for each `data` value as Qcolor objects.
+            Colors for each `data` value as QColor objects.
         """
         if isinstance(mode, str):
             mode = self.enumMap[mode.lower()]
@@ -624,7 +627,7 @@ class ColorMap(object):
     def getGradient(self, p1=None, p2=None):
         """
         Returns a QtGui.QLinearGradient corresponding to this ColorMap.
-        The span and orientiation is given by two points in plot coordinates.
+        The span and orientation is given by two points in plot coordinates.
 
         When no parameters are given for `p1` and `p2`, the gradient is mapped to the
         `y` coordinates 0 to 1, unless the color map is defined for a more limited range.
@@ -634,11 +637,11 @@ class ColorMap(object):
 
         Parameters
         ----------
-        p1: QtCore.QPointF, default (0,0)
-            Starting point (value 0) of the gradient.
-        p2: QtCore.QPointF, default (dy,0)
+        p1: QtCore.QPointF, optional
+            Starting point (value 0) of the gradient. Default value is QPointF(0., 0.)
+        p2: QtCore.QPointF, optional
             End point (value 1) of the gradient. Default parameter `dy` is the span of ``max(pos) - min(pos)``
-            over which the color map is defined, typically `dy=1`.
+            over which the color map is defined, typically `dy=1`.  Default is QPointF(dy, 0.)
         """
         if p1 is None:
             p1 = QtCore.QPointF(0,0)
@@ -669,14 +672,16 @@ class ColorMap(object):
 
         Parameters
         ----------
-        span : tuple (min, max), default (0.0, 1.0)
+        span : tuple of float, optional
             Span of data values covered by the gradient:
 
               - Color map value 0.0 will appear at `min`,
               - Color map value 1.0 will appear at `max`.
+            
+            Default value is (0., 1.)
 
         orientation : str, default 'vertical'
-            Orientiation of the gradient:
+            Orientation of the gradient:
 
               - 'vertical': `span` corresponds to the `y` coordinate.
               - 'horizontal': `span` corresponds to the `x` coordinate.
@@ -698,17 +703,18 @@ class ColorMap(object):
 
         Parameters
         ----------
-        span : tuple (min, max), default (0.0, 1.0)
+        span : tuple of float
             Span of the data values covered by the gradient:
 
               - Color map value 0.0 will appear at `min`.
               - Color map value 1.0 will appear at `max`.
 
+            Default is (0., 1.)
         orientation : str, default 'vertical'
-            Orientiation of the gradient:
+            Orientation of the gradient:
 
               - 'vertical' creates a vertical gradient, where `span` corresponds to the `y` coordinate.
-              - 'horizontal' creates a horizontal gradient, where `span` correspnds to the `x` coordinate.
+              - 'horizontal' creates a horizontal gradient, where `span` corresponds to the `x` coordinate.
 
         width : int or float
             Width of the pen in pixels on screen.
@@ -775,23 +781,24 @@ class ColorMap(object):
             The starting value in the lookup table
         stop: float, default=1.0
             The final value in the lookup table
-        nPts: int, default is 512
+        nPts: int, default=512
             The number of points in the returned lookup table.
-        alpha: True, False, or None
+        alpha: bool, optional
             Specifies whether or not alpha values are included in the table.
             If alpha is None, it will be automatically determined.
-        mode: int or str, default is `ColorMap.BYTE`
+        mode: int or str, default='byte'
             Determines return type as described in :func:`map() <pyqtgraph.ColorMap.map>`, can be
             either `ColorMap.BYTE` (0 to 255), `ColorMap.FLOAT` (0.0 to 1.0) or `ColorMap.QColor`.
 
         Returns
         -------
-        array of color.dtype
+        np.ndarray of {``ColorMap.BYTE``, ``ColorMap.FLOAT``}
             for `ColorMap.BYTE` or `ColorMap.FLOAT`:
 
             RGB values for each `data` value, arranged in the same shape as `data`.
             If alpha values are included the array has shape (`nPts`, 4), otherwise (`nPts`, 3).
-        list of QColor objects
+    
+        list of QColor
             for `ColorMap.QCOLOR`:
 
             Colors for each `data` value as QColor objects.

--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -36,7 +36,7 @@ class ConsoleWidget(QtWidgets.QWidget):
     
     def __init__(self, parent=None, namespace=None, historyFile=None, text=None, editor=None):
         """
-        ==============  ============================================================================
+        ==============  =============================================================================
         **Arguments:**
         namespace       dictionary containing the initial variables present in the default namespace
         historyFile     optional file for storing command history

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -16,8 +16,7 @@ from collections import OrderedDict
 
 import numpy as np
 
-from . import Qt, debug, reload
-from . import getConfigOption
+from . import Qt, debug, getConfigOption, reload
 from .metaarray import MetaArray
 from .Qt import QT_LIB, QtCore, QtGui
 from .util.cupy_helper import getCupy
@@ -501,7 +500,7 @@ def colorCIELab(qcol):
 
     Returns
     -------
-    NumPy array 
+    np.ndarray 
         Color coordinates `[L, a, b]`.
     """
     srgb = qcol.getRgbF()[:3] # get sRGB values from QColor
@@ -536,7 +535,7 @@ def colorDistance(colors, metric='CIE76'):
     ----------
         colors: list of QColor
             Two or more colors to calculate the distances between.
-        metric: string, optional
+        metric: str, optional
             Metric used to determined the difference. Only 'CIE76' is supported at this time,
             where a distance of 2.3 is considered a "just noticeable difference".
             The default may change as more metrics become available.
@@ -1329,8 +1328,8 @@ def applyLookupTable(data, lut):
 
     Parameters
     ----------
-    data : ndarray
-    lut : ndarray
+    data : np.ndarray
+    lut : np.ndarray
         Either cupy or numpy arrays are accepted, though this function has only
         consistently behaved correctly on windows with cuda toolkit version >= 11.1.
     """
@@ -2050,17 +2049,17 @@ def arrayToQPath(x, y, connect='all', finiteCheck=True):
     
     Parameters
     ----------
-    x : (N,) ndarray
-        x-values to be plotted
-    y : (N,) ndarray
-        y-values to be plotted, must be same length as `x`
+    x : np.ndarray
+        x-values to be plotted of shape (N,)
+    y : np.ndarray
+        y-values to be plotted, must be same length as `x` of shape (N,)
     connect : {'all', 'pairs', 'finite', (N,) ndarray}, optional
         Argument detailing how to connect the points in the path. `all` will 
         have sequential points being connected.  `pairs` generates lines
         between every other point.  `finite` only connects points that are
         finite.  If an ndarray is passed, containing int32 values of 0 or 1,
         only values with 1 will connect to the previous point.  Def
-    finiteCheck : bool, default Ture
+    finiteCheck : bool, default True
         When false, the check for finite values will be skipped, which can
         improve performance. If nonfinite values are present in `x` or `y`,
         an empty QPainterPath will be generated.

--- a/pyqtgraph/graphicsItems/ColorBarItem.py
+++ b/pyqtgraph/graphicsItems/ColorBarItem.py
@@ -52,23 +52,23 @@ class ColorBarItem(PlotItem):
             Determines the color map displayed and applied to assigned ImageItem(s).
         values: tuple of float
             The range of image levels covered by the color bar, as ``(min, max)``.
-        width: float, default=25
+        width: float, default=25.0
             The width of the displayed color bar.
         label: str, optional
             Label applied to the color bar axis.
         interactive: bool, default=True
             If `True`, handles are displayed to interactively adjust the level range.
-        limits: `None` or `tuple of float`
+        limits: `tuple of float`, optional
             Limits the adjustment range to `(low, high)`, `None` disables the limit.
         rounding: float, default=1
             Adjusted range values are rounded to multiples of this value.
         orientation: str, default 'vertical'
             'horizontal' or 'h' gives a horizontal color bar instead of the default vertical bar
-        pen: :class:`Qpen` or argument to :func:`~pyqtgraph.mkPen`
+        pen: :class:`QPen` or color_like
             Sets the color of adjustment handles in interactive mode.
-        hoverPen: :class:`QPen` or argument to :func:`~pyqtgraph.mkPen`
-            Sets the color of adjustement handles when hovered over.
-        hoverBrush: :class:`QBrush` or argument to :func:`~pyqtgraph.mkBrush`
+        hoverPen: :class:`QPen` or color_like
+            Sets the color of adjustment handles when hovered over.
+        hoverBrush: :class:`QBrush` or color_like
             Sets the color of movable center region when hovered over.
         """
         super().__init__()

--- a/pyqtgraph/graphicsItems/ColorBarItem.py
+++ b/pyqtgraph/graphicsItems/ColorBarItem.py
@@ -25,9 +25,10 @@ class ColorBarItem(PlotItem):
     A labeled axis is displayed directly next to the gradient to help identify values.
     Handles included in the color bar allow for interactive adjustment.
 
-    A ColorBarItem can be assigned one or more :class:`~pyqtgraph.ImageItem`s that will be displayed 
-    according to the selected color map and levels. The ColorBarItem can be used as a separate
-    element in a :class:`~pyqtgraph.GraphicsLayout` or added to the layout of a 
+    A ColorBarItem can be assigned one or more :class:`~pyqtgraph.ImageItem` s 
+    that will be displayed according to the selected color map and levels. The
+    ColorBarItem can be used as a separate element in a 
+    :class:`~pyqtgraph.GraphicsLayout` or added to the layout of a 
     :class:`~pyqtgraph.PlotItem` used to display image data with coordinate axes.
 
     =============================  =============================================

--- a/pyqtgraph/graphicsItems/GraphicsLayout.py
+++ b/pyqtgraph/graphicsItems/GraphicsLayout.py
@@ -153,7 +153,7 @@ class GraphicsLayout(GraphicsWidget):
 
         Parameters
         ----------
-        item : pyqtgraph.Qt.QtWidgets.QGraphicsLayoutItem
+        item : QGraphicsLayoutItem
             Item to query the index position of
 
         Returns

--- a/pyqtgraph/graphicsItems/GraphicsLayout.py
+++ b/pyqtgraph/graphicsItems/GraphicsLayout.py
@@ -149,10 +149,27 @@ class GraphicsLayout(GraphicsWidget):
         return self.rect()
 
     def itemIndex(self, item):
+        """Return the numerical index of GraphicsItem object passed in
+
+        Parameters
+        ----------
+        item : pyqtgraph.Qt.QtWidgets.QGraphicsLayoutItem
+            Item to query the index position of
+
+        Returns
+        -------
+        int
+            Index of the item within the graphics layout
+
+        Raises
+        ------
+        ValueError
+            Raised if item could not be found inside the GraphicsLayout instance.
+        """
         for i in range(self.layout.count()):
             if self.layout.itemAt(i).graphicsItem() is item:
                 return i
-        raise Exception("Could not determine index of item " + str(item))
+        raise ValueError(f"Could not determine index of item {item}")
     
     def removeItem(self, item):
         """Remove *item* from the layout."""
@@ -171,6 +188,8 @@ class GraphicsLayout(GraphicsWidget):
         self.update()
     
     def clear(self):
+        """Remove all items from the layout and set the current row and column to 0
+        """
         for i in list(self.items.keys()):
             self.removeItem(i)
         self.currentRow = 0

--- a/pyqtgraph/graphicsItems/GraphicsObject.py
+++ b/pyqtgraph/graphicsItems/GraphicsObject.py
@@ -1,13 +1,12 @@
-from ..Qt import QtCore, QtWidgets, QT_LIB
-
+from ..Qt import QT_LIB, QtCore, QtWidgets
 from .GraphicsItem import GraphicsItem
 
 __all__ = ['GraphicsObject']
 class GraphicsObject(GraphicsItem, QtWidgets.QGraphicsObject):
     """
-    **Bases:** :class:`GraphicsItem <pyqtgraph.graphicsItems.GraphicsItem>`, :class:`QtWidgets.QGraphicsObject`
+    **Bases:** :class:`GraphicsItem <pyqtgraph.GraphicsItem>`, :class:`QtWidgets.QGraphicsObject`
 
-    Extension of QGraphicsObject with some useful methods (provided by :class:`GraphicsItem <pyqtgraph.graphicsItems.GraphicsItem>`)
+    Extension of QGraphicsObject with some useful methods (provided by :class:`GraphicsItem <pyqtgraph.GraphicsItem>`)
     """
     _qtBaseClass = QtWidgets.QGraphicsObject
     def __init__(self, *args):

--- a/pyqtgraph/graphicsItems/HistogramLUTItem.py
+++ b/pyqtgraph/graphicsItems/HistogramLUTItem.py
@@ -64,11 +64,11 @@ class HistogramLUTItem(GraphicsWidget):
 
     Attributes
     ----------
-    sigLookupTableChanged : signal
+    sigLookupTableChanged : QtCore.Signal
         Emits the HistogramLUTItem itself when the gradient changes
-    sigLevelsChanged : signal
+    sigLevelsChanged : QtCore.Signal
         Emits the HistogramLUTItem itself while the movable region is changing
-    sigLevelChangeFinished : signal
+    sigLevelChangeFinished : QtCore.Signal
         Emits the HistogramLUTItem itself when the movable region is finished changing
 
     See Also
@@ -195,7 +195,7 @@ class HistogramLUTItem(GraphicsWidget):
         level : float, optional
             Set the fill level. See :meth:`PlotCurveItem.setFillLevel
             <pyqtgraph.PlotCurveItem.setFillLevel>`. Only used if ``fill`` is True.
-        color : color, optional
+        color : color_like, optional
             Color to use for the fill when the histogram ``levelMode == "mono"``. See
             :meth:`PlotCurveItem.setBrush <pyqtgraph.PlotCurveItem.setBrush>`.
         """

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 
 import numpy
 
+from .. import colormap
 from .. import debug as debug
 from .. import functions as fn
 from .. import getConfigOption
@@ -10,7 +11,6 @@ from ..Point import Point
 from ..Qt import QtCore, QtGui, QtWidgets
 from ..util.cupy_helper import getCupy
 from .GraphicsObject import GraphicsObject
-from .. import colormap
 
 translate = QtCore.QCoreApplication.translate
 
@@ -32,7 +32,7 @@ class ImageItem(GraphicsObject):
 
         Parameters
         ----------
-            image: array 
+            image: np.ndarray, optional
                 Image data
         """
         GraphicsObject.__init__(self)
@@ -104,7 +104,7 @@ class ImageItem(GraphicsObject):
     def setBorder(self, b):
         """
         Defines the border drawn around the image. Accepts all arguments supported by 
-        :func:`~pyqtgraph.functions.mkPen`.
+        :func:`~pyqtgraph.mkPen`.
         """
         self.border = fn.mkPen(b)
         self.update()
@@ -138,7 +138,7 @@ class ImageItem(GraphicsObject):
         
         Parameters
         ----------
-            levels: list_like
+            levels: array_like
                 - ``[blackLevel, whiteLevel]`` 
                   sets black and white levels for monochrome data and can be used with a lookup table.
                 - ``[[minR, maxR], [minG, maxG], [minB, maxB]]``
@@ -253,18 +253,21 @@ class ImageItem(GraphicsObject):
                 See :func:`~pyqtgraph.ImageItem.setCompositionMode`
             colorMap: :class:`~pyqtgraph.ColorMap` or `str`
                 Sets a color map. A string will be passed to :func:`colormap.get() <pyqtgraph.colormap.get()>`
-            lut: array
+            lut: array_like
                 Sets a color lookup table to use when displaying the image.
                 See :func:`~pyqtgraph.ImageItem.setLookupTable`.
-            levels: list_like, usally [`min`, `max`]
-                Sets minimum and maximum values to use when rescaling the image data. By default, these will be set to 
-                the estimated minimum and maximum values in the image. If the image array has dtype uint8, no rescaling
-                is necessary. See :func:`~pyqtgraph.ImageItem.setLevels`.
-            opacity: float, 0.0-1.0
-                Overall opacity for an RGB image.
-            rect: :class:`QRectF`, :class:`QRect` or array_like of floats (`x`,`y`,`w`,`h`)
-                Displays the current image within the specified rectangle in plot coordinates.
-                See :func:`~pyqtgraph.ImageItem.setRect`.
+            levels: array_like
+                Shape of (min, max). Sets minimum and maximum values to use when
+                rescaling the image data. By default, these will be set to the
+                estimated minimum and maximum values in the image. If the image array
+                has dtype uint8, no rescaling is necessary. See
+                :func:`~pyqtgraph.ImageItem.setLevels`.
+            opacity: float
+                Overall opacity for an RGB image. Between 0.0-1.0.
+            rect: :class:`QRectF`, :class:`QRect` or array_like
+                Displays the current image within the specified rectangle in plot
+                coordinates. If ``array_like``, should be of the of ``floats 
+                (`x`,`y`,`w`,`h`)`` . See :func:`~pyqtgraph.ImageItem.setRect`.
             update : bool, optional
                 Controls if image immediately updates to reflect the new options.
         """
@@ -351,22 +354,21 @@ class ImageItem(GraphicsObject):
             imageitem.setImage(imagedata.T)
         
         or the interpretation of the data can be changed locally through the ``axisOrder`` keyword or by changing the 
-        `imageAxisOrder` :ref:`global configuration option <apiref_config>`.
+        `imageAxisOrder` :ref:`global configuration option <apiref_config>`
         
         All keywords supported by :func:`~pyqtgraph.ImageItem.setOpts` are also allowed here.
 
         Parameters
         ----------
-        image: array
+        image: np.ndarray, optional
             Image data given as NumPy array with an integer or floating
             point dtype of any bit depth. A 2-dimensional array describes single-valued (monochromatic) data.
             A 3-dimensional array is used to give individual color components. The third dimension must
             be of length 3 (RGB) or 4 (RGBA).
-
-        rect: QRectF, QRect or list_like of floats ``[x, y, w, h]``, optional
-            If given, sets translation and scaling to display the image within the specified rectangle. See 
-            :func:`~pyqtgraph.ImageItem.setRect`.
-
+        rect: QRectF or QRect or array_like, optional
+            If given, sets translation and scaling to display the image within the
+            specified rectangle. If ``array_like`` should be the form of floats
+            ``[x, y, w, h]`` See :func:`~pyqtgraph.ImageItem.setRect`
         autoLevels: bool, optional
             If `True`, ImageItem will automatically select levels based on the maximum and minimum values encountered 
             in the data. For performance reasons, this search subsamples the images and may miss individual bright or
@@ -375,12 +377,10 @@ class ImageItem(GraphicsObject):
             If `False`, the search will be omitted.
 
             The default is `False` if a ``levels`` keyword argument is given, and `True` otherwise.
-            
         levelSamples: int, default 65536
             When determining minimum and maximum values, ImageItem
             only inspects a subset of pixels no larger than this number.
             Setting this larger than the total number of pixels considers all values.
-            
         """
         profile = debug.Profiler()
 
@@ -898,7 +898,7 @@ class ImageItem(GraphicsObject):
         dimensions approximating `targetImageSize` for each axis.
 
         The `bins` argument and any extra keyword arguments are passed to
-        :func:`self.xp.histogram()`. If `bins` is `auto`, a bin number is automatically
+        :func:`numpy.histogram()`. If `bins` is `auto`, a bin number is automatically
         chosen based on the image characteristics:
 
           * Integer images will have approximately `targetHistogramSize` bins,

--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -58,7 +58,7 @@ class InfiniteLine(GraphicsObject):
                         None to show no label (default is None). May optionally
                         include formatting strings to display the line value.
         labelOpts       A dict of keyword arguments to use when constructing the
-                        text label. See :class:`InfLineLabel`.
+                        text label. See :class:`InfLineLabel <pyqtgraph.graphicsItems.InfiniteLine.InfLineLabel>`.
         span            Optional tuple (min, max) giving the range over the view to draw
                         the line. For example, with a vertical line, use span=(0.5, 1)
                         to draw only on the top half of the view.

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -84,18 +84,15 @@ class PColorMeshItem(GraphicsObject):
                                     +---------+
                     (x[i, j], y[i, j])           (x[i, j+1], y[i, j+1])
 
-            "ASCII from: <https://matplotlib.org/3.2.1/api/_as_gen/
-                         matplotlib.pyplot.pcolormesh.html>".
-        colorMap : pg.ColorMap, default pg.colormap.get('viridis')
+            "ASCII from: <https://matplotlib.org/3.2.1/api/_as_gen/matplotlib.pyplot.pcolormesh.html>".
+        colorMap : pg.ColorMap
             Colormap used to map the z value to colors.
+            default ``pg.colormap.get('viridis')``
         edgecolors : dict, default None
             The color of the edges of the polygons.
             Default None means no edges.
             The dict may contains any arguments accepted by :func:`mkColor() <pyqtgraph.mkColor>`.
-            Example:
-
-                ``mkPen(color='w', width=2)``
-
+            Example: ``mkPen(color='w', width=2)``
         antialiasing : bool, default False
             Whether to draw edgelines with antialiasing.
             Note that if edgecolors is None, antialiasing is always False.
@@ -107,7 +104,7 @@ class PColorMeshItem(GraphicsObject):
         self.x = None
         self.y = None
         self.z = None
-        
+
         self.edgecolors = kwargs.get('edgecolors', None)
         self.antialiasing = kwargs.get('antialiasing', False)
         

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -85,10 +85,10 @@ class PColorMeshItem(GraphicsObject):
                     (x[i, j], y[i, j])           (x[i, j+1], y[i, j+1])
 
             "ASCII from: <https://matplotlib.org/3.2.1/api/_as_gen/matplotlib.pyplot.pcolormesh.html>".
-        colorMap : pg.ColorMap
+        colorMap : pyqtgraph.ColorMap
             Colormap used to map the z value to colors.
-            default ``pg.colormap.get('viridis')``
-        edgecolors : dict, default None
+            default ``pyqtgraph.colormap.get('viridis')``
+        edgecolors : dict, optional
             The color of the edges of the polygons.
             Default None means no edges.
             The dict may contains any arguments accepted by :func:`mkColor() <pyqtgraph.mkColor>`.

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -505,7 +505,7 @@ class PlotDataItem(GraphicsObject):
     def setFillBrush(self, *args, **kargs):
         """ 
         Sets the :class:`QtGui.QBrush` used to fill the area under the curve.
-        See :func:`mkBrush() <pyqtgraph.functions.mkBrush>`) for arguments.
+        See :func:`mkBrush() <pyqtgraph.mkBrush>`) for arguments.
         """
         if args[0] is None:
             brush = None
@@ -518,7 +518,7 @@ class PlotDataItem(GraphicsObject):
 
     def setBrush(self, *args, **kargs):
         """
-        See :func:`setFillBrush() <pyqtgraph.PlotdataItem.setFillBrush()`.
+        See :func:`~pyqtgraph.PlotDataItem.setFillBrush`
         """
         return self.setFillBrush(*args, **kargs)
 
@@ -546,7 +546,7 @@ class PlotDataItem(GraphicsObject):
     def setSymbolPen(self, *args, **kargs):
         """ 
         Sets the :class:`QtGui.QPen` used to draw symbol outlines.
-        See :func:`mkPen() <pyqtgraph.functions.mkPen>`) for arguments.
+        See :func:`mkPen() <pyqtgraph.mkPen>`) for arguments.
         """
         pen = fn.mkPen(*args, **kargs)
         if self.opts['symbolPen'] == pen:
@@ -558,7 +558,7 @@ class PlotDataItem(GraphicsObject):
     def setSymbolBrush(self, *args, **kargs):
         """
         Sets the :class:`QtGui.QBrush` used to fill symbols.
-        See :func:`mkBrush() <pyqtgraph.functions.mkBrush>`) for arguments.
+        See :func:`mkBrush() <pyqtgraph.mkBrush>`) for arguments.
         """
         brush = fn.mkBrush(*args, **kargs)
         if self.opts['symbolBrush'] == brush:
@@ -910,7 +910,7 @@ class PlotDataItem(GraphicsObject):
 
     def getDisplayDataset(self):
         """
-        Returns a :class:`PlotDataset <pyqtgraph.PlotDataset>` object that contains data suitable for display 
+        Returns a :class:`~.PlotDataset` object that contains data suitable for display 
         (after mapping and data reduction) as ``dataset.x`` and ``dataset.y``.
         Intended for internal use.
         """

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -1080,7 +1080,7 @@ class PlotDataItem(GraphicsObject):
     # compatbility method for access to dataRect for full dataset:
     def dataRect(self):
         """
-        Returns a bounding rectangle (as :class:`QtGui.QRectF`) for the full set of data.
+        Returns a bounding rectangle (as :class:`QtCore.QRectF`) for the full set of data.
         Will return `None` if there is no data or if all values (x or y) are NaN.
         """
         if self._dataset is None:

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -811,8 +811,8 @@ class PlotDataItem(GraphicsObject):
             self._dataset = None
         else:
             self._dataset = PlotDataset( xData, yData )
-        self._datasetMapped  = None  # invalidata mapped data , will be generated in getData() / getDisplayDataset()
-        self._datasetDisplay = None  # invalidate display data, will be generated in getData() / getDisplayDataset()
+        self._datasetMapped  = None  # invalidata mapped data , will be generated in getData() / _getDisplayDataset()
+        self._datasetDisplay = None  # invalidate display data, will be generated in getData() / _getDisplayDataset()
 
         profiler('set data')
 
@@ -862,7 +862,7 @@ class PlotDataItem(GraphicsObject):
                 if k in self.opts:
                     scatterArgs[v] = self.opts[k]
 
-        dataset = self.getDisplayDataset()
+        dataset = self._getDisplayDataset()
         if dataset is None: # then we have nothing to show
             self.curve.hide()
             self.scatter.hide()
@@ -908,7 +908,7 @@ class PlotDataItem(GraphicsObject):
                 return (None, None)
             return dataset.x, dataset.y
 
-    def getDisplayDataset(self):
+    def _getDisplayDataset(self):
         """
         Returns a :class:`~.PlotDataset` object that contains data suitable for display 
         (after mapping and data reduction) as ``dataset.x`` and ``dataset.y``.
@@ -1072,7 +1072,7 @@ class PlotDataItem(GraphicsObject):
         """
         Returns the displayed data as the tuple (`xData`, `yData`) after mapping and data reduction.
         """
-        dataset = self.getDisplayDataset()
+        dataset = self._getDisplayDataset()
         if dataset is None:
             return (None, None)
         return dataset.x, dataset.y

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -505,8 +505,8 @@ class PlotItem(GraphicsWidget):
     def addItem(self, item, *args, **kargs):
         """
         Add a graphics item to the view box. 
-        If the item has plot data (:class:`~pyqtgrpah.PlotDataItem`, 
-        :class:`~pyqtgraph.PlotCurveItem`, :class:`~pyqtgraph.ScatterPlotItem`), 
+        If the item has plot data (:class:`PlotDataItem <pyqtgraph.PlotDataItem>` , 
+        :class:`~pyqtgraph.PlotCurveItem` , :class:`~pyqtgraph.ScatterPlotItem` ), 
         it may be included in analysis performed by the PlotItem.
         """
         if item in self.items:
@@ -556,7 +556,7 @@ class PlotItem(GraphicsWidget):
             self.legend.addItem(item, name=name)            
 
     def listDataItems(self):
-        """Return a list of all data items (:class:`~pyqtgrpah.PlotDataItem` , 
+        """Return a list of all data items (:class:`PlotDataItem <pyqtgraph.PlotDataItem>`, 
         :class:`~pyqtgraph.PlotCurveItem` , :class:`~pyqtgraph.ScatterPlotItem` , etc)
         contained in this PlotItem."""
         return self.dataItems[:]

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -35,7 +35,7 @@ class PlotItem(GraphicsWidget):
     
     This class provides the ViewBox-plus-axes that appear when using
     :func:`pg.plot() <pyqtgraph.plot>`, :class:`PlotWidget <pyqtgraph.PlotWidget>`,
-    and :func:`GraphicsLayoutWidget.addPlot() <pyqtgraph.GraphicsLayoutWidget.addPlot>`.
+    and :func:`GraphicsLayout.addPlot() <pyqtgraph.GraphicsLayout.addPlot>`.
 
     It's main functionality is:
 
@@ -556,8 +556,8 @@ class PlotItem(GraphicsWidget):
             self.legend.addItem(item, name=name)            
 
     def listDataItems(self):
-        """Return a list of all data items (:class:`~pyqtgrpah.PlotDataItem`, 
-        :class:`~pyqtgraph.PlotCurveItem`, :class:`~pyqtgraph.ScatterPlotItem`, etc)
+        """Return a list of all data items (:class:`~pyqtgrpah.PlotDataItem` , 
+        :class:`~pyqtgraph.PlotCurveItem` , :class:`~pyqtgraph.ScatterPlotItem` , etc)
         contained in this PlotItem."""
         return self.dataItems[:]
 
@@ -645,7 +645,7 @@ class PlotItem(GraphicsWidget):
         :class:`~pyqtgraph.ViewBox`. Plots added after this will be automatically 
         displayed in the legend if they are created with a 'name' argument.
 
-        If a :class:`~pyqtGraph.LegendItem` has already been created using this method, 
+        If a :class:`~pyqtgraph.LegendItem` has already been created using this method, 
         that item will be returned rather than creating a new one.
 
         Accepts the same arguments as :func:`~pyqtgraph.LegendItem.__init__`.
@@ -986,7 +986,7 @@ class PlotItem(GraphicsWidget):
         return ds, auto, method
         
     def setClipToView(self, clip):
-        """Set the default clip-to-view mode for all :class:`~pyqtgraph.PlotDataItem`s managed by this plot.
+        """Set the default clip-to-view mode for all :class:`~pyqtgraph.PlotDataItem` s managed by this plot.
         If *clip* is `True`, then PlotDataItems will attempt to draw only points within the visible
         range of the ViewBox."""
         self.ctrl.clipToViewCheck.setChecked(clip)
@@ -1186,21 +1186,24 @@ class PlotItem(GraphicsWidget):
         
         Parameters
         ----------
-        selection: boolean or tuple of booleans (left, top, right, bottom)
+        selection: bool or tuple of bool 
             Determines which AxisItems will be displayed.
+            If in tuple form, order is (left, top, right, bottom)
             A single boolean value will set all axes, 
             so that ``showAxes(True)`` configures the axes to draw a frame.
-        showValues: optional, boolean or tuple of booleans (left, top, right, bottom)
+        showValues: bool or tuple of bool, optional
             Determines if values will be displayed for the ticks of each axis.
             True value shows values for left and bottom axis (default).
             False shows no values.
+            If in tuple form, order is (left, top, right, bottom)
             None leaves settings unchanged.
             If not specified, left and bottom axes will be drawn with values.
-        size: optional, float or tuple of floats (width, height)
+        size: float or tuple of float, optional
             Reserves as fixed amount of space (width for vertical axis, height for horizontal axis)
             for each axis where tick values are enabled. If only a single float value is given, it
             will be applied for both width and height. If `None` is given instead of a float value,
             the axis reverts to automatic allocation of space.
+            If in tuple form, order is (width, height)
         """
         if selection is True: # shortcut: enable all axes, creating a frame
             selection = (True, True, True, True)

--- a/pyqtgraph/graphicsItems/TargetItem.py
+++ b/pyqtgraph/graphicsItems/TargetItem.py
@@ -125,14 +125,14 @@ class TargetItem(UIGraphicsItem):
 
         Parameters
         ----------
-        args : tuple, list, QPointF, QPoint, pg.Point, or two floats
+        args : tuple or list or QtCore.QPointF or QtCore.QPoint or Point or float
             Two float values or a container that specifies ``(x, y)`` position where the
             TargetItem should be placed
 
         Raises
         ------
         TypeError
-            If args cannot be used to instantiate a pg.Point
+            If args cannot be used to instantiate a Point
         """
         try:
             newPos = Point(*args)
@@ -303,7 +303,7 @@ class TargetItem(UIGraphicsItem):
             displayed
             If a non-formatted string, then the text label will display ``text``, by
             default None
-        labelOpts : dictionary, optional
+        labelOpts : dict, optional
             These arguments are passed on to :class:`~pyqtgraph.TextItem`
         """
         if not text:
@@ -342,10 +342,11 @@ class TargetLabel(TextItem):
     offset : tuple or list or QPointF or QPoint
         Position to set the anchor of the TargetLabel away from the center of
         the target in pixels, by default it is (20, 0).
-    anchor : tuple, list, QPointF or QPoint
+    anchor : tuple or list or QPointF or QPoint
         Position to rotate the TargetLabel about, and position to set the
         offset value to see :class:`~pyqtgraph.TextItem` for more information.
-    kwargs : dict of arguments that are passed on to
+    kwargs : dict 
+        kwargs contains arguments that are passed onto
         :class:`~pyqtgraph.TextItem` constructor, excluding text parameter
     """
 

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -76,7 +76,7 @@ class ViewBox(GraphicsWidget):
     **Bases:** :class:`GraphicsWidget <pyqtgraph.GraphicsWidget>`
 
     Box that allows internal scaling/panning of children by mouse drag.
-    This class is usually created automatically as part of a :class:`PlotItem <pyqtgraph.PlotItem>` or :class:`Canvas <pyqtgraph.canvas.Canvas>` or with :func:`GraphicsLayout.addViewBox() <pyqtgraph.GraphicsLayout.addViewBox>`.
+    This class is usually created automatically as part of a :class:`PlotItem <pyqtgraph.PlotItem>` or :ref:`Canvas <Canvas>` or with :func:`GraphicsLayout.addViewBox() <pyqtgraph.GraphicsLayout.addViewBox>`.
 
     Features:
 

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -17,12 +17,8 @@ from time import perf_counter
 
 import numpy as np
 
-from .. import functions as fn
-from ..Qt import QtCore, QtGui, QtWidgets
-
-from . import ImageViewTemplate_generic as ui_template
-
 from .. import debug as debug
+from .. import functions as fn
 from .. import getConfigOption
 from ..graphicsItems.GradientEditorItem import addGradientListToDocstring
 from ..graphicsItems.ImageItem import *
@@ -31,7 +27,9 @@ from ..graphicsItems.LinearRegionItem import *
 from ..graphicsItems.ROI import *
 from ..graphicsItems.ViewBox import *
 from ..graphicsItems.VTickGroup import VTickGroup
+from ..Qt import QtCore, QtGui, QtWidgets
 from ..SignalProxy import SignalProxy
+from . import ImageViewTemplate_generic as ui_template
 
 try:
     from bottleneck import nanmax, nanmin
@@ -850,7 +848,7 @@ class ImageView(QtWidgets.QWidget):
 
     @addGradientListToDocstring()
     def setPredefinedGradient(self, name):
-        """Set one of the gradients defined in :class:`GradientEditorItem <pyqtgraph.graphicsItems.GradientEditorItem>`.
+        """Set one of the gradients defined in :class:`GradientEditorItem`.
         Currently available gradients are:   
         """
         self.ui.histogram.gradient.loadPreset(name)

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -255,20 +255,20 @@ class ImageView(QtWidgets.QWidget):
 
         Parameters
         ----------
-        img : ndarray
+        img : np.ndarray
             The image to be displayed. See :func:`ImageItem.setImage` and *notes* below.
         autoRange : bool
             Whether to scale/pan the view to fit the image.
         autoLevels : bool
             Whether to update the white/black levels to fit the image.
-        levels : (min, max)
-            The white and black level values to use.
+        levels : tuple
+            (min, max) white and black level values to use.
         axes : dict
             Dictionary indicating the interpretation for each axis. This is only needed to override the default guess.
             Format is::
 
                 {'t':0, 'x':1, 'y':2, 'c':3};
-        xvals : ndarray
+        xvals : np.ndarray
             1D array of values corresponding to the first axis in a 3D image. For video, this array should contain
             the time of each frame.
         pos

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -135,7 +135,7 @@ class GLGraphicsItem(QtCore.QObject):
         
     def setTransform(self, tr):
         """Set the local transform for this object.
-        Must be a :class:`Transform3D <pyqtgraph.Transform3D>` instance. This transform
+        Must be a :class:`Transform3D <pyqtgraph.Transform3D.Transform3D>` instance. This transform
         determines how the local coordinate system of the item is mapped to the coordinate
         system of its parent."""
         self.__transform = Transform3D(tr)

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -135,9 +135,12 @@ class GLGraphicsItem(QtCore.QObject):
         
     def setTransform(self, tr):
         """Set the local transform for this object.
-        Must be a :class:`Transform3D <pyqtgraph.Transform3D.Transform3D>` instance. This transform
-        determines how the local coordinate system of the item is mapped to the coordinate
-        system of its parent."""
+
+        Parameters
+        ----------
+        tr : pyqtgraph.Transform3D
+            Tranformation from the local coordinate system to the parent's.
+        """
         self.__transform = Transform3D(tr)
         self.update()
         

--- a/pyqtgraph/opengl/items/GLAxisItem.py
+++ b/pyqtgraph/opengl/items/GLAxisItem.py
@@ -6,7 +6,7 @@ __all__ = ['GLAxisItem']
 
 class GLAxisItem(GLGraphicsItem):
     """
-    **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
+    **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem.GLGraphicsItem>`
     
     Displays three lines indicating origin and orientation of local coordinate system. 
     

--- a/pyqtgraph/opengl/items/GLGraphItem.py
+++ b/pyqtgraph/opengl/items/GLGraphItem.py
@@ -35,7 +35,7 @@ class GLGraphItem(GLGraphicsItem):
             2D array of shape (M, 2) of connection data, each row contains
             indexes of two nodes that are connected.  Dtype must be integer
             or unsigned.
-        edgeColor: QtGui.QColor | array-like, optional
+        edgeColor: color_like, optional
             The color to draw edges. Accepts the same arguments as 
             :func:`~pyqtgraph.mkColor()`.  If None, no edges will be drawn.
             Default is (1.0, 1.0, 1.0, 0.5).
@@ -44,12 +44,12 @@ class GLGraphItem(GLGraphicsItem):
         nodePositions : np.ndarray
             2D array of shape (N, 3), where each row represents the x, y, z
             coordinates for each node
-        nodeColor : np.ndarray | QColor | str | array-like
+        nodeColor : np.ndarray or float or color_like, optional
             2D array of shape (N, 4) of dtype float32, where each row represents
-            the R, G, B, A vakues in range of 0-1, or for the same color for all
+            the R, G, B, A values in range of 0-1, or for the same color for all
             nodes, provide either QColor type or input for 
             :func:`~pyqtgraph.mkColor()`
-        nodeSize : np.ndarray | float | int
+        nodeSize : np.ndarray or float or int
             Either 2D numpy array of shape (N, 1) where each row represents the
             size of each node, or if a scalar, apply the same size to all nodes
         **kwds

--- a/pyqtgraph/opengl/items/GLGraphItem.py
+++ b/pyqtgraph/opengl/items/GLGraphItem.py
@@ -1,5 +1,6 @@
 from OpenGL.GL import *  # noqa
 import numpy as np
+
 from ... import functions as fn
 from ...Qt import QtCore, QtGui
 from ..GLGraphicsItem import GLGraphicsItem
@@ -34,21 +35,21 @@ class GLGraphItem(GLGraphicsItem):
             2D array of shape (M, 2) of connection data, each row contains
             indexes of two nodes that are connected.  Dtype must be integer
             or unsigned.
-        edgeColor: QColor, array-like, optional.
+        edgeColor: QtGui.QColor | array-like, optional
             The color to draw edges. Accepts the same arguments as 
             :func:`~pyqtgraph.mkColor()`.  If None, no edges will be drawn.
             Default is (1.0, 1.0, 1.0, 0.5).
-        edgeWidth: float, optional.
+        edgeWidth: float, optional
             Value specifying edge width.  Default is 1.0
         nodePositions : np.ndarray
             2D array of shape (N, 3), where each row represents the x, y, z
             coordinates for each node
-        nodeColor : np.ndarray, QColor, str or array like
+        nodeColor : np.ndarray | QColor | str | array-like
             2D array of shape (N, 4) of dtype float32, where each row represents
             the R, G, B, A vakues in range of 0-1, or for the same color for all
             nodes, provide either QColor type or input for 
             :func:`~pyqtgraph.mkColor()`
-        nodeSize : np.ndarray, float or int
+        nodeSize : np.ndarray | float | int
             Either 2D numpy array of shape (N, 1) where each row represents the
             size of each node, or if a scalar, apply the same size to all nodes
         **kwds

--- a/pyqtgraph/opengl/items/GLGridItem.py
+++ b/pyqtgraph/opengl/items/GLGridItem.py
@@ -9,7 +9,7 @@ __all__ = ['GLGridItem']
 
 class GLGridItem(GLGraphicsItem):
     """
-    **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
+    **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem.GLGraphicsItem>`
     
     Displays a wire-frame grid. 
     """

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -1,12 +1,13 @@
 from OpenGL.GL import *  # noqa
 import numpy as np
+
 from ..GLGraphicsItem import GLGraphicsItem
 
 __all__ = ['GLImageItem']
 
 class GLImageItem(GLGraphicsItem):
     """
-    **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
+    **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem.GLGraphicsItem>`
     
     Displays image data as a textured quad.
     """

--- a/pyqtgraph/opengl/items/GLMeshItem.py
+++ b/pyqtgraph/opengl/items/GLMeshItem.py
@@ -10,7 +10,7 @@ __all__ = ['GLMeshItem']
 
 class GLMeshItem(GLGraphicsItem):
     """
-    **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
+    **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem.GLGraphicsItem>`
     
     Displays a 3D triangle mesh. 
     """

--- a/pyqtgraph/opengl/items/GLVolumeItem.py
+++ b/pyqtgraph/opengl/items/GLVolumeItem.py
@@ -8,7 +8,7 @@ __all__ = ['GLVolumeItem']
 
 class GLVolumeItem(GLGraphicsItem):
     """
-    **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem>`
+    **Bases:** :class:`GLGraphicsItem <pyqtgraph.opengl.GLGraphicsItem.GLGraphicsItem>`
     
     Displays volumetric data. 
     """

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -1,10 +1,10 @@
 import builtins
 
-from ..Parameter import Parameter
-from ..ParameterItem import ParameterItem
 from ... import functions as fn
 from ... import icons
 from ...Qt import QtCore, QtGui, QtWidgets, mkQApp
+from ..Parameter import Parameter
+from ..ParameterItem import ParameterItem
 
 
 class WidgetParameterItem(ParameterItem):
@@ -258,8 +258,8 @@ class SimpleParameter(Parameter):
     """
     Parameter representing a single value.
 
-    This parameter is backed by :class:`WidgetParameterItem` to represent the
-    following parameter names through various subclasses:
+    This parameter is backed by :class:`~pyqtgraph.parametertree.parameterTypes.basetypes.WidgetParameterItem`
+     to represent the following parameter names through various subclasses:
 
       - 'int'
       - 'float'
@@ -274,7 +274,7 @@ class SimpleParameter(Parameter):
         Initialize the parameter.
 
         This is normally called implicitly through :meth:`Parameter.create`.
-        The keyword arguments avaialble to :meth:`Parameter.__init__` are
+        The keyword arguments available to :meth:`Parameter.__init__` are
         applicable.
         """
         Parameter.__init__(self, *args, **kargs)

--- a/pyqtgraph/widgets/ColorMapWidget.py
+++ b/pyqtgraph/widgets/ColorMapWidget.py
@@ -6,7 +6,7 @@ from .. import functions as fn
 from .. import parametertree as ptree
 from ..Qt import QtCore
 
-__all__ = ['ColorMapWidget']
+__all__ = ['ColorMapWidget', 'ColorMapParameter']
 
 class ColorMapWidget(ptree.ParameterTree):
     """

--- a/pyqtgraph/widgets/ScatterPlotWidget.py
+++ b/pyqtgraph/widgets/ScatterPlotWidget.py
@@ -82,7 +82,7 @@ class ScatterPlotWidget(QtWidgets.QSplitter):
         Set the list of field names/units to be processed.
         
         The format of *fields* is the same as used by 
-        :func:`ColorMapWidget.setFields <pyqtgraph.widgets.ColorMapWidget.ColorMapParameter.setFields>`
+        :meth:`~pyqtgraph.widgets.ColorMapWidget.ColorMapParameter.setFields`
         """
         self.fields = OrderedDict(fields)
         self.mouseOverField = mouseOverField

--- a/tests/graphicsItems/test_PlotDataItem.py
+++ b/tests/graphicsItems/test_PlotDataItem.py
@@ -83,7 +83,7 @@ def test_nonfinite():
     x = np.array([-np.inf, 0.0, 1.0,  2.0  , np.nan,   4.0 , np.inf])
     y = np.array([    1.0, 0.0,-1.0, np.inf,   2.0 , np.nan,   0.0 ])
     pdi = pg.PlotDataItem(x, y)
-    dataset = pdi.getDisplayDataset()
+    dataset = pdi._getDisplayDataset()
     _assert_equal_arrays( dataset.x, x )
     _assert_equal_arrays( dataset.y, y )
    
@@ -95,7 +95,7 @@ def test_nonfinite():
     y_log[ ~np.isfinite(y_log) ] = np.nan
 
     pdi.setLogMode(True, True)
-    dataset = pdi.getDisplayDataset()
+    dataset = pdi._getDisplayDataset()
     _assert_equal_arrays( dataset.x, x_log )
     _assert_equal_arrays( dataset.y, y_log )
 


### PR DESCRIPTION
This PR is just a start, and I would welcome any input; other maintainers are encouraged to push changes to this branch should they feel a change is worthwhile.

This PR starts with 

* updating the script for `doc/listmissing.py`, which attempts to identify portions of pyqtgraph that are undocumented.
* update `.gitignore` to ignore the build directory.
* Fix `ColorMapWidget` documentation links
* Using the pydata-sphinx-theme ( https://github.com/pydata/pydata-sphinx-theme )

After that, this PR attempts to restructure existing documentation into 4 distinct sections.

* Getting Started
* User Guide
* API Reference
* Contributing

The main `index.html` page is now using panels (heavily borrowed the idea from pandas: https://pandas.pydata.org/docs/ ).  The rest of the changes in this diff has to do with shifting around the relevant