### PR TITLE
Remove pytest extensions from ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
         pip install --upgrade pip
         pip install ${{ matrix.qt-version }} numpy${{ matrix.numpy-version }} scipy pyopengl h5py matplotlib numba
         pip install .
-        pip install pytest pytest-cov pytest-xdist coverage
+        pip install pytest pytest-cov coverage
     - name: "Install Linux VirtualDisplay"
       if: runner.os == 'Linux'
       run: |
@@ -107,7 +107,6 @@ jobs:
       run: |
         mkdir $SCREENSHOT_DIR
         pytest pyqtgraph examples -v \
-          -n auto \
           --junitxml pytest.xml \
           --cov pyqtgraph --cov-report=xml --cov-report=html
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
         pip install --upgrade pip
         pip install ${{ matrix.qt-version }} numpy${{ matrix.numpy-version }} scipy pyopengl h5py matplotlib numba
         pip install .
-        pip install pytest pytest-cov coverage
+        pip install pytest
     - name: "Install Linux VirtualDisplay"
       if: runner.os == 'Linux'
       run: |
@@ -108,7 +108,6 @@ jobs:
         mkdir $SCREENSHOT_DIR
         pytest pyqtgraph examples -v \
           --junitxml pytest.xml \
-          --cov pyqtgraph --cov-report=xml --cov-report=html
       shell: bash
     - name: Upload Screenshots
       uses: actions/upload-artifact@v2

--- a/pyqtgraph/graphicsItems/tests/test_ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/tests/test_ErrorBarItem.py
@@ -13,11 +13,13 @@ def test_ErrorBarItem_defer_data():
     curve = pg.PlotCurveItem(x=x, y=x)
     plot.addItem(curve)
     app.processEvents()
+    app.processEvents()
     r_no_ebi = plot.viewRect()
 
     # ErrorBarItem with no data shouldn't affect the view rect
     err = pg.ErrorBarItem()
     plot.addItem(err)
+    app.processEvents()
     app.processEvents()
     r_empty_ebi = plot.viewRect()
 
@@ -25,12 +27,14 @@ def test_ErrorBarItem_defer_data():
 
     err.setData(x=x, y=x, bottom=x, top=x)
     app.processEvents()
+    app.processEvents()
     r_ebi = plot.viewRect()
 
     assert r_ebi.height() > r_empty_ebi.height()
 
     # unset data, ErrorBarItem disappears and view rect goes back to original
     err.setData(x=None, y=None)
+    app.processEvents()
     app.processEvents()
     r_clear_ebi = plot.viewRect()
 


### PR DESCRIPTION
This PR hopes to address some of the intermittent failures that we have been seeing in CI.  As the CI machines seem to not have significant resources, we should likely not run pytest-xdist.  Also, as we are not keeping track of coverage, there is no reason to collect that information at it stands.