### PR TITLE
Format_RGB32 will always have alpha equal 255

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1503,7 +1503,6 @@ def imageToArray(img, copy=False, transpose=True):
     the QImage is collected before the array, there may be trouble).
     The array will have shape (width, height, (b,g,r,a)).
     """
-    fmt = img.format()
     img_ptr = img.bits()
 
     if QT_LIB.startswith('PyQt'):
@@ -1522,8 +1521,6 @@ def imageToArray(img, copy=False, transpose=True):
 
     arr = np.frombuffer(img_ptr, dtype=np.ubyte)
     arr = arr.reshape(img.height(), img.width(), 4)
-    if fmt == img.Format_RGB32:
-        arr[...,3] = 255
     
     if copy:
         arr = arr.copy()


### PR DESCRIPTION
this also removes the assumption that we are on little-endian.

```python
In [18]: qimg = QtGui.QImage(1, 1, QtGui.QImage.Format.Format_RGB32)

In [19]: qimg.fill(QtCore.Qt.GlobalColor.transparent)

In [20]: np.frombuffer(qimg.bits(), dtype=np.uint8)
Out[20]: array([  0,   0,   0, 255], dtype=uint8)
```