### PR TITLE
don't print out expected Exception

### DIFF
--- a/pyqtgraph/multiprocess/remoteproxy.py
+++ b/pyqtgraph/multiprocess/remoteproxy.py
@@ -505,7 +505,8 @@ class RemoteEventHandler(object):
             if exc is not None:
                 # PySide6 6.1.0 does an attribute lookup for feature testing
                 # in such a case, failure is normal 
-                if excStr[-1] not in ["AttributeError: 'function' object has no attribute 'im_func'\n"]:
+                normal = ["AttributeError"]
+                if not any(excStr[-1].startswith(x) for x in normal):
                     warnings.warn("===== Remote process raised exception on request: =====", RemoteExceptionWarning)
                     warnings.warn(''.join(excStr), RemoteExceptionWarning)
                     warnings.warn("===== Local Traceback to request follows: =====", RemoteExceptionWarning)

--- a/pyqtgraph/multiprocess/remoteproxy.py
+++ b/pyqtgraph/multiprocess/remoteproxy.py
@@ -323,7 +323,7 @@ class RemoteEventHandler(object):
         self.send(request='result', reqId=reqId, callSync='off', opts=dict(result=result))
     
     def replyError(self, reqId, *exc):
-        print("error: %s %s %s" % (self.name, str(reqId), str(exc[1])))
+        # print("error: %s %s %s" % (self.name, str(reqId), str(exc[1])))
         excStr = traceback.format_exception(*exc)
         try:
             self.send(request='error', reqId=reqId, callSync='off', opts=dict(exception=exc[1], excString=excStr))
@@ -503,9 +503,12 @@ class RemoteEventHandler(object):
             #print ''.join(result)
             exc, excStr = result
             if exc is not None:
-                warnings.warn("===== Remote process raised exception on request: =====", RemoteExceptionWarning)
-                warnings.warn(''.join(excStr), RemoteExceptionWarning)
-                warnings.warn("===== Local Traceback to request follows: =====", RemoteExceptionWarning)
+                # PySide6 6.1.0 does an attribute lookup for feature testing
+                # in such a case, failure is normal 
+                if excStr[-1] not in ["AttributeError: 'function' object has no attribute 'im_func'\n"]:
+                    warnings.warn("===== Remote process raised exception on request: =====", RemoteExceptionWarning)
+                    warnings.warn(''.join(excStr), RemoteExceptionWarning)
+                    warnings.warn("===== Local Traceback to request follows: =====", RemoteExceptionWarning)
                 raise exc
             else:
                 print(''.join(excStr))


### PR DESCRIPTION
this fixes the RemoteGraphicsView portion of #1770.

I _think_ this arises from https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1523?filter=allissues.
In a PySide6 6.1.0 installation, within the file Lib/site-packages/PySide6/glue/qtcore.cpp, there is code that probes for some attribute "im_func". In such a case, failure is considered normal. However, remoteproxy.py reports all exceptions, which causes CI to fail.

The quick and dirty workaround done here is to avoid printing out this particular exception.

The real issue is that not all exceptions are errors.