### PR TITLE
implement pg.exec()

### DIFF
--- a/examples/Arrow.py
+++ b/examples/Arrow.py
@@ -51,4 +51,4 @@ anim = a.makeAnimation(loop=-1)
 anim.start()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/BarGraphItem.py
+++ b/examples/BarGraphItem.py
@@ -35,4 +35,4 @@ bg = BarGraph(x=x, y=y1*0.3+2, height=0.4+y1*0.2, width=0.8)
 win.addItem(bg)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/CLIexample.py
+++ b/examples/CLIexample.py
@@ -19,4 +19,4 @@ data = np.random.normal(size=(500,500))
 pg.image(data, title="Simplest possible image example")
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ColorBarItem.py
+++ b/examples/ColorBarItem.py
@@ -97,4 +97,4 @@ main_window = MainWindow()
 
 ## Start Qt event loop
 if __name__ == '__main__':
-    mkQApp().exec_()
+    pg.exec()

--- a/examples/ColorButton.py
+++ b/examples/ColorButton.py
@@ -27,4 +27,4 @@ btn.sigColorChanging.connect(change)
 btn.sigColorChanged.connect(done)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ColorGradientPlots.py
+++ b/examples/ColorGradientPlots.py
@@ -144,4 +144,4 @@ main_window = MainWindow()
 
 ## Start Qt event loop
 if __name__ == '__main__':
-    mkQApp().exec_()
+    pg.exec()

--- a/examples/ConsoleWidget.py
+++ b/examples/ConsoleWidget.py
@@ -30,4 +30,4 @@ c.show()
 c.setWindowTitle('pyqtgraph example: ConsoleWidget')
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/CustomGraphItem.py
+++ b/examples/CustomGraphItem.py
@@ -130,4 +130,4 @@ g.setData(pos=pos, adj=adj, pen=lines, size=1, symbol=symbols, pxMode=False, tex
 
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/DataSlicing.py
+++ b/examples/DataSlicing.py
@@ -58,4 +58,4 @@ imv1.setLevels(-0.003, 0.003)
 update()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/DataTreeWidget.py
+++ b/examples/DataTreeWidget.py
@@ -43,4 +43,4 @@ tree.resize(600,600)
 
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/DateAxisItem.py
+++ b/examples/DateAxisItem.py
@@ -27,4 +27,4 @@ w.setWindowTitle('pyqtgraph example: DateAxisItem')
 w.show()
 
 if __name__ == '__main__':
-    app.exec_()
+    pg.exec()

--- a/examples/DateAxisItem_QtDesigner.py
+++ b/examples/DateAxisItem_QtDesigner.py
@@ -43,4 +43,4 @@ window.setWindowTitle('pyqtgraph example: DateAxisItem_QtDesigner')
 window.show()
 
 if __name__ == '__main__':
-    app.exec_()
+    pg.exec()

--- a/examples/DiffTreeWidget.py
+++ b/examples/DiffTreeWidget.py
@@ -46,4 +46,4 @@ tree.resize(1000, 800)
 
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/Draw.py
+++ b/examples/Draw.py
@@ -43,4 +43,4 @@ img.setDrawKernel(kern, mask=kern, center=(1,1), mode='add')
 img.setLevels([0, 10])
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ErrorBarItem.py
+++ b/examples/ErrorBarItem.py
@@ -27,4 +27,4 @@ plt.addItem(err)
 plt.plot(x, y, symbol='o', pen={'color': 0.8, 'width': 2})
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ExampleApp.py
+++ b/examples/ExampleApp.py
@@ -385,7 +385,7 @@ class ExampleLoader(QtGui.QMainWindow):
 def main():
     app = pg.mkQApp()
     loader = ExampleLoader()
-    app.exec_()
+    pg.exec()
 
 if __name__ == '__main__':
     main()

--- a/examples/FillBetweenItem.py
+++ b/examples/FillBetweenItem.py
@@ -46,4 +46,4 @@ timer.start(30)
 
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/Flowchart.py
+++ b/examples/Flowchart.py
@@ -76,4 +76,4 @@ fc.connectTerminals(fNode['Out'], pw2Node['In'])
 fc.connectTerminals(fNode['Out'], fc['dataOut'])
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/FlowchartCustomNode.py
+++ b/examples/FlowchartCustomNode.py
@@ -151,4 +151,4 @@ fc.connectTerminals(fNode['dataOut'], v2Node['data'])
 fc.connectTerminals(fNode['dataOut'], fc['dataOut'])
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GLBarGraphItem.py
+++ b/examples/GLBarGraphItem.py
@@ -40,4 +40,4 @@ bg = gl.GLBarGraphItem(pos, size)
 w.addItem(bg)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GLImageItem.py
+++ b/examples/GLImageItem.py
@@ -51,4 +51,4 @@ ax = gl.GLAxisItem()
 w.addItem(ax)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GLIsosurface.py
+++ b/examples/GLIsosurface.py
@@ -60,4 +60,4 @@ w.addItem(m2)
 m2.translate(-25, -25, -50)
     
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GLLinePlotItem.py
+++ b/examples/GLLinePlotItem.py
@@ -41,4 +41,4 @@ for i in range(n):
     w.addItem(plt)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GLMeshItem.py
+++ b/examples/GLMeshItem.py
@@ -118,4 +118,4 @@ w.addItem(m5)
 w.addItem(m6)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GLScatterPlotItem.py
+++ b/examples/GLScatterPlotItem.py
@@ -108,4 +108,4 @@ t.timeout.connect(update)
 t.start(50)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GLSurfacePlot.py
+++ b/examples/GLSurfacePlot.py
@@ -93,4 +93,4 @@ timer.timeout.connect(update)
 timer.start(30)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GLViewWidget.py
+++ b/examples/GLViewWidget.py
@@ -28,4 +28,4 @@ ax2.setParentItem(b)
 b.translate(1,1,1)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GLVolumeItem.py
+++ b/examples/GLVolumeItem.py
@@ -59,4 +59,4 @@ ax = gl.GLAxisItem()
 w.addItem(ax)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GLshaders.py
+++ b/examples/GLshaders.py
@@ -100,4 +100,4 @@ w.addItem(m6)
 #m2.translate(-25, -25, -50)
     
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GradientEditor.py
+++ b/examples/GradientEditor.py
@@ -21,4 +21,4 @@ ge = pg.GradientEditorItem()
 mw.setCentralItem(ge)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GradientWidget.py
+++ b/examples/GradientWidget.py
@@ -48,7 +48,7 @@ l.addWidget(w4, 1, 0)
 l.addWidget(label, 1, 1)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()
 
 
 

--- a/examples/GraphItem.py
+++ b/examples/GraphItem.py
@@ -58,4 +58,4 @@ lines = np.array([
 g.setData(pos=pos, adj=adj, pen=lines, size=1, symbol=symbols, pxMode=False)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GraphicsLayout.py
+++ b/examples/GraphicsLayout.py
@@ -79,4 +79,4 @@ p4.plot([1,3,2,4,3,5])
 p5.plot([1,3,2,4,3,5])
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/GraphicsScene.py
+++ b/examples/GraphicsScene.py
@@ -59,4 +59,4 @@ g = pg.GridItem()
 vb.addItem(g)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/HistogramLUT.py
+++ b/examples/HistogramLUT.py
@@ -59,4 +59,4 @@ vb.autoRange()
 hist.setImageItem(img)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ImageItem.py
+++ b/examples/ImageItem.py
@@ -59,4 +59,4 @@ timer.timeout.connect(updateData)
 updateData()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ImageView.py
+++ b/examples/ImageView.py
@@ -64,4 +64,4 @@ imv.ui.roiBtn.setChecked(True)
 imv.roiClicked()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/InfiniteLine.py
+++ b/examples/InfiniteLine.py
@@ -82,4 +82,4 @@ p1.addItem(lr)
 label = pg.InfLineLabel(lr.lines[1], "region 1", position=0.95, rotateAxis=(1,0), anchor=(1, 1))
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/JoystickButton.py
+++ b/examples/JoystickButton.py
@@ -47,4 +47,4 @@ timer.timeout.connect(update)
 timer.start(30)
     
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/Legend.py
+++ b/examples/Legend.py
@@ -40,4 +40,4 @@ legend.addItem(c2, 'curve2')
 legend.addItem(s1, 'scatter')
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/LogPlotTest.py
+++ b/examples/LogPlotTest.py
@@ -31,4 +31,4 @@ p5.setLogMode(x=True, y=False)
 
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/MouseSelection.py
+++ b/examples/MouseSelection.py
@@ -31,4 +31,4 @@ for c in curves:
     c.sigClicked.connect(plotClicked)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/MultiPlotSpeedTest.py
+++ b/examples/MultiPlotSpeedTest.py
@@ -63,4 +63,4 @@ timer.timeout.connect(update)
 timer.start(0)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/MultiPlotWidget.py
+++ b/examples/MultiPlotWidget.py
@@ -33,5 +33,5 @@ ma = MetaArray(data, info=[
 pw.plot(ma, pen='y')
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()
 

--- a/examples/MultiplePlotAxes.py
+++ b/examples/MultiplePlotAxes.py
@@ -61,4 +61,4 @@ p2.addItem(pg.PlotCurveItem([10,20,40,80,40,20], pen='b'))
 p3.addItem(pg.PlotCurveItem([3200,1600,800,400,200,100], pen='r'))
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/NonUniformImage.py
+++ b/examples/NonUniformImage.py
@@ -80,4 +80,4 @@ p.axes['bottom']['item'].setZValue(1000)
 p.axes['left']['item'].setZValue(1000)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/PColorMeshItem.py
+++ b/examples/PColorMeshItem.py
@@ -84,4 +84,4 @@ timer.timeout.connect(updateData)
 updateData()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/PanningPlot.py
+++ b/examples/PanningPlot.py
@@ -31,4 +31,4 @@ timer.timeout.connect(update)
 timer.start(50)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/PlotAutoRange.py
+++ b/examples/PlotAutoRange.py
@@ -41,4 +41,4 @@ timer.timeout.connect(update)
 timer.start(50)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/PlotSpeedTest.py
+++ b/examples/PlotSpeedTest.py
@@ -49,4 +49,4 @@ timer.timeout.connect(update)
 timer.start(0)
     
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/PlotWidget.py
+++ b/examples/PlotWidget.py
@@ -87,4 +87,4 @@ pw3.addItem(line)
 line.setBounds([0,200])
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/Plotting.py
+++ b/examples/Plotting.py
@@ -96,4 +96,4 @@ p9.sigXRangeChanged.connect(updateRegion)
 updatePlot()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ROIExamples.py
+++ b/examples/ROIExamples.py
@@ -158,4 +158,4 @@ def remove():
 r4.sigRemoveRequested.connect(remove)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ROItypes.py
+++ b/examples/ROItypes.py
@@ -119,4 +119,4 @@ t.timeout.connect(updateImage)
 t.start(50)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/RemoteGraphicsView.py
+++ b/examples/RemoteGraphicsView.py
@@ -27,4 +27,4 @@ v.setCentralItem(plt)
 plt.plot([1,4,2,3,6,2,3,4,2,3], pen='g')
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/RemoteSpeedTest.py
+++ b/examples/RemoteSpeedTest.py
@@ -73,4 +73,4 @@ timer.timeout.connect(update)
 timer.start(0)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ScaleBar.py
+++ b/examples/ScaleBar.py
@@ -25,4 +25,4 @@ scale.setParentItem(vb)
 scale.anchor((1, 1), (1, 1), offset=(-20, -20))
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ScatterPlot.py
+++ b/examples/ScatterPlot.py
@@ -135,4 +135,4 @@ w4.addItem(s4)
 s4.sigClicked.connect(clicked)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ScatterPlotSpeedTest.py
+++ b/examples/ScatterPlotSpeedTest.py
@@ -129,4 +129,4 @@ timer.timeout.connect(update)
 timer.start(0)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ScatterPlotWidget.py
+++ b/examples/ScatterPlotWidget.py
@@ -63,4 +63,4 @@ spw.setData(data)
 spw.show()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/SimplePlot.py
+++ b/examples/SimplePlot.py
@@ -6,4 +6,4 @@ import numpy as np
 plt = pg.plot(np.random.normal(size=100), title="Simplest possible plotting example")
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/SpinBox.py
+++ b/examples/SpinBox.py
@@ -129,4 +129,4 @@ layout.addWidget(changedLabel, 2, 1)
 
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/Symbols.py
+++ b/examples/Symbols.py
@@ -36,4 +36,4 @@ plot.plot([14, 15, 16, 17, 18], pen=(248, 187, 208), symbolBrush=(248, 187, 208)
 plot.setXRange(-2, 4)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/TableWidget.py
+++ b/examples/TableWidget.py
@@ -27,4 +27,4 @@ data = np.array([
 w.setData(data)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/TreeWidget.py
+++ b/examples/TreeWidget.py
@@ -49,4 +49,4 @@ b1 = QtGui.QPushButton("Button")
 w.setItemWidget(i1, 1, b1)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/VideoSpeedTest.py
+++ b/examples/VideoSpeedTest.py
@@ -296,4 +296,4 @@ timer.timeout.connect(update)
 timer.start(0)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ViewBox.py
+++ b/examples/ViewBox.py
@@ -94,4 +94,4 @@ t.timeout.connect(updateData)
 t.start(50)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ViewBoxFeatures.py
+++ b/examples/ViewBoxFeatures.py
@@ -82,4 +82,4 @@ l6 = pg.PlotDataItem(y)
 v6.addItem(l6)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/ViewLimits.py
+++ b/examples/ViewLimits.py
@@ -8,4 +8,4 @@ plt = pg.plot(np.random.normal(size=100), title="View limit example")
 plt.centralWidget.vb.setLimits(xMin=-20, xMax=120, minXRange=5, maxXRange=100)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/beeswarm.py
+++ b/examples/beeswarm.py
@@ -32,4 +32,4 @@ win.addItem(err)
 
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/colorMaps.py
+++ b/examples/colorMaps.py
@@ -91,4 +91,4 @@ for map_name in list_of_maps:
 lw.setFixedHeight(num_bars * (height+5) )
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/contextMenu.py
+++ b/examples/contextMenu.py
@@ -136,4 +136,4 @@ box2.setPos(5, 5)
 box2.setScale(0.2)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/crosshair.py
+++ b/examples/crosshair.py
@@ -81,4 +81,4 @@ proxy = pg.SignalProxy(p1.scene().sigMouseMoved, rateLimit=60, slot=mouseMoved)
 
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/customGraphicsItem.py
+++ b/examples/customGraphicsItem.py
@@ -55,4 +55,4 @@ plt.addItem(item)
 plt.setWindowTitle('pyqtgraph example: customGraphicsItem')
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/customPlot.py
+++ b/examples/customPlot.py
@@ -92,4 +92,4 @@ r = pg.PolyLineROI([(0,0), (10, 10)])
 pw.addItem(r)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/designerExample.py
+++ b/examples/designerExample.py
@@ -39,4 +39,4 @@ class MainWindow(TemplateBaseClass):
 win = MainWindow()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/dockarea.py
+++ b/examples/dockarea.py
@@ -112,4 +112,4 @@ win.show()
 
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/fractal.py
+++ b/examples/fractal.py
@@ -107,4 +107,4 @@ depthSpin.valueChanged.connect(update)
 update()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/hdf5.py
+++ b/examples/hdf5.py
@@ -142,4 +142,4 @@ curve.setHDF5(f['data'])
 plt.addItem(curve)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/histogram.py
+++ b/examples/histogram.py
@@ -30,4 +30,4 @@ y = pg.pseudoScatter(vals, spacing=0.15)
 plt2.plot(vals, y, pen=None, symbol='o', symbolSize=5, symbolPen=(255,255,255,200), symbolBrush=(0,0,255,150))
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/imageAnalysis.py
+++ b/examples/imageAnalysis.py
@@ -114,4 +114,4 @@ def imageHoverEvent(event):
 img.hoverEvent = imageHoverEvent
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/infiniteline_performance.py
+++ b/examples/infiniteline_performance.py
@@ -45,4 +45,4 @@ timer.timeout.connect(update)
 timer.start(0)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/isocurve.py
+++ b/examples/isocurve.py
@@ -54,4 +54,4 @@ timer.timeout.connect(update)
 timer.start(50)
     
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/linkedViews.py
+++ b/examples/linkedViews.py
@@ -41,5 +41,5 @@ p3.setLabel('left', "Label to test offset")
 #QtGui.QApplication.processEvents()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()
 

--- a/examples/logAxis.py
+++ b/examples/logAxis.py
@@ -35,4 +35,4 @@ p3.plot(x, y)
 #p.getAxis('bottom').setLogMode(True)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/multiplePlotSpeedTest.py
+++ b/examples/multiplePlotSpeedTest.py
@@ -87,4 +87,4 @@ else:
 plt.autoRange()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/optics_demos.py
+++ b/examples/optics_demos.py
@@ -160,4 +160,4 @@ timer.timeout.connect(update)
 timer.start(40)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/parametertree.py
+++ b/examples/parametertree.py
@@ -179,4 +179,4 @@ s = p.saveState()
 p.restoreState(s)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/relativity/relativity.py
+++ b/examples/relativity/relativity.py
@@ -760,4 +760,4 @@ if __name__ == '__main__':
     win.show()
     win.resize(1100,700)
 
-    app.exec_()
+    pg.exec()

--- a/examples/relativity_demo.py
+++ b/examples/relativity_demo.py
@@ -17,4 +17,4 @@ win.show()
 win.loadPreset(None, 'Twin Paradox (grid)')
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/scrollingPlots.py
+++ b/examples/scrollingPlots.py
@@ -110,4 +110,4 @@ timer.timeout.connect(update)
 timer.start(50)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/template.py
+++ b/examples/template.py
@@ -16,4 +16,4 @@ app = mkQApp()
 # win.setWindowTitle('pyqtgraph example: ____')
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/test_ExampleApp.py
+++ b/examples/test_ExampleApp.py
@@ -8,4 +8,4 @@ from examples.ExampleApp import ExampleLoader
 loader = ExampleLoader()
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -163,7 +163,7 @@ try:
     print("test complete")
     sys.stdout.flush()
     pg.Qt.QtCore.QTimer.singleShot(1000, pg.Qt.QtWidgets.QApplication.quit)
-    pg.Qt.QtWidgets.QApplication.instance().exec_()
+    pg.exec()
     names = [x for x in dir({1}) if not x.startswith('_')]
     for name in names:
         delattr({1}, name)

--- a/examples/text.py
+++ b/examples/text.py
@@ -53,4 +53,4 @@ timer.timeout.connect(update)
 timer.start(10)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/examples/verlet_chain_demo.py
+++ b/examples/verlet_chain_demo.py
@@ -119,4 +119,4 @@ timer.timeout.connect(update)
 timer.start(16)
 
 if __name__ == '__main__':
-    pg.mkQApp().exec_()
+    pg.exec()

--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -334,10 +334,6 @@ if QT_LIB == PYSIDE6:
                 self.setColorAt(pos, color)
         QtGui.QGradient.setStops = __setStops
 
-    if not hasattr(QtWidgets.QApplication, 'exec'):
-        # PySide6 6.0 forwards compatibility to PySide6 6.1
-        QtWidgets.QApplication.exec = QtWidgets.QApplication.exec_
-
 
 if QT_LIB == PYQT6:
     # module.Class.EnumClass.Enum -> module.Class.Enum

--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -450,3 +450,9 @@ def mkQApp(name=None):
     if name is not None:
         QAPP.setApplicationName(name)
     return QAPP
+
+
+# exec() is used within _loadUiType, so we define as exec_() here and rename in pg namespace
+def exec_():
+    app = mkQApp()
+    return app.exec() if hasattr(app, 'exec') else app.exec_()

--- a/pyqtgraph/Qt.py
+++ b/pyqtgraph/Qt.py
@@ -273,13 +273,6 @@ if QT_LIB in [PYQT5, PYQT6, PYSIDE2, PYSIDE6]:
     QtGui.QApplication.setGraphicsSystem = None
 
 
-if QT_LIB in [PYQT5, PYSIDE2]:
-    # Some constructs are getting deprecated in Qt6
-    # recreate the Qt6 structure
-
-    QtWidgets.QApplication.exec = QtWidgets.QApplication.exec_
-
-
 if QT_LIB in [PYQT6, PYSIDE6]:
     # We're using Qt6 which has a different structure so we're going to use a shim to
     # recreate the Qt5 structure

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -11,6 +11,7 @@ __version__ = '0.12.1'
 ## 'Qt' is a local module; it is intended mainly to cover up the differences
 ## between PyQt4 and PySide.
 from .Qt import QtGui, mkQApp
+from .Qt import exec_ as exec
 
 ## not really safe--If we accidentally create another QApplication, the process hangs (and it is very difficult to trace the cause)
 #if QtGui.QApplication.instance() is None:

--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -458,7 +458,7 @@ def startQtEventLoop(name, port, authkey, ppid, debug=False):
     global HANDLER
     HANDLER = RemoteQtEventHandler(conn, name, ppid, debug=debug)
     HANDLER.startEventTimer()
-    app.exec_()
+    app.exec() if hasattr(app, 'exec') else app.exec_()
 
 import threading
 class FileForwarder(threading.Thread):

--- a/pyqtgraph/widgets/JoystickButton.py
+++ b/pyqtgraph/widgets/JoystickButton.py
@@ -99,5 +99,4 @@ if __name__ == '__main__':
         
     b.sigStateChanged.connect(fn)
         
-    app.exec_()
-        
+    app.exec() if hasattr(app, 'exec') else app.exec_()


### PR DESCRIPTION
Related to #1770. PySide6 6.1 deprecates exec_() thus running the examples on PySide6 6.1 have a deprecation warning.
This PR implements pg.exec() and changes all examples to make use of it.

The exec() and exec_() shims added in #1771 are reverted. The intent then was to change the examples from ```pg.mkQApp().exec_()``` to ```pg.mkQApp().exec()```. They had not actually been used yet.