### PR TITLE
Use fallback minStep in dec mode SpinBox (Issue 1756)

### DIFF
--- a/examples/parametertree.py
+++ b/examples/parametertree.py
@@ -82,7 +82,7 @@ params = [
         {'name': 'Units + SI prefix', 'type': 'float', 'value': 1.2e-6, 'step': 1e-6, 'siPrefix': True, 'suffix': 'V'},
         {'name': 'Limits (min=7;max=15)', 'type': 'int', 'value': 11, 'limits': (7, 15), 'default': -6},
         {'name': 'Int suffix', 'type': 'int', 'value': 9, 'suffix': 'V'},
-        {'name': 'DEC stepping', 'type': 'float', 'value': 1.2e6, 'dec': True, 'step': 1, 'siPrefix': True, 'suffix': 'Hz'},
+        {'name': 'DEC stepping', 'type': 'float', 'value': 1.2e6, 'dec': True, 'step': 1, 'minStep': 1.0e-12, 'siPrefix': True, 'suffix': 'Hz'},
         
     ]},
     {'name': 'Save/Restore functionality', 'type': 'group', 'children': [

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -223,6 +223,10 @@ class SpinBox(QtGui.QAbstractSpinBox):
 
             if 'format' not in opts:
                 self.opts['format'] = asUnicode("{value:d}{suffixGap}{suffix}")
+
+        if self.opts['dec']:
+            if self.opts.get('minStep') is None:
+                self.opts['minStep'] = self.opts['step']
         
         if 'delay' in opts:
             self.proxy.setDelay(opts['delay'])


### PR DESCRIPTION
Hello, I made some changes addressing issue #1756

If a SpinBox is in 'dec' mode but there is no 'minStep' value it will set 'minStep' to the same value as 'step'. This fixes the crash mentioned in the issue.

I also made a change to examples/parametertree.py that sets 'minStep' to 1.0e-12 in the DEC stepping spinbox. I did this because while the change mentioned above prevented a crash, it set the minimum step to 1.0, which meant the spinbox could not step from 1 Hz to 0.9 mHz, it would go to 0 Hz instead. Setting 'minStep' to a very small value keeps the behavior similar to how it was before the fix.