### PR TITLE
QVector3D conversion problem in GLViewWidget.py

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/home/j2y/envs/zv/bin/python"
+}

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -421,8 +421,9 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         Pos may be a Vector or an (N,3) array of locations
         """
         cam = self.cameraPosition()
-        if isinstance(pos, np.ndarray):            
-            cam = np.array((cam.x(), cam.y(), cam.z()))  
+        if isinstance(pos, np.ndarray):
+            if isinstance(cam, QtGui.QVector3D):            
+                cam = np.array((cam.x(), cam.y(), cam.z()))  
             cam = cam.reshape((1,) * (pos.ndim - 1) + (3,))
             dist = ((pos-cam)**2).sum(axis=-1)**0.5
         else:

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -422,7 +422,9 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         """
         cam = self.cameraPosition()
         if isinstance(pos, np.ndarray):
-            cam = np.array(cam).reshape((1,)*(pos.ndim-1)+(3,))
+            # cam = np.array(cam).reshape((1,) * (pos.ndim - 1) + (3,)) # not properly converted to numpy arrays
+            cam = np.array((cam[0], cam[1], cam[2]))  # j2y
+            cam = cam.reshape((1,) * (pos.ndim - 1) + (3,))
             dist = ((pos-cam)**2).sum(axis=-1)**0.5
         else:
             dist = (pos-cam).length()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -423,7 +423,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         cam = self.cameraPosition()
         if isinstance(pos, np.ndarray):
             # cam = np.array(cam).reshape((1,) * (pos.ndim - 1) + (3,)) # not properly converted to numpy arrays
-            cam = np.array((cam[0], cam[1], cam[2]))  # j2y
+            cam = np.array((cam[0], cam[1], cam[2]))  
             cam = cam.reshape((1,) * (pos.ndim - 1) + (3,))
             dist = ((pos-cam)**2).sum(axis=-1)**0.5
         else:

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -421,9 +421,8 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         Pos may be a Vector or an (N,3) array of locations
         """
         cam = self.cameraPosition()
-        if isinstance(pos, np.ndarray):
-            # cam = np.array(cam).reshape((1,) * (pos.ndim - 1) + (3,)) # not properly converted to numpy arrays
-            cam = np.array((cam[0], cam[1], cam[2]))  
+        if isinstance(pos, np.ndarray):            
+            cam = np.array((cam.x(), cam.y(), cam.z()))  
             cam = cam.reshape((1,) * (pos.ndim - 1) + (3,))
             dist = ((pos-cam)**2).sum(axis=-1)**0.5
         else:


### PR DESCRIPTION
I fixed an error in GLViewWidget.py
This error happened when I changed the rotation mode from Euler to Quartenion. 
I found that the cause of the error is the wrong conversion of QVector3D to numpy. 