### PR TITLE
Fix the wrong conversion of QVector3D to numpy array in GLViewWidget.py

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -422,7 +422,9 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         """
         cam = self.cameraPosition()
         if isinstance(pos, np.ndarray):
-            cam = np.array(cam).reshape((1,)*(pos.ndim-1)+(3,))
+            if isinstance(cam, QtGui.QVector3D):
+                cam = np.array((cam.x(), cam.y(), cam.z()))
+            cam = cam.reshape((1,)*(pos.ndim-1)+(3,))
             dist = ((pos-cam)**2).sum(axis=-1)**0.5
         else:
             dist = (pos-cam).length()


### PR DESCRIPTION
Fix the wrong conversion of QVector3D to numpy array.