### PR TITLE
implement numba colormap lookup

### DIFF
--- a/pyqtgraph/functions_numba.py
+++ b/pyqtgraph/functions_numba.py
@@ -22,18 +22,19 @@ def rescaleData(data, scale, offset, dtype, clip):
     return data_out
 
 @numba.jit(nopython=True)
-def rescale_and_lookup1d_function(xx, scale, offset, vmin, vmax, lut, yy):
+def rescale_and_lookup1d_function(xx, scale, offset, lut, yy):
+    vmin, vmax = 0, lut.shape[0] - 1
     for r in range(xx.shape[0]):
         for c in range(xx.shape[1]):
             val = (xx[r, c] - offset) * scale
             val = min(max(val, vmin), vmax)
             yy[r, c] = lut[int(val)]
 
-def rescale_and_lookup1d(data, scale, offset, clip, lut):
+def rescale_and_lookup1d(data, scale, offset, lut):
     # data should be floating point and 2d
     # lut is 1d
     data_out = np.empty_like(data, dtype=lut.dtype)
-    rescale_and_lookup1d_function(data, float(scale), float(offset), float(clip[0]), float(clip[1]), lut, data_out)
+    rescale_and_lookup1d_function(data, float(scale), float(offset), lut, data_out)
     return data_out
 
 @numba.jit(nopython=True)

--- a/pyqtgraph/functions_numba.py
+++ b/pyqtgraph/functions_numba.py
@@ -22,19 +22,19 @@ def rescaleData(data, scale, offset, dtype, clip):
     return data_out
 
 @numba.jit(nopython=True)
-def rescale_and_lookup1d_function(xx, scale, offset, lut, yy):
+def _rescale_and_lookup1d_function(data, scale, offset, lut, out):
     vmin, vmax = 0, lut.shape[0] - 1
-    for r in range(xx.shape[0]):
-        for c in range(xx.shape[1]):
-            val = (xx[r, c] - offset) * scale
+    for r in range(data.shape[0]):
+        for c in range(data.shape[1]):
+            val = (data[r, c] - offset) * scale
             val = min(max(val, vmin), vmax)
-            yy[r, c] = lut[int(val)]
+            out[r, c] = lut[int(val)]
 
 def rescale_and_lookup1d(data, scale, offset, lut):
     # data should be floating point and 2d
     # lut is 1d
     data_out = np.empty_like(data, dtype=lut.dtype)
-    rescale_and_lookup1d_function(data, float(scale), float(offset), lut, data_out)
+    _rescale_and_lookup1d_function(data, float(scale), float(offset), lut, data_out)
     return data_out
 
 @numba.jit(nopython=True)

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -512,16 +512,25 @@ class ImageItem(GraphicsObject):
             maxVal = xp.nextafter(maxVal, 2*maxVal)
         rng = maxVal - minVal
         rng = 1 if rng == 0 else rng
-        image = fn.rescaleData(image, scale/rng, offset=minVal, dtype=dtype, clip=(0, num_colors-1))
 
-        levels = None
+        fn_numba = fn.getNumbaFunctions()
+        if xp == numpy and image.flags.c_contiguous and dtype == xp.uint16 and fn_numba is not None:
+            lut, augmented_alpha = self._convert_2dlut_to_1dlut(lut)
+            image = fn_numba.rescale_and_lookup1d(image, scale/rng, minVal, (0, num_colors-1), lut)
+            if image.dtype == xp.uint32:
+                image = image[..., xp.newaxis].view(xp.uint8)
+            return image, None, None, augmented_alpha
+        else:
+            image = fn.rescaleData(image, scale/rng, offset=minVal, dtype=dtype, clip=(0, num_colors-1))
 
-        if image.dtype == xp.uint16 and image.ndim == 2:
-            image, augmented_alpha = self._apply_lut_for_uint16_mono(image, lut)
-            lut = None
+            levels = None
 
-        # image is now of type uint8
-        return image, levels, lut, augmented_alpha
+            if image.dtype == xp.uint16 and image.ndim == 2:
+                image, augmented_alpha = self._apply_lut_for_uint16_mono(image, lut)
+                lut = None
+
+            # image is now of type uint8
+            return image, levels, lut, augmented_alpha
 
     def _try_combine_lut(self, image, levels, lut):
         augmented_alpha = False
@@ -631,21 +640,39 @@ class ImageItem(GraphicsObject):
         # if we are contiguous, we can take a faster codepath where we
         # ensure that the lut is 1d
 
-        if lut.ndim == 2:
-            if lut.shape[1] == 3:   # rgb
-                # convert rgb lut to rgba so that it is 32-bits
-                lut = xp.column_stack([lut, xp.full(lut.shape[0], 255, dtype=xp.uint8)])
-                augmented_alpha = True
-            if lut.shape[1] == 4:   # rgba
-                lut = lut.view(xp.uint32)
+        lut, augmented_alpha = self._convert_2dlut_to_1dlut(lut)
 
-        image = lut.ravel()[image]
-        lut = None
-        # now both levels and lut are None
+        fn_numba = fn.getNumbaFunctions()
+        if xp == numpy and fn_numba is not None:
+            image = fn_numba.numba_take(lut, image)
+        else:
+            image = lut[image]
+
         if image.dtype == xp.uint32:
-            image = image.view(xp.uint8).reshape(image.shape + (4,))
+            image = image[..., xp.newaxis].view(xp.uint8)
 
         return image, augmented_alpha
+
+    def _convert_2dlut_to_1dlut(self, lut):
+        # converts:
+        #   - uint8 (N, 1) to uint8 (N,)
+        #   - uint8 (N, 3) or (N, 4) to uint32 (N,)
+        # this allows faster lookup as 1d lookup is faster
+        xp = self._xp
+        augmented_alpha = False
+
+        if lut.ndim == 1:
+            return lut, augmented_alpha
+
+        if lut.shape[1] == 3:   # rgb
+            # convert rgb lut to rgba so that it is 32-bits
+            lut = xp.column_stack([lut, xp.full(lut.shape[0], 255, dtype=xp.uint8)])
+            augmented_alpha = True
+        if lut.shape[1] == 4:   # rgba
+            lut = lut.view(xp.uint32)
+        lut = lut.ravel()
+
+        return lut, augmented_alpha
 
     def _try_make_qimage(self, image, levels, lut, augmented_alpha):
         xp = self._xp

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -516,7 +516,7 @@ class ImageItem(GraphicsObject):
         fn_numba = fn.getNumbaFunctions()
         if xp == numpy and image.flags.c_contiguous and dtype == xp.uint16 and fn_numba is not None:
             lut, augmented_alpha = self._convert_2dlut_to_1dlut(lut)
-            image = fn_numba.rescale_and_lookup1d(image, scale/rng, minVal, (0, num_colors-1), lut)
+            image = fn_numba.rescale_and_lookup1d(image, scale/rng, minVal, lut)
             if image.dtype == xp.uint32:
                 image = image[..., xp.newaxis].view(xp.uint8)
             return image, None, None, augmented_alpha


### PR DESCRIPTION
https://github.com/pyqtgraph/pyqtgraph/pull/1693#issuecomment-836241886 shows codepaths involving large luts ("uint16lut") are relatively slower. However, they are the codepaths that are taken by VideoSpeedTest.py and ImageView when using "float" and "uint16" dtypes.

Implementing the colormap lookup using Numba gives a decent speedup on Windows. YMMV on other platforms.

|      4096x4096 numba          |    master     |  this PR   |
|              -------------           | ------------- | ---------- |
| float_levels_uint16lut         |    69.9±0ms   |  28.4±0ms  |
| uint16_levels_uint16lut        |    50.7±0ms   |  19.0±0ms  |
| uint16_nolevels_uint16lut      |    50.6±0ms   |  19.0±0ms  |

It is surprising that a numba-ified version of ```np.take()``` should yield a 2.5x speedup.