### PR TITLE
don't rely on QImage-wrapped buffer being writable

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1423,10 +1423,6 @@ def ndarray_to_qimage(arr, fmt):
     h, w = arr.shape[:2]
     bytesPerLine = arr.strides[0]
     qimg = QtGui.QImage(img_ptr, w, h, bytesPerLine, fmt)
-
-    # Note that the bindings that support ndarray directly already hold a reference
-    # to it. The manual reference below is only needed for those bindings that take
-    # in a raw pointer.
     qimg.data = arr
     return qimg
 

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -235,7 +235,7 @@ class ImageItem(GraphicsObject):
             self._processingBuffer = self._xp.empty(shape[:2] + (4,), dtype=self._xp.ubyte)
         else:
             self._processingBuffer = self._displayBuffer
-        self.qimage = fn.makeQImage(self._displayBuffer, transpose=False, copy=False)
+        self.qimage = None
 
     def setImage(self, image=None, autoLevels=None, **kargs):
         """
@@ -471,6 +471,7 @@ class ImageItem(GraphicsObject):
         fn.makeARGB(image, lut=lut, levels=levels, output=self._processingBuffer)
         if self._xp == getCupy():
             self._processingBuffer.get(out=self._displayBuffer)
+        self.qimage = fn.ndarray_to_qimage(self._displayBuffer, QtGui.QImage.Format.Format_ARGB32)
 
         self._renderRequired = False
         self._unrenderable = False


### PR DESCRIPTION
This works around #1784 for ImageItem.py.
It converts a potential PySide6 6.1.1 breakage to a performance loss (that would be limited to PySide6).
