### PR TITLE
Force cameraPosition() to return Vector class. 

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -423,9 +423,6 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         cam = self.cameraPosition()
         if isinstance(pos, np.ndarray):
             cam = np.array(cam).reshape((1,)*(pos.ndim-1)+(3,))
-            # if isinstance(cam, QtGui.QVector3D):
-            #     cam = np.array((cam.x(), cam.y(), cam.z()))
-            cam = cam.reshape((1,)*(pos.ndim-1)+(3,))
             dist = ((pos-cam)**2).sum(axis=-1)**0.5
         else:
             dist = (pos-cam).length()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -422,7 +422,9 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         """
         cam = self.cameraPosition()
         if isinstance(pos, np.ndarray):
-            cam = np.array(cam).reshape((1,)*(pos.ndim-1)+(3,))
+            if isinstance(cam, QtGui.QVector3D):
+                cam = np.array((cam.x(), cam.y(), cam.z()))
+            cam = cam.reshape((1,)*(pos.ndim-1)+(3,))
             dist = ((pos-cam)**2).sum(axis=-1)**0.5
         else:
             dist = (pos-cam).length()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -314,7 +314,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         center = self.opts['center']
         dist = self.opts['distance']
         if self.opts['rotationMethod'] == "quaternion":
-            pos = center - self.opts['rotation'].rotatedVector( Vector(0,0,dist) )
+            pos = Vector(center - self.opts['rotation'].rotatedVector(Vector(0,0,dist) ))
         else:
             # using 'euler' rotation method
             elev = radians(self.opts['elevation'])
@@ -422,8 +422,9 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         """
         cam = self.cameraPosition()
         if isinstance(pos, np.ndarray):
-            if isinstance(cam, QtGui.QVector3D):
-                cam = np.array((cam.x(), cam.y(), cam.z()))
+            cam = np.array(cam).reshape((1,)*(pos.ndim-1)+(3,))
+            # if isinstance(cam, QtGui.QVector3D):
+            #     cam = np.array((cam.x(), cam.y(), cam.z()))
             cam = cam.reshape((1,)*(pos.ndim-1)+(3,))
             dist = ((pos-cam)**2).sum(axis=-1)**0.5
         else:


### PR DESCRIPTION
In quaternion mode, GLViewWidget has problem with QVector3D conversion in ```def pixelSize```, #1792 

I think Vector class minus(-) operator has to return Vector class not Qvector3D, but as it has no minus operator, it returns QVector3D. That's the origin of the problem. 

But as a quick way to fix it, force to convert it to Vector in ```cameraPosition() ``` suggested by [pijyoi](https://github.com/pijyoi).
