### PR TITLE
Fixing GLMeshItem memory leak in face drawing on 64-bit Linux (#1783)

### DIFF
--- a/pyqtgraph/opengl/items/GLMeshItem.py
+++ b/pyqtgraph/opengl/items/GLMeshItem.py
@@ -196,7 +196,7 @@ class GLMeshItem(GLGraphicsItem):
                     if faces is None:
                         glDrawArrays(GL_TRIANGLES, 0, np.product(verts.shape[:-1]))
                     else:
-                        faces = faces.astype(np.uint).flatten()
+                        faces = faces.astype(np.uint32).flatten()
                         glDrawElements(GL_TRIANGLES, faces.shape[0], GL_UNSIGNED_INT, faces)
                 finally:
                     glDisableClientState(GL_NORMAL_ARRAY)


### PR DESCRIPTION
PyOpenGl requires 32-bit uint as corresponding argument to GL_UNSIGNED_INT. On 64-bit Linux, np.uint translates to a 64-bit uint, so changing the astype to explicitly be np.uint32 as required.