### PR TITLE
update cx_freeze example and add a workaround for templates

### DIFF
--- a/examples/cx_freeze/plotTest.py
+++ b/examples/cx_freeze/plotTest.py
@@ -1,5 +1,5 @@
 import sys
-from PyQt4 import QtGui
+from pyqtgraph.Qt import QtGui
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems import TextItem
 # For packages that require scipy, these may be needed: 

--- a/examples/cx_freeze/setup.py
+++ b/examples/cx_freeze/setup.py
@@ -1,5 +1,6 @@
 # Build with `python setup.py build_exe`
 from cx_Freeze import setup, Executable
+from pathlib import Path
 
 import shutil
 from glob import glob
@@ -8,11 +9,23 @@ shutil.rmtree("build", ignore_errors=True)
 shutil.rmtree("dist", ignore_errors=True)
 import sys
 
-includes = ['PyQt4.QtCore', 'PyQt4.QtGui', 'sip', 'pyqtgraph.graphicsItems',
+includes = ['pyqtgraph.graphicsItems',
             'numpy', 'atexit']
 excludes = ['cvxopt','_gtkagg', '_tkagg', 'bsddb', 'curses', 'email', 'pywin.debugger',
     'pywin.debugger.dbgcon', 'pywin.dialogs', 'tcl','tables',
     'Tkconstants', 'Tkinter', 'zmq','PySide','pysideuic','scipy','matplotlib']
+
+# Workaround for making sure the templates are included in the frozen app package
+include_files = []
+import pyqtgraph
+pg_folder = Path(pyqtgraph.__file__).parent
+templates = pg_folder.rglob('*template*.py')
+sources = [str(w) for w in templates]
+destinations = ['lib' + w.replace(str(pg_folder.parent), '') for w in sources]
+for a in zip(sources, destinations):
+    include_files.append(a)
+
+print(include_files)
 
 if sys.version[0] == '2':
     # causes syntax error on py2
@@ -24,11 +37,10 @@ if sys.platform == "win32":
 
 build_exe_options = {'excludes': excludes,
     'includes':includes, 'include_msvcr':True,
-    'compressed':True, 'copy_dependent_files':True, 'create_shared_zip':True,
-    'include_in_shared_zip':True, 'optimize':2}
+    'optimize':1, "include_files": include_files,}
 
 setup(name = "cx_freeze plot test",
-      version = "0.1",
+      version = "0.2",
       description = "cx_freeze plot test",
       options = {"build_exe": build_exe_options},
       executables = [Executable("plotTest.py", base=base)])


### PR DESCRIPTION
Updated the example to a working state with cx_Freeze 6.2

Added a workaround to copy the unreferenced template files to the packaged app.