### PR TITLE
fix click bug on removable ROIs; test

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -801,7 +801,7 @@ class ROI(GraphicsObject):
         if ev.button() == QtCore.Qt.RightButton and self.contextMenuEnabled():
             self.raiseContextMenu(ev)
             ev.accept()
-        elif ev.button() in self.acceptedMouseButtons():
+        elif int(ev.button()) & int(self.acceptedMouseButtons()) > 0:
             ev.accept()
             self.sigClicked.emit(self, ev)
         else:

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -801,7 +801,7 @@ class ROI(GraphicsObject):
         if ev.button() == QtCore.Qt.RightButton and self.contextMenuEnabled():
             self.raiseContextMenu(ev)
             ev.accept()
-        elif int(ev.button()) & int(self.acceptedMouseButtons()) > 0:
+        elif ev.button() & self.acceptedMouseButtons() > 0:
             ev.accept()
             self.sigClicked.emit(self, ev)
         else:

--- a/pyqtgraph/graphicsItems/tests/test_ROI.py
+++ b/pyqtgraph/graphicsItems/tests/test_ROI.py
@@ -153,6 +153,24 @@ def check_getArrayRegion(roi, name, testResize=True, transpose=False):
 
     win.hide()
 
+
+def test_mouseClickEvent():
+    plt = pg.GraphicsView()
+    plt.show()
+    resizeWindow(plt, 200, 200)
+    vb = pg.ViewBox()
+    plt.scene().addItem(vb)
+    vb.resize(200, 200)
+    QtTest.QTest.qWaitForWindowExposed(plt)
+    QtTest.QTest.qWait(100)
+
+    roi = pg.RectROI((0, 0), (10, 20), removable=True)
+    vb.addItem(roi)
+    app.processEvents()
+
+    mouseClick(plt, roi.mapToScene(pg.Point(2, 2)), QtCore.Qt.LeftButton)
+
+
 def test_PolyLineROI():
     rois = [
         (pg.PolyLineROI([[0, 0], [10, 0], [0, 15]], closed=True, pen=0.3), 'closed'),


### PR DESCRIPTION
Looks like `in` stopped working at some point, but this `int` version should be safer and work everywhere.