### PR TITLE
Sanitize input for plotItem.showGrid (was documentation fix for plotItem.showGrid alpha setting)

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -362,7 +362,7 @@ class PlotItem(GraphicsWidget):
         **Arguments:**
         x               (bool) Whether to show the X grid
         y               (bool) Whether to show the Y grid
-        alpha           (0-255) Opacity of the grid
+        alpha           (0.0-1.0) Opacity of the grid
         ==============  =====================================
         """
         if x is None and y is None and alpha is None:
@@ -373,8 +373,8 @@ class PlotItem(GraphicsWidget):
         if y is not None:
             self.ctrl.yGridCheck.setChecked(y)
         if alpha is not None:
-            v = int( fn.clip_scalar(alpha, 0, self.ctrl.gridAlphaSlider.maximum() ) )
-            self.ctrl.gridAlphaSlider.setValue(v)
+            v = fn.clip_scalar(alpha, 0, 1) * self.ctrl.gridAlphaSlider.maximum() # slider range 0 to 255
+            self.ctrl.gridAlphaSlider.setValue( int(v) )
         
     def close(self):
         ## Most of this crap is needed to avoid PySide trouble. 

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -362,7 +362,7 @@ class PlotItem(GraphicsWidget):
         **Arguments:**
         x               (bool) Whether to show the X grid
         y               (bool) Whether to show the Y grid
-        alpha           (0.0-1.0) Opacity of the grid
+        alpha           (0-255) Opacity of the grid
         ==============  =====================================
         """
         if x is None and y is None and alpha is None:
@@ -373,7 +373,7 @@ class PlotItem(GraphicsWidget):
         if y is not None:
             self.ctrl.yGridCheck.setChecked(y)
         if alpha is not None:
-            v = fn.clip_scalar(alpha, 0., 1.)*self.ctrl.gridAlphaSlider.maximum()
+            v = int( fn.clip_scalar(alpha, 0, self.ctrl.gridAlphaSlider.maximum() ) )
             self.ctrl.gridAlphaSlider.setValue(v)
         
     def close(self):


### PR DESCRIPTION
Looking through some issues, I came across #1484:

setting `plotItem.showGrid(True, True, alpha=0.5)` raises `TypeError: setValue(self, int): argument 1 has unexpected type 'numpy.float64'`

This is a documentation error:
The expected alpha value does not range from 0.0 to 1.0 (as in the current docstring), but instead ranges from 0-255.

This PR updates the docstring to show that and adds a cast to int to avoid raising an error.
The `alpha=0.5` value in the original report will no longer result in an error and draw an invisible, fully transparent grid. 
Setting `alpha=127` creates the desired half-transparent grid.

So this should close #1484.