### PR TITLE
implement QPolygonF codepath for connect="finite"

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1768,6 +1768,8 @@ def arrayToQPath(x, y, connect='all', finiteCheck=True):
             if nonfinite_cnt / n < 2 / 100:
                 use_qpolygonf = True
                 finiteCheck = False
+            if nonfinite_cnt == 0:
+                connect = 'all'
 
     if use_qpolygonf:
         backstore = create_qpolygonf(n)

--- a/tests/graphicsItems/test_PlotCurveItem.py
+++ b/tests/graphicsItems/test_PlotCurveItem.py
@@ -25,6 +25,9 @@ def test_PlotCurveItem():
     
     c.setData(data, connect='finite')
     assertImageApproved(p, 'plotcurveitem/connectfinite', "Plot curve with finite points connected.")
+
+    c.setData(data, connect='finite', skipFiniteCheck=True)
+    assertImageApproved(p, 'plotcurveitem/connectfinite', "Plot curve with finite points connected using QPolygonF.")
     
     c.setData(data, connect=np.array([1,1,1,0,1,1,0,0,1,0,0,0,1,1,0,0]))
     assertImageApproved(p, 'plotcurveitem/connectarray', "Plot curve with connection array.")


### PR DESCRIPTION
This PR continues #1796 in optimizing ```arrayToQPath()```, but for connect=finite.


Timings:
| test  | time (s) | remarks | 
| --- | --- | --- |
| all_nonan | 0.043 |  | 
| all_withnan  | 0.175 | 1% nans |
| pairs | 0.414 | operator<< | 
| finite_nonan | 0.040 |  |  
| finite_withnan | 0.126 | 1% nans  |
| array | 0.415 | operator<<  |

Unlike the old ```operator<<``` codepaths, the time taken for this implementation is proportional to the number of nans present in the data. Hence, a heuristic is used to determine when to use the new implementation vs falling back to the old implementation. It is expected that nans are uncommon within the data to be plotted. If that is not the case, then timings should be no worse than before. 

For testing purposes, we do want to be able to force the usage of the new implementation. This is provided for by specifying ```finiteCheck = False```.

Benchmarking script:
```python
import timeit
import numpy as np 
import pyqtgraph.functions as fn

x = np.arange(32768, dtype=np.float64)
y = np.arange(32768, dtype=np.float64)
c = np.random.randint(100, size=32768, dtype=np.uint8) < 99
yn = y.copy()
yn[~c] = np.nan

def test_all_nonan():
    fn.arrayToQPath(x, y, connect='all')

def test_all_withnan():
    fn.arrayToQPath(x, yn, connect='all')

def test_pairs():
    fn.arrayToQPath(x, y, connect='pairs')

def test_finite_nonan():
    fn.arrayToQPath(x, y, connect='finite')

def test_finite_withnan():
    fn.arrayToQPath(x, yn, connect='finite')

def test_array():
    fn.arrayToQPath(x, y, connect=c)

print('all_nonan', timeit.timeit(test_all_nonan, number=100, globals=globals()))
print('all_withnan', timeit.timeit(test_all_withnan, number=100, globals=globals()))
print('pairs', timeit.timeit(test_pairs, number=100, globals=globals()))
print('finite_nonan', timeit.timeit(test_finite_nonan, number=100, globals=globals()))
print('finite_withnan', timeit.timeit(test_finite_withnan, number=100, globals=globals()))
print('array', timeit.timeit(test_array, number=100, globals=globals()))
```