### PR TITLE
error on presence of "Exception:" and "Error:"

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -205,8 +205,8 @@ except:
     process.stderr.close()
 
     if (fail or
-        'exception' in stderr.lower() or
-        'error' in stderr.lower()):
+        'Exception:' in stderr or
+        'Error:' in stderr):
         if (not fail 
             and name == "RemoteGraphicsView" 
             and "pyqtgraph.multiprocess.remoteproxy.ClosedError" in stderr):


### PR DESCRIPTION
This PR seeks to address the CI failure of (macOS, PySide6 6.1.1, colorMaps.py).
On the above configuration, Matplotlib prints out some logging information that contains the string "error", which test_examples.py treats as a failure condition.

This PR changes the failure condition to only trigger upon the presence of the (case-sensitive) strings "Error:" and "Exception:". 