### PR TITLE
remove little-endian assumption for image export

### DIFF
--- a/pyqtgraph/exporters/Exporter.py
+++ b/pyqtgraph/exporters/Exporter.py
@@ -128,8 +128,8 @@ class Exporter(object):
         while len(childs) > 0:
             ch = childs.pop(0)
             tree = self.getPaintItems(ch)
-            if (ch.flags() & ch.ItemStacksBehindParent) or \
-               (ch.zValue() < 0 and (ch.flags() & ch.ItemNegativeZStacksBehindParent)):
+            if (ch.flags() & ch.GraphicsItemFlag.ItemStacksBehindParent) or \
+               (ch.zValue() < 0 and (ch.flags() & ch.GraphicsItemFlag.ItemNegativeZStacksBehindParent)):
                 preItems.extend(tree)
             else:
                 postItems.extend(tree)

--- a/pyqtgraph/exporters/ImageExporter.py
+++ b/pyqtgraph/exporters/ImageExporter.py
@@ -1,8 +1,9 @@
 from .Exporter import Exporter
 from ..parametertree import Parameter
-from ..Qt import QtGui, QtCore, QtSvg, QT_LIB
+from ..Qt import QtCore, QtGui, QtWidgets
 from .. import functions as fn
 import numpy as np
+import sys
 
 translate = QtCore.QCoreApplication.translate
 __all__ = ['ImageExporter']
@@ -73,15 +74,8 @@ class ImageExporter(Exporter):
         targetRect = QtCore.QRect(0, 0, w, h)
         sourceRect = self.getSourceRect()
 
-        bg = np.empty((h, w, 4), dtype=np.ubyte)
-        color = self.params['background']
-        bg[:,:,0] = color.blue()
-        bg[:,:,1] = color.green()
-        bg[:,:,2] = color.red()
-        bg[:,:,3] = color.alpha()
-
-        self.png = fn.makeQImage(bg, alpha=True, copy=False, transpose=False)
-        self.bg = bg
+        self.png = QtGui.QImage(w, h, QtGui.QImage.Format.Format_ARGB32)
+        self.png.fill(self.params['background'])
         
         ## set resolution of image:
         origTargetRect = self.getTargetRect()
@@ -104,13 +98,18 @@ class ImageExporter(Exporter):
         painter.end()
         
         if self.params['invertValue']:
-            mn = bg[...,:3].min(axis=2)
-            mx = bg[...,:3].max(axis=2)
+            bg = fn.qimage_to_ndarray(self.png)
+            if sys.byteorder == 'little':
+                cv = slice(0, 3)
+            else:
+                cv = slice(1, 4)
+            mn = bg[...,cv].min(axis=2)
+            mx = bg[...,cv].max(axis=2)
             d = (255 - mx) - mn
-            bg[...,:3] += d[...,np.newaxis]
+            bg[...,cv] += d[...,np.newaxis]
         
         if copy:
-            QtGui.QApplication.clipboard().setImage(self.png)
+            QtWidgets.QApplication.clipboard().setImage(self.png)
         elif toBytes:
             return self.png
         else:

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -557,15 +557,11 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         pixels[...,3] = 255
         
         glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels)
-        
-        # swap B,R channels for Qt
-        tmp = pixels[...,0].copy()
-        pixels[...,0] = pixels[...,2]
-        pixels[...,2] = tmp
-        pixels = pixels[::-1] # flip vertical
-        
-        img = fn.makeQImage(pixels, transpose=False)
-        return img
+
+        pixels = pixels[::-1].copy() # flip vertical
+
+        qimg = fn.ndarray_to_qimage(pixels, QtGui.QImage.Format.Format_RGBA8888)
+        return qimg
         
     def renderToArray(self, size, format=GL_BGRA, type=GL_UNSIGNED_BYTE, textureSize=1024, padding=256):
         w,h = map(int, size)

--- a/tests/exporters/test_image.py
+++ b/tests/exporters/test_image.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+import numpy as np
 import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
 from pyqtgraph.exporters import ImageExporter
+import pyqtgraph.functions as fn
 
 app = pg.mkQApp()
 
@@ -11,3 +14,15 @@ def test_ImageExporter_filename_dialog():
     p = pg.plot()
     exp = ImageExporter(p.getPlotItem())
     exp.export()
+
+
+def test_ImageExporter_toBytes():
+    p = pg.plot()
+    p.hideAxis('bottom')
+    p.hideAxis('left')
+    exp = ImageExporter(p.getPlotItem())
+    qimg = exp.export(toBytes=True)
+    qimg = qimg.convertToFormat(QtGui.QImage.Format.Format_RGBA8888)
+    data = fn.qimage_to_ndarray(qimg)
+    black = (0, 0, 0, 255)
+    assert np.all(data == black), "Exported image should be entirely black."


### PR DESCRIPTION
Remove little-endian assumption for image saving in:
1) ImageExporter.py
2) GLViewWidget.py

Note that for ImageExporter.py, we leave the image format as ARGB32 instead of switching to RGBA8888 in order to not have any unknown/unintended changes in rendering. (It is known, for instance, from #1738, that using RGB32 enables subpixel text font rendering)