### PR TITLE
Fix BusyCursor to use internal stack provided by setOverrideCursor/restoreOverrideCursor

### DIFF
--- a/pyqtgraph/widgets/BusyCursor.py
+++ b/pyqtgraph/widgets/BusyCursor.py
@@ -8,12 +8,19 @@ __all__ = ["BusyCursor"]
 
 @contextmanager
 def BusyCursor():
+    """
+    Display a busy mouse cursor during long operations.
+    Usage::
+        with BusyCursor():
+            doLongOperation()
+    May be nested. If called from a non-gui thread, then the cursor will not be affected.
+    """
     app = QtCore.QCoreApplication.instance()
-    active = (app is not None) and (QtCore.QThread.currentThread() == app.thread())
+    in_gui_thread = (app is not None) and (QtCore.QThread.currentThread() == app.thread())
     try:
-        if active:
+        if in_gui_thread:
             QtGui.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
         yield
     finally:
-        if active:
+        if in_gui_thread:
             QtGui.QApplication.restoreOverrideCursor()

--- a/pyqtgraph/widgets/BusyCursor.py
+++ b/pyqtgraph/widgets/BusyCursor.py
@@ -1,25 +1,19 @@
 # -*- coding: utf-8 -*-
-from ..Qt import QtGui, QtCore, QT_LIB
+from contextlib import contextmanager
+
+from ..Qt import QtGui, QtCore
 
 __all__ = ["BusyCursor"]
 
 
-class BusyCursor(object):
-    """Class for displaying a busy mouse cursor during long operations.
-    Usage::
-
-        with pyqtgraph.BusyCursor():
-            doLongOperation()
-
-    May be nested. If called from a non-gui thread, then the cursor will not be affected.
-    """
-
-    def __enter__(self):
-        app = QtCore.QCoreApplication.instance()
-        self._active = (app is not None) and (QtCore.QThread.currentThread() == app.thread())
-        if self._active:
+@contextmanager
+def BusyCursor():
+    app = QtCore.QCoreApplication.instance()
+    active = (app is not None) and (QtCore.QThread.currentThread() == app.thread())
+    try:
+        if active:
             QtGui.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
-
-    def __exit__(self, *args):
-        if self._active:
+        yield
+    finally:
+        if active:
             QtGui.QApplication.restoreOverrideCursor()

--- a/pyqtgraph/widgets/BusyCursor.py
+++ b/pyqtgraph/widgets/BusyCursor.py
@@ -14,9 +14,6 @@ class BusyCursor(object):
     May be nested. If called from a non-gui thread, then the cursor will not be affected.
     """
 
-    active = []
-    nesting_count = 0
-
     def __enter__(self):
         app = QtCore.QCoreApplication.instance()
         self._active = (app is not None) and (QtCore.QThread.currentThread() == app.thread())

--- a/pyqtgraph/widgets/BusyCursor.py
+++ b/pyqtgraph/widgets/BusyCursor.py
@@ -19,24 +19,10 @@ class BusyCursor(object):
 
     def __enter__(self):
         app = QtCore.QCoreApplication.instance()
-        isGuiThread = (app is not None) and (QtCore.QThread.currentThread() == app.thread())
-        if isGuiThread and QtGui.QApplication.instance() is not None:
-            if QT_LIB == "PySide":
-                # pass CursorShape rather than QCursor for PySide
-                # see https://bugreports.qt.io/browse/PYSIDE-243
-                QtGui.QApplication.setOverrideCursor(QtCore.Qt.CursorShape.WaitCursor)
-            else:
-                QtGui.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
-            BusyCursor.active.append(self)
-            BusyCursor.nesting_count += 1
-            self._active = True
-        else:
-            self._active = False
+        self._active = (app is not None) and (QtCore.QThread.currentThread() == app.thread())
+        if self._active:
+            QtGui.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
 
     def __exit__(self, *args):
         if self._active:
-            BusyCursor.active.pop(-1)
-            if len(BusyCursor.active) == 0:
-                for _ in range(BusyCursor.nesting_count):
-                    QtGui.QApplication.restoreOverrideCursor()
-                BusyCursor.nesting_count = 0
+            QtGui.QApplication.restoreOverrideCursor()

--- a/pyqtgraph/widgets/BusyCursor.py
+++ b/pyqtgraph/widgets/BusyCursor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from ..Qt import QtGui, QtCore, QT_LIB
 
-__all__ = ['BusyCursor']
+__all__ = ["BusyCursor"]
 
 
 class BusyCursor(object):
@@ -13,6 +13,7 @@ class BusyCursor(object):
 
     May be nested. If called from a non-gui thread, then the cursor will not be affected.
     """
+
     active = []
     nesting_count = 0
 
@@ -20,7 +21,7 @@ class BusyCursor(object):
         app = QtCore.QCoreApplication.instance()
         isGuiThread = (app is not None) and (QtCore.QThread.currentThread() == app.thread())
         if isGuiThread and QtGui.QApplication.instance() is not None:
-            if QT_LIB == 'PySide':
+            if QT_LIB == "PySide":
                 # pass CursorShape rather than QCursor for PySide
                 # see https://bugreports.qt.io/browse/PYSIDE-243
                 QtGui.QApplication.setOverrideCursor(QtCore.Qt.CursorShape.WaitCursor)

--- a/pyqtgraph/widgets/BusyCursor.py
+++ b/pyqtgraph/widgets/BusyCursor.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
 from ..Qt import QtGui, QtCore, QT_LIB
 
 __all__ = ['BusyCursor']
+
 
 class BusyCursor(object):
     """Class for displaying a busy mouse cursor during long operations.
@@ -12,6 +14,7 @@ class BusyCursor(object):
     May be nested. If called from a non-gui thread, then the cursor will not be affected.
     """
     active = []
+    nesting_count = 0
 
     def __enter__(self):
         app = QtCore.QCoreApplication.instance()
@@ -24,6 +27,7 @@ class BusyCursor(object):
             else:
                 QtGui.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
             BusyCursor.active.append(self)
+            BusyCursor.nesting_count += 1
             self._active = True
         else:
             self._active = False
@@ -32,4 +36,6 @@ class BusyCursor(object):
         if self._active:
             BusyCursor.active.pop(-1)
             if len(BusyCursor.active) == 0:
-                QtGui.QApplication.restoreOverrideCursor()
+                for _ in range(BusyCursor.nesting_count):
+                    QtGui.QApplication.restoreOverrideCursor()
+                BusyCursor.nesting_count = 0

--- a/pyqtgraph/widgets/BusyCursor.py
+++ b/pyqtgraph/widgets/BusyCursor.py
@@ -11,8 +11,10 @@ def BusyCursor():
     """
     Display a busy mouse cursor during long operations.
     Usage::
+
         with BusyCursor():
             doLongOperation()
+
     May be nested. If called from a non-gui thread, then the cursor will not be affected.
     """
     app = QtCore.QCoreApplication.instance()

--- a/pyqtgraph/widgets/BusyCursor.py
+++ b/pyqtgraph/widgets/BusyCursor.py
@@ -12,7 +12,7 @@ def BusyCursor():
     active = (app is not None) and (QtCore.QThread.currentThread() == app.thread())
     try:
         if active:
-            QtGui.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
+            QtGui.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
         yield
     finally:
         if active:

--- a/tests/widgets/test_busycursor.py
+++ b/tests/widgets/test_busycursor.py
@@ -6,11 +6,8 @@ pg.mkQApp()
 
 def test_nested_busy_cursors_clear_after_all_exit():
     with pg.BusyCursor():
+        wait_cursor = pg.Qt.QtCore.Qt.CursorShape.WaitCursor
         with pg.BusyCursor():
-            assert (
-                pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.CursorShape.WaitCursor
-            ), "Cursor should be waiting"
-        assert (
-            pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.CursorShape.WaitCursor
-        ), "Cursor should be waiting"
+            assert pg.Qt.QtGui.QApplication.overrideCursor().shape() == wait_cursor, "Cursor should be waiting"
+        assert pg.Qt.QtGui.QApplication.overrideCursor().shape() == wait_cursor, "Cursor should be waiting"
     assert pg.Qt.QtGui.QApplication.overrideCursor() is None, "No override cursor should be set"

--- a/tests/widgets/test_busycursor.py
+++ b/tests/widgets/test_busycursor.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+import pyqtgraph as pg
+
+pg.mkQApp()
+
+
+def test_nested_busy_cursors_clear_after_all_exit():
+    with pg.BusyCursor():
+        with pg.BusyCursor():
+            assert pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.WaitCursor, "Cursor should be waiting"
+        assert pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.WaitCursor, "Cursor should be waiting"
+    assert pg.Qt.QtGui.QApplication.overrideCursor() is None, "No override cursor should be set"

--- a/tests/widgets/test_busycursor.py
+++ b/tests/widgets/test_busycursor.py
@@ -7,6 +7,6 @@ pg.mkQApp()
 def test_nested_busy_cursors_clear_after_all_exit():
     with pg.BusyCursor():
         with pg.BusyCursor():
-            assert pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.WaitCursor, "Cursor should be waiting"
-        assert pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.WaitCursor, "Cursor should be waiting"
+            assert pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.CursorShape.WaitCursor, "Cursor should be waiting"
+        assert pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.CursorShape.WaitCursor, "Cursor should be waiting"
     assert pg.Qt.QtGui.QApplication.overrideCursor() is None, "No override cursor should be set"

--- a/tests/widgets/test_busycursor.py
+++ b/tests/widgets/test_busycursor.py
@@ -7,6 +7,10 @@ pg.mkQApp()
 def test_nested_busy_cursors_clear_after_all_exit():
     with pg.BusyCursor():
         with pg.BusyCursor():
-            assert pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.CursorShape.WaitCursor, "Cursor should be waiting"
-        assert pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.CursorShape.WaitCursor, "Cursor should be waiting"
+            assert (
+                pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.CursorShape.WaitCursor
+            ), "Cursor should be waiting"
+        assert (
+            pg.Qt.QtGui.QApplication.overrideCursor().shape() == pg.Qt.QtCore.Qt.CursorShape.WaitCursor
+        ), "Cursor should be waiting"
     assert pg.Qt.QtGui.QApplication.overrideCursor() is None, "No override cursor should be set"


### PR DESCRIPTION
`restoreOverrideCursor` previously cleared all cursors, so the old code had a bug where nested busy cursors would never clear themselves.

I don't actually know for sure that all our supported versions of Qt have the new behavior, so I'm going to keep this as draft until the CI tells me it's safe to use this new code.