### PR TITLE
try using QPainter.drawPixmapFragments

### DIFF
--- a/examples/ScatterPlotSpeedTest.py
+++ b/examples/ScatterPlotSpeedTest.py
@@ -24,8 +24,6 @@ param = ptree.Parameter.create(name=translate('ScatterPlot', 'Parameters'), type
     dict(name='count', title=translate('ScatterPlot', 'Count:    '), type='int', limits=[1, None], value=500, step=100),
     dict(name='size', title=translate('ScatterPlot', 'Size:    '), type='int', limits=[1, None], value=10),
     dict(name='randomize', title=translate('ScatterPlot', 'Randomize:    '), type='bool', value=False),
-    dict(name='_USE_PXFRAGS', title='_USE_PXFRAGS:    ', type='bool', value=pyqtgraph.graphicsItems.ScatterPlotItem._USE_PXFRAGS),
-    dict(name='_USE_QRECT', title='_USE_QRECT:    ', type='bool', value=pyqtgraph.graphicsItems.ScatterPlotItem._USE_QRECT),
     dict(name='pxMode', title='pxMode:    ', type='bool', value=True),
     dict(name='useCache', title='useCache:    ', type='bool', value=True),
     dict(name='mode', title=translate('ScatterPlot', 'Mode:    '), type='list', values={translate('ScatterPlot', 'New Item'): 'newItem', translate('ScatterPlot', 'Reuse Item'): 'reuseItem', translate('ScatterPlot', 'Simulate Pan/Zoom'): 'panZoom', translate('ScatterPlot', 'Simulate Hover'): 'hover'}, value='reuseItem'),
@@ -69,8 +67,6 @@ def mkDataAndItem():
 
 def mkItem():
     global item
-    pyqtgraph.graphicsItems.ScatterPlotItem._USE_PXFRAGS = param['_USE_PXFRAGS']
-    pyqtgraph.graphicsItems.ScatterPlotItem._USE_QRECT = param['_USE_QRECT']
     item = pg.ScatterPlotItem(pxMode=param['pxMode'], **getData())
     item.opts['useCache'] = param['useCache']
     p.clear()
@@ -124,7 +120,7 @@ def update():
 mkDataAndItem()
 for name in ['count', 'size']:
     param.child(name).sigValueChanged.connect(mkDataAndItem)
-for name in ['_USE_PXFRAGS', '_USE_QRECT', 'useCache', 'pxMode', 'randomize']:
+for name in ['useCache', 'pxMode', 'randomize']:
     param.child(name).sigValueChanged.connect(mkItem)
 param.child('paused').sigValueChanged.connect(lambda _, v: timer.stop() if v else timer.start())
 timer.timeout.connect(update)

--- a/examples/ScatterPlotSpeedTest.py
+++ b/examples/ScatterPlotSpeedTest.py
@@ -24,6 +24,7 @@ param = ptree.Parameter.create(name=translate('ScatterPlot', 'Parameters'), type
     dict(name='count', title=translate('ScatterPlot', 'Count:    '), type='int', limits=[1, None], value=500, step=100),
     dict(name='size', title=translate('ScatterPlot', 'Size:    '), type='int', limits=[1, None], value=10),
     dict(name='randomize', title=translate('ScatterPlot', 'Randomize:    '), type='bool', value=False),
+    dict(name='_USE_PXFRAGS', title='_USE_PXFRAGS:    ', type='bool', value=pyqtgraph.graphicsItems.ScatterPlotItem._USE_PXFRAGS),
     dict(name='_USE_QRECT', title='_USE_QRECT:    ', type='bool', value=pyqtgraph.graphicsItems.ScatterPlotItem._USE_QRECT),
     dict(name='pxMode', title='pxMode:    ', type='bool', value=True),
     dict(name='useCache', title='useCache:    ', type='bool', value=True),
@@ -68,6 +69,7 @@ def mkDataAndItem():
 
 def mkItem():
     global item
+    pyqtgraph.graphicsItems.ScatterPlotItem._USE_PXFRAGS = param['_USE_PXFRAGS']
     pyqtgraph.graphicsItems.ScatterPlotItem._USE_QRECT = param['_USE_QRECT']
     item = pg.ScatterPlotItem(pxMode=param['pxMode'], **getData())
     item.opts['useCache'] = param['useCache']
@@ -122,7 +124,7 @@ def update():
 mkDataAndItem()
 for name in ['count', 'size']:
     param.child(name).sigValueChanged.connect(mkDataAndItem)
-for name in ['_USE_QRECT', 'useCache', 'pxMode', 'randomize']:
+for name in ['_USE_PXFRAGS', '_USE_QRECT', 'useCache', 'pxMode', 'randomize']:
     param.child(name).sigValueChanged.connect(mkItem)
 param.child('paused').sigValueChanged.connect(lambda _, v: timer.stop() if v else timer.start())
 timer.timeout.connect(update)

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -1134,9 +1134,7 @@ class ScatterPlotItem(GraphicsObject):
 
                 if _USE_PXFRAGS:
                     # x, y is the center of the target rect
-                    # drawPixmapFragments takes floating-point coords,
-                    # so casting to int here is for rounding towards zero
-                    xy = pts[:, viewMask].T.astype(int)
+                    xy = pts[:, viewMask].T
                     sr = self.data['sourceRect'][viewMask]
 
                     if not hasattr(self, 'pixmap_fragments'):

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 import warnings
-from itertools import repeat, chain
-try:
-    from itertools import imap
-except ImportError:
-    imap = map
 import itertools
 import math
 import numpy as np
@@ -17,7 +12,6 @@ from .GraphicsObject import GraphicsObject
 from .. import getConfigOption
 from collections import OrderedDict
 from .. import debug
-from ..python2_3 import basestring
 
 if QT_LIB == 'PySide2':
     from shiboken2 import wrapInstance
@@ -92,7 +86,7 @@ def drawSymbol(painter, symbol, size, pen, brush):
     painter.scale(size, size)
     painter.setPen(pen)
     painter.setBrush(brush)
-    if isinstance(symbol, basestring):
+    if isinstance(symbol, str):
         symbol = Symbols[symbol]
     if np.isscalar(symbol):
         symbol = list(Symbols.values())[symbol % len(Symbols)]
@@ -215,7 +209,7 @@ class SymbolAtlas(object):
         if new:
             self._extend(new)
 
-        return list(imap(self._coords.__getitem__, keys))
+        return list(map(self._coords.__getitem__, keys))
 
     def __len__(self):
         return len(self._coords)
@@ -658,7 +652,7 @@ class ScatterPlotItem(GraphicsObject):
                 pens = pens[kargs['mask']]
             if len(pens) != len(dataSet):
                 raise Exception("Number of pens does not match number of points (%d != %d)" % (len(pens), len(dataSet)))
-            dataSet['pen'] = list(imap(_mkPen, pens))
+            dataSet['pen'] = list(map(_mkPen, pens))
         else:
             self.opts['pen'] = _mkPen(*args, **kargs)
 
@@ -680,7 +674,7 @@ class ScatterPlotItem(GraphicsObject):
                 brushes = brushes[kargs['mask']]
             if len(brushes) != len(dataSet):
                 raise Exception("Number of brushes does not match number of points (%d != %d)" % (len(brushes), len(dataSet)))
-            dataSet['brush'] = list(imap(_mkBrush, brushes))
+            dataSet['brush'] = list(map(_mkBrush, brushes))
         else:
             self.opts['brush'] = _mkBrush(*args, **kargs)
 
@@ -866,7 +860,7 @@ class ScatterPlotItem(GraphicsObject):
         if self.opts['pxMode'] and self.opts['useCache']:
             w, pw = 0, self.fragmentAtlas.maxWidth
         else:
-            w, pw = max(chain([(self._maxSpotWidth, self._maxSpotPxWidth)],
+            w, pw = max(itertools.chain([(self._maxSpotWidth, self._maxSpotPxWidth)],
                               self._measureSpotSizes(**kwargs)))
         self._maxSpotWidth = w
         self._maxSpotPxWidth = pw

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -154,6 +154,17 @@ class PixmapFragments:
         self.alloc(0)
 
     def alloc(self, size):
+        # The C++ native API is:
+        #   drawPixmapFragments(const PixmapFragment *fragments, int fragmentCount,
+        #                       const QPixmap &pixmap)
+        #
+        # PySide exposes this API whereas PyQt wraps it to be more Pythonic.
+        # In PyQt, a Python list of PixmapFragment instances needs to be provided.
+        # This is inefficient because:
+        # 1) constructing the Python list involves calling sip.wrapinstance multiple times.
+        #    - this is mitigated here by reusing the instance pointers
+        # 2) PyQt will anyway deconstruct the Python list and repack the PixmapFragment
+        #    instances into a contiguous array, in order to call the underlying C++ native API.
         self.arr = np.empty((size, 10), dtype=np.float64)
         if QT_LIB.startswith('PyQt'):
             self.ptrs = list(map(sip.wrapinstance,


### PR DESCRIPTION
This PR implements the method shown in https://github.com/pyqtgraph/pyqtgraph/issues/1781#issuecomment-858306326 to collapse multiple calls to drawPixmap() to a single call to drawPixmapFragments().

It's only meant to be an optimization for PySide bindings. On PySide bindings, it shows only a very small speedup on ScatterPlotSpeedTest.py. This is only meant to be a proof of concept to see if it's worthwhile to take things further (by someone else with more knowledge of how scatter plots are used).

As an aside, during testing with ScatterPlotSpeedTest.py, it appeared to me that using _USE_QRECT was slower on _all_ current bindings. i.e. the premise that it was faster on PyQt bindings didn't seem to be true. Perhaps someone more familiar with scatter plots could check this out.