### PR TITLE
fix ScatterPlot render issues on PyQt6 6.1

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -23,6 +23,7 @@ from .GraphicsObject import GraphicsObject
 from .UIGraphicsItem import UIGraphicsItem
 from .. import getConfigOption
 import warnings
+import sys
 
 translate = QtCore.QCoreApplication.translate
 
@@ -1287,7 +1288,7 @@ class ROI(GraphicsObject):
             return np.empty((width, height), dtype=float)
         
         im = QtGui.QImage(width, height, QtGui.QImage.Format.Format_ARGB32)
-        im.fill(0x0)
+        im.fill(QtCore.Qt.GlobalColor.transparent)
         p = QtGui.QPainter(im)
         p.setPen(fn.mkPen(None))
         p.setBrush(fn.mkBrush('w'))
@@ -1297,8 +1298,9 @@ class ROI(GraphicsObject):
         p.translate(-bounds.topLeft())
         p.drawPath(shape)
         p.end()
-        mask = fn.imageToArray(im, transpose=True)[:,:,0].astype(float) / 255.
-        return mask
+        cidx = 0 if sys.byteorder == 'little' else 3
+        mask = fn.qimage_to_ndarray(im)[...,cidx].T
+        return mask.astype(float) / 255
         
     def getGlobalTransform(self, relativeTo=None):
         """Return global transformation (rotation angle+translation) required to move 

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -120,7 +120,7 @@ def renderSymbol(symbol, size, pen, brush, device=None):
     penPxWidth = max(math.ceil(pen.widthF()), 1)
     if device is None:
         device = QtGui.QImage(int(size+penPxWidth), int(size+penPxWidth), QtGui.QImage.Format.Format_ARGB32)
-        device.fill(0)
+        device.fill(QtCore.Qt.GlobalColor.transparent)
     p = QtGui.QPainter(device)
     try:
         p.setRenderHint(p.RenderHint.Antialiasing)


### PR DESCRIPTION
This PR fixes #1832.

The problem may have to do with the signature of ``QImage.fill()``` being changed slightly.

PyQt5 5.15, PyQt6 6.0
```python
In [4]: QtGui.QImage.fill?
Docstring:
fill(self, Qt.GlobalColor)
fill(self, Union[QColor, Qt.GlobalColor, QGradient])
fill(self, int)
Type:      builtin_function_or_method
```

PyQt6 6.1
```python
In [2]: QtGui.QImage.fill?
Docstring:
fill(self, Qt.GlobalColor)
fill(self, Union[QColor, Qt.GlobalColor, int, QGradient])
fill(self, int)
Type:      builtin_function_or_method
```

Doing a search for other potential problems in the library yields:
```
$ git grep "fill(0"
pyqtgraph/graphicsItems/ROI.py:        im.fill(0x0)
pyqtgraph/widgets/RemoteGraphicsView.py:            self.img.fill(0xffffffff)
```
I don't understand ROI enough to say whether it needs the fix.

ScatterPlot needs the fix because it needs the undrawn background to be transparent.
RemoteGraphicsView doesn't seem to be affected, likely because it draws on the whole QImage.
