### PR TITLE
Allow border=False in GraphicsLayout

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsLayout.py
+++ b/pyqtgraph/graphicsItems/GraphicsLayout.py
@@ -13,11 +13,12 @@ class GraphicsLayout(GraphicsWidget):
     This is usually created automatically as part of a :class:`GraphicsWindow <pyqtgraph.GraphicsWindow>` or :class:`GraphicsLayoutWidget <pyqtgraph.GraphicsLayoutWidget>`.
     """
 
-
     def __init__(self, parent=None, border=None):
         GraphicsWidget.__init__(self, parent)
         if border is True:
             border = (100,100,100)
+        elif border is False:
+            border = None  
         self.border = border
         self.layout = QtGui.QGraphicsGridLayout()
         self.setLayout(self.layout)


### PR DESCRIPTION
In response to Issue [#1593 ](https://github.com/pyqtgraph/pyqtgraph/issues/1593)

This fixes errors of setting the property of border=False in the GraphicsLayoutWidget and shows graph without borders. 

That might be enough to fix this issue and it doesn't break any other tests.