### PR TITLE
Separate out mouse events stolen by AxisItem

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1188,11 +1188,12 @@ class AxisItem(GraphicsWidget):
         lv = self.linkedView()
         if lv is None:
             return
+        # Did the event occur inside the linked ViewBox (and not over the axis iteself)?
         if lv.sceneBoundingRect().contains(event.scenePos()):
-            print('in')
+            # pass event to linked ViewBox without marking it as single axis zoom
             lv.wheelEvent(event)
         else:
-            print('out')
+            # pass event to linked viewbox with appropriate single axis zoom parameter
             if self.orientation in ['left', 'right']:
                 lv.wheelEvent(event, axis=1)
             else:
@@ -1203,8 +1204,11 @@ class AxisItem(GraphicsWidget):
         lv = self.linkedView()
         if lv is None:
             return
+        # Did the mouse down event occur inside the linked ViewBox (and not the axis)?
         if lv.sceneBoundingRect().contains(event.buttonDownScenePos()):
+            # pass event to linked ViewBox without marking it as single axis pan
             return lv.mouseDragEvent(event)
+        # otherwise pass event to linked viewbox with appropriate single axis parameter
         if self.orientation in ['left', 'right']:
             return lv.mouseDragEvent(event, axis=1)
         else:

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1188,9 +1188,11 @@ class AxisItem(GraphicsWidget):
         lv = self.linkedView()
         if lv is None:
             return
-        if lv.geometry().contains(event.scenePos()):
+        if lv.sceneBoundingRect().contains(event.scenePos()):
+            print('in')
             lv.wheelEvent(event)
         else:
+            print('out')
             if self.orientation in ['left', 'right']:
                 lv.wheelEvent(event, axis=1)
             else:
@@ -1201,7 +1203,7 @@ class AxisItem(GraphicsWidget):
         lv = self.linkedView()
         if lv is None:
             return
-        if lv.geometry().contains(event.scenePos()):
+        if lv.sceneBoundingRect().contains(event.buttonDownScenePos()):
             return lv.mouseDragEvent(event)
         if self.orientation in ['left', 'right']:
             return lv.mouseDragEvent(event, axis=1)

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1151,7 +1151,7 @@ class AxisItem(GraphicsWidget):
         pen, p1, p2 = axisSpec
         p.setPen(pen)
         p.drawLine(p1, p2)
-        p.translate(0.5,0)  ## resolves some damn pixel ambiguity
+        # p.translate(0.5,0)  ## resolves some damn pixel ambiguity
 
         ## draw ticks
         for pen, p1, p2 in tickSpecs:
@@ -1184,20 +1184,25 @@ class AxisItem(GraphicsWidget):
         else:
             self._updateHeight()
 
-    def wheelEvent(self, ev):
+    def wheelEvent(self, event):
         lv = self.linkedView()
         if lv is None:
             return
-        if self.orientation in ['left', 'right']:
-            lv.wheelEvent(ev, axis=1)
+        if lv.geometry().contains(event.scenePos()):
+            lv.wheelEvent(event)
         else:
-            lv.wheelEvent(ev, axis=0)
-        ev.accept()
+            if self.orientation in ['left', 'right']:
+                lv.wheelEvent(event, axis=1)
+            else:
+                lv.wheelEvent(event, axis=0)
+        event.accept()
 
     def mouseDragEvent(self, event):
         lv = self.linkedView()
         if lv is None:
             return
+        if lv.geometry().contains(event.scenePos()):
+            return lv.mouseDragEvent(event)
         if self.orientation in ['left', 'right']:
             return lv.mouseDragEvent(event, axis=1)
         else:


### PR DESCRIPTION
While it graphically makes sense to draw the AxisItem on top of what is plotted, particularly for images, this has unintended side-effects:
If AxisItem is placed above the ViewBox, which places itself at z order -100, then it will grab mouse events inside its bounding box. And this bounding box overlaps the plot. It overlaps *all* of the plot when the ticks are extended to draw a grid.

This PR adds a check to the handling of mouse events in AxisItem:
If the (wheel event) or (button down) occurred within the bounds of the linked ViewBox, then the ViewBox gets to handle the event as if it had been assigned to it directly. 

A good test for this is to run the "GraphicsItems / Scatter Plot" example and add a grid by including
```w3.showGrid(x=True, y=True)``` at the end of example (3):
Mouse wheel zoom and drag events should still behave differently when performed on the axes vs. plot, even with the grid drawn on top. Mouse clicks also still get properly directed to the individual points of the ScatterPlotItem.

While looking at this, I came across the line:
```python 
p.translate(0.5,0)  ## resolves some damn pixel ambiguity 
```
in the `drawPicture()` method (L.1154) of AxisItem.

Does anybody have some context for that? Are we drawing all of our axis ticks offset half a pixel to the right?
Is this compensated for in generating the tick specs? I did not see it.
And why does it affect only the x direction?

I am tempted to remove the translation...

Closes #1843.