### PR TITLE
make getColors and getStops behavior more consistent; add tests

### DIFF
--- a/pyqtgraph/colormap.py
+++ b/pyqtgraph/colormap.py
@@ -5,6 +5,8 @@ from os import path, listdir
 from collections.abc import Callable, Sequence
 import warnings
 
+__all__ = ['ColorMap']
+
 _mapCache = {}
 
 def listMaps(source=None):
@@ -598,32 +600,44 @@ class ColorMap(object):
         pen.setCosmetic(True)
         return pen
 
-    def getColors(self, mode=None):
-        """Returns a list of all color stops, converted to the specified mode.
-        If `mode` is None, no conversion is performed.
+    def getColors(self, mode=BYTE):
+        """
+        Returns a tuple (stops, colors) containing a list of all stops (ranging 0.0 to 1.0)
+        and a list of the associated colors.
+        
+        The parameter `mode` can be one of
+        - `ColorMap.BYTE` or 'byte' to return colors as RGBA tuples in byte format (0-255)
+        - `ColorMap.FLOAT` or 'float' to return colors as RGBA tuples in float format (0.0 to 1.0)
+        - `ColorMap.QCOLOR' or 'qcolor' to return a list of QColors
+        The default is byte format.
+        """
+        stops, color = self.getStops(mode=mode)
+        return color
+
+    def getStops(self, mode=BYTE):
+        """
+        Returns a tuple (stops, colors) containing a list of all stops (ranging 0.0 to 1.0)
+        and a list of the associated colors.
+        
+        The parameter `mode` can be one of
+        - `ColorMap.BYTE` or 'byte' to return colors as RGBA tuples in byte format (0-255)
+        - `ColorMap.FLOAT` or 'float' to return colors as RGBA tuples in float format (0.0 to 1.0)
+        - `ColorMap.QCOLOR' or 'qcolor' to return a list of QColors
+        The default is byte format.
         """
         if isinstance(mode, str):
             mode = self.enumMap[mode.lower()]
 
-        color = self.color
-        if mode in [self.BYTE, self.QCOLOR] and color.dtype.kind == 'f':
-            color = (color * 255).astype(np.ubyte)
-        elif mode == self.FLOAT and color.dtype.kind != 'f':
-            color = color.astype(float) / 255.
-
-        if mode == self.QCOLOR:
-            color = [QtGui.QColor(*x) for x in color]
-
-        return color
-
-    def getStops(self, mode):
-        ## Get fully-expanded set of RGBA stops in either float or byte mode.
         if mode not in self.stopsCache:
             color = self.color
             if mode == self.BYTE and color.dtype.kind == 'f':
                 color = (color*255).astype(np.ubyte)
             elif mode == self.FLOAT and color.dtype.kind != 'f':
                 color = color.astype(float) / 255.
+            elif mode == self.QCOLOR:
+                if color.dtype.kind == 'f':
+                    color = (color*255).astype(np.ubyte)
+                color = [QtGui.QColor(*x) for x in color]
             self.stopsCache[mode] = (self.pos, color)
         return self.stopsCache[mode]
 

--- a/pyqtgraph/colormap.py
+++ b/pyqtgraph/colormap.py
@@ -602,13 +602,13 @@ class ColorMap(object):
 
     def getColors(self, mode=BYTE):
         """
-        Returns a tuple (stops, colors) containing a list of all stops (ranging 0.0 to 1.0)
-        and a list of the associated colors.
+        Returns a list of the colors associated with the stops of the color map.
         
         The parameter `mode` can be one of
-        - `ColorMap.BYTE` or 'byte' to return colors as RGBA tuples in byte format (0-255)
-        - `ColorMap.FLOAT` or 'float' to return colors as RGBA tuples in float format (0.0 to 1.0)
-        - `ColorMap.QCOLOR' or 'qcolor' to return a list of QColors
+            - `ColorMap.BYTE` or 'byte' to return colors as RGBA tuples in byte format (0 to 255)
+            - `ColorMap.FLOAT` or 'float' to return colors as RGBA tuples in float format (0.0 to 1.0)
+            - `ColorMap.QCOLOR` or 'qcolor' to return a list of QColors
+            
         The default is byte format.
         """
         stops, color = self.getStops(mode=mode)
@@ -620,9 +620,10 @@ class ColorMap(object):
         and a list of the associated colors.
         
         The parameter `mode` can be one of
-        - `ColorMap.BYTE` or 'byte' to return colors as RGBA tuples in byte format (0-255)
-        - `ColorMap.FLOAT` or 'float' to return colors as RGBA tuples in float format (0.0 to 1.0)
-        - `ColorMap.QCOLOR' or 'qcolor' to return a list of QColors
+            - `ColorMap.BYTE` or 'byte' to return colors as RGBA tuples in byte format (0 to 255)
+            - `ColorMap.FLOAT` or 'float' to return colors as RGBA tuples in float format (0.0 to 1.0)
+            - `ColorMap.QCOLOR` or 'qcolor' to return a list of QColors
+
         The default is byte format.
         """
         if isinstance(mode, str):

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -1,0 +1,75 @@
+import pytest
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
+
+pos = [0.0, 0.5, 1.0]
+qcols = [
+    QtGui.QColor('#FF0000'),
+    QtGui.QColor('#00FF00'),
+    QtGui.QColor('#0000FF')
+]
+float_tuples = [
+    (1.0, 0.0, 0.0, 1.0),
+    (0.0, 1.0, 0.0, 1.0),
+    (0.0, 0.0, 1.0, 1.0)
+]
+int_tuples = [
+    (255,  0,  0,255),
+    (  0,255,  0,255),
+    (  0,  0,255,255)
+] 
+
+@pytest.mark.parametrize("color_list", (qcols, int_tuples))
+def test_ColorMap_getStops(color_list):
+    cm = pg.ColorMap(pos, color_list, name='test')
+    # default is byte format:
+    stops, colors = cm.getStops()
+    assert (stops == pos).all()
+    assert (colors == int_tuples).all()
+
+    # manual byte format:
+    stops, colors = cm.getStops(pg.ColorMap.BYTE)
+    assert (stops == pos).all()
+    assert (colors == int_tuples).all()
+
+    stops, colors = cm.getStops('bYTe')
+    assert (stops == pos).all()
+    assert (colors == int_tuples).all()
+
+    # manual float format:
+    stops, colors = cm.getStops(pg.ColorMap.FLOAT)
+    assert (stops == pos).all()
+    assert (colors == float_tuples).all()
+
+    stops, colors = cm.getStops('floaT')
+    assert (stops == pos).all()
+    assert (colors == float_tuples).all()
+
+    # manual QColor format:
+    stops, colors = cm.getStops(pg.ColorMap.QCOLOR)
+    assert (stops == pos).all()
+    for actual, good in zip(colors, qcols):
+        assert actual.getRgbF() == good.getRgbF()
+
+    stops, colors = cm.getStops('qColor')
+    assert (stops == pos).all()
+    for actual, good in zip(colors, qcols):
+        assert actual.getRgbF() == good.getRgbF()
+
+
+@pytest.mark.parametrize("color_list", (qcols, int_tuples))
+def test_ColorMap_getColors(color_list):
+    cm = pg.ColorMap(pos, color_list, name='from QColors')
+
+    colors = cm.getColors()
+    assert (colors == int_tuples).all()
+
+    colors = cm.getColors('byte')
+    assert (colors == int_tuples).all()
+
+    colors = cm.getColors('float')
+    assert (colors == float_tuples).all()
+
+    colors = cm.getColors('qcolor')
+    for actual, good in zip(colors, qcols):
+        assert actual.getRgbF() == good.getRgbF()


### PR DESCRIPTION
This PR seeks to address the not very well-defined behavior of the `getColors` and `getStops` methods of ColorMap, which lead to problems such as exhibited in #1850.

The issue there seems to be that an undefined mode parameter to the `getStops()` method used to return the internal color values "as stored", which in this case used to be in byte format.

Returning the data in an undefined internal format seems like a bad idea:
E.g. restoring the originally intended hsv interpolations or other color space conversions benefits from a change to a higher precision internal float representation. The performance cost of converting to the user-desired format is also small, since `getStops()` already implements a caching method.

This PR tries to update the `getColors()` and `getStops()` methods as follows:
- default return format is byte, which would have been the previous default in most cases I can see, and works best with QColor initialization (see the example code in #1849).
- `getColors()` now internally calls `getStops()` to reduce code duplication and to make use of the existing cache.
- both methods can now also return colors as a list of QColors, which was already implemented, but not documented. I believe it may have worked only when the internal representation was byte.
- both methods now support string specifiers 'byte', 'float' and 'qcolor' in addition to the integer enumeration values. Unknown method strings will raise an error. 

The PR also adds some basic tests for these format conversions; more tests for the code in colormap.py seems needed, though.