### PR TITLE
Deprecate MetaArray Entirely (for 0.14 release)

### DIFF
--- a/pyqtgraph/metaarray/MetaArray.py
+++ b/pyqtgraph/metaarray/MetaArray.py
@@ -132,6 +132,10 @@ class MetaArray(object):
   
     def __init__(self, data=None, info=None, dtype=None, file=None, copy=False, **kwargs):
         object.__init__(self)
+        warnings.warn(
+            'MetaArray is deprecated and will be removed in 0.14.',
+            DeprecationWarning, stacklevel=2
+        )    
         self._isHDF = False
         
         if file is not None:


### PR DESCRIPTION
We've had some internal discussions about this, but basically MetaArray is not used elsewhere within the library, it's not tested, and I suspect [xarray](https://xarray.pydata.org/en/stable/) could likely fulfill the roll better.

Doing a github advanced search for MetaArray, I'm showing some other repositories that have import statements for it, but didn't see much actual usage.

If you are dependent on MetaArray, and this deprecation will affect you, please open a discussion and get a conversation started, we want to hear from you.