### PR TITLE
Disable unused ColorBarItem ticks

### DIFF
--- a/pyqtgraph/graphicsItems/ColorBarItem.py
+++ b/pyqtgraph/graphicsItems/ColorBarItem.py
@@ -85,7 +85,7 @@ class ColorBarItem(PlotItem):
         for key in ['left','right','top','bottom']:
             self.showAxis(key)
             axis = self.getAxis(key)
-            axis.setZValue(1)
+            axis.setZValue(0.5)
             # select main axis:
             if self.horizontal and key == 'bottom':
                 self.axis = axis
@@ -93,7 +93,8 @@ class ColorBarItem(PlotItem):
                 self.axis = axis
                 self.axis.setWidth(45)
             else: # show other axes to create frame
-                axis.setStyle( showValues=False, tickLength=0 )
+                axis.setTicks( [] )
+                axis.setStyle( showValues=False )
         self.axis.setStyle( showValues=True )
         self.axis.unlinkFromView()
         self.axis.setRange( self.values[0], self.values[1] )


### PR DESCRIPTION
This addresses the issue described in #1866 by applying the solution conveniently included in the report.
Thank you @paulmueller !

Since ColorBarItem uses an unlinked AxisItem to display the scale information, only the ticks on the main axis move with adjustment. The unsynchronized ticks on the opposite axis (used to close the frame) were hidden by setting their size to zero.
 However, these length-zero ticks become visible at large screen or export resolutions, possibly as a result of Qt's handling of line end caps?

The proper solution is to clear out the list of ticks, so that no drawing occurs in the first place. This is also much more elegant, and I am sure it is technically faster. 

The only other change here is to move the ColorBarItem AxisItems from z=1 to z=0.5 which is the new default for AxisItems generated by PlotItem.

Closes #1866