### PR TITLE
Allow adding items to GLViewWidget before show

### DIFF
--- a/examples/GLViewWidget.py
+++ b/examples/GLViewWidget.py
@@ -6,10 +6,10 @@ Very basic 3D graphics example; create a view widget and add a few items.
 ## Add path to library (just for examples; you do not need this)
 import initExample
 
-from pyqtgraph.Qt import QtCore, QtGui, mkQApp
+import pyqtgraph as pg
 import pyqtgraph.opengl as gl
 
-app = mkQApp("GLViewWidget Example")
+pg.mkQApp("GLViewWidget Example")
 w = gl.GLViewWidget()
 w.opts['distance'] = 20
 w.show()

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -228,10 +228,11 @@ class GLGraphicsItem(QtCore.QObject):
         view, as it may be obscured or outside of the current view area."""
         return self.__visible
     
-    def setInitialized(self, init=True):
-        self.__initialized = init
+    def initialize(self):
+        self.initializeGL()
+        self.__initialized = True
 
-    def initialized(self):
+    def isInitialized(self):
         return self.__initialized
     
     def initializeGL(self):
@@ -240,7 +241,7 @@ class GLGraphicsItem(QtCore.QObject):
         The widget's GL context is made current before this method is called.
         (So this would be an appropriate time to generate lists, upload textures, etc.)
         """
-        self.setInitialized()
+        pass
     
     def setupGLState(self):
         """

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -1,8 +1,7 @@
 from OpenGL.GL import *
 from OpenGL import GL
-from ..Qt import QtGui, QtCore
+from ..Qt import QtCore
 from .. import Transform3D
-from ..python2_3 import basestring
 
 
 GLOptions = {
@@ -42,6 +41,7 @@ class GLGraphicsItem(QtCore.QObject):
         self.__children = set()
         self.__transform = Transform3D()
         self.__visible = True
+        self.__initialized = False
         self.setParentItem(parentItem)
         self.setDepthValue(0)
         self.__glOpts = {}
@@ -91,7 +91,7 @@ class GLGraphicsItem(QtCore.QObject):
             
         
         """
-        if isinstance(opts, basestring):
+        if isinstance(opts, str):
             opts = GLOptions[opts]
         self.__glOpts = opts.copy()
         self.update()
@@ -228,6 +228,11 @@ class GLGraphicsItem(QtCore.QObject):
         view, as it may be obscured or outside of the current view area."""
         return self.__visible
     
+    def setInitialized(self, init=True):
+        self.__initialized = init
+
+    def initialized(self):
+        return self.__initialized
     
     def initializeGL(self):
         """
@@ -235,7 +240,7 @@ class GLGraphicsItem(QtCore.QObject):
         The widget's GL context is made current before this method is called.
         (So this would be an appropriate time to generate lists, upload textures, etc.)
         """
-        pass
+        self.setInitialized()
     
     def setupGLState(self):
         """
@@ -245,7 +250,7 @@ class GLGraphicsItem(QtCore.QObject):
         for k,v in self.__glOpts.items():
             if v is None:
                 continue
-            if isinstance(k, basestring):
+            if isinstance(k, str):
                 func = getattr(GL, k)
                 func(*v)
             else:

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -434,10 +434,11 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         return xDist / self.width()
         
     def mousePressEvent(self, ev):
-        self.mousePos = ev.localPos()
+        lpos = ev.position() if hasattr(ev, 'position') else ev.localPos()
+        self.mousePos = lpos
         
     def mouseMoveEvent(self, ev):
-        lpos = ev.localPos()
+        lpos = ev.position() if hasattr(ev, 'position') else ev.localPos()
         diff = lpos - self.mousePos
         self.mousePos = lpos
         

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -102,8 +102,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         if self.isValid():
             self.makeCurrent()
             try:
-                item.initializeGL()
-                item.setInitialized()
+                item.initialize()
             except:
                 self.checkOpenGLVersion('Error while adding item %s to GLViewWidget.' % str(item))
                 
@@ -129,10 +128,12 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         self.update()        
         
     def initializeGL(self):
+        """
+        Initialize items that were not initialized during addItem().
+        """
         for item in self.items:
-            if not item.initialized():
-                item.initializeGL()
-                item.setInitialized()
+            if not item.isInitialized():
+                item.initialize()
         
     def setBackgroundColor(self, *args, **kwds):
         """

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -8,7 +8,6 @@ import warnings
 from math import cos, sin, tan, radians
 ##Vector = QtGui.QVector3D
 
-ShareWidget = None
 
 class GLViewWidget(QtWidgets.QOpenGLWidget):
     
@@ -99,10 +98,12 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
 
     def addItem(self, item):
         self.items.append(item)
-        if hasattr(item, 'initializeGL'):
+
+        if self.isValid():
             self.makeCurrent()
             try:
                 item.initializeGL()
+                item.setInitialized()
             except:
                 self.checkOpenGLVersion('Error while adding item %s to GLViewWidget.' % str(item))
                 
@@ -128,7 +129,10 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         self.update()        
         
     def initializeGL(self):
-        self.resizeGL(self.width(), self.height())
+        for item in self.items:
+            if not item.initialized():
+                item.initializeGL()
+                item.setInitialized()
         
     def setBackgroundColor(self, *args, **kwds):
         """

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -1,4 +1,4 @@
-from ..Qt import QtCore, QtGui, QtWidgets, QT_LIB
+from ..Qt import QtCore, QtGui, QtWidgets
 from OpenGL.GL import *
 import OpenGL.GL.framebufferobjects as glfbo
 import numpy as np
@@ -466,13 +466,9 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         #self.swapBuffers()
         
     def wheelEvent(self, ev):
-        delta = 0
-        if QT_LIB in ['PyQt4', 'PySide']:
-            delta = ev.delta()
-        else:
-            delta = ev.angleDelta().x()
-            if delta == 0:
-                delta = ev.angleDelta().y()
+        delta = ev.angleDelta().x()
+        if delta == 0:
+            delta = ev.angleDelta().y()
         if (ev.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier):
             self.opts['fov'] *= 0.999**delta
         else:

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -54,9 +54,6 @@ class GLLinePlotItem(GLGraphicsItem):
                 #self.vbo.pop(arg, None)
         self.update()
 
-    def initializeGL(self):
-        pass
-        
     def paint(self):
         if self.pos is None:
             return

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -317,13 +317,9 @@ class GraphicsView(QtGui.QGraphicsView):
         super().wheelEvent(ev)
         if not self.mouseEnabled:
             return
-        delta = 0
-        if QT_LIB in ['PyQt4', 'PySide']:
-            delta = ev.delta()
-        else:
-            delta = ev.angleDelta().x()
-            if delta == 0:
-                delta = ev.angleDelta().y()
+        delta = ev.angleDelta().x()
+        if delta == 0:
+            delta = ev.angleDelta().y()
                 
         sc = 1.001 ** delta
         #self.scale *= sc


### PR DESCRIPTION
Since the move from QGLWidget to QOpenGLWidget, it has become necessary for GLViewWidget to be shown before it gets a valid OpenGL Context. This results in some scripts previously working with pyqtgraph <= 0.11.1 to fail with pyqtgraph >= 0.12.0, with little clue as to the reason, e.g. #1787

~~This PR prints a more helpful warning when it detects such a situation, and hopefully the user will be able to remedy it themselves.~~

Technically, only GLImageItem and GLScatterPlotItem were affected because they made OpenGL calls in their pseudo-InitializeGL() method. ~~This PR also modifies GLImageItem to defer its initialization to a later stage as its initialization is trivial.~~

Annotated script documenting the required change. This example also demonstrates how to put a GLViewWidget inside a QMainWindow.
```python
import pyqtgraph as pg
from pyqtgraph.Qt import QtWidgets
import pyqtgraph.opengl as gl
import numpy as np
import scipy.misc

app = pg.mkQApp()
win = QtWidgets.QMainWindow()
win.resize(640, 480)
# with QGLWidget, QMainWindow::show() can be called here
# win.show()

glv = gl.GLViewWidget()
glv.opts['elevation'] = 90
glv.opts['azimuth'] = 0    

win.setCentralWidget(glv)
# with QOpenGLWidget, QMainWindow::show() must be called _only_ after
#   QMainWindow::setCentralWidget()
#   GLImageItem and GLScatterPlotItem can only be added after GLViewWidget
#       has been shown
win.show()

image = scipy.misc.face()
tex, _ = pg.makeRGBA(image)
glii = gl.GLImageItem(tex)
s = 1/128
glii.scale(s, s, 1)
w, h = tex.shape[:2]    # GLImageItem uses a transposed image
w *= s
h *= s
glii.translate(-w/2, -h/2, 0)
glv.addItem(glii)

spots = np.array([[-w/2, -h/2, 0, 1, 0, 0, 0.5],
                  [-w/2,  h/2, 0, 0, 1, 0, 0.5],
                  [ w/2,  h/2, 0, 0, 0, 1, 0.5],
                  [ w/2, -h/2, 0, 0, 1, 1, 0.5]])
glspi = gl.GLScatterPlotItem(pos=spots[:,:3], size=50, color=spots[:,3:])
glv.addItem(glspi)

app.exec_()
```
