### PR TITLE
Fix LineROI handle positions

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -1676,8 +1676,8 @@ class LineROI(ROI):
         pos2 = Point(pos2)
         d = pos2-pos1
         l = d.length()
-        ra = Point(1, 0).angle(d, units="radians")
-        c = Point(-width/2. * sin(ra), -width/2. * cos(ra))
+        ra = d.angle(Point(1, 0), units="radians")
+        c = Point(width/2. * sin(ra), -width/2. * cos(ra))
         pos1 = pos1 + c
         
         ROI.__init__(self, pos1, size=Point(l, width), angle=degrees(ra), **args)

--- a/tests/graphicsItems/test_ROI.py
+++ b/tests/graphicsItems/test_ROI.py
@@ -6,6 +6,7 @@ import platform
 from pyqtgraph.Qt import QtCore, QtGui, QtTest
 from tests.image_testing import assertImageApproved
 from tests.ui_testing import mouseMove, mouseDrag, mouseClick, resizeWindow
+import math
 
 app = pg.mkQApp()
 pg.setConfigOption("mouseRateLimit", 0)
@@ -251,4 +252,22 @@ def test_PolyLineROI():
         assert len(r.getState()['points']) == 3
     
     plt.hide()
-    
+
+
+@pytest.mark.parametrize("p1,p2", [
+    ((1, 1), (2, 5)),
+    ((0.1, 0.1), (-1, 5)),
+    ((3, -1), (5, -6)),
+    ((-2, 1), (-4, -8)),
+])
+def test_LineROI_coords(p1, p2):
+    pw = pg.plot()
+
+    lineroi = pg.LineROI(p1, p2, width=0.5, pen="r")
+    pw.addItem(lineroi)
+
+    # first two handles are the scale-rotate handles positioned by pos1, pos2
+    for expected, (name, scenepos) in zip([p1, p2], lineroi.getSceneHandlePositions()):
+        got = lineroi.mapSceneToParent(scenepos)
+        assert math.isclose(got.x(), expected[0])
+        assert math.isclose(got.y(), expected[1])


### PR DESCRIPTION
Fixes issue noted in #1813 with a simpler change

----

Script to see the change:

```python
import pyqtgraph as pg

app = pg.mkQApp()

pw = pg.plot()
pw.showGrid(x=True, y=True)
pw.setAspectLocked(True)

lineroi = pg.LineROI(pos1=(1, 1), pos2=(2, 5), width=0.5, pen="r")
rectroi = pg.RectROI(pos=(1, 1), size=(1, 4))

pw.addItem(lineroi)
pw.addItem(rectroi)

for name, scenepos in lineroi.getSceneHandlePositions():
    print(lineroi.mapSceneToParent(scenepos))

app.exec()
```

On master:

![lineroi_pos_master](https://user-images.githubusercontent.com/943602/124358392-e7984d80-dbd4-11eb-83d5-e2fad96cc80d.png)

```
PyQt5.QtCore.QPointF(1.4850712500726662, 1.0)
PyQt5.QtCore.QPointF(2.4850712500726657, -3.0)
PyQt5.QtCore.QPointF(2.2276068751089992, -0.9393660937409172)
```

On this branch:

![lineroi_pos_branch](https://user-images.githubusercontent.com/943602/124358394-e9faa780-dbd4-11eb-9efb-ed92eb98896a.png)

```
PyQt5.QtCore.QPointF(0.999999999999999, 0.9999999999999993)
PyQt5.QtCore.QPointF(1.9999999999999993, 5.0)
PyQt5.QtCore.QPointF(1.257464374963667, 3.060633906259083)
```

----

I initially suspected this behavior might have something to do with ROIs being used typically with images and images commonly having an inverted y axis, but comparing to `RectROI` seems to confirm this was just not caught. Behavior on master isn't really right for an inverted y axis either.