### PR TITLE
Raise TypeError instead of Exception

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -722,7 +722,7 @@ def eq(a, b):
         else:
             return e.all()
     else:
-        raise Exception("== operator returned type %s" % str(type(e)))
+        raise TypeError("== operator returned type %s" % str(type(e)))
 
 
 def affineSliceCoords(shape, origin, vectors, axes):


### PR DESCRIPTION
#### What does this PR do?
This is to raise a TypeError instead of general Exception in the eq function, which is in charge of checking a is b equality,  to make it easier to catch in outer scopes. 

#### What testing has been done on this PR?
`pytest tests`

#### What are the relevant issues?
 Raise TypeError instead of Exception in pg.eq [#1815](hhttps://github.com/pyqtgraph/pyqtgraph/issues/1815). 
Design aspects discussed in issue. 

#### Do the docs need to be updated?
No 
