### PR TITLE
Fix GLTextItem with Python 3.10

### DIFF
--- a/pyqtgraph/opengl/items/GLTextItem.py
+++ b/pyqtgraph/opengl/items/GLTextItem.py
@@ -68,15 +68,15 @@ class GLTextItem(GLGraphicsItem):
         viewport = glGetIntegerv(GL_VIEWPORT)
 
         text_pos = self.__project(self.pos, modelview, projection, viewport)
-        text_pos[1] = viewport[3] - text_pos[1]
 
+        text_pos.setY(viewport[3] - text_pos.y())
         text_pos /= self.view().devicePixelRatio()
 
         painter = QtGui.QPainter(self.view())
         painter.setPen(self.color)
         painter.setFont(self.font)
         painter.setRenderHints(QtGui.QPainter.RenderHint.Antialiasing | QtGui.QPainter.RenderHint.TextAntialiasing)
-        painter.drawText(text_pos[0], text_pos[1], self.text)
+        painter.drawText(text_pos, self.text)
         painter.end()
 
     def __project(self, obj_pos, modelview, projection, viewport):
@@ -86,12 +86,11 @@ class GLTextItem(GLGraphicsItem):
         proj_vec = np.matmul(projection.T, view_vec)
 
         if proj_vec[3] == 0.0:
-            return
+            return QtCore.QPointF(0, 0)
 
         proj_vec[0:3] /= proj_vec[3]
 
-        return np.array([
-            viewport[0] + (1.0 + proj_vec[0]) * viewport[2] / 2.0,
-            viewport[1] + (1.0 + proj_vec[1]) * viewport[3] / 2.0,
-            (1.0 + proj_vec[2]) / 2.0
-        ])
+        return QtCore.QPointF(
+            viewport[0] + (1.0 + proj_vec[0]) * viewport[2] / 2,
+            viewport[1] + (1.0 + proj_vec[1]) * viewport[3] / 2
+        )


### PR DESCRIPTION
drawText() expects int arguments and Python 3.10 does not allow for
implicit rounding.

Fixes this test failure:
```
____________________ testExamples[ GLTextItem.py - PyQt5 ] _____________________

Error while drawing item <pyqtgraph.opengl.items.GLTextItem.GLTextItem object at 0x7f66c1d031c0>.
Error while drawing item <pyqtgraph.opengl.items.GLTextItem.GLTextItem object at 0x7f66c1d032e0>.

/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/GLViewWidget.py:275: RuntimeWarning: 
Traceback (most recent call last):
  File "<stdin>", line 11, in <module>
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/Qt/__init__.py", line 407, in exec_
    return app.exec() if hasattr(app, 'exec') else app.exec_()
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/GLViewWidget.py", line 254, in paintGL
    self.drawItemTree(useItemNames=useItemNames)
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/GLViewWidget.py", line 294, in drawItemTree
    self.drawItemTree(i, useItemNames=useItemNames)
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/GLViewWidget.py", line 275, in drawItemTree
    debug.printExc()
  --- exception caught here ---
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/GLViewWidget.py", line 272, in drawItemTree
    i.paint()
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/items/GLTextItem.py", line 79, in paint
    painter.drawText(text_pos[0], text_pos[1], self.text)
TypeError: arguments did not match any overloaded call:
  drawText(self, Union[QPointF, QPoint], str): argument 1 has unexpected type 'numpy.float64'
  drawText(self, QRectF, int, str): argument 1 has unexpected type 'numpy.float64'
  drawText(self, QRect, int, str): argument 1 has unexpected type 'numpy.float64'
  drawText(self, QRectF, str, option: QTextOption = QTextOption()): argument 1 has unexpected type 'numpy.float64'
  drawText(self, QPoint, str): argument 1 has unexpected type 'numpy.float64'
  drawText(self, int, int, int, int, int, str): argument 1 has unexpected type 'numpy.float64'
  drawText(self, int, int, str): argument 1 has unexpected type 'numpy.float64'
  debug.printExc()

Failed Text Example Test Located in GLTextItem.py
----------------------------- Captured stdout call -----------------------------
Text
Error while drawing item <pyqtgraph.opengl.items.GLTextItem.GLTextItem object at 0x7f66c1d031c0>.
Error while drawing item <pyqtgraph.opengl.items.GLTextItem.GLTextItem object at 0x7f66c1d032e0>.

/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/GLViewWidget.py:275: RuntimeWarning: 
Traceback (most recent call last):
  File "<stdin>", line 11, in <module>
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/Qt/__init__.py", line 407, in exec_
    return app.exec() if hasattr(app, 'exec') else app.exec_()
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/GLViewWidget.py", line 254, in paintGL
    self.drawItemTree(useItemNames=useItemNames)
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/GLViewWidget.py", line 294, in drawItemTree
    self.drawItemTree(i, useItemNames=useItemNames)
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/GLViewWidget.py", line 275, in drawItemTree
    debug.printExc()
  --- exception caught here ---
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/GLViewWidget.py", line 272, in drawItemTree
    i.paint()
  File "/builddir/build/BUILD/pyqtgraph-0.12.2/pyqtgraph/opengl/items/GLTextItem.py", line 79, in paint
    painter.drawText(text_pos[0], text_pos[1], self.text)
TypeError: arguments did not match any overloaded call:
  drawText(self, Union[QPointF, QPoint], str): argument 1 has unexpected type 'numpy.float64'
  drawText(self, QRectF, int, str): argument 1 has unexpected type 'numpy.float64'
  drawText(self, QRect, int, str): argument 1 has unexpected type 'numpy.float64'
  drawText(self, QRectF, str, option: QTextOption = QTextOption()): argument 1 has unexpected type 'numpy.float64'
  drawText(self, QPoint, str): argument 1 has unexpected type 'numpy.float64'
  drawText(self, int, int, int, int, int, str): argument 1 has unexpected type 'numpy.float64'
  drawText(self, int, int, str): argument 1 has unexpected type 'numpy.float64'
  debug.printExc()
```