### PR TITLE
implement GLPainterItem

### DIFF
--- a/examples/GLBarGraphItem.py
+++ b/examples/GLBarGraphItem.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Demonstrate use of GLLinePlotItem to draw cross-sections of a surface.
+This example demonstrates the use of GLBarGraphItem.
 
 """
 ## Add path to library (just for examples; you do not need this)

--- a/examples/GLPainterItem.py
+++ b/examples/GLPainterItem.py
@@ -48,10 +48,9 @@ class GLPainterItem(pg.opengl.GLGraphicsItem.GLGraphicsItem):
         painter.drawText(rect, af.AlignBottom | af.AlignLeft, 'BL')
         painter.drawText(rect, af.AlignBottom | af.AlignRight, 'BR')
 
-        opts = self.view().getCameraPosition()
-        opts['fov'] = self.view().fov()
+        opts = self.view().cameraParams()
         lines = []
-        center = opts['pos']
+        center = opts['center']
         lines.append(f"center : ({center.x():.1f}, {center.y():.1f}, {center.z():.1f})")
         for key in ['distance', 'fov', 'elevation', 'azimuth']:
             lines.append(f"{key} : {opts[key]:.1f}")

--- a/examples/GLPainterItem.py
+++ b/examples/GLPainterItem.py
@@ -1,0 +1,94 @@
+"""
+Demonstrate using QPainter on a subclass of GLGraphicsItem.
+"""
+## Add path to library (just for examples; you do not need this)
+import initExample
+
+import pyqtgraph as pg
+import pyqtgraph.opengl
+from pyqtgraph.Qt import QtCore, QtGui
+import OpenGL.GL as GL
+
+SIZE = 32
+
+class GLPainterItem(pg.opengl.GLGraphicsItem.GLGraphicsItem):
+    def __init__(self, **kwds):
+        super().__init__()
+        glopts = kwds.pop('glOptions', 'additive')
+        self.setGLOptions(glopts)
+
+    def compute_projection(self):
+        modelview = GL.glGetDoublev(GL.GL_MODELVIEW_MATRIX)
+        projection = GL.glGetDoublev(GL.GL_PROJECTION_MATRIX)
+        mvp = projection.T @ modelview.T
+        mvp = QtGui.QMatrix4x4(mvp.ravel().tolist())
+
+        # note that QRectF.bottom() != QRect.bottom()
+        rect = QtCore.QRectF(self.view().rect())
+        ndc_to_viewport = QtGui.QMatrix4x4()
+        ndc_to_viewport.viewport(rect.left(), rect.bottom(), rect.width(), -rect.height())
+
+        return ndc_to_viewport * mvp
+
+    def paint(self):
+        self.setupGLState()
+
+        painter = QtGui.QPainter(self.view())
+        self.draw(painter)
+        painter.end()
+
+    def draw(self, painter):
+        painter.setPen(QtCore.Qt.GlobalColor.white)
+        painter.setRenderHints(QtGui.QPainter.RenderHint.Antialiasing | QtGui.QPainter.RenderHint.TextAntialiasing)
+
+        rect = self.view().rect()
+        af = QtCore.Qt.AlignmentFlag
+
+        painter.drawText(rect, af.AlignTop | af.AlignRight, 'TR')
+        painter.drawText(rect, af.AlignBottom | af.AlignLeft, 'BL')
+        painter.drawText(rect, af.AlignBottom | af.AlignRight, 'BR')
+
+        opts = self.view().opts
+        lines = []
+        center = opts['center']
+        lines.append(f"center : ({center.x():.1f}, {center.y():.1f}, {center.z():.1f})")
+        for key in ['distance', 'fov', 'elevation', 'azimuth']:
+            lines.append(f"{key} : {opts[key]:.1f}")
+        xyz = self.view().cameraPosition()
+        lines.append(f"xyz : ({xyz.x():.1f}, {xyz.y():.1f}, {xyz.z():.1f})")
+        info = "\n".join(lines)
+        painter.drawText(rect, af.AlignTop | af.AlignLeft, info)
+
+        project = self.compute_projection()
+
+        hsize = SIZE // 2
+        for xi in range(-hsize, hsize+1):
+            for yi in range(-hsize, hsize+1):
+                if xi == -hsize and yi == -hsize:
+                    # skip one corner for visual orientation
+                    continue
+                vec3 = QtGui.QVector3D(xi, yi, 0)
+                pos = project.map(vec3).toPointF()
+                painter.drawEllipse(pos, 1, 1)
+
+
+pg.mkQApp("GLPainterItem Example")
+glv = pg.opengl.GLViewWidget()
+glv.show()
+glv.setWindowTitle('pyqtgraph example: GLPainterItem')
+glv.setCameraPosition(distance=50, elevation=90, azimuth=0)
+
+griditem = pg.opengl.GLGridItem()
+griditem.setSize(SIZE, SIZE)
+griditem.setSpacing(1, 1)
+glv.addItem(griditem)
+
+axisitem = pg.opengl.GLAxisItem()
+axisitem.setSize(SIZE/2, SIZE/2, 1)
+glv.addItem(axisitem)
+
+paintitem = GLPainterItem()
+glv.addItem(paintitem)
+
+if __name__ == '__main__':
+    pg.exec()

--- a/examples/GLPainterItem.py
+++ b/examples/GLPainterItem.py
@@ -48,9 +48,10 @@ class GLPainterItem(pg.opengl.GLGraphicsItem.GLGraphicsItem):
         painter.drawText(rect, af.AlignBottom | af.AlignLeft, 'BL')
         painter.drawText(rect, af.AlignBottom | af.AlignRight, 'BR')
 
-        opts = self.view().opts
+        opts = self.view().getCameraPosition()
+        opts['fov'] = self.view().fov()
         lines = []
-        center = opts['center']
+        center = opts['pos']
         lines.append(f"center : ({center.x():.1f}, {center.y():.1f}, {center.z():.1f})")
         for key in ['distance', 'fov', 'elevation', 'azimuth']:
             lines.append(f"{key} : {opts[key]:.1f}")

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -70,51 +70,15 @@ conditionalExamples = {
         False,
         reason="Test is being problematic on CI machines"
     ),
-    'GLVolumeItem.py': exceptionCondition(
-        not darwin_opengl_broken,
-        reason=darwin_opengl_reason
-    ),
-    'GLIsosurface.py': exceptionCondition(
-        not darwin_opengl_broken,
-        reason=darwin_opengl_reason
-    ),
-    'GLSurfacePlot.py': exceptionCondition(
-        not darwin_opengl_broken,
-        reason=darwin_opengl_reason
-    ),
-    'GLScatterPlotItem.py': exceptionCondition(
-        not darwin_opengl_broken,
-        reason=darwin_opengl_reason
-    ),
-    'GLshaders.py': exceptionCondition(
-        not darwin_opengl_broken,
-        reason=darwin_opengl_reason
-    ),
-    'GLTextItem.py': exceptionCondition(
-        not darwin_opengl_broken,
-        reason=darwin_opengl_reason
-    ),
-    'GLLinePlotItem.py': exceptionCondition(
-        not darwin_opengl_broken,
-        reason=darwin_opengl_reason
-    ),
-    'GLMeshItem.py': exceptionCondition(
-        not darwin_opengl_broken,
-        reason=darwin_opengl_reason
-    ),
-    'GLImageItem.py': exceptionCondition(
-        not darwin_opengl_broken,
-        reason=darwin_opengl_reason
-    ),
-    'GLBarGraphItem.py': exceptionCondition(
-        not darwin_opengl_broken,
-        reason=darwin_opengl_reason
-    ),
-    'GLViewWidget.py': exceptionCondition(
+}
+
+openglExamples = ['GLViewWidget.py']
+openglExamples.extend(utils.examples_['3D Graphics'].values())
+for key in openglExamples:
+    conditionalExamples[key] = exceptionCondition(
         not darwin_opengl_broken,
         reason=darwin_opengl_reason
     )
-}
 
 @pytest.mark.skipif(
     Qt.QT_LIB == "PySide2"

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -74,6 +74,7 @@ examples_ = OrderedDict([
         ('Mesh', 'GLMeshItem.py'),
         ('Image', 'GLImageItem.py'),
         ('Text', 'GLTextItem.py'),
+        ('BarGraph', 'GLBarGraphItem.py'),
         ('Painter', 'GLPainterItem.py'),
     ])),
     ('Widgets', OrderedDict([
@@ -106,7 +107,6 @@ others = dict([
     ('ScaleBar', 'ScaleBar.py'),
     ('ViewBox', 'ViewBox.py'),
     ('GradientEditor', 'GradientEditor.py'),
-    ('GLBarGraphItem', 'GLBarGraphItem.py'),
     ('GLViewWidget', 'GLViewWidget.py'),
     ('DiffTreeWidget', 'DiffTreeWidget.py'),
     ('MultiPlotWidget', 'MultiPlotWidget.py'),

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -74,6 +74,7 @@ examples_ = OrderedDict([
         ('Mesh', 'GLMeshItem.py'),
         ('Image', 'GLImageItem.py'),
         ('Text', 'GLTextItem.py'),
+        ('Painter', 'GLPainterItem.py'),
     ])),
     ('Widgets', OrderedDict([
         ('PlotWidget', 'PlotWidget.py'),

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -308,22 +308,6 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
 
         self.update()
         
-    def getCameraPosition(self):
-        opts = { 'pos': self.opts['center'],
-                 'distance' : self.opts['distance'] }
-        if self.opts['rotationMethod'] == "quaternion":
-            opts['rotation'] = self.opts['rotation']
-        else:
-            opts['elevation'] = self.opts['elevation']
-            opts['azimuth'] = self.opts['azimuth']
-        return opts
-
-    def setFov(self, fov):
-        self.opts['fov'] = fov
-
-    def fov(self):
-        return self.opts['fov']
-
     def cameraPosition(self):
         """Return current position of camera based on center, dist, elevation, and azimuth"""
         center = self.opts['center']
@@ -340,6 +324,21 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
                 center.z() + dist * sin(elev)
             )
         return pos
+
+    def setCameraParams(self, **kwds):
+        valid_keys = {'center', 'rotation', 'distance', 'fov', 'elevation', 'azimuth'}
+        if not set(kwds).issubset(valid_keys):
+            raise ValueError(f'valid keywords are {valid_keys}')
+
+        self.setCameraPosition(pos=kwds.get('center'), distance=kwds.get('distance'),
+                               elevation=kwds.get('elevation'), azimuth=kwds.get('azimuth'),
+                               rotation=kwds.get('rotation'))
+        if 'fov' in kwds:
+            self.opts['fov'] = kwds['fov']
+
+    def cameraParams(self):
+        valid_keys = {'center', 'rotation', 'distance', 'fov', 'elevation', 'azimuth'}
+        return { k : self.opts[k] for k in valid_keys }
 
     def orbit(self, azim, elev):
         """Orbits the camera around the center position. *azim* and *elev* are given in degrees."""

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -327,7 +327,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
 
     def setCameraParams(self, **kwds):
         valid_keys = {'center', 'rotation', 'distance', 'fov', 'elevation', 'azimuth'}
-        if not set(kwds).issubset(valid_keys):
+        if not valid_keys.issuperset(kwds):
             raise ValueError(f'valid keywords are {valid_keys}')
 
         self.setCameraPosition(pos=kwds.get('center'), distance=kwds.get('distance'),

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -308,6 +308,22 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
 
         self.update()
         
+    def getCameraPosition(self):
+        opts = { 'pos': self.opts['center'],
+                 'distance' : self.opts['distance'] }
+        if self.opts['rotationMethod'] == "quaternion":
+            opts['rotation'] = self.opts['rotation']
+        else:
+            opts['elevation'] = self.opts['elevation']
+            opts['azimuth'] = self.opts['azimuth']
+        return opts
+
+    def setFov(self, fov):
+        self.opts['fov'] = fov
+
+    def fov(self):
+        return self.opts['fov']
+
     def cameraPosition(self):
         """Return current position of camera based on center, dist, elevation, and azimuth"""
         center = self.opts['center']


### PR DESCRIPTION
While playing around with GLTextItem, I found that it would not scale well when drawing many text items. In the following script, for example, it is very sluggish to rotate the scene.
```python
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore, QtGui
import pyqtgraph.opengl as gl

pg.mkQApp("GLTextItem Example")

gvw = gl.GLViewWidget()
gvw.opts['elevation'] = 90
gvw.opts['azimuth'] = 0
gvw.opts['distance'] = 50
gvw.show()

size = 50
griditem = gl.GLGridItem()
griditem.setSize(size, size)
griditem.setSpacing(1, 1)
gvw.addItem(griditem)

axisitem = gl.GLAxisItem()
gvw.addItem(axisitem)

for xi in range(size+1):
    for yi in range(size+1):
        pos = (xi - size/2, yi - size/2, 0)
        gvw.addItem(gl.GLTextItem(pos=pos, text='.'))
pg.exec()
```

I also came across #662, which seems to be asking for a generalization of what GLTextItem provides.

As a demonstration / proof-of-concept, this PR implements GLPainterItem, allowing the user to issue multiple arbitrary painter method calls. The (rough) equivalent example to the above script is provided and it rotates smoothly. I think the main overhead in the GLTextItem example above must have been in constructing and destructing the QPainter object.