### PR TITLE
Code completion in pyqtgraph's console

### DIFF
--- a/pyqtgraph/console/CmdInput.py
+++ b/pyqtgraph/console/CmdInput.py
@@ -29,7 +29,7 @@ class CmdInput(PopupLineEditor):
         elif ev.key() == QtCore.Qt.Key.Key_Return and not self.completer().popup().isVisible():
             # Completer takes precedence if present
             self.execCmd()
-        elif (ctrlPressed and ev.key() == QtCore.Qt.Key.Key_Space):
+        elif ctrlPressed and ev.key() == QtCore.Qt.Key.Key_Space:
             self.sigCompleteRequested.emit(self.text())
             ev.accept()
             return

--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -516,7 +516,7 @@ class ConsoleWidget(QtGui.QWidget):
         options = [c.name for c in script.complete(fuzzy=True)]
         # Options are broken up by '.', '(', and other characters that start a new 'clause' in the expression
         # So, it's not as easy as just concatenating with the reference string
-        prefix = re.sub(f'({CLAUSE_MARKERS}){NON_CLAUSE_MARKERS}', r'\1', newText)
+        prefix = re.sub(f'({CLAUSE_MARKERS})?{NON_CLAUSE_MARKERS}$', r'\1', newText)
         self.completerModel.setStringList([prefix + o for o in options])
 
     def handleCompleterRequest(self, newText):

--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -2,7 +2,7 @@
 import sys, re, os, time, traceback, subprocess
 import pickle
 
-from ..Qt import QtCore, QtGui, QT_LIB, QtWidgets
+from ..Qt import QtCore, QtGui, QT_LIB
 from ..python2_3 import basestring
 from .. import exceptionHandling as exceptionHandling
 from .. import getConfigOption
@@ -513,7 +513,11 @@ class ConsoleWidget(QtGui.QWidget):
         except ImportError:
             return
         script = jedi.Interpreter(newText, [self.globals(), self.locals()])
-        options = [c.name for c in script.complete(fuzzy=True)]
+        try:
+            options = [c.name for c in script.complete(fuzzy=True)]
+        except:
+            # A variety of syntax errors can trip here
+            options = []
         # Options are broken up by '.', '(', and other characters that start a new 'clause' in the expression
         # So, it's not as easy as just concatenating with the reference string
         prefix = re.sub(f'({CLAUSE_MARKERS})?{NON_CLAUSE_MARKERS}$', r'\1', newText)

--- a/pyqtgraph/widgets/PopupLineEditor.py
+++ b/pyqtgraph/widgets/PopupLineEditor.py
@@ -1,0 +1,133 @@
+from ..Qt import QtWidgets, QtCore, QtGui
+
+
+class StringListValidator(QtGui.QValidator):
+
+  def __init__(self, parent=None, strList=None,
+               model: QtCore.QStringListModel=None,
+               validateCase=False) -> None:
+    super().__init__(parent)
+    self.validateCase = validateCase
+    self.strList = strList
+    self.model = model
+
+  def validate(self, input_: str, pos: int):
+    if self.model:
+      self.strList = [self.model.index(ii, 0).data() for ii in range(self.model.rowCount())]
+    strList = cmpStrList = [input_] if self.strList is None else self.strList
+    cmpInput = input_
+    if not self.validateCase:
+      cmpInput = input_.lower()
+      cmpStrList = [s.lower() for s in strList]
+
+    try:
+      matchIdx = cmpStrList.index(cmpInput)
+      input_ = strList[matchIdx]
+      state = self.State.Acceptable
+    except ValueError:
+      if any(cmpInput in str_ for str_ in cmpStrList):
+        state = self.State.Intermediate
+      else:
+        state = self.State.Invalid
+    return state, input_, pos
+
+class PopupLineEditor(QtWidgets.QLineEdit):
+  def __init__(self, parent: QtWidgets.QWidget=None,
+               model: QtCore.QAbstractItemModel=None,
+               placeholderText='Press Tab or type...',
+               clearOnComplete=True,
+               forceMatch=True,
+               validatePrefix=True,
+               validateCase=False):
+    super().__init__(parent)
+    self.setPlaceholderText(placeholderText)
+    self.clearOnComplete = clearOnComplete
+    self.forceMatch = forceMatch
+    self.validateCase = validateCase
+    self.model: QtCore.QAbstractListModel = QtCore.QStringListModel()
+    if model is None:
+      model = self.model
+
+    if validatePrefix:
+      self.vdator = StringListValidator(parent=self, validateCase=validateCase)
+      self.setValidator(self.vdator)
+    else:
+      self.vdator = None
+
+    self.setModel(model)
+
+  def setModel(self, model: QtCore.QAbstractListModel):
+    completer = QtWidgets.QCompleter(model, self)
+    completer.setCaseSensitivity(QtCore.Qt.CaseSensitivity.CaseInsensitive)
+    completer.setCompletionRole(QtCore.Qt.ItemDataRole.DisplayRole)
+    completer.setFilterMode(QtCore.Qt.MatchFlag.MatchContains)
+    # if self.vdator is None:
+    #   completer.setCompletionMode(completer.CompletionMode.UnfilteredPopupCompletion)
+    if self.clearOnComplete:
+      completer.activated.connect(lambda: QtCore.QTimer.singleShot(0, self.clear))
+
+    self.textChanged.connect(lambda: self.resetCompleterPrefix())
+
+    self.setCompleter(completer)
+    self.model = model
+    if self.forceMatch and self.vdator is not None:
+      self.vdator.model = model
+
+  # TODO: Get working with next prev focusing for smoother logic
+  # def focusNextPrevChild(self, nextChild: bool):
+  #   if self.forceMatch and self.text() not in self.completer().model().stringList():
+  #     dummyFocusEv = QtGui.QFocusEvent(QtCore.QEvent.FocusOut)
+  #     self.focusOutEvent(dummyFocusEv)
+  #     return False
+  #   return super().focusNextPrevChild(nextChild)
+
+  def _chooseNextCompletion(self, incAmt=1):
+    completer = self.completer()
+    popup = completer.popup()
+    if popup.isVisible() and popup.currentIndex().isValid():
+      nextIdx = (completer.currentRow()+incAmt)%completer.completionCount()
+      completer.setCurrentRow(nextIdx)
+    else:
+      completer.complete()
+    popup.show()
+    popup.setCurrentIndex(completer.currentIndex())
+    popup.setFocus()
+
+  def event(self, ev: QtCore.QEvent):
+    if ev.type() != ev.KeyPress:
+      return super().event(ev)
+
+    ev: QtGui.QKeyEvent
+    key = ev.key()
+    if key == QtCore.Qt.Key.Key_Tab:
+      incAmt = 1
+    elif key == QtCore.Qt.Key.Key_Backtab:
+      incAmt = -1
+    else:
+      return super().event(ev)
+    self._chooseNextCompletion(incAmt)
+    return True
+
+  def focusOutEvent(self, ev: QtGui.QFocusEvent):
+    reason = ev.reason()
+    if reason in [QtCore.Qt.FocusReason.TabFocusReason, QtCore.Qt.FocusReason.BacktabFocusReason,
+                  QtCore.Qt.FocusReason.OtherFocusReason]:
+      # Simulate tabbing through completer options instead of losing focus
+      self.setFocus()
+      completer = self.completer()
+      if completer is None:
+        return
+      incAmt = 1 if reason == QtCore.Qt.FocusReason.TabFocusReason else -1
+
+      self._chooseNextCompletion(incAmt)
+      ev.accept()
+      return
+    else:
+      super().focusOutEvent(ev)
+
+  def clear(self):
+    super().clear()
+
+  def resetCompleterPrefix(self):
+    if self.text() == '':
+      self.completer().setCompletionPrefix('')

--- a/pyqtgraph/widgets/PopupLineEditor.py
+++ b/pyqtgraph/widgets/PopupLineEditor.py
@@ -3,131 +3,121 @@ from ..Qt import QtWidgets, QtCore, QtGui
 
 class StringListValidator(QtGui.QValidator):
 
-  def __init__(self, parent=None, strList=None,
-               model: QtCore.QStringListModel=None,
-               validateCase=False) -> None:
-    super().__init__(parent)
-    self.validateCase = validateCase
-    self.strList = strList
-    self.model = model
+    def __init__(self, parent=None,strList=None, model=None, validateCase=False):
+        super().__init__(parent)
+        self.validateCase = validateCase
+        self.strList = strList
+        self.model = model
 
-  def validate(self, input_: str, pos: int):
-    if self.model:
-      self.strList = [self.model.index(ii, 0).data() for ii in range(self.model.rowCount())]
-    strList = cmpStrList = [input_] if self.strList is None else self.strList
-    cmpInput = input_
-    if not self.validateCase:
-      cmpInput = input_.lower()
-      cmpStrList = [s.lower() for s in strList]
+    def validate(self, input_, pos):
+        if self.model:
+            self.strList = [self.model.index(ii, 0).data() for ii in range(self.model.rowCount())]
+        strList = cmpStrList = [input_] if self.strList is None else self.strList
+        cmpInput = input_
+        if not self.validateCase:
+            cmpInput = input_.lower()
+            cmpStrList = [s.lower() for s in strList]
 
-    try:
-      matchIdx = cmpStrList.index(cmpInput)
-      input_ = strList[matchIdx]
-      state = self.State.Acceptable
-    except ValueError:
-      if any(cmpInput in str_ for str_ in cmpStrList):
-        state = self.State.Intermediate
-      else:
-        state = self.State.Invalid
-    return state, input_, pos
+        try:
+            matchIdx = cmpStrList.index(cmpInput)
+            input_ = strList[matchIdx]
+            state = self.State.Acceptable
+        except ValueError:
+            if any(cmpInput in str_ for str_ in cmpStrList):
+                state = self.State.Intermediate
+            else:
+                state = self.State.Invalid
+        return state, input_, pos
 
 class PopupLineEditor(QtWidgets.QLineEdit):
-  def __init__(self, parent: QtWidgets.QWidget=None,
-               model: QtCore.QAbstractItemModel=None,
-               placeholderText='Press Tab or type...',
-               clearOnComplete=True,
-               forceMatch=True,
-               validatePrefix=True,
-               validateCase=False):
-    super().__init__(parent)
-    self.setPlaceholderText(placeholderText)
-    self.clearOnComplete = clearOnComplete
-    self.forceMatch = forceMatch
-    self.validateCase = validateCase
-    self.model: QtCore.QAbstractListModel = QtCore.QStringListModel()
-    if model is None:
-      model = self.model
+    def __init__(self, parent=None,
+                 model=None,
+                 placeholderText='Press Tab or type...',
+                 clearOnComplete=True,
+                 forceMatch=True,
+                 validatePrefix=True,
+                 validateCase=False):
+        super().__init__(parent)
+        self.setPlaceholderText(placeholderText)
+        self.clearOnComplete = clearOnComplete
+        self.forceMatch = forceMatch
+        self.validateCase = validateCase
+        self.model: QtCore.QAbstractListModel = QtCore.QStringListModel()
+        if model is None:
+            model = self.model
 
-    if validatePrefix:
-      self.vdator = StringListValidator(parent=self, validateCase=validateCase)
-      self.setValidator(self.vdator)
-    else:
-      self.vdator = None
+        if validatePrefix:
+            self.vdator = StringListValidator(parent=self, validateCase=validateCase)
+            self.setValidator(self.vdator)
+        else:
+            self.vdator = None
 
-    self.setModel(model)
+        self.setModel(model)
 
-  def setModel(self, model: QtCore.QAbstractListModel):
-    completer = QtWidgets.QCompleter(model, self)
-    completer.setCaseSensitivity(QtCore.Qt.CaseSensitivity.CaseInsensitive)
-    completer.setCompletionRole(QtCore.Qt.ItemDataRole.DisplayRole)
-    completer.setFilterMode(QtCore.Qt.MatchFlag.MatchContains)
-    # if self.vdator is None:
-    #   completer.setCompletionMode(completer.CompletionMode.UnfilteredPopupCompletion)
-    if self.clearOnComplete:
-      completer.activated.connect(lambda: QtCore.QTimer.singleShot(0, self.clear))
+    def setModel(self, model):
+        completer = QtWidgets.QCompleter(model, self)
+        completer.setCaseSensitivity(QtCore.Qt.CaseSensitivity.CaseInsensitive)
+        completer.setCompletionRole(QtCore.Qt.ItemDataRole.DisplayRole)
+        completer.setFilterMode(QtCore.Qt.MatchFlag.MatchContains)
+        if self.clearOnComplete:
+            def clearLater():
+                QtCore.QTimer.singleShot(0, self.clear)
+            completer.activated.connect(clearLater)
 
-    self.textChanged.connect(lambda: self.resetCompleterPrefix())
+        self.textChanged.connect(self.resetCompleterPrefix)
 
-    self.setCompleter(completer)
-    self.model = model
-    if self.forceMatch and self.vdator is not None:
-      self.vdator.model = model
+        self.setCompleter(completer)
+        self.model = model
+        if self.forceMatch and self.vdator is not None:
+            self.vdator.model = model
 
-  # TODO: Get working with next prev focusing for smoother logic
-  # def focusNextPrevChild(self, nextChild: bool):
-  #   if self.forceMatch and self.text() not in self.completer().model().stringList():
-  #     dummyFocusEv = QtGui.QFocusEvent(QtCore.QEvent.FocusOut)
-  #     self.focusOutEvent(dummyFocusEv)
-  #     return False
-  #   return super().focusNextPrevChild(nextChild)
+    def _chooseNextCompletion(self, incAmt=1):
+        completer = self.completer()
+        popup = completer.popup()
+        if popup.isVisible() and popup.currentIndex().isValid():
+            nextIdx = (completer.currentRow()+incAmt)%completer.completionCount()
+            completer.setCurrentRow(nextIdx)
+        else:
+            completer.complete()
+        popup.show()
+        popup.setCurrentIndex(completer.currentIndex())
+        popup.setFocus()
 
-  def _chooseNextCompletion(self, incAmt=1):
-    completer = self.completer()
-    popup = completer.popup()
-    if popup.isVisible() and popup.currentIndex().isValid():
-      nextIdx = (completer.currentRow()+incAmt)%completer.completionCount()
-      completer.setCurrentRow(nextIdx)
-    else:
-      completer.complete()
-    popup.show()
-    popup.setCurrentIndex(completer.currentIndex())
-    popup.setFocus()
+    def event(self, ev):
+        if ev.type() != ev.Type.KeyPress:
+            return super().event(ev)
 
-  def event(self, ev: QtCore.QEvent):
-    if ev.type() != ev.KeyPress:
-      return super().event(ev)
+        ev: QtGui.QKeyEvent
+        key = ev.key()
+        if key == QtCore.Qt.Key.Key_Tab:
+            incAmt = 1
+        elif key == QtCore.Qt.Key.Key_Backtab:
+            incAmt = -1
+        else:
+            return super().event(ev)
+        self._chooseNextCompletion(incAmt)
+        return True
 
-    ev: QtGui.QKeyEvent
-    key = ev.key()
-    if key == QtCore.Qt.Key.Key_Tab:
-      incAmt = 1
-    elif key == QtCore.Qt.Key.Key_Backtab:
-      incAmt = -1
-    else:
-      return super().event(ev)
-    self._chooseNextCompletion(incAmt)
-    return True
+    def focusOutEvent(self, ev):
+        reason = ev.reason()
+        if reason in [QtCore.Qt.FocusReason.TabFocusReason, QtCore.Qt.FocusReason.BacktabFocusReason,
+                      QtCore.Qt.FocusReason.OtherFocusReason]:
+            # Simulate tabbing through completer options instead of losing focus
+            self.setFocus()
+            completer = self.completer()
+            if completer is None:
+                return
+            incAmt = 1 if reason == QtCore.Qt.FocusReason.TabFocusReason else -1
 
-  def focusOutEvent(self, ev: QtGui.QFocusEvent):
-    reason = ev.reason()
-    if reason in [QtCore.Qt.FocusReason.TabFocusReason, QtCore.Qt.FocusReason.BacktabFocusReason,
-                  QtCore.Qt.FocusReason.OtherFocusReason]:
-      # Simulate tabbing through completer options instead of losing focus
-      self.setFocus()
-      completer = self.completer()
-      if completer is None:
-        return
-      incAmt = 1 if reason == QtCore.Qt.FocusReason.TabFocusReason else -1
+            self._chooseNextCompletion(incAmt)
+            ev.accept()
+            return
+        else:
+            super().focusOutEvent(ev)
 
-      self._chooseNextCompletion(incAmt)
-      ev.accept()
-      return
-    else:
-      super().focusOutEvent(ev)
+    def clear(self):
+        super().clear()
 
-  def clear(self):
-    super().clear()
-
-  def resetCompleterPrefix(self):
-    if self.text() == '':
-      self.completer().setCompletionPrefix('')
+    def resetCompleterPrefix(self):
+        if self.text() == '':
+            self.completer().setCompletionPrefix('')


### PR DESCRIPTION
Uses either Jedi or poor man's Jedi (if you don't have it in your environment) to provide code completion on Ctrl+Space

Non-jedi version just suggests words from past history, jedi just spawns an interpreter and calls `.complete()`

- [ ] Non-jedi completer:
    - [ ] `CLAUSE` definitions should probably be checked to ensure they're exhaustive (https://github.com/pyqtgraph/pyqtgraph/pull/1893/files#diff-3d7000126a6585e9ef1feafd8b50057555f610a325295b295fb5a0452e1ffbbbR15)
    - [ ] I have no idea how to make a robust completion model, some review of my implementation would be good
    - [ ] Should ignore history that results in an exception
    - [x] Double+ dot-accessors (`pg.plot(x, y).getViewBox()`)
    - [x] Assignment operators (`x = np.ones`)
- [ ] Jedi completer:
    - [ ] all `import` statements aren't prefixed properly
    - [ ] API compatibility issues for older Jedi versions
- [ ] Implementation of `PopupLineEditor` was pulled from one of my other projects so it still needs converting to pyqtgraph format:
    - [x] Lambdas connected to slots -> local or new functions
    - [ ] Function documentation
    - [x] Type hint removal
    - [ ] Auditing next/prev focusing logic
        - [ ] Tab key should complete selection and close popup instead of cycling through options
        - [ ] Platform-agnostic hotkey instead of "Ctrl" (Does `Qt.Key.Key_Control` map to "Option" on Mac?)
    - [ ] Resolve issues on Qt bindings that open the popup in the screen corner rather than on top of the line edit
- [ ] Compile regexes (this is an easy one)

 - If someone has a more intuitive (least "astonishing") alternative for refreshing the completion model compared to waiting for Ctrl+Space, I'm all ears.
 - If someone has a 'dumb' replacement for missing `jedi` that's better than just looking for words in the history, I'm all ears.
     - I could probably try `dir` or `vars` on the current object etc., but that sounded like a lot of work and at a certain point I don't want to re-implement `jedi` just for this console

https://user-images.githubusercontent.com/23620506/125359019-b25bd000-e337-11eb-8d27-0ac809ea3325.mp4

