### PR TITLE
Cleanup GLViewWidget

### DIFF
--- a/examples/GLBarGraphItem.py
+++ b/examples/GLBarGraphItem.py
@@ -13,9 +13,9 @@ import numpy as np
 
 app = pg.mkQApp("GLBarGraphItem Example")
 w = gl.GLViewWidget()
-w.opts['distance'] = 40
 w.show()
 w.setWindowTitle('pyqtgraph example: GLBarGraphItem')
+w.setCameraPosition(distance=40)
 
 gx = gl.GLGridItem()
 gx.rotate(90, 0, 1, 0)

--- a/examples/GLImageItem.py
+++ b/examples/GLImageItem.py
@@ -15,9 +15,9 @@ import numpy as np
 
 app = pg.mkQApp("GLImageItem Example")
 w = gl.GLViewWidget()
-w.opts['distance'] = 200
 w.show()
 w.setWindowTitle('pyqtgraph example: GLImageItem')
+w.setCameraPosition(distance=200)
 
 ## create volume data set to slice three images from
 shape = (100,100,70)

--- a/examples/GLLinePlotItem.py
+++ b/examples/GLLinePlotItem.py
@@ -13,9 +13,9 @@ import numpy as np
 
 app = pg.mkQApp("GLLinePlotItem Example")
 w = gl.GLViewWidget()
-w.opts['distance'] = 40
 w.show()
 w.setWindowTitle('pyqtgraph example: GLLinePlotItem')
+w.setCameraPosition(distance=40)
 
 gx = gl.GLGridItem()
 gx.rotate(90, 0, 1, 0)

--- a/examples/GLScatterPlotItem.py
+++ b/examples/GLScatterPlotItem.py
@@ -15,9 +15,9 @@ import numpy as np
 
 app = pg.mkQApp("GLScatterPlotItem Example")
 w = gl.GLViewWidget()
-w.opts['distance'] = 20
 w.show()
 w.setWindowTitle('pyqtgraph example: GLScatterPlotItem')
+w.setCameraPosition(distance=20)
 
 g = gl.GLGridItem()
 w.addItem(g)

--- a/examples/GLViewWidget.py
+++ b/examples/GLViewWidget.py
@@ -11,9 +11,9 @@ import pyqtgraph.opengl as gl
 
 pg.mkQApp("GLViewWidget Example")
 w = gl.GLViewWidget()
-w.opts['distance'] = 20
 w.show()
 w.setWindowTitle('pyqtgraph example: GLViewWidget')
+w.setCameraPosition(distance=20)
 
 ax = gl.GLAxisItem()
 ax.setSize(5,5,5)

--- a/examples/GLVolumeItem.py
+++ b/examples/GLVolumeItem.py
@@ -14,9 +14,9 @@ from pyqtgraph import functions as fn
 
 app = pg.mkQApp("GLVolumeItem Example")
 w = gl.GLViewWidget()
-w.opts['distance'] = 200
 w.show()
 w.setWindowTitle('pyqtgraph example: GLVolumeItem')
+w.setCameraPosition(distance=200)
 
 g = gl.GLGridItem()
 g.scale(10, 10, 1)

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -486,7 +486,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
                 return
             try:
                 del self.keysPressed[ev.key()]
-            except:
+            except KeyError:
                 self.keysPressed = {}
             self.evalKeyState()
         

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -33,8 +33,8 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         
         self.setFocusPolicy(QtCore.Qt.FocusPolicy.ClickFocus)
 
-        if rotationMethod not in {"euler", "quaternion"}:
-            raise RuntimeError("Rotation method should be either 'euler' or 'quaternion'")
+        if rotationMethod not in ["euler", "quaternion"]:
+            raise ValueError("Rotation method should be either 'euler' or 'quaternion'")
         
         self.opts = {
             'center': Vector(0,0,0),  ## will always appear at the center of the widget

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -152,11 +152,6 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
     def devicePixelRatio(self):
         return self.devicePixelRatioF()
         
-    def resizeGL(self, w, h):
-        pass
-        #glViewport(*self.getViewport())
-        #self.update()
-
     def setProjection(self, region=None):
         m = self.projectionMatrix(region)
         glMatrixMode(GL_PROJECTION)

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -382,7 +382,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
             cVec = self.opts['center'] - cPos
             dist = cVec.length()  ## distance from camera to center
             xDist = dist * 2. * tan(0.5 * radians(self.opts['fov']))  ## approx. width of view at distance of center point
-            xScale = xDist / self.deviceWidth()
+            xScale = xDist / self.width()
             zVec = QtGui.QVector3D(0,0,1)
             xVec = QtGui.QVector3D.crossProduct(zVec, cVec).normalized()
             yVec = QtGui.QVector3D.crossProduct(xVec, zVec).normalized()
@@ -407,7 +407,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
                 fov = radians(self.opts['fov'])
                 dist = (self.opts['center'] - self.cameraPosition()).length()
                 fov_factor = tan(fov / 2) * 2
-                scale_factor = dist * fov_factor / self.deviceWidth()
+                scale_factor = dist * fov_factor / self.width()
                 z = scale_factor * cos(elev) * dy
                 x = scale_factor * (sin(azim) * dx - sin(elev) * cos(azim) * dy)
                 y = scale_factor * (cos(azim) * dx + sin(elev) * sin(azim) * dy)
@@ -429,7 +429,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         else:
             dist = (pos-cam).length()
         xDist = dist * 2. * tan(0.5 * radians(self.opts['fov']))
-        return xDist / self.deviceWidth()
+        return xDist / self.width()
         
     def mousePressEvent(self, ev):
         lpos = ev.position() if hasattr(ev, 'position') else ev.localPos()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -230,6 +230,8 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         if viewport is None:
             glViewport(*self.getViewport())
         else:
+            # note: the following code means that we have defined "viewport"
+            #       to be in device pixels.
             glViewport(*viewport)
         self.setProjection(region=region)
         self.setModelview()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -550,6 +550,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
             glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, texwidth, texwidth)
             glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depth_buf)
 
+            viewport_orig = self.opts['viewport']
             self.opts['viewport'] = (0, 0, w, h)  # viewport is the complete image; this ensures that paintGL(region=...)
                                                   # is interpreted correctly.
             p2 = 2 * padding
@@ -572,7 +573,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
                     output[x+padding:x2-padding, y+padding:y2-padding] = data[padding:w2-padding, -(h2-padding):-padding]
                     
         finally:
-            self.opts['viewport'] = None
+            self.opts['viewport'] = viewport_orig
             glfbo.glBindFramebuffer(glfbo.GL_FRAMEBUFFER, 0)
             glBindTexture(GL_TEXTURE_2D, 0)
             if tex is not None:

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -72,11 +72,11 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         self._updateScreen(window.screen())
         
     def deviceWidth(self):
-        dpr = self.devicePixelRatio()
+        dpr = self.devicePixelRatioF()
         return int(self.width() * dpr)
 
     def deviceHeight(self):
-        dpr = self.devicePixelRatio()
+        dpr = self.devicePixelRatioF()
         return int(self.height() * dpr)
 
     def reset(self):
@@ -148,9 +148,6 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
             return (0, 0, self.deviceWidth(), self.deviceHeight())
         else:
             return vp
-        
-    def devicePixelRatio(self):
-        return self.devicePixelRatioF()
         
     def setProjection(self, region=None):
         m = self.projectionMatrix(region)

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -4,6 +4,7 @@ import OpenGL.GL.framebufferobjects as glfbo
 import numpy as np
 from .. import Vector
 from .. import functions as fn
+from .. import getConfigOption
 import warnings
 from math import cos, sin, tan, radians
 ##Vector = QtGui.QVector3D
@@ -90,7 +91,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         self.opts['azimuth'] = 45            ## camera's azimuthal angle in degrees 
                                              ## (rotation around z-axis 0 points along x-axis)
         self.opts['viewport'] = None         ## glViewport params; None == whole widget
-        self.setBackgroundColor('k')        
+        self.setBackgroundColor(getConfigOption('background'))
 
     def addItem(self, item):
         self.items.append(item)

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -540,8 +540,8 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
             ## Test texture dimensions first
             glTexImage2D(GL_PROXY_TEXTURE_2D, 0, GL_RGBA, texwidth, texwidth, 0, GL_RGBA, GL_UNSIGNED_BYTE, None)
             if glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_WIDTH) == 0:
-                raise Exception("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % shape[:2])
-            ## create teture
+                raise RuntimeError("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % data.shape[:2])
+            ## create texture
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texwidth, texwidth, 0, GL_RGBA, GL_UNSIGNED_BYTE, data.transpose((1,0,2)))
 
             # Create depth buffer

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -54,8 +54,6 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         self.keysPressed = {}
         self.keyTimer = QtCore.QTimer()
         self.keyTimer.timeout.connect(self.evalKeyState)
-        self.makeCurrent()
-
 
     def _updateScreen(self, screen):
         self._updatePixelRatio()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -550,7 +550,6 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
             glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, texwidth, texwidth)
             glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depth_buf)
 
-            viewport_orig = self.opts['viewport']
             self.opts['viewport'] = (0, 0, w, h)  # viewport is the complete image; this ensures that paintGL(region=...)
                                                   # is interpreted correctly.
             p2 = 2 * padding
@@ -573,7 +572,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
                     output[x+padding:x2-padding, y+padding:y2-padding] = data[padding:w2-padding, -(h2-padding):-padding]
                     
         finally:
-            self.opts['viewport'] = viewport_orig
+            self.opts['viewport'] = None
             glfbo.glBindFramebuffer(glfbo.GL_FRAMEBUFFER, 0)
             glBindTexture(GL_TEXTURE_2D, 0)
             if tex is not None:

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -45,6 +45,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
             'azimuth': 45,            ## camera's azimuthal angle in degrees 	
                                       ## (rotation around z-axis 0 points along x-axis)	
             'viewport': None,         ## glViewport params; None == whole widget
+                                      ## note that 'viewport' is in device pixels
             'rotationMethod': rotationMethod
         }
         self.reset()
@@ -146,10 +147,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         if vp is None:
             return (0, 0, self.deviceWidth(), self.deviceHeight())
         else:
-            # note: the following code means that we have defined opts['viewport']
-            #       to be in device independent pixels.
-            dpr = self.devicePixelRatio()
-            return tuple([int(x * dpr) for x in vp])
+            return vp
         
     def devicePixelRatio(self):
         return self.devicePixelRatioF()
@@ -232,8 +230,6 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         if viewport is None:
             glViewport(*self.getViewport())
         else:
-            # note: the following code means that we have defined "viewport"
-            #       to be in device pixels.
             glViewport(*viewport)
         self.setProjection(region=region)
         self.setModelview()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -535,20 +535,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         """
         Read the current buffer pixels out as a QImage.
         """
-        w = self.deviceWidth()
-        h = self.deviceHeight()
-        self.repaint()
-        pixels = np.empty((h, w, 4), dtype=np.ubyte)
-        pixels[:] = 128
-        pixels[...,0] = 50
-        pixels[...,3] = 255
-        
-        glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels)
-
-        pixels = pixels[::-1].copy() # flip vertical
-
-        qimg = fn.ndarray_to_qimage(pixels, QtGui.QImage.Format.Format_RGBA8888)
-        return qimg
+        return self.grabFramebuffer()
         
     def renderToArray(self, size, format=GL_BGRA, type=GL_UNSIGNED_BYTE, textureSize=1024, padding=256):
         w,h = map(int, size)

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -258,14 +258,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
                 except:
                     from .. import debug
                     debug.printExc()
-                    msg = "Error while drawing item %s." % str(item)
-                    ver = glGetString(GL_VERSION)
-                    if ver is not None:
-                        ver = ver.split()[0]
-                        if int(ver.split(b'.')[0]) < 2:
-                            print(msg + " The original exception is printed above; however, pyqtgraph requires OpenGL version 2.0 or greater for many of its 3D features and your OpenGL version is %s. Installing updated display drivers may resolve this issue." % ver)
-                        else:
-                            print(msg)
+                    print("Error while drawing item %s." % str(item))
                     
                 finally:
                     glPopAttrib()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -155,9 +155,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
     def setProjection(self, region=None):
         m = self.projectionMatrix(region)
         glMatrixMode(GL_PROJECTION)
-        glLoadIdentity()
-        a = np.array(m.copyDataTo()).reshape((4,4))
-        glMultMatrixf(a.transpose())
+        glLoadMatrixf(m.data())
 
     def projectionMatrix(self, region=None):
         if region is None:
@@ -183,11 +181,9 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         return tr
         
     def setModelview(self):
-        glMatrixMode(GL_MODELVIEW)
-        glLoadIdentity()
         m = self.viewMatrix()
-        a = np.array(m.copyDataTo()).reshape((4,4))
-        glMultMatrixf(a.transpose())
+        glMatrixMode(GL_MODELVIEW)
+        glLoadMatrixf(m.data())
         
     def viewMatrix(self):
         tr = QtGui.QMatrix4x4()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -21,10 +21,8 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         ================ ==============================================================
         **Arguments:**
         parent           (QObject, optional): Parent QObject. Defaults to None.
-        devicePixelRatio (float, optional):  High-DPI displays Qt5 should automatically
-                         detect the correct resolution. For Qt4, specify the 
-                         ``devicePixelRatio`` argument when initializing the widget 
-                         (usually this value is 1-2). Defaults to None.
+        devicePixelRatio No longer in use. High-DPI displays should automatically
+                         detect the correct resolution.
         rotationMethod   (str): Mechanimsm to drive the rotation method, options are 
                          'euler' and 'quaternion'. Defaults to 'euler'.
         ================ ==============================================================
@@ -46,7 +44,6 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
             'azimuth': 45,            ## camera's azimuthal angle in degrees 	
                                       ## (rotation around z-axis 0 points along x-axis)	
             'viewport': None,         ## glViewport params; None == whole widget
-            'devicePixelRatio': devicePixelRatio,
             'rotationMethod': rotationMethod
         }
         self.reset()
@@ -152,10 +149,6 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
             return tuple([int(x * dpr) for x in vp])
         
     def devicePixelRatio(self):
-        dpr = self.opts['devicePixelRatio']
-        if dpr is not None:
-            return dpr
-        
         return self.devicePixelRatioF()
         
     def resizeGL(self, w, h):

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -524,7 +524,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         fb = None
         depth_buf = None
         try:
-            output = np.empty((w, h, 4), dtype=np.ubyte)
+            output = np.empty((h, w, 4), dtype=np.ubyte)
             fb = glfbo.glGenFramebuffers(1)
             glfbo.glBindFramebuffer(glfbo.GL_FRAMEBUFFER, fb )
             
@@ -539,7 +539,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
             if glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_WIDTH) == 0:
                 raise RuntimeError("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % data.shape[:2])
             ## create texture
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texwidth, texwidth, 0, GL_RGBA, GL_UNSIGNED_BYTE, data.transpose((1,0,2)))
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texwidth, texwidth, 0, GL_RGBA, GL_UNSIGNED_BYTE, data)
 
             # Create depth buffer
             depth_buf = glGenRenderbuffers(1)
@@ -565,8 +565,8 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
                     
                     ## read texture back to array
                     data = glGetTexImage(GL_TEXTURE_2D, 0, format, type)
-                    data = np.fromstring(data, dtype=np.ubyte).reshape(texwidth,texwidth,4).transpose(1,0,2)[:, ::-1]
-                    output[x+padding:x2-padding, y+padding:y2-padding] = data[padding:w2-padding, -(h2-padding):-padding]
+                    data = np.frombuffer(data, dtype=np.ubyte).reshape(texwidth,texwidth,4)[::-1, ...]
+                    output[y+padding:y2-padding, x+padding:x2-padding] = data[-(h2-padding):-padding, padding:w2-padding]
                     
         finally:
             self.opts['viewport'] = None

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -99,5 +99,5 @@ class GLImageItem(GLGraphicsItem):
         glTexCoord2f(0,1)
         glVertex3f(0, self.data.shape[1], 0)
         glEnd()
-        glDisable(GL_TEXTURE_3D)
+        glDisable(GL_TEXTURE_2D)
                 

--- a/pyqtgraph/opengl/items/GLTextItem.py
+++ b/pyqtgraph/opengl/items/GLTextItem.py
@@ -65,12 +65,11 @@ class GLTextItem(GLGraphicsItem):
 
         modelview = glGetDoublev(GL_MODELVIEW_MATRIX)
         projection = glGetDoublev(GL_PROJECTION_MATRIX)
-        viewport = glGetIntegerv(GL_VIEWPORT)
 
+        viewport = [0, 0, self.view().width(), self.view().height()]
         text_pos = self.__project(self.pos, modelview, projection, viewport)
 
         text_pos.setY(viewport[3] - text_pos.y())
-        text_pos /= self.view().devicePixelRatio()
 
         painter = QtGui.QPainter(self.view())
         painter.setPen(self.color)

--- a/pyqtgraph/opengl/items/GLTextItem.py
+++ b/pyqtgraph/opengl/items/GLTextItem.py
@@ -1,8 +1,8 @@
 from OpenGL.GL import *
 import numpy as np
-from pyqtgraph.Qt import QtCore, QtGui
-from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
-import pyqtgraph.functions as fn
+from ...Qt import QtCore, QtGui
+from .. GLGraphicsItem import GLGraphicsItem
+from ... import functions as fn
 
 __all__ = ['GLTextItem']
 

--- a/pyqtgraph/opengl/items/GLTextItem.py
+++ b/pyqtgraph/opengl/items/GLTextItem.py
@@ -39,7 +39,7 @@ class GLTextItem(GLGraphicsItem):
         args = ['pos', 'color', 'text', 'font']
         for k in kwds.keys():
             if k not in args:
-                raise ArgumentError('Invalid keyword argument: %s (allowed arguments are %s)' % (k, str(args)))
+                raise ValueError('Invalid keyword argument: %s (allowed arguments are %s)' % (k, str(args)))
         for arg in args:
             if arg in kwds:
                 value = kwds[arg]

--- a/pyqtgraph/widgets/RawImageWidget.py
+++ b/pyqtgraph/widgets/RawImageWidget.py
@@ -162,4 +162,4 @@ if HAVE_OPENGL:
             glTexCoord2f(0, 0)
             glVertex3f(-1, 1, 0)
             glEnd()
-            glDisable(GL_TEXTURE_3D)
+            glDisable(GL_TEXTURE_2D)


### PR DESCRIPTION
tries to cleanup various parts of GLViewWidget

UPDATE:
non-cosmetic changes:
* remove redefinitions of width(), height(), devicePixelRatio()
* trivially implement readQImage() with grabFrameBuffer()
* fail upfront if not at least OpenGL (non-ES) 2.0
* fix setCameraPosition euler mode
* fix renderToArray() on hidpi systems
* change renderToArray() to output non-transposed images (this could be considered an API change)