### PR TITLE
None-check AxisItem.label before access

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -233,6 +233,10 @@ class AxisItem(GraphicsWidget):
 
         ## Set the position of the label
         nudge = 5
+        if self.label is None: # self.label is set to None on close, but resize events can still occur.
+            self.picture = None
+            return
+            
         br = self.label.boundingRect()
         p = QtCore.QPointF(0, 0)
         if self.orientation == 'left':


### PR DESCRIPTION
I was clicking things while the tests were running, and I managed to cause the error messages included below. These were printed by the test suite after all tests had been declared "pass".

They both seem to originate from `AxisItem`'s `resizeEvent()` getting called after `self.label` has already been set to `None` by the `close()` method. I am not aware of another reason that would change `self.label` to be None.

This mini PR adds a None check, so that tear down can still proceed cleanly even if resize events are generated. 

```
========================== 265 passed, 7 skipped in 280.11s (0:04:40) ===========================      
Traceback (most recent call last):
  File "C:\e\prog\pg_dev\pyqtgraph\pyqtgraph\graphicsItems\AxisItem.py", line 236, in resizeEvent      
    br = self.label.boundingRect()
AttributeError: 'NoneType' object has no attribute 'boundingRect'
Traceback (most recent call last):
  File "C:\e\prog\pg_dev\pyqtgraph\pyqtgraph\graphicsItems\AxisItem.py", line 236, in resizeEvent      
    br = self.label.boundingRect()
AttributeError: 'NoneType' object has no attribute 'boundingRect'
```