### PR TITLE
Remove the use of pyqtgraph.ptime

### DIFF
--- a/examples/ImageItem.py
+++ b/examples/ImageItem.py
@@ -34,14 +34,14 @@ data = np.random.normal(size=(15, 600, 600), loc=1024, scale=64).astype(np.uint1
 i = 0
 
 updateTime = perf_counter()
-fps = 0
+elapsed = 0
 
 timer = QtCore.QTimer()
 timer.setSingleShot(True)
 # not using QTimer.singleShot() because of persistence on PyQt. see PR #1605
 
 def updateData():
-    global img, data, i, updateTime, fps
+    global img, data, i, updateTime, elapsed
 
     ## Display the data
     img.setImage(data[i])
@@ -49,11 +49,11 @@ def updateData():
 
     timer.start(1)
     now = perf_counter()
-    fps2 = 1.0 / (now-updateTime)
+    elapsed_now = now - updateTime
     updateTime = now
-    fps = fps * 0.9 + fps2 * 0.1
-    
-    #print "%0.1f fps" % fps
+    elapsed = elapsed * 0.9 + elapsed_now * 0.1
+
+    # print(f"{1 / elapsed:.1f} fps")
     
 timer.timeout.connect(updateData)
 updateData()

--- a/examples/ImageItem.py
+++ b/examples/ImageItem.py
@@ -9,7 +9,7 @@ import initExample
 from pyqtgraph.Qt import QtCore, QtGui
 import numpy as np
 import pyqtgraph as pg
-import pyqtgraph.ptime as ptime
+from time import perf_counter
 
 app = pg.mkQApp("ImageItem Example")
 
@@ -33,7 +33,7 @@ view.setRange(QtCore.QRectF(0, 0, 600, 600))
 data = np.random.normal(size=(15, 600, 600), loc=1024, scale=64).astype(np.uint16)
 i = 0
 
-updateTime = ptime.time()
+updateTime = perf_counter()
 fps = 0
 
 timer = QtCore.QTimer()
@@ -48,7 +48,7 @@ def updateData():
     i = (i+1) % data.shape[0]
 
     timer.start(1)
-    now = ptime.time()
+    now = perf_counter()
     fps2 = 1.0 / (now-updateTime)
     updateTime = now
     fps = fps * 0.9 + fps2 * 0.1

--- a/examples/MultiPlotSpeedTest.py
+++ b/examples/MultiPlotSpeedTest.py
@@ -11,7 +11,8 @@ import initExample
 from pyqtgraph.Qt import QtGui, QtCore
 import numpy as np
 import pyqtgraph as pg
-from pyqtgraph.ptime import time
+
+from time import perf_counter
 # pg.setConfigOptions(useOpenGL=True)
 app = pg.mkQApp("MultiPlot Speed Test")
 
@@ -38,7 +39,7 @@ plot.addItem(rgn)
 
 data = np.random.normal(size=(nPlots*23,nSamples))
 ptr = 0
-lastTime = time()
+lastTime = perf_counter()
 fps = None
 count = 0
 def update():
@@ -49,7 +50,7 @@ def update():
         curves[i].setData(data[(ptr+i)%data.shape[0]])
 
     ptr += nPlots
-    now = time()
+    now = perf_counter()
     dt = now - lastTime
     lastTime = now
     if fps is None:

--- a/examples/PColorMeshItem.py
+++ b/examples/PColorMeshItem.py
@@ -9,7 +9,6 @@ import initExample
 from pyqtgraph.Qt import QtCore, QtGui
 import numpy as np
 import pyqtgraph as pg
-import pyqtgraph.ptime as ptime
 
 app = pg.mkQApp("PColorMesh Example")
 

--- a/examples/PColorMeshItem.py
+++ b/examples/PColorMeshItem.py
@@ -6,7 +6,7 @@ Demonstrates very basic use of PColorMeshItem
 ## Add path to library (just for examples; you do not need this)
 import initExample
 
-from pyqtgraph.Qt import QtCore, QtGui
+from pyqtgraph.Qt import QtCore
 import numpy as np
 import pyqtgraph as pg
 

--- a/examples/PlotSpeedTest.py
+++ b/examples/PlotSpeedTest.py
@@ -3,13 +3,15 @@
 """
 Update a simple plot as rapidly as possible to measure speed.
 """
-import initExample
+
 ## Add path to library (just for examples; you do not need this)
-from time import perf_counter
+import initExample
+
 from collections import deque
 from pyqtgraph.Qt import QtGui, QtCore
 import numpy as np
 import pyqtgraph as pg
+from time import perf_counter
 
 app = pg.mkQApp("Plot Speed Test")
 

--- a/examples/RemoteSpeedTest.py
+++ b/examples/RemoteSpeedTest.py
@@ -16,6 +16,7 @@ from pyqtgraph.Qt import QtGui, QtCore
 import pyqtgraph as pg
 import pyqtgraph.widgets.RemoteGraphicsView
 import numpy as np
+from time import perf_counter
 
 app = pg.mkQApp()
 
@@ -45,7 +46,7 @@ rplt = view.pg.PlotItem()
 rplt._setProxyOptions(deferGetattr=True)  ## speeds up access to rplt.plot
 view.setCentralItem(rplt)
 
-lastUpdate = pg.ptime.time()
+lastUpdate = perf_counter()
 avgFps = 0.0
 
 def update():
@@ -62,7 +63,7 @@ def update():
     if lcheck.isChecked():
         lplt.plot(data, clear=True)
         
-    now = pg.ptime.time()
+    now = perf_counter()
     fps = 1.0 / (now - lastUpdate)
     lastUpdate = now
     avgFps = avgFps * 0.8 + fps * 0.2

--- a/examples/ScatterPlotSpeedTest.py
+++ b/examples/ScatterPlotSpeedTest.py
@@ -12,9 +12,9 @@ import initExample
 import numpy as np
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtGui, QtCore, QtWidgets
-from pyqtgraph.ptime import time
 import pyqtgraph.parametertree as ptree
 import pyqtgraph.graphicsItems.ScatterPlotItem
+from time import perf_counter
 
 translate = QtCore.QCoreApplication.translate
 
@@ -43,7 +43,7 @@ data = {}
 item = pg.ScatterPlotItem()
 hoverBrush = pg.mkBrush('y')
 ptr = 0
-lastTime = time()
+lastTime = perf_counter()
 fps = None
 timer = QtCore.QTimer()
 
@@ -104,7 +104,7 @@ def update():
         new.setBrush(hoverBrush)
 
     ptr += 1
-    now = time()
+    now = perf_counter()
     dt = now - lastTime
     lastTime = now
     if fps is None:

--- a/examples/VideoSpeedTest.py
+++ b/examples/VideoSpeedTest.py
@@ -15,8 +15,9 @@ import sys
 import numpy as np
 
 import pyqtgraph as pg
-import pyqtgraph.ptime as ptime
 from pyqtgraph.Qt import QtGui, QtCore, QT_LIB
+from time import perf_counter
+
 
 pg.setConfigOption('imageAxisOrder', 'row-major')
 
@@ -247,7 +248,7 @@ ui.numbaCheck.toggled.connect(noticeNumbaCheck)
 
 
 ptr = 0
-lastTime = ptime.time()
+lastTime = perf_counter()
 fps = None
 def update():
     global ui, ptr, lastTime, fps, LUT, img
@@ -281,7 +282,7 @@ def update():
         #img.setImage(data[ptr%data.shape[0]], autoRange=False)
 
     ptr += 1
-    now = ptime.time()
+    now = perf_counter()
     dt = now - lastTime
     lastTime = now
     if fps is None:

--- a/examples/infiniteline_performance.py
+++ b/examples/infiniteline_performance.py
@@ -4,7 +4,8 @@ import initExample ## Add path to library (just for examples; you do not need th
 from pyqtgraph.Qt import QtGui, QtCore
 import numpy as np
 import pyqtgraph as pg
-from pyqtgraph.ptime import time
+from time import perf_counter
+
 app = pg.mkQApp("Infinite Line Performance")
 
 p = pg.plot()
@@ -20,7 +21,7 @@ for i in range(100):
 
 data = np.random.normal(size=(50, 5000))
 ptr = 0
-lastTime = time()
+lastTime = perf_counter()
 fps = None
 
 
@@ -28,7 +29,7 @@ def update():
     global curve, data, ptr, p, lastTime, fps
     curve.setData(data[ptr % 10])
     ptr += 1
-    now = time()
+    now = perf_counter()
     dt = now - lastTime
     lastTime = now
     if fps is None:

--- a/examples/multiplePlotSpeedTest.py
+++ b/examples/multiplePlotSpeedTest.py
@@ -4,6 +4,7 @@ import initExample ## Add path to library (just for examples; you do not need th
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
 import numpy as np
+from time import perf_counter
 
 app = pg.mkQApp()
 plt = pg.PlotWidget()
@@ -18,7 +19,7 @@ plt.show()
 plt.enableAutoRange(False, False)
 
 def plot():
-    start = pg.ptime.time()
+    start = perf_counter()
     n = 15
     pts = 100
     x = np.linspace(0, 0.8, pts)
@@ -38,7 +39,7 @@ def plot():
             #item.setPen(pg.mkPen('w'))
             #plt.addItem(item)
             
-    dt = pg.ptime.time() - start
+    dt = perf_counter() - start
     print("Create plots took: %0.3fms" % (dt*1000))
 
 ## Plot and clear 5 times, printing the time it took
@@ -55,7 +56,7 @@ for i in range(5):
 def fastPlot():
     ## Different approach:  generate a single item with all data points.
     ## This runs about 20x faster.
-    start = pg.ptime.time()
+    start = perf_counter()
     n = 15
     pts = 100
     x = np.linspace(0, 0.8, pts)
@@ -71,7 +72,7 @@ def fastPlot():
     item.setPen(pg.mkPen('w'))
     plt.addItem(item)
     
-    dt = pg.ptime.time() - start
+    dt = perf_counter() - start
     print("Create plots took: %0.3fms" % (dt*1000))
 
 

--- a/examples/multiplePlotSpeedTest.py
+++ b/examples/multiplePlotSpeedTest.py
@@ -40,7 +40,7 @@ def plot():
             #plt.addItem(item)
             
     dt = perf_counter() - start
-    print("Create plots took: %0.3fms" % (dt*1000))
+    print(f"Create plots tooks {dt * 1000:.3f} ms")
 
 ## Plot and clear 5 times, printing the time it took
 for i in range(5):

--- a/examples/relativity/relativity.py
+++ b/examples/relativity/relativity.py
@@ -8,6 +8,8 @@ from pyqtgraph.parametertree import types as pTypes
 import pyqtgraph.configfile
 from pyqtgraph.python2_3 import xrange
 
+from time import perf_counter
+
 
 class RelativityGUI(QtGui.QWidget):
     def __init__(self):
@@ -130,13 +132,13 @@ class RelativityGUI(QtGui.QWidget):
 
     def setAnimation(self, a):
         if a:
-            self.lastAnimTime = pg.ptime.time()
+            self.lastAnimTime = perf_counter()
             self.animTimer.start(int(self.animDt*1000))
         else:
             self.animTimer.stop()
             
     def stepAnimation(self):
-        now = pg.ptime.time()
+        now = perf_counter()
         dt = (now-self.lastAnimTime) * self.params['Animation Speed']
         self.lastAnimTime = now
         self.animTime += dt

--- a/examples/scrollingPlots.py
+++ b/examples/scrollingPlots.py
@@ -7,6 +7,7 @@ import initExample ## Add path to library (just for examples; you do not need th
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
 import numpy as np
+from time import perf_counter
 
 win = pg.GraphicsLayoutWidget(show=True)
 win.setWindowTitle('pyqtgraph example: Scrolling Plots')
@@ -67,7 +68,7 @@ def update2():
 chunkSize = 100
 # Remove chunks after we have 10
 maxChunks = 10
-startTime = pg.ptime.time()
+startTime = perf_counter()
 win.nextRow()
 p5 = win.addPlot(colspan=2)
 p5.setLabel('bottom', 'Time', 's')
@@ -78,7 +79,7 @@ ptr5 = 0
 
 def update3():
     global p5, data5, ptr5, curves
-    now = pg.ptime.time()
+    now = perf_counter()
     for c in curves:
         c.setPos(-(now-startTime), 0)
     

--- a/examples/verlet_chain/chain.py
+++ b/examples/verlet_chain/chain.py
@@ -67,7 +67,7 @@ class ChainSim(pg.QtCore.QObject):
     def update(self):
         # approximate physics with verlet integration
         
-        now = pg.ptime.time()
+        now = time.perf_counter()
         if self.lasttime is None:
             dt = 0
         else:

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -1,17 +1,16 @@
 # -*- coding: utf-8 -*-
-import time
 import weakref
 import warnings
+from time import perf_counter, perf_counter_ns
 
 from ..Qt import QtCore, QtGui, QT_LIB, isQObjectAlive
 from ..Point import Point
 from .. import functions as fn
-from .. import ptime as ptime
 from .mouseEvents import *
 from .. import debug as debug
 from .. import getConfigOption
 
-getMillis = lambda: int(round(time.time() * 1000))
+getMillis = lambda: perf_counter_ns() // 10 ** 6
 
 
 if QT_LIB.startswith('PyQt'):
@@ -198,7 +197,7 @@ class GraphicsScene(QtGui.QGraphicsScene):
                 # button is pressed' send mouseMoveEvents and mouseDragEvents
                 super().mouseMoveEvent(ev)
                 if self.mouseGrabberItem() is None:
-                    now = ptime.time()
+                    now = perf_counter()
                     init = False
                     ## keep track of which buttons are involved in dragging
                     for btn in [QtCore.Qt.MouseButton.LeftButton, QtCore.Qt.MouseButton.MiddleButton, QtCore.Qt.MouseButton.RightButton]:

--- a/pyqtgraph/GraphicsScene/mouseEvents.py
+++ b/pyqtgraph/GraphicsScene/mouseEvents.py
@@ -1,7 +1,7 @@
+from time import perf_counter
 from ..Point import Point
 from ..Qt import QtCore, QtGui
 import weakref
-from .. import ptime as ptime
 
 class MouseDragEvent(object):
     """
@@ -164,7 +164,7 @@ class MouseClickEvent(object):
         self._button = pressEvent.button()
         self._buttons = pressEvent.buttons()
         self._modifiers = pressEvent.modifiers()
-        self._time = ptime.time()
+        self._time = perf_counter()
         self.acceptedItem = None
         
     def accept(self):

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -207,7 +207,6 @@ elif QT_LIB == PYSIDE2:
     isQObjectAlive = shiboken2.isValid
     import PySide2
     VERSION_INFO = 'PySide2 ' + PySide2.__version__ + ' Qt ' + QtCore.__version__
-
 elif QT_LIB == PYSIDE6:
     import PySide6.QtCore, PySide6.QtGui, PySide6.QtWidgets
     _copy_attrs(PySide6.QtCore, QtCore)

--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+from time import perf_counter
 import weakref
 
 from .Qt import QtCore
-from .ptime import time
 from . import ThreadsafeTimer
 from .functions import SignalBlock
 
@@ -60,7 +60,7 @@ class SignalProxy(QtCore.QObject):
             self.timer.stop()
             self.timer.start(int(self.delay * 1000) + 1)
         else:
-            now = time()
+            now = perf_counter()
             if self.lastFlushTime is None:
                 leakTime = 0
             else:
@@ -76,7 +76,7 @@ class SignalProxy(QtCore.QObject):
             return False
         args, self.args = self.args, None
         self.timer.stop()
-        self.lastFlushTime = time()
+        self.lastFlushTime = perf_counter()
         self.sigDelayed.emit(args)
         return True
 

--- a/pyqtgraph/debug.py
+++ b/pyqtgraph/debug.py
@@ -10,7 +10,7 @@ from __future__ import print_function
 
 import sys, traceback, time, gc, re, types, weakref, inspect, os, cProfile, threading
 import warnings
-from . import ptime
+from time import perf_counter
 from numpy import ndarray
 from .Qt import QtCore, QT_LIB
 from .util import cprint
@@ -529,7 +529,7 @@ class Profiler(object):
         obj._delayed = delayed
         obj._markCount = 0
         obj._finished = False
-        obj._firstTime = obj._lastTime = ptime.time()
+        obj._firstTime = obj._lastTime = perf_counter()
         obj._newMsg("> Entering " + obj._name)
         return obj
 
@@ -541,7 +541,7 @@ class Profiler(object):
         if msg is None:
             msg = str(self._markCount)
         self._markCount += 1
-        newTime = ptime.time()
+        newTime = perf_counter()
         self._newMsg("  %s: %0.4f ms", 
                      msg, (newTime - self._lastTime) * 1000)
         self._lastTime = newTime
@@ -569,7 +569,7 @@ class Profiler(object):
         if msg is not None:
             self(msg)
         self._newMsg("< Exiting %s, total time: %0.4f ms", 
-                     self._name, (ptime.time() - self._firstTime) * 1000)
+                     self._name, (perf_counter() - self._firstTime) * 1000)
         type(self)._depth -= 1
         if self._depth < 1:
             self.flush()

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -15,6 +15,7 @@ Widget used for displaying 2D or 3D data. Features:
 import os
 from math import log10
 import numpy as np
+from time import perf_counter
 
 from ..Qt import QtCore, QtGui, QT_LIB
 from .. import functions as fn
@@ -29,7 +30,6 @@ from ..graphicsItems.InfiniteLine import *
 from ..graphicsItems.ViewBox import *
 from ..graphicsItems.VTickGroup import VTickGroup
 from ..graphicsItems.GradientEditorItem import addGradientListToDocstring
-from .. import ptime as ptime
 from .. import debug as debug
 from ..SignalProxy import SignalProxy
 from .. import getConfigOption
@@ -390,7 +390,7 @@ class ImageView(QtGui.QWidget):
             self.playTimer.stop()
             return
             
-        self.lastPlayTime = ptime.time()
+        self.lastPlayTime = perf_counter()
         if not self.playTimer.isActive():
             self.playTimer.start(16)
             
@@ -483,12 +483,12 @@ class ImageView(QtGui.QWidget):
             if key == QtCore.Qt.Key.Key_Right:
                 self.play(20)
                 self.jumpFrames(1)
-                self.lastPlayTime = ptime.time() + 0.2  ## 2ms wait before start
+                self.lastPlayTime = perf_counter() + 0.2  ## 2ms wait before start
                                                         ## This happens *after* jumpFrames, since it might take longer than 2ms
             elif key == QtCore.Qt.Key.Key_Left:
                 self.play(-20)
                 self.jumpFrames(-1)
-                self.lastPlayTime = ptime.time() + 0.2
+                self.lastPlayTime = perf_counter() + 0.2
             elif key == QtCore.Qt.Key.Key_Up:
                 self.play(-100)
             elif key == QtCore.Qt.Key.Key_Down:
@@ -501,7 +501,7 @@ class ImageView(QtGui.QWidget):
             self.play(0)
         
     def timeout(self):
-        now = ptime.time()
+        now = perf_counter()
         dt = now - self.lastPlayTime
         if dt < 0:
             return

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -483,8 +483,8 @@ class ImageView(QtGui.QWidget):
             if key == QtCore.Qt.Key.Key_Right:
                 self.play(20)
                 self.jumpFrames(1)
-                self.lastPlayTime = perf_counter() + 0.2  ## 2ms wait before start
-                                                        ## This happens *after* jumpFrames, since it might take longer than 2ms
+                # effectively pause playback for 0.2 s
+                self.lastPlayTime = perf_counter() + 0.2  
             elif key == QtCore.Qt.Key.Key_Left:
                 self.play(-20)
                 self.jumpFrames(-1)

--- a/pyqtgraph/ptime.py
+++ b/pyqtgraph/ptime.py
@@ -7,6 +7,7 @@ Distributed under MIT/X11 license. See license.txt for more information.
 
 
 import sys
+import warnings
 
 if sys.version_info[0] < 3:
     from time import clock
@@ -20,11 +21,20 @@ time = None
 
 def winTime():
     """Return the current time in seconds with high precision (windows version, use Manager.time() to stay platform independent)."""
+    warnings.warn(
+        "'pg.time' will be removed from the library in the first release following January, 2022.  Use time.perf_counter instead",
+        DeprecationWarning, stacklevel=2
+    )
     return clock() + START_TIME
 
 def unixTime():
     """Return the current time in seconds with high precision (unix version, use Manager.time() to stay platform independent)."""
+    warnings.warn(
+        "'pg.time' will be removed from the library in the first release following January, 2022.  Use time.perf_counter instead",
+        DeprecationWarning, stacklevel=2
+    )
     return system_time()
+
 
 if sys.platform.startswith('win'):
     cstart = clock()  ### Required to start the clock in windows

--- a/pyqtgraph/widgets/ProgressDialog.py
+++ b/pyqtgraph/widgets/ProgressDialog.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
+from time import perf_counter
 from ..Qt import QtGui, QtCore
-from .. import ptime
 
 __all__ = ['ProgressDialog']
 
@@ -207,7 +207,7 @@ class ProgressDialog(QtGui.QProgressDialog):
         # Qt docs say this should happen automatically, but that doesn't seem
         # to be the case.
         if self.windowModality() == QtCore.Qt.WindowModality.WindowModal:
-            now = ptime.time()
+            now = perf_counter()
             if self._lastProcessEvents is None or (now - self._lastProcessEvents) > 0.2:
                 QtGui.QApplication.processEvents()
                 self._lastProcessEvents = now

--- a/pyqtgraph/widgets/ValueLabel.py
+++ b/pyqtgraph/widgets/ValueLabel.py
@@ -1,5 +1,5 @@
+from time import perf_counter
 from ..Qt import QtCore, QtGui
-from ..ptime import time
 from .. import functions as fn
 
 __all__ = ['ValueLabel']
@@ -38,7 +38,7 @@ class ValueLabel(QtGui.QLabel):
         self.formatStr = formatStr
     
     def setValue(self, value):
-        now = time()
+        now = perf_counter()
         self.values.append((now, value))
         cutoff = now - self.averageTime
         while len(self.values) > 0 and self.values[0][0] < cutoff:


### PR DESCRIPTION
With us supporting python3.7+, we have no more need for the ptime module
and can instead safely use perf_counter for everything.