### PR TITLE
Factor out palette-related code from "named colors" PR

### DIFF
--- a/examples/paletteDisplay.py
+++ b/examples/paletteDisplay.py
@@ -1,0 +1,467 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+Adjust color palettes and apply them to a running plot
+"""
+
+## Add path to library (just for examples; you do not need this)
+import initExample
+
+import numpy as np
+
+from pyqtgraph.Qt import mkQApp, QtCore, QtGui, QtWidgets
+from pyqtgraph.ptime import time
+import pyqtgraph as pg
+
+class MainWindow(QtWidgets.QMainWindow):
+    """ example application main window """
+    def __init__(self, *args, **kwargs):
+        super(MainWindow, self).__init__(*args, **kwargs)
+        palette = pg.Palette('relaxed')
+        print('setting xxx')
+        qcol = QtGui.QColor('#0x0')
+        print(qcol.name(), qcol.isValid())
+        # qcol = pg.mkColor(np.inf)
+        # print(qcol.name() )
+        qcol = pg.mkColor(True)
+        print(qcol.name() )
+        
+        # palette.mkColor(255, 255, 255, 255)
+        # palette.mkColor(255, 200, 150)
+        # palette.mkColor( ( (255, 200, 150), 0.5 ) )
+
+        
+        quit()
+        pg.setConfigOption('imageAxisOrder', 'row-major')
+        
+        force_dark = False # start in forced dark mode?
+        self.setWindowTitle('pyqtgraph example: Palette editor')
+        self.resize(1024,768)
+
+        self.palette_options = (
+            ('system (reapply to update)', 'system', []),
+            ('legacy', 'legacy', []),
+            ('relaxed (dark)' , 'relaxed_dark',  []),
+            ('relaxed (light)', 'relaxed_light', []),
+            ('pastels (light)', 'pastels', []),
+            ('mono green', 'monochrome', ['green']),
+            ('mono amber', 'monochrome', ['amber']),
+            ('mono blue' , 'monochrome', ['blue' ]),
+            ('synthwave' , 'synthwave', []),
+        )
+
+        self.colormap_options = (
+            'CET-C1', 'CET-C2','CET-C6','CET-C7', 'CET-R2', 'CET-R4',
+            'CET-L8', 'CET-L16', 'CET-CBC1', 'CET-CBC2', 'none'
+        )
+
+        app = QtWidgets.QApplication.instance()
+        self.q_palette = {
+            'system' : app.palette(),
+            'dark'   : self.make_dark_QPalette()
+        }
+        app.setStyle("Fusion")
+        
+        self.ui = self.prepare_ui() # relocate long-winded window layout
+        # dictionary self.ui contains references to UI elements
+
+        if force_dark:
+            self.ui['dark'].setChecked(True)
+            self.handle_dark_button(True)
+        
+        self.open_palette = pg.palette.Palette('system')
+        self.open_palette.apply()
+        self.update_color_fields( self.open_palette )
+
+        self.num_points = 30        
+        # configure overview plot with four colors:
+        plt = self.ui['plot1']
+        plt.enableAutoRange(False)
+        plt.setYRange( 0, 4, padding=0 )
+        plt.setXRange( 0, self.num_points, padding=0 ) 
+        for key in ('left','right','top','bottom'):
+            ax = plt.getAxis(key)
+            ax.show()
+            ax.setZValue(0.1)
+
+        self.curves = []
+        curve = pg.PlotCurveItem(pen='p0', brush=('p0',127))
+        curve.setFillLevel(0)
+        self.curves.append( (1, 1, curve) ) # dataset 1, vertical offset 3        
+        plt.addItem(curve)
+        curve = pg.ScatterPlotItem(
+            symbol='o', size=5, pen='p0', brush=('p0',127),
+            hoverable=True, hoverPen='gr_acc', hoverBrush='p0')
+        self.curves.append( (1, 1, curve) ) # dataset 1, vertical offset 2
+        plt.addItem(curve)
+
+        pen_list = ['p2', 'p4', 'p6'] # add three more plots
+        for idx, pen in enumerate( pen_list ):
+            curve = pg.PlotCurveItem()
+            curve.setPen(pen, width=5)
+            self.curves.append( (3+2*idx, 1.5+0.8*idx, curve) ) # datasets 2+, vertical offset 3+
+            plt.addItem(curve)
+
+        # configure tall plot with eight colors and region overlay:
+        plt = self.ui['plot2']
+        plt.enableAutoRange(False)
+        plt.setYRange( -0.6, 8.6, padding=0 )
+        plt.setXRange( 0, self.num_points, padding=0 )
+        plt.getAxis('bottom').hide()
+        plt.getAxis('left').setLabel('plot color')
+        plt.getAxis('left').setGrid(0.5) # 63)
+
+        pen_list = [('p0',2),('p1',2),('p2',2),('p3',2),('p4',2),('p5',2),('p6',2),('p7',2),('p8',2)] # add right-side plots for each main color
+        for idx, pen in enumerate( pen_list ):
+            curve = pg.PlotCurveItem(pen=pen)
+            self.curves.append( (1+idx, idx, curve) ) # datasets 2+, vertical offset by index
+            plt.addItem(curve)
+        item = pg.LinearRegionItem( values=(4, 8), orientation='vertical' )
+        plt.addItem(item)
+        
+        # show off some color text:
+        col_list = [
+            ('k','black'),('b','blue'),('c','cyan'),('g','green'),('y','yellow'),
+            ('r','red'),('m','magenta'),('w','white')]
+        for idx in range(9):
+            name = 'm{:d}'.format(idx)
+            col_list.append( (name, '## '+name+' ##') )
+
+        for idx, (color,text) in enumerate( col_list ):
+            text_item = pg.TextItem(text, color=color, anchor=(1,0))
+            text_item.setPos( self.num_points, 7.7 - idx/3 ) 
+            plt.addItem(text_item)       
+
+        self.show()
+
+        # prepare for continuous updates and frame rate measurement
+        self.last_time = time()
+        self.fps = None
+        self.timer = QtCore.QTimer(singleShot=False)
+        self.timer.timeout.connect( self.timed_update )
+
+        # prepare initial data and display in plots
+        self.data = np.zeros((10, self.num_points ))
+        self.data[0,:] = np.arange( self.data.shape[1] ) # used as x data
+        self.phases = np.zeros(10)
+        self.timed_update()
+
+    ### handle GUI interaction ###############################################
+    def update_color_fields(self, pal):
+        """ update line edit fields for selected palette """
+        if pal is None:
+            print('palette is None!')
+            return
+        for key in self.ui['widget_from_color_key']:
+            wid = self.ui['widget_from_color_key'][key]
+            qcol = pal[key]
+            if wid is not None:
+                wid.setText( qcol.name() )
+
+    def handle_palette_select(self, idx):
+        """ user selected a palette in dropdown menu """
+        text, identifier, args = self.palette_options[idx]
+        del text # not needed here
+        self.open_palette = pg.Palette(identifier, *args)
+        print('loaded palette:', identifier, args)
+        
+        self.ui['bar_p'].setColorMap(self.open_palette.map_p)
+        self.ui['bar_m'].setColorMap(self.open_palette.map_m)
+
+        if identifier in pg.palette.PALETTE_DEFINITIONS:
+            info = pg.palette.PALETTE_DEFINITIONS[identifier]
+            print(info)
+            map_p_info = info['map_p']
+            self.ui['map_p_info'].setText( str(map_p_info) )
+            map_m_info = info['map_m']
+            self.ui['map_m_info'].setText( str(map_m_info) )
+            if map_p_info is None:
+                identifier, start, step = 'none', 0.000, 0.125
+            else:
+                identifier, start, step = map_p_info
+            self.ui['sample_start'].setText('{:+.3f}'.format(start))
+            self.ui['sample_step' ].setText('{:+.3f}'.format(step) )
+            for idx, map_id in enumerate( self.colormap_options ):
+                if map_id == identifier:
+                    # print('found colormap at idx',idx)
+                    self.ui['colormaps'].setCurrentIndex(idx)
+        self.update_color_fields(self.open_palette)
+        self.open_palette.apply()
+        
+    def handle_colormap_select(self, param=None):
+        """ user selected a colormap in dropdown menu or changed start / step vales """
+        del param # drop index sent by QComboBox
+        identifier = self.ui['colormaps'].currentText()
+        if identifier == 'none':
+            return
+        start = self.ui['sample_start'].text()
+        step  = self.ui['sample_step' ].text()
+        try:
+            start = float(start)
+        except ValueError:
+            start = 0.0
+        self.ui['sample_start'].setText('{:+.3f}'.format(start) )
+        try:
+            step = float(step)
+        except ValueError:
+            step = 0.125
+        self.ui['sample_step'].setText('{:+.3f}'.format(step) )
+        self.open_palette.sampleColorMap( cmap=identifier, start=start, step=step )
+        # print('applied color map {:s} starting at {:.3f} with step {:3f}'.format(identifier, start, step) )
+        
+        self.update_color_fields(self.open_palette)
+        self.open_palette.apply()
+        
+    def handle_color_update(self):
+        """ figure out what color field was updated """
+        source = self.sender()
+        key = self.ui['color_key_from_widget'][source]
+        requested = source.text()
+        if len(requested) < 1:
+            value = 0x808080
+        else:
+            if requested[0] == '#': 
+                requested = requested[1:]
+            try:
+                value = int(requested,16)
+            except ValueError:
+                value = 0x808080
+        color = '#{:06x}'.format(value)
+        print('color value is',color)
+        # source.setText(color)
+        self.open_palette[key] = color
+        self.update_color_fields(self.open_palette)
+        self.open_palette.apply()
+        
+        print('color update requested for',key)
+
+    def handle_update_button(self, active):
+        """ start/stop timer """
+        if active:
+            self.timer.start(1)
+        else:
+            self.timer.stop()
+
+    def handle_dark_button(self, active):
+        """ manually switch to dark palette to test on windows """
+        app = QtWidgets.QApplication.instance()
+        if active:
+            app.setPalette( self.q_palette['dark'] ) # apply dark QPalette
+        else:
+            app.setPalette( self.q_palette['system'] ) # reapply QPalette stored at start-up
+
+    def timed_update(self):
+        """ update loop, called by timer """
+        size = self.phases.shape[0]
+        self.speed = np.linspace(0.01, 0.06, size) 
+        self.phases += self.speed * np.random.normal(1, 1, size=size)
+        for idx in range(1, self.data.shape[0]):
+            self.data[idx, :-1] = self.data[idx, 1:] # roll
+        self.data[1:, -1] = 0.5 * np.sin( self.phases[1:] )
+        xdata = self.data[0,:]
+        for idx, offset, curve in self.curves:
+            curve.setData( x=xdata, y=( offset + self.data[idx,:] ) )
+
+        now = time()
+        dt = now - self.last_time
+        self.last_time = now
+        if self.fps is None:
+            self.fps = 1.0/dt
+        else:
+            s = np.clip(dt*3., 0, 1)
+            self.fps = self.fps * (1-s) + (1.0/dt) * s
+        self.ui['plot2'].setTitle('%0.1f fps' % self.fps)
+        QtWidgets.QApplication.processEvents()  ## force complete redraw for every plot
+        
+
+    ### Qt color definitions for dark palette on Windows #####################
+    def make_dark_QPalette(self):
+        """ manually define a dark mode palette """
+        BLACK      = QtGui.QColor('#000000')
+        BG_LIGHT   = QtGui.QColor('#505354')
+        BG_NORMAL  = QtGui.QColor('#2e3132')
+        BG_DARK    = QtGui.QColor('#0e1112')
+        FG_LIGHT   = QtGui.QColor('#f0f4f5')
+        FG_NORMAL  = QtGui.QColor('#d4d8d9')
+        FG_DARK    = QtGui.QColor('#b8bcbd')
+        SEL_LIGHT  = QtGui.QColor('#148CD2')
+        SEL_NORMAL = QtGui.QColor('#1464A0')
+        SEL_DARK   = QtGui.QColor('#14506E')
+        qpal = QtGui.QPalette( QtGui.QColor(BG_DARK) )
+        for ptype in (  QtGui.QPalette.ColorGroup.Active,  QtGui.QPalette.ColorGroup.Inactive ):
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.Window, BG_NORMAL )
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.WindowText, FG_LIGHT ) # or white?
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.Base, BG_DARK )
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.Text, FG_LIGHT )
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.AlternateBase, BG_DARK )
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.ToolTipBase, BG_LIGHT )
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.ToolTipText, FG_LIGHT )
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.Button, BG_NORMAL )
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.ButtonText, FG_LIGHT )
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.Link, SEL_NORMAL )
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.LinkVisited, FG_NORMAL )
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.Highlight, SEL_LIGHT )
+            qpal.setColor( ptype, QtGui.QPalette.ColorRole.HighlightedText, BLACK )
+        qpal.setColor( QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Button, BG_NORMAL )
+        qpal.setColor( QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.ButtonText, FG_DARK )
+        qpal.setColor( QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.WindowText, FG_DARK )
+        return qpal
+        
+    ##########################################################################
+    def prepare_ui(self):
+        """ Boring Qt window layout code is implemented here """
+        ui = {}
+        main_wid = QtWidgets.QWidget()
+        self.setCentralWidget(main_wid)
+        
+        color_fields = (
+            # key, description, reference to line edit field)
+            ['gr_bg' , (0,0), 'graph background'   ],
+            ['gr_fg' , (1,0), 'graph foreground'   ],
+            ['gr_txt', (2,0), 'graph text'         ],
+            ['gr_reg', (3,0), 'graph region'       ], 
+            ['gr_acc', (4,0), 'graphical accent'   ], 
+            ['gr_hlt', (5,0), 'graphical highlight'],
+            ['p0', (0,1), ' plot 0'], ['p1', (1,1), ' plot 1'],
+            ['p2', (2,1), ' plot 2'], ['p3', (3,1), ' plot 3'],
+            ['p4', (4,1), ' plot 4'], ['p5', (5,1), ' plot 5'],
+            ['p6', (6,1), ' plot 6'], ['p7', (7,1), ' plot 7'],
+            ['p8', (8,1), ' plot 8']
+        )
+
+        gr_wid1 = pg.GraphicsLayoutWidget(show=True)
+        ui['plot1'] = gr_wid1.addPlot()
+
+        gr_wid2 = pg.GraphicsLayoutWidget(show=True)
+        ui['bar_p'] = pg.ColorBarItem(orientation='horizontal', width=16, interactive=False)
+        gr_wid2.addItem( ui['bar_p'] )
+        gr_wid2.nextRow()
+
+        ui['bar_m'] = pg.ColorBarItem(orientation='horizontal', width=16, interactive=False)
+        gr_wid2.addItem( ui['bar_m'] )
+        gr_wid2.nextRow()
+        
+        ui['plot2'] = gr_wid2.addPlot()
+
+        main_layout = QtWidgets.QHBoxLayout( main_wid )
+        l_wid = QtWidgets.QWidget()
+        main_layout.addWidget(l_wid)
+        main_layout.addWidget(gr_wid2)
+        
+        l_layout = QtWidgets.QGridLayout( l_wid )
+        l_layout.setContentsMargins(0,0,0,0)
+        l_layout.setSpacing(1)
+        row_idx = 0
+
+        label = QtWidgets.QLabel('Override system style:')
+        l_layout.addWidget( label, row_idx,0, 1,2 )
+
+        label = QtWidgets.QLabel('Select a palette:')
+        l_layout.addWidget( label, row_idx,2, 1,2 )
+        row_idx += 1
+
+        btn = QtWidgets.QPushButton('Apply dark GUI')
+        btn.setCheckable(True)
+        btn.setChecked(False)
+        btn.clicked.connect(self.handle_dark_button)
+
+        box = QtWidgets.QComboBox()
+        for text, identifier, args in self.palette_options:
+            del identifier, args # not needed here
+            box.addItem(text)
+        box.activated.connect(self.handle_palette_select)
+
+        l_layout.addWidget( box, row_idx,2, 1,2 )
+        l_layout.addWidget( btn, row_idx,0, 1,2 )
+        ui['dark'] = btn
+        row_idx += 1
+
+        label = QtWidgets.QLabel('Sampled color map:')
+        l_layout.addWidget( label, row_idx,0, 1,2 )
+        label = QtWidgets.QLabel('start')
+        l_layout.addWidget( label, row_idx,2, 1,1 )
+        label = QtWidgets.QLabel('step')
+        l_layout.addWidget( label, row_idx,3, 1,1 )
+        row_idx += 1
+        
+        box = QtWidgets.QComboBox()
+        for identifier in self.colormap_options:
+            box.addItem(identifier)
+        ui['colormaps'] = box
+        ui['colormaps'].activated.connect(self.handle_colormap_select)
+        l_layout.addWidget( box, row_idx,0, 1,2 )
+        row_idx += 1
+
+        label = QtWidgets.QLabel('Plot color sampling (start/step)')
+        ui['sample_start_p'] = QtWidgets.QLineEdit(' 0.000')
+        ui['sample_start_p'].editingFinished.connect(self.handle_colormap_select)
+        ui['sample_step_p' ] = QtWidgets.QLineEdit('+0.125')
+        ui['sample_step_p' ].editingFinished.connect(self.handle_colormap_select)
+        l_layout.addWidget( label, row_idx,0, 1,2 )
+        l_layout.addWidget( ui['sample_start_p'], row_idx,2, 1,1 )
+        l_layout.addWidget( ui['sample_step_p' ], row_idx,3, 1,1 )
+        row_idx += 1
+
+        label = QtWidgets.QLabel('Mono color sampling (start/step)')
+        ui['sample_start_m'] = QtWidgets.QLineEdit(' 0.000')
+        ui['sample_start_m'].editingFinished.connect(self.handle_colormap_select)
+        ui['sample_step_m' ] = QtWidgets.QLineEdit('+0.125')
+        ui['sample_step_m' ].editingFinished.connect(self.handle_colormap_select)
+        l_layout.addWidget( label, row_idx,0, 1,2 )
+        l_layout.addWidget( ui['sample_start_m'], row_idx,2, 1,1 )
+        l_layout.addWidget( ui['sample_step_m' ], row_idx,3, 1,1 )
+        row_idx += 1
+
+        spacer = QtWidgets.QWidget()
+        spacer.setFixedHeight(10)
+        l_layout.addWidget( spacer, row_idx,0, 1,2 )
+        row_idx += 1
+
+        label = QtWidgets.QLabel('Functional colors:')
+        l_layout.addWidget( label, row_idx,0, 1,2 )
+        row_idx += 1
+
+        row =  0
+        ui['widget_from_color_key'] = {} # look-up for color editing fields
+        ui['color_key_from_widget'] = {} # reverse look-up for color editing fields
+        for field_list in color_fields:
+            key, pos, text = field_list
+            lab  = QtWidgets.QLabel(text)
+            lab.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+            edt = QtWidgets.QLineEdit()
+            edt.editingFinished.connect(self.handle_color_update)
+            row = row_idx + pos[0]
+            col = 2 * pos[1]  # 0 or 2
+            l_layout.addWidget( lab, row,col+0, 1,1 )
+            l_layout.addWidget( edt, row,col+1, 1,1 )
+            ui['color_key_from_widget'][edt] = key
+            ui['widget_from_color_key'][key] = edt
+        row_idx = row
+            
+        btn = QtWidgets.QPushButton('generate continuous data')
+        btn.setCheckable(True)
+        btn.setChecked(False)
+        btn.clicked.connect(self.handle_update_button)
+        l_layout.addWidget( btn, row_idx,0, 1,2 )
+        row_idx += 1
+
+        spacer = QtWidgets.QWidget()
+        spacer.setFixedHeight(10)
+        l_layout.addWidget( spacer, row_idx,0, 1,2 )
+        row_idx += 1
+
+        label = QtWidgets.QLabel('Overview:')
+        l_layout.addWidget( label, row_idx,0, 1,4 )
+        row_idx += 1
+        
+        l_layout.addWidget( gr_wid1, row_idx,0, 1,4 )
+        row_idx += 1
+
+        return ui
+
+mkQApp("Palette editor")
+main_window = MainWindow()
+
+## Start Qt event loop
+if __name__ == '__main__':
+    pg.exec()

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -273,6 +273,8 @@ from .SRTTransform import SRTTransform
 from .Transform3D import Transform3D
 from .SRTTransform3D import SRTTransform3D
 from .functions import *
+from .palette import *
+from .styleRegistry import *
 from .graphicsWindows import *
 from .SignalProxy import *
 from .colormap import *

--- a/pyqtgraph/palette.py
+++ b/pyqtgraph/palette.py
@@ -1,0 +1,519 @@
+from . import Qt
+from .Qt import QtCore, QtGui, QtWidgets
+
+import numpy as np
+
+import warnings
+
+# from . import functions as fn # namedColorManager
+from . import colormap
+
+__all__ = ['Palette']
+
+LEGACY_COLORS = {
+    'b': QtGui.QColor(  0,  0,255,255),
+    'g': QtGui.QColor(  0,255,  0,255),
+    'r': QtGui.QColor(255,  0,  0,255),
+    'c': QtGui.QColor(  0,255,255,255),
+    'm': QtGui.QColor(255,  0,255,255),
+    'y': QtGui.QColor(255,255,  0,255),
+    'k': QtGui.QColor(  0,  0,  0,255),
+    'w': QtGui.QColor(255,255,255,255),
+    's': QtGui.QColor(100,100,150,255),
+    'gr_acc':QtGui.QColor(200,200,100,255), # graphical accent color: pastel yellow
+    'gr_reg':QtGui.QColor(  0,  0,255, 50)  # graphical region marker: translucent blue
+}
+
+PALETTE_DEFINITIONS = {
+    'legacy': {
+        'plotColorMap': {'hslCycle': {'hue':0.0}, 'sampleStep': 1/9 },
+        'monoColorMap': {'mono':'neutral', 'sampleStep': 1/(9-1) },
+        # --- monochrome ramp ---
+        # 'm0':'#000000', 'm1':'#1e1e1e',
+        # 'm2':'#353535', 'm3':'#4e4e4e',
+        # 'm4':'#696969', 'm5':'#858585',
+        # 'm6':'#a2a2a2', 'm7':'#c0c0c0',
+        # 'm8':'#dfdfdf', 'm9':'#ffffff',
+        # --- legacy colors ---
+        'b': (  0,  0,255,255), 'g': (  0,255,  0,255), 'r': (255,  0,  0,255), 
+        'c': (  0,255,255,255), 'm': (255,  0,255,255), 'y': (255,255,  0,255),
+        'k': (  0,  0,  0,255), 'w': (255,255,255,255),
+        'd': (150,150,150,255), 'l': (200,200,200,255), 's': (100,100,150,255),
+        # --- manually assigned plot colors ---
+        # 'p0':'l', 'p1':'y', 'p2':'r', 'p3':'m',
+        # 'p4':'b', 'p5':'c', 'p6':'g', 'p7':'d',
+        # --- functional colors ---
+        'gr_fg' : 'd', 'gr_bg' : 'k',
+        'gr_txt': 'd', 'gr_acc': (200,200,100,255),
+        'gr_hlt': 'r', 'gr_reg': (  0,  0,255,100)
+    },
+    'relaxed': {
+        'plotColorMap': {'get':'PAL-relaxed_bright', 'sampleStep':1/9 },
+        'monoColorMap': {'mono':'warm', 'sampleStep':1/(9-1) },
+        # 'colormap_sampling': ('CET-C6', 0.450, -0.125),
+        # 'colormap_sampling': ('PAL-relaxed_bright', 0.0, 1.0/9),
+        # --- extra warm (CIElab A=3 B=3) monochrome ramp ---
+        # 'm0':'#1a120e', 'm1':'#2e2624',
+        # 'm2':'#443c39', 'm3':'#5c5350',
+        # 'm4':'#746b68', 'm5':'#8e8481',
+        # 'm6':'#a89e9b', 'm7':'#c4b9b6',
+        # 'm8':'#dfd5d2', 'm9':'#fcf1ee',
+        # --- functional colors ---
+        'gr_fg':'m5', 'gr_bg':'m0', 'gr_txt':'m7',
+        'gr_acc':'#ffa84c', 'gr_hlt':'#4cb2ff', 'gr_reg': ('#b36b1e',0.63),
+        # --- legacy colors ---
+        'b':'p6', 'c':'p0', 'g':'p1', 'y':'p2', 'r':'p4' ,'m':'p5',
+        'k':'m0', 'd':'m3', 'l':'m6', 'w': 'm9',
+        's': 'gr_hlt'
+    },
+    'relaxed_light':{
+        'plotColorMap': {'get':'PAL-relaxed', 'sampleStep': 1/9 },
+        'monoColorMap': {'mono':'warm', 'sampleStep':1/(9-1) },
+        # 'colormap_sampling': ('CET-C1', 0.640, -0.125),
+        # 'colormap_sampling': ('PAL-relaxed', 0.0, 0.125),
+        # --- slightly warm (CIElab A=1 B=2) monochrome ramp ---
+        # 'm0':'#100c08', 'm1':'#262321',
+        # 'm2':'#3d3a37', 'm3':'#55524f',
+        # 'm4':'#6f6b68', 'm5':'#8a8683',
+        # 'm6':'#a5a19e', 'm7':'#c2bdba',
+        # 'm8':'#dfdbd8', 'm9':'#fdf8f5',
+        # --- functional colors ---
+        'gr_fg' : 'm5', 'gr_bg' : 'm9', #'#101518',
+        'gr_txt': 'm2', 'gr_acc': '#ad5a00', 
+        'gr_hlt': '#0080ff', 'gr_reg': ('#b36b1e',0.63),
+        # legacy colors:
+        'b':'p7', 'c':'p0', 'g':'#509d46', 'y':'p1', 'r':'p3' ,'m':'p5',
+        'k':'m0', 'd':'m3', 'l':'m6', 'w': 'm8', 
+        's': 'gr_hlt'
+    },
+    'pastels':{
+        'plotColorMap': {'get':'CET-C7', 'subset':(0.06, 1.00), 'sampleStep':1/9 },
+        'monoColorMap': {'mono':'warm', 'sampleStep':1/(9-1) },
+        # 'colormap_sampling': ('CET-C7', 0.060, +0.125),
+        # --- slightly warm (CIElab A=1 B=2) monochrome ramp ---
+        # 'm0':'#100c08', 'm1':'#262321',
+        # 'm2':'#3d3a37', 'm3':'#55524f',
+        # 'm4':'#6f6b68', 'm5':'#8a8683',
+        # 'm6':'#a5a19e', 'm7':'#c2bdba',
+        # 'm8':'#dfdbd8', 'm9':'#fdf8f5',
+        # --- functional colors ---
+        'gr_fg' : 'm6', 'gr_bg' : 'm9', #'#101518',
+        'gr_txt': 'm3', 'gr_acc': '#e07050', 
+        'gr_hlt': '#e03020', 'gr_reg': ('#ffc0b0',0.63),
+        # legacy colors:
+        'b':'p3', 'c':'p4', 'g':'p5', 'y':'p6', 'r':'p1' ,'m':'p2',
+        'k':'m0', 'd':'m3', 'l':'m6', 'w': 'm8', 
+        's': 'gr_hlt'
+    },
+    'retrowave':{
+        'plotColorMap': {'get':'CET-L8', 'subset':(0.275, 0.700), 'sampleStep':1/(9-1) },
+        'monoColorMap': {'mono':'warm', 'sampleStep':1/(9-1) },
+        # 'colormap_sampling': ('CET-L8', 0.275, 0.100),
+        # --- cool monochrome ramp with no true black ---
+        # 'm0':'#16212a', 'm1':'#27353e',
+        # 'm2':'#3c4a54', 'm3':'#51606a',
+        # 'm4':'#687782', 'm5':'#808f9a',
+        # 'm6':'#98a8b3', 'm7':'#b1c1cd',
+        # 'm8':'#cbdce7', 'm9':'#e6f2ff',
+        # --- functional colors ---
+        'gr_fg' : '#599FA6', 'gr_bg' : 'm0',
+        'gr_txt': '#00E0FF', 'gr_acc': '#40B0BF',
+        'gr_hlt': '#00E0FF', 'gr_reg': ('#599CA6',0.67),
+        # legacy colors:
+        'b':'#398bfc', 'c':'gr_txt', 'g':'#39fc49', 'y':'p7', 'r':'p4' , 'm':'p1',
+        'k':'m0' , 'd': 'm3', 'l': 'm6', 'w':'m9', 's': 'gr_hlt'
+    }
+}
+
+class Palette(object):
+    """
+    A Palette object provides a set of colors that can conveniently applied 
+    to the PyQtGraph color scheme.
+    It specifies at least the following colors, but additional ones can be added:
+    Plot colors:
+      'p0' to 'p8'  typically sampled from a color map
+    Primary colors:
+      'b', 'c', 'g', 'y', 'r', 'm'
+    Monochrome colors:
+      'm0' to 'm8'  ranging from foreground to background.
+      'k', 'd', 'l', 'w'  black, dark gray, light gray and white, typically parts of the 'm0' to 'm8' range
+      's' slate gray
+    System colors:
+      'gr_bg', 'gr_fg', 'gr_txt'  graph background, foreground and text colors
+      'gr_wdw'  window background color
+      'gr_reg'  partially transparent region shading color
+      'gr_acc'  accent for UI elements
+      'gr_hlt'  highlight for selected elements
+    """
+    # def __init__(self, plotColorMap=None, monoColorMap=None, colors=None ):
+    
+    def __init__(self, identifier, *args):
+        """
+        Initializes a predefined palette.
+        The following identifiers are supported:
+        
+        =============== =========================================================================
+        'legacy'        (default) Reproduces the previous PyQtGraph color scheme.
+        'relaxed'       An alternative dark color scheme that avoids intense cyan and magenta.
+        'relaxed_light' A variation of the 'relaxed' color scheme with a light background.
+        'retrowave'     A neon/sunset color scheme inspired by retro-styled computer graphics.
+        'monochrome'    A monochrome color scheme that mimics old computer screens.
+                        The color can be set by an optional parameter accepted by
+                        `ColorMap.makeMonochrome`. Default is 'green'.
+        =============== =========================================================================
+        """
+        # 'application'   Attempts to extract colors from the Qt palette to match the system style.
+        #                 Note that this palette is often incomplete or overriden by stylesheets.
+        super().__init__()
+        
+        self._colors = LEGACY_COLORS.copy()
+        self._isDarkMode = None # is set when assigning gr_bg color
+        self.map_p = None # color map for plot color sampling
+        self.map_m = None # color map for monochrome color sampling
+        
+        identifier = identifier.lower()
+        if identifier not in PALETTE_DEFINITIONS:
+            raise ValueError(f"Unknown palette definition '{identifier}''.")
+        definition = PALETTE_DEFINITIONS[identifier]
+        for key, prefix in ( ('plotColorMap','p'), ('monoColorMap','m') ):
+            if key not in definition:
+                raise KeyError(f"Palette definition does not include key '{key}'.")
+            map_definition = definition.pop(key)
+            cmap = None
+            if 'get' in map_definition:
+                cmap = colormap.get( map_definition['get'] ) # load color map
+            elif 'mono' in map_definition:
+                cmap = colormap.makeMonochrome( map_definition['mono'] ) # pass 'color' parameter
+            elif 'hslCycle' in map_definition:
+                cmap = colormap.makeHslCycle( **map_definition['hslCycle'] ) # pass keyword dictionary
+            if cmap is None:
+                raise ValueError(f"Invalid color map descriptor: {map_definition}")
+            if 'subset' in map_definition:
+                cmap = cmap.getSubset( *map_definition['subset'] )
+            if prefix == 'p':
+                cmap.setMappingMode('repeat')
+                self.map_p = cmap
+            else:
+                cmap.setMappingMode('clip')
+                self.map_m = cmap
+            nColors = 9
+            sampleStep = map_definition.get('sampleStep', 1/(nColors-1) ) # default to sample including 0.0 and 1.0
+            if sampleStep is not None:
+                self.sampleColorMap(colorMap=cmap, prefix=prefix, start=0., step=None, nColors=nColors)
+        for key, value in definition.items():            
+            print('defining:', key, value)
+            alpha = None
+            # unwrap (value, alpha) tuple:
+            if not isinstance(value, str) and hasattr(value, '__len__') and len(value) == 2:
+                value, alpha = value
+                
+            if value in self._colors:
+                qcol = QtGui.QColor( self._colors[value] )
+                if alpha is not None: qcol.setAlphaF(alpha)
+                self._colors[key] = QtGui.QColor( self._colors[value] )
+                continue
+            else:
+                print('calling QColor with', value )
+                if isinstance( value, str ):
+                    qcol = QtGui.QColor( value )
+                    if alpha is not None: qcol.setAlphaF(alpha)
+                    self._colors[key] = qcol
+                    continue
+                if isinstance( value, tuple ):
+                    qcol = QtGui.QColor( *value )
+                    if alpha is not None: qcol.setAlphaF(alpha)
+                    self._colors[key] = qcol
+                    continue
+                else:
+                    raise ValueError("Palette color specifiers must be '#[AA]RRGGBB' or (R,G,B,A) integer tuples. Found {value}.")
+ 
+    def __getitem__(self, identifier):
+        """ 
+        Convenient shorthand access to palette colors.
+        """
+        if isinstance(identifier, str):
+            return self._colors[identifier]
+        if isinstance(identifier, float):
+            return self.map_m[ identifier ]
+        if isinstance(identifier, (int, np.integer)):
+            return self.map_p[ identifier/9 ]
+        if hasattr(identifier, '__len__'):
+            if len(identifier) == 2:
+                idx, num = identifier
+                return self.map_p[ idx/num ]
+        raise ValueError(f"Invalid palette color identifier {identifier}")
+            
+        
+
+        # if isinstance(key, str): # access by color name
+        #     return self.palette.get(key,None)
+        # if isinstance(key, int): # access by plot color index
+        #     idx = key % 9 # map to 0 to 8
+        #     key = 'p'+str(idx)
+        #     return self.palette.get(key,None)
+        # return None
+
+    # def __setitem__(self, key, color):
+    #     """
+    #     Convenient shorthand to add or update palette colors
+    #     """
+    #     if not isinstance(color, QtGui.QColor):
+    #         color = QtGui.QColor(color)
+    #         self._colors[key] = color 
+
+
+            
+    #     if isinstance(identifier, (QtGui.QColor, QtCore.Qt.GlobalColor)):
+    #         return QtGui.QColor(identifier)
+    #     alpha = None
+        
+    #     if isinstance(identifier, str):
+    #         if len(identifier) <= 0: raise ValueError('Color name cannot be empty.')
+    #         # if identifier[0]
+                
+    #     alpha = None
+    #     if isinstance(identifier, str): # return known QColor
+    #         name = identifier
+    #         if color_dict is None or name not in color_dict:
+    #             if name[0] != '#':
+    #                 raise ValueError('Undefined color name '+str(identifier))
+    #             return QtGui.QColor( name )
+    #         else:
+    #             return color_dict[name] 
+    #     if not hasattr(identifier, '__len__'):
+    #         raise ValueError('Invalid color definition '+str(identifier))
+    #     qcol = None
+    #     if len(identifier) == 2:
+    #         name, alpha = identifier
+    #         if color_dict is None or name not in color_dict:
+    #             if name[0] != '#':
+    #                 raise ValueError('Undefined color identifier '+str(identifier))
+    #             qcol = QtGui.QColor( name )
+    #         else:
+    #             qcol = color_dict[ name ]
+    #     elif len(identifier) in (3,4):
+    #         qcol = QtGui.QColor( *identifier )
+        
+    #     if alpha is not None and qcol is not None:
+    #         # distinct QColors are now created for each color
+    #         # qcol = QtGui.QColor(qcol) # make a copy before changing alpha
+    #         qcol.setAlpha( alpha )
+    #     return qcol
+        
+    def setPlotColorMap(self, colorMap):
+        """  Sets the color map used to sample plot colors """
+        self.self.map_p = colorMap
+
+    def plotColorMap(self):
+        """ Returns the ColorMap object used to create plot colors or 'None' if not assigned. """
+        return self.map_p
+
+    def setMonoColorMap(self, colorMap):
+        """  Sets the color map used to sample plot colors """
+        self.self.map_m = colorMap
+
+    def monoColorMap(self):
+        """ Returns the ColorMap object used to create monochrome colors or 'None' if not assigned. """
+        return self.map_m
+
+    def sampleColorMap(self, colorMap=None, prefix='p', start=0., step=None, nColors=9  ):
+        """
+        Sample a ColorMap to update defined plot colors.
+        When used to set plot colors (prefixed 'p') or monochrome colors (prefixed 'm'), the applied 
+        color map is stored for sampling additional color. It can be retrieved with `plotColorMap()`
+        or `monoColorMap()`
+        =============  ===============================================================================
+        **Arguments**
+        cmap           (ColorMap or string)
+                       A ColorMap object to be sampled or a name understood by ``colormp.get()``
+                       If used to update the plot (prefix 'p') or monochrome (prefix 'm') colors, 
+                       this color map will be stored to sample additional colors if needed.
+                       'None' will sample a previously assigned color map if present.
+        prefix         (string) 
+                       default 'p' assigns colors as 'p0' to 'pXX', at least 'p8' is required.
+                       Additional sets can be defined with a different prefix, e.g. 'col_0' to 'col_7'
+                       All prefixes need to start with 'p', 'm' or 'col' to avoid namespace overlap with 
+                       functional colors and hexadecimal numbers. 
+        start          (float) 
+                       first sampled value (default is 0.000)
+        step           (float)
+                       step between samples. Default 'None' equally samples n colors from a 
+                       linear colormap, including values 0.0 and 1.0.
+                       Color values > 1. and < 0. wrap around!
+        nColors        default '9': Number of assigned colors. 
+                       Any palette needs to include 'p0' to 'p8'.
+        =============  ===============================================================================
+        """
+        if not (
+            prefix[0]=='p' or
+            prefix[0]=='m' or
+            ( len(prefix)>=3 and prefix[:3]=='col')
+        ):
+            raise ValueError("'prefix' of plot color needs to start with 'p', 'm' or 'col'.")
+        cmap = colorMap
+        if cmap is None: 
+            if prefix[0] != 'm': cmap = self.map_p
+            else               : cmap = self.map_m
+        elif isinstance(cmap, str):
+            cmap = colormap.get(cmap) # obtain ColorMap if identifier is given
+        if cmap is None:
+            raise ValueError("Please specify 'colorMap' parameter unless a default colormap is already defined.")
+        if not isinstance( cmap, colormap.ColorMap ):
+            raise ValueError(f"Failed to obtain ColorMap object for 'colorMap = {cmap}'.")
+            
+        if prefix == 'p':
+            self.map_p = cmap # replace plot color map
+        elif prefix == 'm':
+            self.map_n = cmap # replace monochrome color map
+        if step is None:
+            step = 1 / nColors # equally sample [0 to 1[ by default, appropriate for a cyclical map
+        for cnt in range(nColors):
+            val = start + cnt * step
+            # print( val )
+            if val > 1.0 or val < 0.0: # don't touch 1.0 value,
+                val = val % 1. # but otherwise map to [0 to 1[ range
+            qcol = cmap.mapToQColor(val)
+            key = prefix + str(cnt)
+            print(key, qcol.name() )
+            self._colors[key] = qcol
+            
+    def add(self, colors):
+        """
+        Add colors given in dictionary 'colors' to the palette
+        All colors will be converted to QColor.
+        Setting 'gr_bg' with a mean color value < 127 will set the palette's 'dark' property
+        """
+        for key in colors:
+            col = identifier_to_QColor( colors[key], color_dict=self.palette )
+            if key == 'gr_bg':
+                bg_tuple = col.getRgb()
+                self.dark = bool( sum( bg_tuple[:3] ) < 3 * 127 ) # dark mode?
+            self.palette[key] = col
+            
+    # def addDefaultRamp(self):
+    #     """
+    #     Adds a default ramp of grays m0 to m9,
+    #     linearized according to CIElab lightness value
+    #     """
+    #     pass
+    #     # todo: define based on start, intermediate, end colors
+    #     # to give grays with different warmth and range of contrast
+
+    def emulateSystem(self):
+        """
+        Retrieves the current Qt 'active' palette and extracts the following colors:
+        =====================================  ============================================================================
+        'gr_fg','gr_txt' from ColorRole.Text   (foreground color used with Base)
+        'gr_bg'  from ColorRole.Base           (background color for e.g. text entry widgets)
+        'gr_wdw' from ColorRole.Window         (a general background color)
+        'gr_reg' from ColorRole.AlternateBase  (alternating row background color)
+        'gr_acc' from ColorRole.Link           (color used for unvisited hyperlinks)
+        'gr_hlt' from ColorRole.Highlight      (color to indicate a selected item)
+        =====================================  ============================================================================
+        """
+        app = QtWidgets.QApplication.instance()
+        if app is None: return None        
+        qPalette = app.palette()
+        col_grp = QtGui.QPalette.ColorGroup.Active
+        colors = {}
+        for key, alpha, col_role in (
+            ('gr_bg' , None, QtGui.QPalette.ColorRole.Base),       # background color for e.g. text entry
+            ('gr_fg' , None, QtGui.QPalette.ColorRole.WindowText), # overall foreground text color
+            ('gr_txt', None, QtGui.QPalette.ColorRole.Text),       # foreground color used with Base
+            ('gr_reg',  128, QtGui.QPalette.ColorRole.AlternateBase), # alternating row background color
+            ('gr_acc', None, QtGui.QPalette.ColorRole.Link),       # color of unvisited hyperlink
+            # ('gr_reg',  128, QtGui.QPalette.ColorRole.Highlight), # alternating row background color
+            # ('gr_acc', None, QtGui.QPalette.ColorRole.Highlight),       # color of unvisited hyperlink
+            ('gr_hlt', None, QtGui.QPalette.ColorRole.Highlight),  # color to indicate a selected item
+            ('ui_wind', None, QtGui.QPalette.ColorRole.Window),    # a general background color
+            ('ui_text', None, QtGui.QPalette.ColorRole.WindowText) #  overall foreground text color
+        ):
+            qcol = qPalette.color(col_grp, col_role)
+            if alpha is not None: qcol.setAlpha(alpha)
+            colors[key] = qcol
+        self.add(colors)        
+        colors = {
+            'b': QtCore.Qt.GlobalColor.blue , 'c': QtCore.Qt.GlobalColor.cyan, 
+            'g': QtCore.Qt.GlobalColor.green, 'y': QtCore.Qt.GlobalColor.yellow,
+            'r': QtCore.Qt.GlobalColor.red  , 'm': QtCore.Qt.GlobalColor.magenta,
+            'w': QtCore.Qt.GlobalColor.white, 's': QtCore.Qt.GlobalColor.gray,
+            'k': QtCore.Qt.GlobalColor.black, 'l': QtCore.Qt.GlobalColor.lightGray,
+            'd': QtCore.Qt.GlobalColor.darkGray
+        }
+        if not self.dark: # darken some colors for light mode
+            colors['c'] = QtCore.Qt.GlobalColor.darkCyan
+            colors['g'] = QtCore.Qt.GlobalColor.darkGreen
+            colors['y'] = QtCore.Qt.GlobalColor.darkYellow
+            colors['m'] = QtCore.Qt.GlobalColor.darkMagenta
+        self.add(colors)
+        colors = { 
+            'p'+str(idx) : name 
+            for idx, name in enumerate( ('gr_fg', 'gr_hlt', 'y','g','c','b','m','r','s') ) 
+        }
+        self.add(colors)
+
+        if self.dark:
+            self.map_p = colormap.get('PAL-relaxed_bright')
+            cmap_m = colormap.makeMonochrome() # neutral gray ramp
+            cmap_m.reverse() # switch to light-to-dark
+        else:
+            self.map_p = colormap.get('PAL-relaxed')
+            cmap_m = colormap.makeMonochrome() # neutral gray ramp
+        print('monochrome color map:', cmap_m)
+        self.sampleColorMap(colorMap=cmap_m, prefix='m')  # also sets self.map_m
+
+
+    def setMonochrome(self, color='green'):
+        """ 
+        Updates graph colors with a set based on 'monochrome' color map,
+        imitating a monochrome computer screen
+        ==============  =================================================================
+        **Arguments:**
+        color           Primary color description. Can be one of predefined identifiers
+                        'green', 'amber', 'blue'
+                        or a tuple of relative R,G,B contributions in range 0.0 to 1.0
+        ==============  =================================================================
+    """
+        print('preparing monochrome map for',str(color))
+        cmap = colormap.makeMonochrome(color)
+        if cmap is None: 
+            raise ValueError("Failed to generate color for '"+str(color)+"'")
+        # define colors 'p0' (near-white) to 'p8' (dark, but visible against background)
+        self.sampleColorMap( colorMap=cmap, prefix='p', start=1.0, step=-1/8 )
+        # define colors 'm0' (near-white) to 'm8' (near-black):
+        self.sampleColorMap( colorMap=cmap, prefix='m', start=1.0, step=-1/9) 
+        colors =  {
+            'gr_bg' : 'm0', 'gr_fg' : 'm4',
+            'gr_txt': 'm6', 'gr_acc': 'm6',
+            'gr_hlt': 'm8', 'gr_reg': ('m1',192),
+            'k': 'm0', 'd': 'm1', 's': 'm3', 'l': 'm6', 'w': 'm9'
+        }        
+        self.add( colors )        
+        # make a dictionary of plot colors (except darkest and lightest) to emulate primary colors:
+        needed = { # int RGB colors that we are looking to emulate:
+            'b': np.array((  0,  0,255)), 'c': np.array((  0,160,160)), 
+            'g': np.array((  0,255,  0)), 'y': np.array((160,160,  0)),
+            'r': np.array((255,  0,  0)), 'm': np.array((160,  0,160))
+        }
+        
+        # project legacy colors onto monochrome reference to assigne them somewhat logically
+        ref_color = np.array( self.palette['m5'].getRgb()[:3] )
+        brightness = [ # estimate brightness of wanted colors "projected" into monochrome color space
+            (np.sum( ref_color * needed[key] ), key) 
+            for key in needed
+        ]
+        brightness = sorted(brightness, key=lambda brightness: brightness[0])
+        # print( brightness )
+        choice = ('m3','m4','m5','m6','m7','m8') # 6 candidates for 6 needed colors
+        colors = {
+            key: choice[idx] # assign in order of dark to bright
+            for idx, (_, key) in enumerate(brightness)
+        }
+        self.add( colors )
+        
+    def apply(self):
+        """
+        Applies this palette to the overall PyQtGraph color scheme.
+        This provides the palette to NamedColorManager, which triggers a global refresh of named colors
+        """
+        fn.STYLE_REGISTRY.redefinePalette( colors=self.palette )

--- a/pyqtgraph/styleRegistry.py
+++ b/pyqtgraph/styleRegistry.py
@@ -1,0 +1,301 @@
+from .Qt import QtCore, QtGui
+
+
+# import numpy as np
+import weakref
+import itertools
+# import collections
+# import warnings
+# import time
+from .palette import Palette
+from . import functions as fn
+
+__all__ = ['StyleRegistry']
+
+# An instantiated QObject is required to emit QSignals. 
+# functions.py initializes and maintains STYLE_REGISTRY for this purpose.
+class StyleRegistry(QtCore.QObject):
+    """
+    Provides style change signals and provides access to the current palette
+    Instantiated by 'functions.py' and retrievable as functions.STYLE_REGISTRY
+    """
+    graphStyleChanged = QtCore.Signal() # equated to pyqtSignal in qt.py for PyQt
+    _registrationGenerator = itertools.count()
+
+    def __init__(self):
+        """ initialization """
+        super().__init__()
+       
+        # needs to be externally assigned :
+        # importing palette (-> colormap -> functions) creates a circular import.
+        self._palette = Palette('legacy')
+        
+        # set of objects that are registered for update on palette change:
+        self.registered_objects = {} # stores registration: (weakref(object), descriptor), deletion handled by weakref.finalize
+        # DEBUG
+        # self.registered_history = {} # stores all previous registrations for debugging
+        self.color_cache = weakref.WeakValueDictionary() # keeps a cache of QColor objects, key: (name, alpha)
+        self.pen_cache   = weakref.WeakValueDictionary() # keeps a cache of QPen   objects, key: (name, width, alpha)
+        self.brush_cache = weakref.WeakValueDictionary() # keeps a cache of QBrush objects, key: (name, alpha)
+
+    def palette(self):
+        """
+        Returns the currently active palette
+        """
+        return self._palette
+        
+        
+    def getPaletteColor(self, identifier, alpha=None):
+        """
+        Returns a color from the currently active palette
+        """    
+        if identifier not in self._palette._colors:
+            raise ValueError(f"Identifier '{identifier}' is not part of current palette.")
+        qcol = QtGui.QColor( self._palette._colors[identifier] )
+        if alpha is not None: qcol.setAlphaF(alpha)
+        return qcol
+        
+    def samplePlotColor(self, idx, num=9, alpha=None):
+        """
+        Returns a sampled color from the plot color map
+
+        Parameters
+        ----------
+        idx   : (int) plot color index
+        num   : (int, optional) total number of sample steps, default to 9.
+        alpha : (float, optional) overriding alpha value
+        """
+        qcol = self._palette.map_p[idx/num]
+        if alpha is not None: qcol.setAlphaF(alpha)
+        return qcol
+
+    def sampleMonoColor(self, value, alpha=None):
+        """
+        Returns a sampled color from the monochrome color map
+
+        Parameters
+        ----------
+        value : (float) plot color index 0.0-1.0
+        alpha : (float, optional) overriding alpha value
+        """
+        qcol = self._palette.map_m[value]
+        if alpha is not None: qcol.setAlphaF(alpha)
+        return qcol
+
+    # def getRegisteredColor( self, color_desc, skipCache=False ):
+    #     """ 
+    #     Returns a registered QColor according to (name, alpha) color descriptor
+    #     Setting skipCache = True creates a new registered QColor that is not added to the cache
+    #     Otherwise the color is cached and reused on the next request with the same pen id.
+    #     """
+    #     register = True # register, unless this is a hex code color
+    #     # print('color descriptor:',color_desc)
+    #     desc = self.confirmColorDescriptor(color_desc)
+    #     if desc is False: return None # not a valid color id
+    #     name, alpha = desc
+    #     if name is None:
+    #         return QtGui.QColor(0, 0, 0, 0) # fully transparent
+    #     if name[0] == '#': # skip cache and registry for fixed hex colors
+    #         name, alpha_from_hex = _expand_rgba_hex_string( name )
+    #         if name is None: return None
+    #         if alpha is None and alpha_from_hex is not None:
+    #             # alpha = alpha_from_hex
+    #             desc = (name, alpha_from_hex) # handle extended 4 bytes rgba hex strings
+    #         # print('preparing hex color:',name)
+    #         skipCache = True
+    #         register  = False
+    #     elif name not in self.color_dic:
+    #         warnings.warn(f"Unknown color identifier '{name}' encountered.")
+    #         return None # unknown color identifier
+    #     if not skipCache and desc in self.color_cache:
+    #         return self.color_cache[desc]
+    #     qcol = QtGui.QColor()
+    #     self._update_QColor(qcol, desc)
+    #     if register: self.register(qcol, desc) # register for updates on palette change
+    #     if not skipCache: # skipCache disable both reading and writing cache
+    #         self.color_cache[desc] = qcol
+    #     return qcol
+        
+    # def getRegisteredPen( self, pen_desc, skipCache=False ):
+    #     """
+    #     Returns a registered QPen according to (name, width, alpha) pen descriptor
+    #     Setting skipCache = True creates a new registered QPen that is not added to the cache.
+    #     Otherwise the pen is cached and reused on the next request with the same pen descriptor.
+    #     """
+    #     register = True # register, unless this is a hex code color
+    #     # print('pen descriptor:',pen_desc)
+    #     desc = self.confirmPenDescriptor(pen_desc)
+    #     if desc is False: return None # not a valid pen id
+    #     name, width, alpha = desc
+    #     if name is None:
+    #         return QtGui.QPen( QtCore.Qt.PenStyle.NoPen )
+    #     if name[0] == '#': # skip cache and registry for fixed hex colors
+    #         name, alpha_from_hex = _expand_rgba_hex_string( name )
+    #         if name is None: return None
+    #         if alpha is None and alpha_from_hex is not None:
+    #             # alpha = alpha_from_hex
+    #             desc = (name, width, alpha_from_hex) # handle extended 4 bytes rgba hex strings
+    #         # print('preparing hex pen:',name)
+    #         skipCache = True
+    #         register  = False
+    #     elif name not in self.color_dic:
+    #         warnings.warn(f"Unknown color identifier '{name}' encountered in pen descriptor.")
+    #         return None # unknown color identifier
+    #     if not skipCache and desc in self.pen_cache:
+    #         return self.pen_cache[desc]
+    #     qpen = QtGui.QPen()
+    #     self._update_QPen(qpen,desc)
+    #     if register: self.register( qpen, desc ) # register for updates on palette change
+    #     if not skipCache: # skipCache disable both reading and writing cache
+    #         self.pen_cache[desc] = qpen
+    #     return qpen
+
+    # def getRegisteredBrush( self, brush_desc, skipCache=False ):
+    #     """
+    #     Returns a registered QBrush according to (name, alpha) brush descriptor
+    #     Setting skipCache = True creates a new registered QBrush that is not added to the cache.
+    #     Otherwise the brush is cached and reused on the next request with the same descriptor.
+    #     """
+    #     register = True # register, unless this is a hex code color
+    #     # print('brush descriptor:',brush_desc)
+    #     desc = self.confirmColorDescriptor(brush_desc) # brush id is the same (name, alpha) format as color id
+    #     if desc is False: return None # not a valid brush id
+    #     name, alpha = desc
+    #     if name is None:
+    #         return QtGui.QBrush( QtCore.Qt.BrushStyle.NoBrush ) 
+    #     if name[0] == '#': # skip cache and registry for fixed hex colors
+    #         name, alpha_from_hex = _expand_rgba_hex_string( name )
+    #         if name is None: return None
+    #         if alpha is None and alpha_from_hex is not None:
+    #             # alpha = alpha_from_hex
+    #             desc = (name, alpha_from_hex) # handle extended 4 bytes rgba hex strings
+    #         skipCache = True
+    #         register  = False
+    #     elif name not in self.color_dic:
+    #         warnings.warn(f"Unknown color identifier '{name}' encountered in brush descriptor.")
+    #         return None # unknown color identifier
+    #     if not skipCache and desc in self.brush_cache:
+    #         return self.brush_cache[desc]
+    #     qbrush = QtGui.QBrush(QtCore.Qt.BrushStyle.SolidPattern) # make sure this brush fills once color is set
+    #     self._update_QBrush(qbrush,desc)
+    #     if register: self.register( qbrush, desc ) # register for updates on palette change
+    #     if not skipCache: # skipCache disable both reading and writing cache
+    #         self.brush_cache[desc] = qbrush
+    #     return qbrush
+        
+    # def _update_QColor(self, qcol, desc):
+    #     """ updates qcol to match descriptor for current palette """
+    #     # print('updating color to match',desc)
+    #     name, alpha = desc
+    #     if name[0] != '#':
+    #         qcol.setRgba( self.color_dic[name].rgba() )
+    #     else:
+    #         qcol.setNamedColor(name) # set from hex string
+    #     if alpha is not None: qcol.setAlpha(alpha)
+    #     # print('= hex:', qcol.name() )
+
+    # def _update_QPen(self, qpen, desc):
+    #     """ updates qpen to match descriptor for current palette """
+    #     # print('updating pen to match',desc)
+    #     name, width, alpha = desc
+    #     if name[0] != '#':
+    #         if alpha is None:
+    #             qpen.setColor( self.color_dic[name] ) # automatically copies
+    #         else:
+    #             qcol = QtGui.QColor(self.color_dic[name]) # make a copy
+    #             qcol.setAlpha(alpha)
+    #             qpen.setColor(qcol)
+    #     else: # set from hex string instead:
+    #         qcol = QtGui.QColor(name)
+    #         if alpha is not None: qcol.setAlpha(alpha)
+    #         qpen.setColor(qcol)
+    #     if width is not None:
+    #         qpen.setWidth(width)
+    #     # print('= hex:', qpen.color().name() )
+
+    # def _update_QBrush(self, qbrush, desc):
+    #     """ updates qbrush to match descriptor for current palette """
+    #     # print('updating brush',qbrush,'to match',desc)
+    #     name, alpha = desc
+    #     if name[0] != '#':
+    #         if alpha is None:
+    #             qbrush.setColor( self.color_dic[name] ) # automatically copies
+    #         else:
+    #             qcol = QtGui.QColor(self.color_dic[name]) # make a copy
+    #             qcol.setAlpha(alpha)
+    #             qbrush.setColor(qcol)
+    #     else: # set from hex string instead:
+    #         qcol = QtGui.QColor(name)
+    #         if alpha is not None: qcol.setAlpha(alpha)
+    #         qbrush.setColor(qcol)
+    #     # print('= hex:', qbrush.color().name(), qbrush.color().alpha() )
+
+    # def register(self, obj, desc):
+    #     """
+    #     Registers obj (QColor, QPen or QBrush) to be updated according to the descriptor on palette change
+    #     """
+    #     if hasattr(obj,'colorRegistration'):
+    #         registration = obj.registration
+    #         if registration in self.registered_objects:
+    #             # if this object is already registered, we should not try to add another finalize call.
+    #             return
+    #     else:
+    #         registration = next(StyleRegistry._registrationGenerator)
+    #         obj.registration = registration # patch in attribute
+    #     self.registered_objects[registration] = (weakref.ref(obj), desc)
+    #     # DEBUG:
+    #     # self.registered_history[registration] = (weakref.ref(obj), desc)
+    #     fin = weakref.finalize(obj, self.unregister, registration )
+    #     fin.atexit = False # no need to clean up registry on program exit
+    #     # DEBUG:
+    #     # print('registering', registration, '(',str(obj),'):',str(desc))
+
+    # def unregister(self, registration):
+    #     """
+    #     Removes obj (QColor, QPen or QBrush) from the registry, usually called by finalize on deletion
+    #     """
+    #     obj, desc = self.registered_objects.pop(registration, (False, False))        
+    #     if obj is False:
+    #         # DEBUG:
+    #         # obj_hist, desc_hist = self.registered_history.get(registration, (False, False))
+    #         # if obj_hist is not False:
+    #         #     raise RuntimeError(f'Unregistered object {registration} already unregistered, previously registered as {obj_hist} ({desc_hist}).')
+    #         raise RuntimeError(f'Unregistered object {registration} unlisted.')
+
+    #     # DEBUG:
+    #     # print('unregistering', registration, '(',str(obj),'):',str(desc))
+    #     del obj, desc
+
+    # def redefinePalette(self, colors=None):
+    #     """ 
+    #     Update list of registered colors if 'colors' dictionary is given
+    #     Emits paletteHasChanged signals to color objects and widgets, even if color_dict is None 
+    #     """
+    #     if colors is not None:
+    #         for key in DEFAULT_COLORS:
+    #             if key not in colors:
+    #                 raise ValueError(f"Palette definition is missing '{key}'")
+    #         self.color_dic.clear()
+    #         self.color_dic.update(colors)
+
+    #     # notifies registered color objects of new assignments:
+    #     for ref, desc in self.registered_objects.values():
+    #         # ref, desc = self.registered_objects[key]
+    #         obj = ref()
+    #         # print('updating', obj)
+    #         if obj is None:
+    #             warnings.warn(f"Expired object with descriptor '{desc})' remains in color registry.", RuntimeWarning)
+    #         elif isinstance(obj, QtGui.QColor):
+    #             self._update_QColor(obj, desc)
+    #         elif isinstance(obj, QtGui.QPen):
+    #             self._update_QPen(obj, desc)
+    #         elif isinstance(obj, QtGui.QBrush):
+    #             self._update_QBrush(obj, desc)
+    #     # notify all graphics widgets that redraw is required:
+    #     self.graphStyleChanged.emit()
+
+
+print('initializing style registry')
+STYLE_REGISTRY = StyleRegistry()
+print('registering with functions')
+fn.STYLE_REGISTRY = STYLE_REGISTRY

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -70,7 +70,7 @@ def test_types():
     check_param_types(param.child('bool'), bool, bool, False, all_objs, types)
 
     # color
-    types = ['color', 'int0', 'int', 'float', 'npfloat', 'npint', 'list']
+    types = ['color', 'int0', 'int', 'float', 'bigfloat', 'npfloat', 'npint', 'list']
     init = QtGui.QColor(128, 128, 128, 255)
     check_param_types(param.child('color'), QtGui.QColor, pg.mkColor, init, all_objs, types)
 


### PR DESCRIPTION
This is work-in-progress code that extracts (and hopes to clean up) the main palette management code from my earlier PR #1625.
Palette colors and UI monochromes are now sampled from color maps, which means that generation of an arbitrary number of plot colors by `functions.intColor()` and the monochrome generation for float values passed to `mkColor()` can be maintained while matching the alternative color schemes.

Once the code is in better shape, it should allow color presets (to be selected before plots are initialized) with less complexity and bugs than the original proposal... and will hopefully be less painful to review :)