### PR TITLE
make antialiasing optional for paintGL in PlotCurveItem

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -641,9 +641,6 @@ class PlotCurveItem(GraphicsObject):
                     gl.glHint(gl.GL_LINE_SMOOTH_HINT, gl.GL_NICEST)
                 else:
                     gl.glDisable(gl.GL_LINE_SMOOTH)
-                    gl.glDisable(gl.GL_BLEND)
-                    gl.glBlendFunc(gl.GL_ONE, gl.GL_ZERO)
-                    gl.glHint(gl.GL_LINE_SMOOTH_HINT, gl.GL_DONT_CARE)
 
                 gl.glDrawArrays(gl.GL_LINE_STRIP, 0, int(pos.size / pos.shape[-1]))
             finally:

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -628,10 +628,18 @@ class PlotCurveItem(GraphicsObject):
                     width = 1
                 gl.glPointSize(width)
                 gl.glLineWidth(width)
-                gl.glEnable(gl.GL_LINE_SMOOTH)
-                gl.glEnable(gl.GL_BLEND)
-                gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
-                gl.glHint(gl.GL_LINE_SMOOTH_HINT, gl.GL_NICEST)
+
+                # enable antialiasing if requested
+                if self._exportOpts is not False:
+                    aa = self._exportOpts.get('antialias', True)
+                else:
+                    aa = self.opts['antialias']
+                if aa:
+                    gl.glEnable(gl.GL_LINE_SMOOTH)
+                    gl.glEnable(gl.GL_BLEND)
+                    gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
+                    gl.glHint(gl.GL_LINE_SMOOTH_HINT, gl.GL_NICEST)
+
                 gl.glDrawArrays(gl.GL_LINE_STRIP, 0, int(pos.size / pos.shape[-1]))
             finally:
                 gl.glDisableClientState(gl.GL_VERTEX_ARRAY)

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -639,6 +639,11 @@ class PlotCurveItem(GraphicsObject):
                     gl.glEnable(gl.GL_BLEND)
                     gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
                     gl.glHint(gl.GL_LINE_SMOOTH_HINT, gl.GL_NICEST)
+                else:
+                    gl.glDisable(gl.GL_LINE_SMOOTH)
+                    gl.glDisable(gl.GL_BLEND)
+                    gl.glBlendFunc(gl.GL_ONE, gl.GL_ZERO)
+                    gl.glHint(gl.GL_LINE_SMOOTH_HINT, gl.GL_DONT_CARE)
 
                 gl.glDrawArrays(gl.GL_LINE_STRIP, 0, int(pos.size / pos.shape[-1]))
             finally:


### PR DESCRIPTION
## Summary
This PR makes antialiasing optional when OpenGL is used with PlotCurveItem as described in #1926.

I checked for `antialias` in `self._exportOpts` as it is done in `paint`. Is this necessary for this to be inside paint/paintGL or could it also be in e.g. `updateData` to improve performance a little bit?