### PR TITLE
fix log mode by reverting to previous formulation

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -701,7 +701,7 @@ class PlotDataItem(GraphicsObject):
                     eps = np.finfo(y.dtype).eps
                 else:
                     eps = 1
-                y = np.copysign(np.log10(np.abs(y)+eps), y)
+                y = np.sign(y) * np.log10(np.abs(y)+eps)
 
         ds = self.opts['downsample']
         if not isinstance(ds, int):


### PR DESCRIPTION
this formulation is in the documentation for setLogMode() https://pyqtgraph.readthedocs.io/en/latest/graphicsItems/plotdataitem.html?highlight=setlogmode#pyqtgraph.PlotDataItem.setLogMode

fixes #1933 

Powers of 10 should plot a straight line
```python
import pyqtgraph as pg
pg.mkQApp()
pw = pg.PlotWidget()
pw.show()
pi = pw.getPlotItem()
pi.setLogMode(x=False, y=True)
x = range(-10, 11)
y = [(10.**p) for p in x]
pi.plot(x, y, symbol='o')
pg.exec()
```