### PR TITLE
Remove unnecessary casting of `toPlainText` to str

### DIFF
--- a/pyqtgraph/flowchart/Node.py
+++ b/pyqtgraph/flowchart/Node.py
@@ -504,7 +504,7 @@ class NodeGraphicsItem(GraphicsObject):
         #GraphicsObject.setZValue(self, z)
         
     def labelChanged(self):
-        newName = str(self.nameItem.toPlainText())
+        newName = self.nameItem.toPlainText()
         if newName != self.node.name():
             self.node.rename(newName)
             

--- a/pyqtgraph/flowchart/Terminal.py
+++ b/pyqtgraph/flowchart/Terminal.py
@@ -311,7 +311,7 @@ class TerminalGraphicsItem(GraphicsObject):
         self.menu = None
 
     def labelChanged(self):
-        newName = str(self.label.toPlainText())
+        newName = self.label.toPlainText()
         if newName != self.term.name():
             self.term.rename(newName)
 

--- a/pyqtgraph/flowchart/library/Data.py
+++ b/pyqtgraph/flowchart/library/Data.py
@@ -177,7 +177,7 @@ class TextEdit(QtWidgets.QTextEdit):
         self.lastText = None
 
     def focusOutEvent(self, ev):
-        text = str(self.toPlainText())
+        text = self.toPlainText()
         if text != self.lastText:
             self.lastText = text
             self.on_update()
@@ -234,12 +234,12 @@ class EvalNode(Node):
         l.update(args)
         ## try eval first, then exec
         try:  
-            text = str(self.text.toPlainText()).replace('\n', ' ')
+            text = self.text.toPlainText().replace('\n', ' ')
             output = eval(text, globals(), l)
         except SyntaxError:
             fn = "def fn(**args):\n"
             run = "\noutput=fn(**args)\n"
-            text = fn + "\n".join(["    "+l for l in str(self.text.toPlainText()).split('\n')]) + run
+            text = fn + "\n".join(["    "+l for l in self.text.toPlainText().split('\n')]) + run
             if sys.version_info.major == 2:
                 exec(text)
             elif sys.version_info.major == 3:
@@ -253,7 +253,7 @@ class EvalNode(Node):
         
     def saveState(self):
         state = Node.saveState(self)
-        state['text'] = str(self.text.toPlainText())
+        state['text'] = self.text.toPlainText()
         #state['terminals'] = self.saveTerminals()
         return state
         


### PR DESCRIPTION
Slight fixup to #1939 which also removes unnecessary `str` casting of `QTextEdit.toPlainText`. Both libraries return `str` objects.
  * https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtwidgets/qtextedit.html#QTextEdit
  * https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QTextEdit.html#PySide2.QtWidgets.PySide2.QtWidgets.QTextEdit.toPlainText

Note: intentionally leaves out one instance instance in parametertypes.py to avoid merge conflict with #1919. This is fixed on that PR anyway.