### PR TITLE
Remove python 2 code paths

### DIFF
--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -129,9 +129,6 @@ def renamePyc(startDir):
                 os.rename(fileName, name2)
                 
 path = os.path.split(__file__)[0]
-if __version__ is None and not hasattr(sys, 'frozen') and sys.version_info[0] == 2: ## If we are frozen, there's a good chance we don't have the original .py files anymore.
-    renamePyc(path)
-
 
 ## Import almost everything to make it available from a single namespace
 ## don't import the more complex systems--canvas, parametertree, flowchart, dockarea

--- a/pyqtgraph/flowchart/library/Data.py
+++ b/pyqtgraph/flowchart/library/Data.py
@@ -240,14 +240,11 @@ class EvalNode(Node):
             fn = "def fn(**args):\n"
             run = "\noutput=fn(**args)\n"
             text = fn + "\n".join(["    "+l for l in self.text.toPlainText().split('\n')]) + run
-            if sys.version_info.major == 2:
-                exec(text)
-            elif sys.version_info.major == 3:
-                ldict = locals()
-                exec(text, globals(), ldict)
-                output = ldict['output']
+            ldict = locals()
+            exec(text, globals(), ldict)
+            output = ldict['output']
         except:
-            print("Error processing node: %s" % self.name())
+            print(f"Error processing node: {self.name()}")
             raise
         return output
         

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -843,36 +843,31 @@ class AxisItem(GraphicsWidget):
 
     def logTickStrings(self, values, scale, spacing):
         estrings = ["%0.1g"%x for x in 10 ** np.array(values).astype(float) * np.array(scale)]
-
-        if sys.version_info < (3, 0):
-            # python 2 does not support unicode strings like that
-            return estrings
-        else:  # python 3+
-            convdict = {"0": "⁰",
-                        "1": "¹",
-                        "2": "²",
-                        "3": "³",
-                        "4": "⁴",
-                        "5": "⁵",
-                        "6": "⁶",
-                        "7": "⁷",
-                        "8": "⁸",
-                        "9": "⁹",
-                        }
-            dstrings = []
-            for e in estrings:
-                if e.count("e"):
-                    v, p = e.split("e")
-                    sign = "⁻" if p[0] == "-" else ""
-                    pot = "".join([convdict[pp] for pp in p[1:].lstrip("0")])
-                    if v == "1":
-                        v = ""
-                    else:
-                        v = v + "·"
-                    dstrings.append(v + "10" + sign + pot)
+        convdict = {"0": "⁰",
+                    "1": "¹",
+                    "2": "²",
+                    "3": "³",
+                    "4": "⁴",
+                    "5": "⁵",
+                    "6": "⁶",
+                    "7": "⁷",
+                    "8": "⁸",
+                    "9": "⁹",
+                    }
+        dstrings = []
+        for e in estrings:
+            if e.count("e"):
+                v, p = e.split("e")
+                sign = "⁻" if p[0] == "-" else ""
+                pot = "".join([convdict[pp] for pp in p[1:].lstrip("0")])
+                if v == "1":
+                    v = ""
                 else:
-                    dstrings.append(e)
-            return dstrings
+                    v = v + "·"
+                dstrings.append(v + "10" + sign + pot)
+            else:
+                dstrings.append(e)
+        return dstrings
 
     def generateDrawSpecs(self, p):
         """

--- a/pyqtgraph/ptime.py
+++ b/pyqtgraph/ptime.py
@@ -9,12 +9,8 @@ Distributed under MIT/X11 license. See license.txt for more information.
 import sys
 import warnings
 
-if sys.version_info[0] < 3:
-    from time import clock
-    from time import time as system_time
-else:
-    from time import perf_counter as clock
-    from time import time as system_time
+from time import perf_counter as clock
+from time import time as system_time
 
 START_TIME = None
 time = None

--- a/pyqtgraph/reload.py
+++ b/pyqtgraph/reload.py
@@ -30,9 +30,6 @@ except ImportError:
     orig_reload = reload
 
 
-py3 = sys.version_info >= (3,)
-
-
 def reloadAll(prefix=None, debug=False):
     """Automatically reload all modules whose __file__ begins with *prefix*.
 
@@ -239,7 +236,7 @@ def updateClass(old, new, debug):
     ## but it fixes a few specific cases (pyqt signals, for one)
     for attr in dir(old):
         oa = getattr(old, attr)
-        if (py3 and inspect.isfunction(oa)) or inspect.ismethod(oa):
+        if inspect.isfunction(oa) or inspect.ismethod(oa):
             # note python2 has unbound methods, whereas python3 just uses plain functions
             try:
                 na = getattr(new, attr)

--- a/pyqtgraph/util/lru_cache.py
+++ b/pyqtgraph/util/lru_cache.py
@@ -9,8 +9,6 @@ import sys
 import itertools
 
 
-_IS_PY3 = sys.version_info[0] == 3
-
 class LRUCache(object):
     '''
     This LRU cache should be reasonable for short collections (until around 100 items), as it does a
@@ -37,10 +35,7 @@ class LRUCache(object):
         self.resizeTo = resizeTo
         self._counter = 0
         self._dict = {}
-        if _IS_PY3:
-            self._nextTime = itertools.count(0).__next__
-        else:
-            self._nextTime = itertools.count(0).next
+        self._nextTime = itertools.count(0).__next__
 
     def __getitem__(self, key):
         item = self._dict[key]
@@ -74,54 +69,25 @@ class LRUCache(object):
     def clear(self):
         self._dict.clear()
  
-    if _IS_PY3:
-        def values(self):
-            return [i[1] for i in self._dict.values()]
-        
-        def keys(self):
-            return [x[0] for x in self._dict.values()]
-        
-        def _resizeTo(self):
-            ordered = sorted(self._dict.values(), key=operator.itemgetter(2))[:self.resizeTo]
-            for i in ordered:
-                del self._dict[i[0]]
-                
-        def items(self, accessTime=False):
-            '''
-            :param bool accessTime:
-                If True sorts the returned items by the internal access time.
-            '''
-            if accessTime:
-                for x in sorted(self._dict.values(), key=operator.itemgetter(2)):
-                    yield x[0], x[1]
-            else:
-                for x in self._dict.items():
-                    yield x[0], x[1]
-                    
-    else:
-        def values(self):
-            return [i[1] for i in self._dict.values()]
-        
-        def keys(self):
-            return [x[0] for x in self._dict.values()]
-            
-        
-        def _resizeTo(self):
-            ordered = sorted(self._dict.values(), key=operator.itemgetter(2))[:self.resizeTo]
-            for i in ordered:
-                del self._dict[i[0]]
-                
-        def items(self, accessTime=False):
-            '''
-            ============= ======================================================
-            **Arguments**
-            accessTime    (bool) If True sorts the returned items by the 
-                          internal access time.
-            ============= ======================================================
-            '''
-            if accessTime:
-                for x in sorted(self._dict.values(), key=operator.itemgetter(2)):
-                    yield x[0], x[1]
-            else:
-                for x in self._dict.items():
-                    yield x[0], x[1]
+    def values(self):
+        return [i[1] for i in self._dict.values()]
+
+    def keys(self):
+        return [x[0] for x in self._dict.values()]
+
+    def _resizeTo(self):
+        ordered = sorted(self._dict.values(), key=operator.itemgetter(2))[:self.resizeTo]
+        for i in ordered:
+            del self._dict[i[0]]
+
+    def items(self, accessTime=False):
+        '''
+        :param bool accessTime:
+            If True sorts the returned items by the internal access time.
+        '''
+        if accessTime:
+            for x in sorted(self._dict.values(), key=operator.itemgetter(2)):
+                yield x[0], x[1]
+        else:
+            for x in self._dict.items():
+                yield x[0], x[1]


### PR DESCRIPTION
A search for `sys.version_info` showed several locations still checking for Python 2. This PR removes those branches and assumes Python 3 throughout.