### PR TITLE
Extend docs template to add a banner for the user survey

### DIFF
--- a/doc/source/_templates/page.html
+++ b/doc/source/_templates/page.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block body %}
-    <p style="border:2px solid Tomato;font-weight:bold">
+    <p style="border:2px solid Tomato;padding: 1em;font-weight:bold">
         Hey there! The PyQtGraph team is conducting a user survey.
         If you have 5&ndash;10 minutes, we'd appreciate your feedback.
         <a href="https://pyqtgraph.readthedocs.io/en/latest/">Link to the survey</a>

--- a/doc/source/_templates/page.html
+++ b/doc/source/_templates/page.html
@@ -1,0 +1,9 @@
+{% extends "layout.html" %}
+{% block body %}
+    <p style="border:2px solid Tomato;font-weight:bold">
+        Hey there! The PyQtGraph team is conducting a user survey.
+        If you have 5&ndash;10 minutes, we'd appreciate your feedback.
+        <a href="https://pyqtgraph.readthedocs.io/en/latest/">Link to the survey</a>
+    </p>
+    {{ body }}
+{% endblock %}


### PR DESCRIPTION
Submitting this before the survey goes out to collaborate on the details.

Currently it's just a paragraph on top of the body of ~every page. I think we could do a dismissible message/banner type thing, but that might be more annoying? Starting simple in any case. Suggestions welcome on anything about it really.

https://pyqtgraph--1959.org.readthedocs.build/en/1959/

@NilsNemitz @j9ac9k 