### PR TITLE
perform arrayToQPath in chunks

### DIFF
--- a/benchmarks/arrayToQPath.py
+++ b/benchmarks/arrayToQPath.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pyqtgraph as pg
+
+rng = np.random.default_rng(12345)
+
+class _TimeSuite:
+    params = ([10_000, 100_000, 1_000_000], ['all', 'finite', 'pairs', 'array'])
+
+    def setup(self, nelems, connect):
+        self.xdata = np.arange(nelems, dtype=np.float64)
+        self.ydata = rng.standard_normal(nelems, dtype=np.float64)
+        if connect == 'array':
+            self.connect_array = np.ones(nelems, dtype=bool)
+        if self.have_nonfinite:
+            self.ydata[::5000] = np.nan
+
+    def time_test(self, nelems, connect):
+        if connect == 'array':
+            connect = self.connect_array
+        pg.arrayToQPath(self.xdata, self.ydata, connect=connect)
+
+class TimeSuiteAllFinite(_TimeSuite):
+    def __init__(self):
+        super().__init__()
+        self.have_nonfinite = False
+
+class TimeSuiteWithNonFinite(_TimeSuite):
+    def __init__(self):
+        super().__init__()
+        self.have_nonfinite = True

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1903,14 +1903,14 @@ def _arrayToQPath_all(x, y, finiteCheck):
     numchunks = (n + chunksize - 1) // chunksize
     minchunks = 3
 
+    backfill_idx = None
+    if finiteCheck and not all_isfinite:
+        backfill_idx = _compute_backfill_indices(isfinite)
+
     if numchunks < minchunks:
         # too few chunks, batching would be a pessimization
         poly = create_qpolygonf(n)
         arr = ndarray_from_qpolygonf(poly)
-
-        backfill_idx = None
-        if finiteCheck and not all_isfinite:
-            backfill_idx = _compute_backfill_indices(isfinite)
 
         if backfill_idx is None:
             arr[:, 0] = x
@@ -1924,10 +1924,6 @@ def _arrayToQPath_all(x, y, finiteCheck):
             path.reserve(n)
         path.addPolygon(poly)
         return path
-
-    backfill_idx = None
-    if finiteCheck and not all_isfinite:
-        backfill_idx = _compute_backfill_indices(isfinite)
 
     # at this point, we have numchunks >= minchunks
 

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1895,17 +1895,15 @@ def _arrayToQPath_all(x, y, finiteCheck):
     if n == 0:
         return QtGui.QPainterPath()
 
+    backfill_idx = None
     if finiteCheck:
         isfinite = np.isfinite(x) & np.isfinite(y)
-        all_isfinite = np.all(isfinite)
+        if not np.all(isfinite):
+            backfill_idx = _compute_backfill_indices(isfinite)
 
     chunksize = 10000
     numchunks = (n + chunksize - 1) // chunksize
     minchunks = 3
-
-    backfill_idx = None
-    if finiteCheck and not all_isfinite:
-        backfill_idx = _compute_backfill_indices(isfinite)
 
     if numchunks < minchunks:
         # too few chunks, batching would be a pessimization


### PR DESCRIPTION
This PR optimizes ```arrayToQPath()``` with the following techniques:
1) creation of path in chunks
   * this reduces the amount of temporary memory being occupied by QPolygonF
2) reserving memory used by QPainterPath.
   * internally, elements are appended into QPainterPath one-by-one.
   * reserving avoids memory re-allocation and the resultant copying
3) deferring patching of non-finite values
   * this avoids creation of new copies of input data x and y by patching directly into the final buffer

The code was restructured and refactored to allow easier reasoning and to prevent changes in one mode from affecting another mode. Despite the larger code, I believe that the code is easier to follow now than before.

### master (PySide6 / Windows)
```
[ 75.00%] ··· arrayToQPath.TimeSuiteAllFinite.time_test
[ 75.00%] ··· ========= ============= ============ ============= ============
              --                                param2
              --------- -----------------------------------------------------
                param1       all         finite        pairs        array
              ========= ============= ============ ============= ============
                10000     90.7±0.3μs   95.7±0.5μs   1.03±0.01ms    1.06±0ms
                100000   2.35±0.02ms   2.50±0.1ms   11.9±0.09ms   12.0±0.1ms
               1000000    26.0±0.3ms   26.8±0.1ms    121±0.8ms    119±0.7ms
              ========= ============= ============ ============= ============

[100.00%] ··· arrayToQPath.TimeSuiteWithNonFinite.time_test                                                          ok
[100.00%] ··· ========= ============= ============= ============ =============
              --                                param2
              --------- ------------------------------------------------------
                param1       all          finite       pairs         array
              ========= ============= ============= ============ =============
                10000      448±2μs       181±1μs      1.52±0ms      1.54±0ms
                100000   6.49±0.02ms   3.06±0.01ms   17.5±0.1ms   17.6±0.08ms
               1000000    65.2±0.3ms    33.1±0.2ms   175±0.5ms     174±0.3ms
              ========= ============= ============= ============ =============
```

### this PR (PySide6 / Windows)
```
[ 75.00%] ··· arrayToQPath.TimeSuiteAllFinite.time_test                                                              ok
[ 75.00%] ··· ========= ============= ============= ============= =============
              --                                 param2
              --------- -------------------------------------------------------
                param1       all          finite        pairs         array
              ========= ============= ============= ============= =============
                10000     81.4±0.2μs    91.1±0.4μs   1.06±0.01ms   1.10±0.03ms
                100000   1.31±0.02ms   1.41±0.03ms   10.9±0.04ms   11.1±0.04ms
               1000000   13.4±0.06ms   14.1±0.07ms    112±0.6ms     110±0.3ms
              ========= ============= ============= ============= =============

[100.00%] ··· arrayToQPath.TimeSuiteWithNonFinite.time_test                                                          ok
[100.00%] ··· ========= ============= ============= ============= =============
              --                                 param2
              --------- -------------------------------------------------------
                param1       all          finite        pairs         array
              ========= ============= ============= ============= =============
                10000      179±5μs      115±0.2μs    1.16±0.03ms   1.18±0.01ms
                100000   2.59±0.03ms   1.37±0.01ms    12.2±0.1ms   12.3±0.09ms
               1000000    21.9±0.1ms    14.6±0.2ms    125±0.4ms     122±0.2ms
              ========= ============= ============= ============= =============
```