### PR TITLE
fix: ImageView calling deprecated QGraphicsItem.scale()

### DIFF
--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -358,13 +358,15 @@ class ImageView(QtGui.QWidget):
         
         profiler()
 
-        self.imageItem.resetTransform()
-        if scale is not None:
-            self.imageItem.scale(*scale)
-        if pos is not None:
-            self.imageItem.setPos(*pos)
-        if transform is not None:
-            self.imageItem.setTransform(transform)
+        if transform is None:
+            transform = QtGui.QTransform()
+            # note that the order of transform is
+            #   scale followed by translate
+            if pos is not None:
+                transform.translate(*pos)
+            if scale is not None:
+                transform.scale(*scale)
+        self.imageItem.setTransform(transform)
 
         profiler()
 


### PR DESCRIPTION
This PR is meant to address #1967. A leftover usage of QGraphicsItem.scale() within the library.

In addition, it fixes another problem. The documentation for ImageView says that the ```transform``` option overrides ```pos``` and ```scale```. 
```
        pos                Change the position of the displayed image
        scale              Change the scale of the displayed image
        transform          Set the transform of the displayed image. This option overrides *pos*  and *scale*.
```
However, because ```setPos()``` was used, which acts independently of ```setTransfrom()```, this was not actually true.
(Related to the discussions in #1726)

Now, the question is whether fixing the code to match the docs is in fact the right thing to do.

