### PR TITLE
Fix: updateDecimate should not unhide intentionaly hidden curves

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -246,7 +246,7 @@ class PlotItem(GraphicsWidget):
         
         if labels is None:
             labels = {}
-        for label in list(self.axes.keys()):b
+        for label in list(self.axes.keys()):
             if label in kargs:
                 labels[label] = kargs[label]
                 del kargs[label]

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -1006,7 +1006,7 @@ class PlotItem(GraphicsWidget):
     
     def _max_trace_wrapper_slot(self, check_state):
         if check_state:
-            self.updateDecimation(self)
+            self.updateDecimation()
         else:
             for curve in self.curves:
                 curve.show()

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -1003,7 +1003,6 @@ class PlotItem(GraphicsWidget):
     def clipToViewMode(self):
         return self.ctrl.clipToViewCheck.isChecked()
     
-    
     def _handle_max_traces_toggle(self, check_state):
         if check_state:
             self.updateDecimation()

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -240,13 +240,13 @@ class PlotItem(GraphicsWidget):
         self.ctrl.avgParamList.itemClicked.connect(self.avgParamListClicked)
         self.ctrl.averageGroup.toggled.connect(self.avgToggled)
         
-        self.ctrl.maxTracesCheck.toggled.connect(self.updateDecimation)
+        self.ctrl.maxTracesCheck.toggled.connect(self._max_trace_wrapper_slot)
         self.ctrl.forgetTracesCheck.toggled.connect(self.updateDecimation)
         self.ctrl.maxTracesSpin.valueChanged.connect(self.updateDecimation)
         
         if labels is None:
             labels = {}
-        for label in list(self.axes.keys()):
+        for label in list(self.axes.keys()):b
             if label in kargs:
                 labels[label] = kargs[label]
                 del kargs[label]
@@ -1002,10 +1002,18 @@ class PlotItem(GraphicsWidget):
         
     def clipToViewMode(self):
         return self.ctrl.clipToViewCheck.isChecked()
-
+    
+    
+    def _max_trace_wrapper_slot(self, check_state):
+        if check_state:
+            self.updateDecimation(self)
+        else:
+            for curve in self.curves:
+                curve.show()
+    
     def updateDecimation(self):
         if not self.ctrl.maxTracesCheck.isChecked():
-            numCurves = len(self.curves)
+            return
         else:
             numCurves = self.ctrl.maxTracesSpin.value()
 

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -240,7 +240,7 @@ class PlotItem(GraphicsWidget):
         self.ctrl.avgParamList.itemClicked.connect(self.avgParamListClicked)
         self.ctrl.averageGroup.toggled.connect(self.avgToggled)
         
-        self.ctrl.maxTracesCheck.toggled.connect(self._max_trace_wrapper_slot)
+        self.ctrl.maxTracesCheck.toggled.connect(self._handle_max_traces_toggle)
         self.ctrl.forgetTracesCheck.toggled.connect(self.updateDecimation)
         self.ctrl.maxTracesSpin.valueChanged.connect(self.updateDecimation)
         
@@ -1004,7 +1004,7 @@ class PlotItem(GraphicsWidget):
         return self.ctrl.clipToViewCheck.isChecked()
     
     
-    def _max_trace_wrapper_slot(self, check_state):
+    def _handle_max_traces_toggle(self, check_state):
         if check_state:
             self.updateDecimation()
         else:

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -1012,6 +1012,16 @@ class PlotItem(GraphicsWidget):
                 curve.show()
     
     def updateDecimation(self):
+        """Reduce or increase number of visible curves depending from Max Traces spinner value
+        if Max Traces is checked in the context menu. Destroy not visible curves if forget traces
+        is checked. This function is called in most cases automaticaly when Max Traces GUI elements
+        are triggered. Also it is auto-called when state of PlotItem is updated, state restored
+        or new items being added/removed.
+        
+        This can cause unexpected/conflicting state of curve visibility (or destruction) if curve
+        visibilities are controlled externaly. In case of external control it is adviced to disable
+        the Max Traces checkbox (or context menu) to prevent user from the unexpected
+        curve state change."""
         if not self.ctrl.maxTracesCheck.isChecked():
             return
         else:

--- a/tests/graphicsItems/PlotItem/test_PlotItem.py
+++ b/tests/graphicsItems/PlotItem/test_PlotItem.py
@@ -54,6 +54,18 @@ def test_PlotItem_maxTraces():
     assert curve1 not in item.curves, "curve1 should not be in the item's curves"
 
 
+def test_PlotItem_preserve_external_visibility_control():
+    item = pg.PlotItem()
+    curve1 = pg.PlotDataItem(np.random.normal(size=10))
+    curve2 = pg.PlotDataItem(np.random.normal(size=10))
+    item.addItem(curve1)
+    curve1.hide()
+    item.addItem(curve2)
+    assert not curve1.isVisible()
+    item.removeItem(curve2)
+    assert not curve1.isVisible()
+
+
 def test_plotitem_menu_initialize():
     """Test the menu initialization of the plotitem"""
     item = pg.PlotItem()


### PR DESCRIPTION
make update decimate to not unhide curves when items added/removed,
while preserving the Max Traces well behavior.

this fixes #1970 

- [x] implementation of bug-fix
- [x] add test if hidden curves stays hidden while adding/removing other item.
- [x] doc for MaxTrace and mention external possibilities to control curve visibility. (or add doc string to `updateDecimate`)