### PR TITLE
Change hardcoded padding into initialization parameter

### DIFF
--- a/pyqtgraph/widgets/ColorButton.py
+++ b/pyqtgraph/widgets/ColorButton.py
@@ -19,8 +19,9 @@ class ColorButton(QtGui.QPushButton):
     sigColorChanging = QtCore.Signal(object)  ## emitted whenever a new color is picked in the color dialog
     sigColorChanged = QtCore.Signal(object)   ## emitted when the selected color is accepted (user clicks OK)
     
-    def __init__(self, parent=None, color=(128,128,128)):
+    def __init__(self, parent=None, color=(128,128,128), padding=6):
         QtGui.QPushButton.__init__(self, parent)
+        self.padding = (padding, padding, -padding, -padding) if isinstance(padding, (int, float)) else padding
         self.setColor(color)
         self.colorDialog = QtGui.QColorDialog()
         self.colorDialog.setOption(QtGui.QColorDialog.ColorDialogOption.ShowAlphaChannel, True)
@@ -37,7 +38,7 @@ class ColorButton(QtGui.QPushButton):
     def paintEvent(self, ev):
         super().paintEvent(ev)
         p = QtGui.QPainter(self)
-        rect = self.rect().adjusted(6, 6, -6, -6)
+        rect = self.rect().adjusted(*self.padding)
         ## draw white base, then texture for indicating transparency, then actual color
         p.setBrush(functions.mkBrush('w'))
         p.drawRect(rect)


### PR DESCRIPTION
The hardcoded `ColorButton` padding value of 6 is generally okay, but starts to become undesirable when the button is very small (e.g. when the button is 15px high/wide, the padding takes up 12 of these pixels, leaving almost nothing for the actual color portion.

So let's move the hardcoded value to a default value, and allow the user to be able to change this padding value and also allow defining the value on a per-side basis (via passing in a tuple or list of inputs to supply to the `QRect.adjusted()` method).