### PR TITLE
Re-enable Matplotlib Exporter Test for Qt6

### DIFF
--- a/tests/exporters/test_matplotlib.py
+++ b/tests/exporters/test_matplotlib.py
@@ -3,13 +3,15 @@ import pytest
 import pyqtgraph as pg
 from pyqtgraph.exporters import MatplotlibExporter
 pytest.importorskip("matplotlib")
+import matplotlib
 
 app = pg.mkQApp()
 
 skip_qt6 = pytest.mark.skipif(
-    pg.Qt.QT_LIB in ["PySide6", "PyQt6"],
+    # availability of QtAgg signifies Qt6 support
+    pg.Qt.QT_LIB in ["PySide6", "PyQt6"] and "QtAgg" not in matplotlib.rcsetup.interactive_bk,
     reason= (
-        "Matplotlib has no Qt6 support yet, "
+        "installed version of Matplotlib does not support Qt6, "
         "see https://github.com/matplotlib/matplotlib/pull/19255"
     )
 )


### PR DESCRIPTION
Matplotlib 3.5.0 adds support for Qt6. This PR re-enables the skipped Matplotlib exporter tests when it detects the presence of Qt6 support.

Testing against Matplotlib 3.5.0b1 however causes CI segfaults for PySide2.

Testing locally on Windows, the offending line seems to be:
https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/backends/backend_qtagg.py#L77,
which is the same workaround used by pyqtgraph until https://github.com/pyqtgraph/pyqtgraph/pull/1223
(To be clear, there is no more segfault after commenting out the offending line)

I don't have a MWE to raise the issue on Matplotlib.
