### PR TITLE
Fix Python 3.10 GLGradientLegendItem call to QPainter.drawText

### DIFF
--- a/pyqtgraph/opengl/items/GLGradientLegendItem.py
+++ b/pyqtgraph/opengl/items/GLGradientLegendItem.py
@@ -78,6 +78,6 @@ class GLGradientLegendItem(GLGraphicsItem):
             x = 1.1 * self.size[0] + self.pos[0]
             y = self.size[1] - labelPosition * self.size[1] + self.pos[1] + 8
             ##todo: fonts
-            painter.drawText(x, y, labelText)
+            painter.drawText(QtCore.QPointF(x, y), labelText)
         painter.end()
 


### PR DESCRIPTION
In Python 3.10, there seems to be some issue with `QPainter.drawText(float, float, str)` signature.  We have seen this before in #1887.  While testing python 3.10 out on the code-base this came up as a test failure.  This modifies the call to that method to use a QPointF object instead.