### PR TITLE
skip tests using scipy if not installed

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -39,6 +39,8 @@ def test_interpolateArray_order1():
 
 
 def check_interpolateArray(order):
+    pytest.importorskip("scipy")
+
     def interpolateArray(data, x):
         result = pg.interpolateArray(data, x, order=order)
         assert result.shape == x.shape[:-1] + data.shape[x.shape[-1]:]


### PR DESCRIPTION
scipy is an optional dependency for pyqtgraph but is used in the test suite for verifying interpolation results.
This PR skips those 2 tests if scipy is not installed.

This leaves ```numpy``` as the only mandatory dependency for running ```pytest tests```.
```pyopengl``` is additionally required to run ```pytest examples```.