### PR TITLE
Include the ability to add multiple y axes to plots

### DIFF
--- a/examples/MultiplePlotAxes.py
+++ b/examples/MultiplePlotAxes.py
@@ -2,7 +2,7 @@
 """
 Demonstrates a way to put multiple axes around a single plot.
 """
-import initExample  ## Add path to library (just for examples; you do not need this)
+import initExample ## Add path to library (just for examples; you do not need this)
 
 import pyqtgraph as pg
 

--- a/examples/MultiplePlotAxes.py
+++ b/examples/MultiplePlotAxes.py
@@ -1,64 +1,34 @@
 # -*- coding: utf-8 -*-
 """
-Demonstrates a way to put multiple axes around a single plot. 
-
-(This will eventually become a built-in feature of PlotItem)
-
+Demonstrates a way to put multiple axes around a single plot.
 """
-import initExample ## Add path to library (just for examples; you do not need this)
+import initExample  ## Add path to library (just for examples; you do not need this)
 
 import pyqtgraph as pg
-from pyqtgraph.Qt import QtCore, QtGui
-import numpy as np
 
 pg.mkQApp()
 
+# Create a new plot as normal
 pw = pg.PlotWidget()
 pw.show()
 pw.setWindowTitle('pyqtgraph example: MultiplePlotAxes')
 p1 = pw.plotItem
 p1.setLabels(left='axis 1')
+p1.getViewBox().setMouseMode(p1.vb.RectMode)
+p1.plot([1, 2, 4, 8, 16, 32])
 
-## create a new ViewBox, link the right axis to its coordinate system
-p2 = pg.ViewBox()
-p1.showAxis('right')
-p1.scene().addItem(p2)
-p1.getAxis('right').linkToView(p2)
-p2.setXLink(p1)
-p1.getAxis('right').setLabel('axis2', color='#0000ff')
-
-## create third ViewBox. 
-## this time we need to create a new axis as well.
-p3 = pg.ViewBox()
+# Now create a couple of additional axes
+ax2 = pg.AxisItem('right')
+ax2.setLabel('axis2', color='#0000ff')
 ax3 = pg.AxisItem('right')
-p1.layout.addItem(ax3, 2, 3)
-p1.scene().addItem(p3)
-ax3.linkToView(p3)
-p3.setXLink(p1)
-ax3.setZValue(-10000)
 ax3.setLabel('axis 3', color='#ff0000')
 
+# Add axis 2 to the plot and associated a data curve with it at the same time
+p1.addAxis(ax2, 'right1', pg.PlotCurveItem([10, 20, 40, 80, 40, 20], pen='b'))
 
-## Handle view resizing 
-def updateViews():
-    ## view has resized; update auxiliary views to match
-    global p1, p2, p3
-    p2.setGeometry(p1.vb.sceneBoundingRect())
-    p3.setGeometry(p1.vb.sceneBoundingRect())
-    
-    ## need to re-update linked axes since this was called
-    ## incorrectly while views had different shapes.
-    ## (probably this should be handled in ViewBox.resizeEvent)
-    p2.linkedViewChanged(p1.vb, p2.XAxis)
-    p3.linkedViewChanged(p1.vb, p3.XAxis)
-
-updateViews()
-p1.vb.sigResized.connect(updateViews)
-
-
-p1.plot([1,2,4,8,16,32])
-p2.addItem(pg.PlotCurveItem([10,20,40,80,40,20], pen='b'))
-p3.addItem(pg.PlotCurveItem([3200,1600,800,400,200,100], pen='r'))
+# An example of linking a data curve to an axis which already exists on the plot
+p1.addAxis(ax3, 'right2')
+p1.linkDataToAxis(pg.PlotCurveItem([3200, 1600, 800, 400, 200, 100], pen='r'), 'right2')
 
 if __name__ == '__main__':
     pg.exec()

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -390,7 +390,7 @@ class PlotItem(GraphicsWidget):
 
         self.stackedViews.add(view)
         # These signals will be emitted by the top level view when it handles these events
-        self.vb.sigMouseDragZoomed.connect(view.mouseDragEvent)
+        self.vb.sigMouseDragged.connect(view.mouseDragEvent)
         self.vb.sigMouseWheelZoomed.connect(view.wheelEvent)
         self.vb.sigHistoryChanged.connect(view.scaleHistory)
 
@@ -758,7 +758,6 @@ class PlotItem(GraphicsWidget):
         layout. See removeItem(), clearPlots(), or clear() if removing the items themselves is required.
         """
         while self.layout.count() > 0:
-            item = self.layout.itemAt(0)
             self.layout.removeAt(0)
 
     def rebuildLayout(self):

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -94,6 +94,9 @@ class ViewBox(GraphicsWidget):
     sigStateChanged = QtCore.Signal(object)
     sigTransformChanged = QtCore.Signal(object)
     sigResized = QtCore.Signal(object)
+    sigMouseDragZoomed = QtCore.Signal(object, object)
+    sigMouseWheelZoomed = QtCore.Signal(object, object)
+    sigHistoryChanged = QtCore.Signal(object)
 
     ## mouse modes
     PanMode = 3
@@ -1219,6 +1222,7 @@ class ViewBox(GraphicsWidget):
         self.scaleBy(s, center)
         ev.accept()
         self.sigRangeChangedManually.emit(mask)
+        self.sigMouseWheelZoomed.emit(ev, axis)
 
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.MouseButton.RightButton and self.menuEnabled():
@@ -1260,6 +1264,7 @@ class ViewBox(GraphicsWidget):
                     self.rbScaleBox.hide()
                     ax = QtCore.QRectF(Point(ev.buttonDownPos(ev.button())), Point(pos))
                     ax = self.childGroup.mapRectFromParent(ax)
+                    self.sigMouseDragZoomed.emit(ev, axis)
                     self.showAxRect(ax)
                     self.axHistoryPointer += 1
                     self.axHistory = self.axHistory[:self.axHistoryPointer] + [ax]
@@ -1325,6 +1330,7 @@ class ViewBox(GraphicsWidget):
         ptr = max(0, min(len(self.axHistory)-1, self.axHistoryPointer+d))
         if ptr != self.axHistoryPointer:
             self.axHistoryPointer = ptr
+            self.sigHistoryChanged.emit(d)
             self.showAxRect(self.axHistory[ptr])
 
     def updateScaleBox(self, p1, p2):
@@ -1468,7 +1474,7 @@ class ViewBox(GraphicsWidget):
 
         bounds = QtCore.QRectF(range[0][0], range[1][0], range[0][1]-range[0][0], range[1][1]-range[1][0])
         return bounds
-        
+
     def update(self, *args, **kwargs):
         self.prepareForPaint()
         GraphicsWidget.update(self, *args, **kwargs)
@@ -1736,3 +1742,4 @@ class ViewBox(GraphicsWidget):
 
 
 from .ViewBoxMenu import ViewBoxMenu
+

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -94,7 +94,7 @@ class ViewBox(GraphicsWidget):
     sigStateChanged = QtCore.Signal(object)
     sigTransformChanged = QtCore.Signal(object)
     sigResized = QtCore.Signal(object)
-    sigMouseDragZoomed = QtCore.Signal(object, object)
+    sigMouseDragged = QtCore.Signal(object, object)
     sigMouseWheelZoomed = QtCore.Signal(object, object)
     sigHistoryChanged = QtCore.Signal(object)
 
@@ -1264,7 +1264,7 @@ class ViewBox(GraphicsWidget):
                     self.rbScaleBox.hide()
                     ax = QtCore.QRectF(Point(ev.buttonDownPos(ev.button())), Point(pos))
                     ax = self.childGroup.mapRectFromParent(ax)
-                    self.sigMouseDragZoomed.emit(ev, axis)
+                    self.sigMouseDragged.emit(ev, axis)
                     self.showAxRect(ax)
                     self.axHistoryPointer += 1
                     self.axHistory = self.axHistory[:self.axHistoryPointer] + [ax]
@@ -1283,6 +1283,9 @@ class ViewBox(GraphicsWidget):
                 if x is not None or y is not None:
                     self.translateBy(x=x, y=y)
                 self.sigRangeChangedManually.emit(self.state['mouseEnabled'])
+                if axis is None:
+                    # This event happened directly in the view box, so propagate to any stacked views
+                    self.sigMouseDragged.emit(ev, axis)
         elif ev.button() & QtCore.Qt.MouseButton.RightButton:
             #print "vb.rightDrag"
             if self.state['aspectLocked'] is not False:

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -219,9 +219,15 @@ class ViewBoxMenu(QtGui.QMenu):
 
     def set3ButtonMode(self):
         self.view().setLeftButtonAction('pan')
+        if len(self.view().stackedViews) > 0:
+            for view in self.view().stackedViews:
+                view.setLeftButtonAction('pan')
         
     def set1ButtonMode(self):
         self.view().setLeftButtonAction('rect')
+        if len(self.view().stackedViews) > 0:
+            for view in self.view().stackedViews:
+                view.setLeftButtonAction('rect')
         
     def setViewList(self, views):
         names = ['']


### PR DESCRIPTION
## Description
Creates the ability to add multiple y axes to PyQTGraph plots. This is done through PlotItem.addAxis() so it will work with any existing and previous saved plots. These changes should be invisible to any existing plots and not change their end functionality in any way.

Note that this is similar to PR #1359 and is being opened to explore merging functionality between them. The differences here are that the changes are integrated directly into PlotItem/View Box, it has example support for propagating zoom events through stacked views, as well as support for dynamically re-linking data with axes during runtime. However, this does not yet include multiple x axes.

## Example/Testing:
The existing MultiplePlotAxes example is rewritten to use the new addAxis() api. It demonstrates adding a couple additional axes to the right of the plot, as well as zoom functionality for each view box. All existing tests/examples still function properly
