### PR TITLE
Fix Some Import Issues

### DIFF
--- a/pyqtgraph/dockarea/Container.py
+++ b/pyqtgraph/dockarea/Container.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from ..Qt import QtCore, QtGui, QtWidgets
 import weakref
+from .Dock import Dock
+
 
 class Container(object):
     #sigStretchChanged = QtCore.Signal()  ## can't do this here; not a QObject.
@@ -245,7 +247,7 @@ class TContainer(Container, QtGui.QWidget):
 
 
     def _insertItem(self, item, index):
-        if not isinstance(item, Dock.Dock):
+        if not isinstance(item, Dock):
             raise Exception("Tab containers may hold only docks, not other containers.")
         self.stack.insertWidget(index, item)
         self.hTabLayout.insertWidget(index, item.label)
@@ -288,5 +290,3 @@ class TContainer(Container, QtGui.QWidget):
             x = max(x, wx)
             y = max(y, wy)
         self.setStretch(x, y)
-        
-from . import Dock

--- a/pyqtgraph/parametertree/parameterTypes/action.py
+++ b/pyqtgraph/parametertree/parameterTypes/action.py
@@ -1,4 +1,5 @@
-from .. import ParameterItem, Parameter
+from ..ParameterItem import ParameterItem
+from ..Parameter import Parameter
 from ...Qt import QtWidgets, QtCore
 
 

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -1,6 +1,8 @@
 import builtins
 
-from .. import ParameterItem, Parameter
+from ..ParameterItem import ParameterItem
+from ..Parameter import Parameter
+
 from ... import functions as fn
 from ...Qt import QtWidgets, QtCore, QtGui
 from ... import icons

--- a/pyqtgraph/parametertree/parameterTypes/bool.py
+++ b/pyqtgraph/parametertree/parameterTypes/bool.py
@@ -1,5 +1,5 @@
-from pyqtgraph.Qt import QtWidgets
-from pyqtgraph.parametertree.parameterTypes import WidgetParameterItem
+from ...Qt import QtWidgets
+from .basetypes import WidgetParameterItem
 
 
 class BoolParameterItem(WidgetParameterItem):

--- a/pyqtgraph/parametertree/parameterTypes/calendar.py
+++ b/pyqtgraph/parametertree/parameterTypes/calendar.py
@@ -1,5 +1,5 @@
 from ...Qt import QtWidgets, QtCore
-from .. import Parameter
+from ..Parameter import Parameter
 from .basetypes import WidgetParameterItem
 
 

--- a/pyqtgraph/parametertree/parameterTypes/checklist.py
+++ b/pyqtgraph/parametertree/parameterTypes/checklist.py
@@ -2,7 +2,7 @@ from . import BoolParameterItem, SimpleParameter
 from .basetypes import GroupParameterItem, GroupParameter, WidgetParameterItem
 from .list import ListParameter
 from .slider import Emitter
-from .. import ParameterItem
+from ..ParameterItem import ParameterItem
 from ... import functions as fn
 from ...Qt import QtWidgets
 

--- a/pyqtgraph/parametertree/parameterTypes/file.py
+++ b/pyqtgraph/parametertree/parameterTypes/file.py
@@ -2,7 +2,7 @@ import os
 import re
 
 from .str import StrParameterItem
-from .. import Parameter
+from ..Parameter import Parameter
 from ...Qt import QtWidgets, QtGui, QtCore
 
 

--- a/pyqtgraph/parametertree/parameterTypes/font.py
+++ b/pyqtgraph/parametertree/parameterTypes/font.py
@@ -1,5 +1,5 @@
 from .basetypes import WidgetParameterItem
-from .. import Parameter
+from ..Parameter import Parameter
 from ...Qt import QtWidgets, QtGui
 
 

--- a/pyqtgraph/parametertree/parameterTypes/list.py
+++ b/pyqtgraph/parametertree/parameterTypes/list.py
@@ -2,7 +2,7 @@ import warnings
 from collections import OrderedDict
 
 from .basetypes import WidgetParameterItem
-from .. import Parameter
+from ..Parameter import Parameter
 from ...Qt import QtWidgets
 from ... import functions as fn
 

--- a/pyqtgraph/parametertree/parameterTypes/pen.py
+++ b/pyqtgraph/parametertree/parameterTypes/pen.py
@@ -1,5 +1,5 @@
 from .basetypes import WidgetParameterItem
-from .. import Parameter
+from ..Parameter import Parameter
 from ... import functions as fn
 from ...Qt import QtWidgets, QtGui, QtCore
 from ...widgets.PenSelectorDialog import PenSelectorDialog

--- a/pyqtgraph/parametertree/parameterTypes/progress.py
+++ b/pyqtgraph/parametertree/parameterTypes/progress.py
@@ -1,5 +1,5 @@
 from ...Qt import QtWidgets
-from .. import Parameter
+from ..Parameter import Parameter
 from .basetypes import WidgetParameterItem
 
 

--- a/pyqtgraph/parametertree/parameterTypes/slider.py
+++ b/pyqtgraph/parametertree/parameterTypes/slider.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .basetypes import WidgetParameterItem, Emitter
-from .. import Parameter
+from ..Parameter import Parameter
 from ...Qt import QtCore, QtWidgets
 
 class SliderParameterItem(WidgetParameterItem):

--- a/pyqtgraph/parametertree/parameterTypes/str.py
+++ b/pyqtgraph/parametertree/parameterTypes/str.py
@@ -1,5 +1,5 @@
-from pyqtgraph.Qt import QtWidgets
-from pyqtgraph.parametertree.parameterTypes import WidgetParameterItem
+from ...Qt import QtWidgets
+from .basetypes import WidgetParameterItem
 
 
 class StrParameterItem(WidgetParameterItem):

--- a/pyqtgraph/parametertree/parameterTypes/text.py
+++ b/pyqtgraph/parametertree/parameterTypes/text.py
@@ -1,5 +1,5 @@
 from .basetypes import WidgetParameterItem
-from .. import Parameter
+from ..Parameter import Parameter
 from ...Qt import QtWidgets, QtCore
 
 


### PR DESCRIPTION
This PR addresses two issues.

1. Some parameter types used non-relative imports which does not conform to the rest of the library standards.
2. Some imports were done in such a way that when `isort` redoes the ordering, they would break.  
