### PR TITLE
optimize ``create_qpolygonf`` for PySide2 and PyQt5

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -2184,9 +2184,12 @@ def ndarray_from_qpolygonf(polyline):
     return memory
 
 def create_qpolygonf(size):
-    if QT_LIB in ('PyQt6', 'PySide6'):
+    if QT_LIB == 'PyQt6':
         polyline = QtGui.QPolygonF()
         polyline.fill(QtCore.QPointF(), size)
+    elif QT_LIB == 'PySide6':
+        polyline = QtGui.QPolygonF()
+        polyline.resize(size)
     else:
         polyline = QtGui.QPolygonF(size)
     return polyline

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -2184,7 +2184,7 @@ def ndarray_from_qpolygonf(polyline):
     return memory
 
 def create_qpolygonf(size):
-    if QT_LIB == 'PyQt6':
+    if QT_LIB in ('PyQt6', 'PySide6'):
         polyline = QtGui.QPolygonF()
         polyline.fill(QtCore.QPointF(), size)
     else:

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -43,7 +43,7 @@ __all__ = [
     # 'ndarray_from_qimage',
     'imageToArray', 'colorToAlpha',
     'gaussianFilter', 'downsample', 'arrayToQPath',
-    # 'ndarray_from_qpolygonf', 'arrayToQPolygonF',
+    # 'ndarray_from_qpolygonf', 'create_qpolygonf', 'arrayToQPolygonF',
     'isocurve', 'traceImage', 'isosurface',
     'invertQTransform',
     'pseudoScatter', 'toposort', 'disconnect', 'SignalBlock']
@@ -1919,7 +1919,7 @@ def _arrayToQPath_all(x, y, finiteCheck):
 
     if numchunks < minchunks:
         # too few chunks, batching would be a pessimization
-        poly = QtGui.QPolygonF(n)
+        poly = create_qpolygonf(n)
         arr = ndarray_from_qpolygonf(poly)
 
         if backfill_idx is None:
@@ -1989,7 +1989,7 @@ def _arrayToQPath_finite(x, y, isfinite=None):
 
     # create a single polygon able to hold the largest chunk
     maxlen = max(len(chunk) for chunk in xchunks)
-    subpoly = QtGui.QPolygonF(maxlen)
+    subpoly = create_qpolygonf(maxlen)
     subarr = ndarray_from_qpolygonf(subpoly)
 
     # resize and fill do not change the capacity
@@ -2183,6 +2183,14 @@ def ndarray_from_qpolygonf(polyline):
     memory = np.frombuffer(buffer, np.double).reshape((-1, 2))
     return memory
 
+def create_qpolygonf(size):
+    if QT_LIB == 'PyQt6':
+        polyline = QtGui.QPolygonF()
+        polyline.resize(size)
+    else:
+        polyline = QtGui.QPolygonF(size)
+    return polyline
+
 def arrayToQPolygonF(x, y):
     """
     Utility function to convert two 1D-NumPy arrays representing curve data
@@ -2215,7 +2223,7 @@ def arrayToQPolygonF(x, y):
     ):
         raise ValueError("Arguments must be 1D and the same size")
     size = x.size
-    polyline = QtGui.QPolygonF(size)
+    polyline = create_qpolygonf(size)
     memory = ndarray_from_qpolygonf(polyline)
     memory[:, 0] = x
     memory[:, 1] = y

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -2186,7 +2186,7 @@ def ndarray_from_qpolygonf(polyline):
 def create_qpolygonf(size):
     if QT_LIB == 'PyQt6':
         polyline = QtGui.QPolygonF()
-        polyline.fill(QtGui.QPointF(), size)
+        polyline.fill(QtCore.QPointF(), size)
     else:
         polyline = QtGui.QPolygonF(size)
     return polyline

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -43,7 +43,7 @@ __all__ = [
     # 'ndarray_from_qimage',
     'imageToArray', 'colorToAlpha',
     'gaussianFilter', 'downsample', 'arrayToQPath',
-    # 'ndarray_from_qpolygonf', 'create_qpolygonf', 'arrayToQPolygonF',
+    # 'ndarray_from_qpolygonf', 'arrayToQPolygonF',
     'isocurve', 'traceImage', 'isosurface',
     'invertQTransform',
     'pseudoScatter', 'toposort', 'disconnect', 'SignalBlock']
@@ -1919,7 +1919,7 @@ def _arrayToQPath_all(x, y, finiteCheck):
 
     if numchunks < minchunks:
         # too few chunks, batching would be a pessimization
-        poly = create_qpolygonf(n)
+        poly = QtGui.QPolygonF(n)
         arr = ndarray_from_qpolygonf(poly)
 
         if backfill_idx is None:
@@ -1989,7 +1989,7 @@ def _arrayToQPath_finite(x, y, isfinite=None):
 
     # create a single polygon able to hold the largest chunk
     maxlen = max(len(chunk) for chunk in xchunks)
-    subpoly = create_qpolygonf(maxlen)
+    subpoly = QtGui.QPolygonF(maxlen)
     subarr = ndarray_from_qpolygonf(subpoly)
 
     # resize and fill do not change the capacity
@@ -2183,14 +2183,6 @@ def ndarray_from_qpolygonf(polyline):
     memory = np.frombuffer(buffer, np.double).reshape((-1, 2))
     return memory
 
-def create_qpolygonf(size):
-    polyline = QtGui.QPolygonF()
-    if QT_LIB.startswith('PyQt'):
-        polyline.fill(QtCore.QPointF(), size)
-    else:
-        polyline.resize(size)
-    return polyline
-
 def arrayToQPolygonF(x, y):
     """
     Utility function to convert two 1D-NumPy arrays representing curve data
@@ -2223,7 +2215,7 @@ def arrayToQPolygonF(x, y):
     ):
         raise ValueError("Arguments must be 1D and the same size")
     size = x.size
-    polyline = create_qpolygonf(size)
+    polyline = QtGui.QPolygonF(size)
     memory = ndarray_from_qpolygonf(polyline)
     memory[:, 0] = x
     memory[:, 1] = y

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -2186,7 +2186,7 @@ def ndarray_from_qpolygonf(polyline):
 def create_qpolygonf(size):
     if QT_LIB == 'PyQt6':
         polyline = QtGui.QPolygonF()
-        polyline.resize(size)
+        polyline.fill(QtGui.QPointF(), size)
     else:
         polyline = QtGui.QPolygonF(size)
     return polyline

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -377,7 +377,7 @@ def test_arrayToQPath(xs, ys, connect, expected):
 
 def test_ndarray_from_qpolygonf():
     # test that we get an empty ndarray from an empty QPolygonF
-    poly = pg.functions.create_qpolygonf(0)
+    poly = QtGui.QPolygonF(0)
     arr = pg.functions.ndarray_from_qpolygonf(poly)
     assert isinstance(arr, np.ndarray)
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -377,7 +377,7 @@ def test_arrayToQPath(xs, ys, connect, expected):
 
 def test_ndarray_from_qpolygonf():
     # test that we get an empty ndarray from an empty QPolygonF
-    poly = QtGui.QPolygonF(0)
+    poly = pg.functions.create_qpolygonf(0)
     arr = pg.functions.ndarray_from_qpolygonf(poly)
     assert isinstance(arr, np.ndarray)
 


### PR DESCRIPTION
remove ``create_qpolygonf``: PyQt and PySide support the constructor with the size argument so this function is not needed anymore.

This change brings a small performance boots (~2us / call)