### PR TITLE
Fix displace between selection area and mouse pos

### DIFF
--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -65,7 +65,7 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         """
         GraphicsWidget.__init__(self)
         GraphicsWidgetAnchor.__init__(self)
-        self.setFlag(self.GraphicsItemFlag.ItemIgnoresTransformations)
+        # self.setFlag(self.GraphicsItemFlag.ItemIgnoresTransformations)
         self.layout = QtGui.QGraphicsGridLayout()
         self.layout.setVerticalSpacing(verSpacing)
         self.layout.setHorizontalSpacing(horSpacing)

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -65,7 +65,7 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         """
         GraphicsWidget.__init__(self)
         GraphicsWidgetAnchor.__init__(self)
-        # self.setFlag(self.GraphicsItemFlag.ItemIgnoresTransformations)
+        self.setFlag(self.GraphicsItemFlag.ItemIgnoresTransformations)
         self.layout = QtGui.QGraphicsGridLayout()
         self.layout.setVerticalSpacing(verSpacing)
         self.layout.setHorizontalSpacing(horSpacing)

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1242,7 +1242,7 @@ class ViewBox(GraphicsWidget):
         ev.accept()  ## we accept all buttons
 
         pos = ev.scenePos()
-        dif = pos - ev.lastPos()
+        dif = pos - ev.lastScenePos()
         dif = dif * -1
 
         ## Ignore axes if mouse is disabled

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1241,9 +1241,8 @@ class ViewBox(GraphicsWidget):
         ## if axis is specified, event will only affect that axis.
         ev.accept()  ## we accept all buttons
 
-        pos = ev.pos()
-        lastPos = ev.lastPos()
-        dif = pos - lastPos
+        pos = ev.scenePos()
+        dif = pos - ev.lastPos()
         dif = dif * -1
 
         ## Ignore axes if mouse is disabled
@@ -1258,14 +1257,14 @@ class ViewBox(GraphicsWidget):
                 if ev.isFinish():  ## This is the final move in the drag; change the view scale now
                     #print "finish"
                     self.rbScaleBox.hide()
-                    ax = QtCore.QRectF(Point(ev.buttonDownPos(ev.button())), Point(pos))
-                    ax = self.childGroup.mapRectFromParent(ax)
+                    ax = QtCore.QRectF(Point(ev.buttonDownScenePos(ev.button())), Point(pos))
+                    ax = self.childGroup.mapRectFromScene(ax)
                     self.showAxRect(ax)
                     self.axHistoryPointer += 1
                     self.axHistory = self.axHistory[:self.axHistoryPointer] + [ax]
                 else:
                     ## update shape of scale box
-                    self.updateScaleBox(ev.buttonDownPos(), ev.pos())
+                    self.updateScaleBox(ev.buttonDownScenePos(), ev.scenePos())
             else:
                 tr = self.childGroup.transform()
                 tr = fn.invertQTransform(tr)
@@ -1329,7 +1328,7 @@ class ViewBox(GraphicsWidget):
 
     def updateScaleBox(self, p1, p2):
         r = QtCore.QRectF(p1, p2)
-        r = self.childGroup.mapRectFromParent(r)
+        r = self.childGroup.mapRectFromScene(r)
         self.rbScaleBox.setPos(r.topLeft())
         tr = QtGui.QTransform.fromScale(r.width(), r.height())
         self.rbScaleBox.setTransform(tr)


### PR DESCRIPTION
For a plot with x- and y-grid lines, the selection area's bottom right corner (created for mouse interaction mode set to RectMode) is (stronlgy) displaced from the mouse cursor position.
Detail information see #1937.
There's some problems in `ViewBox.mouseDragEvent()` and `ViewBox.updateScaleBox()`.
When gird is on, the mouse drag event is sent by the` AxisItem`, when grid is off, the mouse drag event is sent by `ViewBox`.
So with grid off, `ev.buttonDownPos()` in `mouseDragEvent()` return a position in the coordinate of `ViewBox`, which is right for `r = self.childGroup.mapRectFromParent(r)` in `updateScaleBox()`.
But with grid on, `ev.buttonDownPos()` in `mouseDragEvent()` return a position in the coordinate of `AxisItem`, which is not consistent with the need of `self.childGroup.mapRectFromParent(r)` in `updateScaleBox()`.
This problem is fixed by using scene coordinate in these two places.
