### PR TITLE
Fix deprecation warnings

### DIFF
--- a/pyqtgraph/graphicsItems/TargetItem.py
+++ b/pyqtgraph/graphicsItems/TargetItem.py
@@ -138,7 +138,7 @@ class TargetItem(UIGraphicsItem):
     def sigDragged(self):
         warnings.warn(
             "'sigDragged' has been deprecated and will be removed in 0.13.0.  Use "
-            "`sigPositionChanged` instead",
+            "`sigPositionChangeFinished` instead",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/pyqtgraph/ptime.py
+++ b/pyqtgraph/ptime.py
@@ -18,7 +18,7 @@ time = None
 def winTime():
     """Return the current time in seconds with high precision (windows version, use Manager.time() to stay platform independent)."""
     warnings.warn(
-        "'pg.time' will be removed from the library in the first release following January, 2022.  Use time.perf_counter instead",
+        "'pg.time' will be removed from the library in the first release following January, 2022.",
         DeprecationWarning, stacklevel=2
     )
     return clock() + START_TIME
@@ -26,7 +26,7 @@ def winTime():
 def unixTime():
     """Return the current time in seconds with high precision (unix version, use Manager.time() to stay platform independent)."""
     warnings.warn(
-        "'pg.time' will be removed from the library in the first release following January, 2022.  Use time.perf_counter instead",
+        "'pg.time' will be removed from the library in the first release following January, 2022.",
         DeprecationWarning, stacklevel=2
     )
     return system_time()


### PR DESCRIPTION
- `TargetItem.sigDragged` deprecation warning now recommends sigPositionChangeFinished
- `ptime.time` now has no recommended replacement (time.perf_counter is not compatible)