### PR TITLE
Fix WidgetGroup handling of QSplitter + code cleanup

### DIFF
--- a/pyqtgraph/WidgetGroup.py
+++ b/pyqtgraph/WidgetGroup.py
@@ -15,7 +15,7 @@ import weakref, inspect
 __all__ = ['WidgetGroup']
 
 def splitterState(w):
-    s = bytes(w.saveState().toPercentEncoding()).decode()
+    s = w.saveState().toPercentEncoding().data().decode()
     return s
     
 def restoreSplitter(w, s):


### PR DESCRIPTION
Old method of getting splitter state ended up with `"b'...'"` in the result (looks like a pyqt bug).