### PR TITLE
RemoteGraphicsView.py : implement pickle protocol

### DIFF
--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -8,7 +8,120 @@ from .. import CONFIG_OPTIONS
 import mmap, tempfile, os, atexit, sys, random
 
 __all__ = ['RemoteGraphicsView']
-        
+
+
+def serialize_mouse_enum(*args):
+    # PyQt6 can pickle enums and flags but cannot cast to int
+    # PyQt5 5.12, PyQt5 5.15, PySide2 5.15, PySide6 can pickle enums but not flags
+    # PySide2 5.12 cannot pickle enums nor flags
+    # MouseButtons and KeyboardModifiers are flags
+    if QT_LIB != 'PyQt6':
+        args = [int(x) for x in args]
+    return args
+
+
+class MouseEvent(QtGui.QMouseEvent):
+    @staticmethod
+    def get_state(obj, picklable=False):
+        typ = obj.type()
+        if isinstance(typ, int):
+            # PyQt6 returns an int here instead of QEvent.Type,
+            # but its QtGui.QMouseEvent constructor takes only QEvent.Type.
+            # Note however that its QtCore.QEvent constructor accepts both
+            # QEvent.Type and int.
+            typ = QtCore.QEvent.Type(typ)
+        lpos = obj.position() if hasattr(obj, 'position') else obj.localPos()
+        gpos = obj.globalPosition() if hasattr(obj, 'globalPosition') else obj.screenPos()
+        btn, btns, mods = obj.button(), obj.buttons(), obj.modifiers()
+        if picklable:
+            typ, btn, btns, mods = serialize_mouse_enum(typ, btn, btns, mods)
+        return typ, lpos, gpos, btn, btns, mods
+
+    def __init__(self, rhs):
+        super().__init__(*self.get_state(rhs))
+
+    def __getstate__(self):
+        return self.get_state(self, picklable=True)
+
+    def __setstate__(self, state):
+        typ, lpos, gpos, btn, btns, mods = state
+        typ = QtCore.QEvent.Type(typ)
+        if QT_LIB != 'PyQt6':
+            btn = QtCore.Qt.MouseButton(btn)
+            btns = QtCore.Qt.MouseButtons(btns)
+            mods = QtCore.Qt.KeyboardModifiers(mods)
+        super().__init__(typ, lpos, gpos, btn, btns, mods)
+
+
+class WheelEvent(QtGui.QWheelEvent):
+    @staticmethod
+    def get_state(obj, picklable=False):
+        # {PyQt6, PySide6}      have position()
+        # {PyQt5, PySide2} 5.15 have position()
+        # {PyQt5, PySide2} 5.15 have posF() (contrary to C++ docs)
+        # {PyQt5, PySide2} 5.12 have posF()
+        lpos = obj.position() if hasattr(obj, 'position') else obj.posF()
+        gpos = obj.globalPosition() if hasattr(obj, 'globalPosition') else obj.globalPosF()
+        pixdel, angdel, btns = obj.pixelDelta(), obj.angleDelta(), obj.buttons()
+        mods, phase, inverted = obj.modifiers(), obj.phase(), obj.inverted()
+        if picklable:
+            btns, mods, phase = serialize_mouse_enum(btns, mods, phase)
+        return lpos, gpos, pixdel, angdel, btns, mods, phase, inverted
+
+    def __init__(self, rhs):
+        items = list(self.get_state(rhs))
+        items[1] = items[0]     # gpos = lpos
+        super().__init__(*items)
+
+    def __getstate__(self):
+        return self.get_state(self, picklable=True)
+
+    def __setstate__(self, state):
+        pos, gpos, pixdel, angdel, btns, mods, phase, inverted = state
+        if QT_LIB != 'PyQt6':
+            btns = QtCore.Qt.MouseButtons(btns)
+            mods = QtCore.Qt.KeyboardModifiers(mods)
+            phase = QtCore.Qt.ScrollPhase(phase)
+        super().__init__(pos, gpos, pixdel, angdel, btns, mods, phase, inverted)
+
+
+class EnterEvent(QtGui.QEnterEvent):
+    @staticmethod
+    def get_state(obj):
+        lpos = obj.position() if hasattr(obj, 'position') else obj.localPos()
+        wpos = obj.scenePosition() if hasattr(obj, 'scenePosition') else obj.windowPos()
+        gpos = obj.globalPosition() if hasattr(obj, 'globalPosition') else obj.screenPos()
+        return lpos, wpos, gpos
+
+    def __init__(self, rhs):
+        super().__init__(*self.get_state(rhs))
+
+    def __getstate__(self):
+        return self.get_state(self)
+
+    def __setstate__(self, state):
+        super().__init__(*state)
+
+
+class LeaveEvent(QtCore.QEvent):
+    @staticmethod
+    def get_state(obj, picklable=False):
+        typ = obj.type()
+        if picklable:
+            typ, = serialize_mouse_enum(typ)
+        return typ,
+
+    def __init__(self, rhs):
+        super().__init__(*self.get_state(rhs))
+
+    def __getstate__(self):
+        return self.get_state(self, picklable=True)
+
+    def __setstate__(self, state):
+        typ, = state
+        typ = QtCore.QEvent.Type(typ)
+        super().__init__(typ)
+
 
 class RemoteGraphicsView(QtGui.QWidget):
     """
@@ -90,65 +203,32 @@ class RemoteGraphicsView(QtGui.QWidget):
         p.drawImage(self.rect(), self._img, self._img.rect())
         p.end()
 
-    def serialize_mouse_enum(self, *args):
-        # PyQt6 can pickle enums and flags but cannot cast to int
-        # PyQt5 5.12, PyQt5 5.15, PySide2 5.15, PySide6 can pickle enums but not flags
-        # PySide2 5.12 cannot pickle enums nor flags
-        # MouseButtons and KeyboardModifiers are flags
-        if QT_LIB != 'PyQt6':
-            args = [int(x) for x in args]
-        return args
-
-    def serialize_mouse_event(self, ev):
-        lpos = ev.position() if hasattr(ev, 'position') else ev.localPos()
-        gpos = ev.globalPosition() if hasattr(ev, 'globalPosition') else ev.screenPos()
-        typ, btn, btns, mods = self.serialize_mouse_enum(
-            ev.type(), ev.button(), ev.buttons(), ev.modifiers())
-        return (typ, lpos, gpos, btn, btns, mods)
-
-    def serialize_wheel_event(self, ev):
-        # {PyQt6, PySide6}      have position()
-        # {PyQt5, PySide2} 5.15 have position()
-        # {PyQt5, PySide2} 5.15 have posF() (contrary to C++ docs)
-        # {PyQt5, PySide2} 5.12 have posF()
-        lpos = ev.position() if hasattr(ev, 'position') else ev.posF()
-        # gpos = ev.globalPosition() if hasattr(ev, 'globalPosition') else ev.globalPosF()
-        gpos = lpos     # RemoteGraphicsView Renderer assumes to be at (0, 0)
-        btns, mods, phase = self.serialize_mouse_enum(ev.buttons(), ev.modifiers(), ev.phase())
-        return (lpos, gpos, ev.pixelDelta(), ev.angleDelta(), btns, mods, phase, ev.inverted())
-
     def mousePressEvent(self, ev):
-        self._view.mousePressEvent(self.serialize_mouse_event(ev), _callSync='off')
+        self._view.mousePressEvent(MouseEvent(ev), _callSync='off')
         ev.accept()
         return super().mousePressEvent(ev)
 
     def mouseReleaseEvent(self, ev):
-        self._view.mouseReleaseEvent(self.serialize_mouse_event(ev), _callSync='off')
+        self._view.mouseReleaseEvent(MouseEvent(ev), _callSync='off')
         ev.accept()
         return super().mouseReleaseEvent(ev)
 
     def mouseMoveEvent(self, ev):
-        self._view.mouseMoveEvent(self.serialize_mouse_event(ev), _callSync='off')
+        self._view.mouseMoveEvent(MouseEvent(ev), _callSync='off')
         ev.accept()
         return super().mouseMoveEvent(ev)
         
     def wheelEvent(self, ev):
-        self._view.wheelEvent(self.serialize_wheel_event(ev), _callSync='off')
+        self._view.wheelEvent(WheelEvent(ev), _callSync='off')
         ev.accept()
         return super().wheelEvent(ev)
 
     def enterEvent(self, ev):
-        lpos = ev.position() if hasattr(ev, 'position') else ev.localPos()
-        wpos = ev.scenePosition() if hasattr(ev, 'scenePosition') else ev.windowPos()
-        gpos = ev.globalPosition() if hasattr(ev, 'globalPosition') else ev.screenPos()
-
-        lws = lpos, wpos, gpos
-        self._view.enterEvent(lws, _callSync='off')
+        self._view.enterEvent(EnterEvent(ev), _callSync='off')
         return super().enterEvent(ev)
         
     def leaveEvent(self, ev):
-        typ, = self.serialize_mouse_enum(ev.type())
-        self._view.leaveEvent(typ, _callSync='off')
+        self._view.leaveEvent(LeaveEvent(ev), _callSync='off')
         return super().leaveEvent(ev)
         
     def remoteProcess(self):
@@ -250,45 +330,3 @@ class Renderer(GraphicsView):
             self.render(p, self.viewRect(), self.rect())
             p.end()
             self.sceneRendered.emit((iwidth, iheight, self.shm.size(), self.shmFileName()))
-
-    def deserialize_mouse_event(self, mouse_event):
-        typ, pos, gpos, btn, btns, mods = mouse_event
-        typ = QtCore.QEvent.Type(typ)
-        if QT_LIB != 'PyQt6':
-            btn = QtCore.Qt.MouseButton(btn)
-            btns = QtCore.Qt.MouseButtons(btns)
-            mods = QtCore.Qt.KeyboardModifiers(mods)
-        return QtGui.QMouseEvent(typ, pos, gpos, btn, btns, mods)
-
-    def deserialize_wheel_event(self, wheel_event):
-        pos, gpos, pixelDelta, angleDelta, btns, mods, phase, inverted = wheel_event
-        if QT_LIB != 'PyQt6':
-            btns = QtCore.Qt.MouseButtons(btns)
-            mods = QtCore.Qt.KeyboardModifiers(mods)
-            phase = QtCore.Qt.ScrollPhase(phase)
-        return QtGui.QWheelEvent(pos, gpos, pixelDelta, angleDelta, btns, mods, phase, inverted)
-
-    def mousePressEvent(self, mouse_event):
-        ev = self.deserialize_mouse_event(mouse_event)
-        return super().mousePressEvent(ev)
-
-    def mouseMoveEvent(self, mouse_event):
-        ev = self.deserialize_mouse_event(mouse_event)
-        return super().mouseMoveEvent(ev)
-
-    def mouseReleaseEvent(self, mouse_event):
-        ev = self.deserialize_mouse_event(mouse_event)
-        return super().mouseReleaseEvent(ev)
-    
-    def wheelEvent(self, wheel_event):
-        ev = self.deserialize_wheel_event(wheel_event)
-        return super().wheelEvent(ev)
-
-    def enterEvent(self, lws):
-        ev = QtGui.QEnterEvent(*lws)
-        return super().enterEvent(ev)
-
-    def leaveEvent(self, typ):
-        typ = QtCore.QEvent.Type(typ)
-        ev = QtCore.QEvent(typ)
-        return super().leaveEvent(ev)


### PR DESCRIPTION
RemoteGraphicsView does manual serialization and deserialization of mouse events because not all the Qt objects are picklable and different Qt bindings have different degrees of pickability.
This PR reimplements the serialization and deserialization to make use of the Python pickle protocol. In particular, it makes the deserialization transparent to the Renderer class.