### PR TITLE
Disable and comment the prepareForPaint call in ViewBox.update()

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1468,10 +1468,17 @@ class ViewBox(GraphicsWidget):
 
         bounds = QtCore.QRectF(range[0][0], range[1][0], range[0][1]-range[0][0], range[1][1]-range[1][0])
         return bounds
-        
-    def update(self, *args, **kwargs):
-        self.prepareForPaint()
-        GraphicsWidget.update(self, *args, **kwargs)
+
+    # Including a prepareForPaint call is part of the Qt strategy to
+    # defer expensive redraw opertions until requested by a 'sigPrepareForPaint' signal
+    # 
+    # However, as currently implemented, a call to prepareForPaint as part of the regular 
+    # 'update' call results in an undesired reset of pan/zoom:
+    # https://github.com/pyqtgraph/pyqtgraph/issues/2029
+    #
+    # def update(self, *args, **kwargs):
+    #     self.prepareForPaint()
+    #     GraphicsWidget.update(self, *args, **kwargs)
 
     def updateViewRange(self, forceX=False, forceY=False):
         ## Update viewRange to match targetRange as closely as possible, given


### PR DESCRIPTION
This addresses #2029, where a recent change to ViewBox was found to result in an unwanted reset of viewing range with each update of data. All the credit for experimentation and triangulating the problem goes to @pijyoi , @j9ac9k and @JeanBilheux .

But since the problem was introduced as part of my PR #1992, I thought I should propose a PR to fix it.

This change reverts the addition of a `prepareForPaint()` call in `ViewBox.update()`. This was added since it appeared to result in a more user-friendly failure mode for the basically unsupported case of data with infinite values, at least on OSX. This addition was not part of the main functionality of #1992, but no side effects were known or expected at the time. 

But since such side effects clearly exist after all, I believe a revert to the previous state is the best solution.
This was found to solve the issue in https://github.com/pyqtgraph/pyqtgraph/issues/2029#issuecomment-952408770_

Closes #2029