### PR TITLE
AxisItem: Ignore drag/wheel events on ViewBox.

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1186,8 +1186,8 @@ class AxisItem(GraphicsWidget):
             return
         # Did the event occur inside the linked ViewBox (and not over the axis iteself)?
         if lv.sceneBoundingRect().contains(event.scenePos()):
-            # pass event to linked ViewBox without marking it as single axis zoom
-            lv.wheelEvent(event)
+            event.ignore()
+            return
         else:
             # pass event to linked viewbox with appropriate single axis zoom parameter
             if self.orientation in ['left', 'right']:
@@ -1202,8 +1202,8 @@ class AxisItem(GraphicsWidget):
             return
         # Did the mouse down event occur inside the linked ViewBox (and not the axis)?
         if lv.sceneBoundingRect().contains(event.buttonDownScenePos()):
-            # pass event to linked ViewBox without marking it as single axis pan
-            return lv.mouseDragEvent(event)
+            event.ignore()
+            return
         # otherwise pass event to linked viewbox with appropriate single axis parameter
         if self.orientation in ['left', 'right']:
             return lv.mouseDragEvent(event, axis=1)


### PR DESCRIPTION
Fixes #1975 (and #1937)

There is no need to re-dispatch the events in AxisItem, just to ignore them. The view box will correctly receive them.