### PR TITLE
re-add UTF-8 encoding to example app code loader

### DIFF
--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -481,7 +481,7 @@ class ExampleLoader(QtWidgets.QMainWindow):
         env['PYTHONPATH'] = f'{path}'
         if edited:
             proc = subprocess.Popen([sys.executable, '-'], stdin=subprocess.PIPE, cwd=path, env=env)
-            code = self.ui.codeView.toPlainText()
+            code = self.ui.codeView.toPlainText().encode('UTF-8')
             proc.stdin.write(code)
             proc.stdin.close()
         else:


### PR DESCRIPTION
This re-adds the UTF-8 encoding used by the example app to run code from the editor.

Works on my machine  :) 
I think this just restores the previous code, but it would be great if someone can test on different architectures.

Closes #2060