### PR TITLE
ViewBox quantization limit

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -575,7 +575,10 @@ class ViewBox(GraphicsWidget):
                 mn -= dy*0.5
                 mx += dy*0.5
             # Make sure that the range include a usable number of quantization steps:
-            quantization_limit = (mn+mx) * 0.5 * 3e-15 # ~10 discrete steps of double resolution
+            #    approx. eps  : 3e-16
+            #    * min. steps : 10
+            #    * mean value : (mn+mx)*0.5 
+            quantization_limit = (mn+mx) * 1.5e-15 # +/-10 discrete steps of double resolution
             if mx-mn < 2*quantization_limit:
                 mn -= quantization_limit
                 mx += quantization_limit

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -574,7 +574,7 @@ class ViewBox(GraphicsWidget):
                     dy = 1
                 mn -= dy*0.5
                 mx += dy*0.5
-            # Make sure that the range include a usable number of quantization steps:
+            # Make sure that the range includes a usable number of quantization steps:
             #    approx. eps  : 3e-16
             #    * min. steps : 10
             #    * mean value : (mn+mx)*0.5 

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -922,7 +922,6 @@ class ViewBox(GraphicsWidget):
                         childRange = self.childrenBounds(frac=fractionVisible)
                 ## Make corrections to range
                 xr = childRange[ax]
-                print('childRange:',xr)
                 if xr is not None:
                     if self.state['autoPan'][ax]:
                         x = sum(xr) * 0.5
@@ -930,16 +929,9 @@ class ViewBox(GraphicsWidget):
                         childRange[ax] = [x-w2, x+w2]
                     else:
                         padding = self.suggestPadding(ax)
-                        print('padding:',padding)
                         wp = (xr[1] - xr[0]) * padding
-                        print('wp:', wp)
-                        # if padding > 0: # padding is requested, make sure that it does not collapse for large numbers:
-                        #     xr_mid = (xr[1] + xr[0]) * 0.5 # a relative range of 1e-13 of the mean can display 
-                        #     wp = max(wp, xr_mid*1e-13)     # approximately 300x the fractional resolution of a double
-                        #     print('--> wp:', wp)
                         childRange[ax][0] -= wp
                         childRange[ax][1] += wp
-                        print('--> childRange:',xr)
                     targetRect[ax] = childRange[ax]
                     args['xRange' if ax == 0 else 'yRange'] = targetRect[ax]
 


### PR DESCRIPTION
This is meant to address #2056, where the vertical axis collapses when a list of large, constant values is plotted.

The reason for this is that the default 1.0 span of the auto-scaling eventually becomes smaller than the effective (~3e-16) resolution of a double float, and the range calculations break down.

This PR sets the minimum displayed range to 6E-15 of the center value, which makes sure that at least 20 quantization steps are on screen. At this level, the errors become obvious, but the plot remains visible, and the axis manages to calculate ticks and labels.

For values < 1.6e+14, the behavior should be unchanged, *except* that there is now a hard lower limit on the plot range: It is no longer possible to deliberately collapse the axis range to zero. However, I could not come up with a good reason to do so.

Here is some code to play around with, based on the report in #2056:
```python
from pyqtgraph.Qt import QtGui
import pyqtgraph as pg

app = pg.mkQApp()
mw = QtGui.QMainWindow()
cw = QtGui.QWidget()
mw.setCentralWidget(cw)
l = QtGui.QVBoxLayout()
cw.setLayout(l)

pw = pg.PlotWidget(name='Plot1') 
l.addWidget(pw)
mw.show()
constant = 8e15 # now keeps working until other things break for >8e130 
p1 = pw.plot(y=[constant,constant])

# uncomment this to see quantization errors:
# p1 = pw.plot(y=[constant,constant+1,constant+2])

# uncomment this to see hard limit on axis range:
# pw.setYRange(constant-0, constant+0, padding=0)

if __name__ == '__main__':
    pg.exec()
```

Closes #2056, I hope.