### PR TITLE
Separate x and y flags for AxisItem.setLogMode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ PyQtGraph developers are highly encouraged to (but not required) to use [`pre-co
 To run the test suite, after installing the above dependencies run
 
 ```bash
-python -m pytest examples tests
+python -m pytest pyqtgraph/examples tests
 ```
 
 ### Tox

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -205,20 +205,24 @@ class AxisItem(GraphicsWidget):
         self.prepareGeometryChange()
         self.update()
 
-    def setLogMode(self, log):
+    def setLogMode(self, x=None, y=None):
         """
-        If *log* is True, then ticks are displayed on a logarithmic scale and values
+        Set log scaling for x and/or y axes.
+        If an axis is set to log scale, ticks are displayed on a logarithmic scale and values
         are adjusted accordingly. (This is usually accessed by changing the log mode
         of a :func:`PlotItem <pyqtgraph.PlotItem.setLogMode>`)
         The linked ViewBox will be informed of the change.
         """
-        self.logMode = log
+        if x is not None and self.orientation in ('top', 'bottom'):
+            self.logMode = x
+            if self._linkedView is not None:
+                self._linkedView().setLogMode('x', x)
+        if y is not None and self.orientation in ('left', 'right'):
+            self.logMode = y
+            if self._linkedView is not None:
+                self._linkedView().setLogMode('y', y)
         self.picture = None
-        if self._linkedView is not None:
-            if self.orientation in ('top', 'bottom'):
-                self._linkedView().setLogMode('x', log)
-            elif self.orientation in ('left', 'right'):
-                self._linkedView().setLogMode('y', log)
+
         self.update()
 
     def setTickFont(self, font):

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -205,22 +205,40 @@ class AxisItem(GraphicsWidget):
         self.prepareGeometryChange()
         self.update()
 
-    def setLogMode(self, x=None, y=None):
+    def setLogMode(self, *args, **kwargs):
         """
         Set log scaling for x and/or y axes.
-        If an axis is set to log scale, ticks are displayed on a logarithmic scale and values
-        are adjusted accordingly. (This is usually accessed by changing the log mode
-        of a :func:`PlotItem <pyqtgraph.PlotItem.setLogMode>`)
-        The linked ViewBox will be informed of the change.
+
+        If two positional arguments are provided, the first will set log scaling
+        for the x axis and the second for the y axis. If a single positional
+        argument is provided, it will set the log scaling along the direction of
+        the AxisItem. Alternatively, x and y can be passed as keyword arguments.
+
+        If an axis is set to log scale, ticks are displayed on a logarithmic scale
+        and values are adjusted accordingly. (This is usually accessed by changing
+        the log mode of a :func:`PlotItem <pyqtgraph.PlotItem.setLogMode>`.) The 
+        linked ViewBox will be informed of the change.
         """
-        if x is not None and self.orientation in ('top', 'bottom'):
-            self.logMode = x
-            if self._linkedView is not None:
-                self._linkedView().setLogMode('x', x)
-        if y is not None and self.orientation in ('left', 'right'):
-            self.logMode = y
-            if self._linkedView is not None:
-                self._linkedView().setLogMode('y', y)
+        if len(args) == 1:
+            self.logMode = args[0]
+        else:
+            if len(args) == 2:
+                x, y = args
+            else:
+                x = kwargs.get('x')
+                y = kwargs.get('y')
+
+            if x is not None and self.orientation in ('top', 'bottom'):
+                self.logMode = x
+            if y is not None and self.orientation in ('left', 'right'):
+                self.logMode = y
+        
+        if self._linkedView is not None:
+            if self.orientation in ('top', 'bottom'):           
+                self._linkedView().setLogMode('x', self.logMode)    
+            elif self.orientation in ('left', 'right'):
+                self._linkedView().setLogMode('y', self.logMode)    
+
         self.picture = None
 
         self.update()

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -907,10 +907,10 @@ class PlotItem(GraphicsWidget):
         for i in self.items:
             if hasattr(i, 'setLogMode'):
                 i.setLogMode(x,y)
-        self.getAxis('bottom').setLogMode(x)
-        self.getAxis('top').setLogMode(x)
-        self.getAxis('left').setLogMode(y)
-        self.getAxis('right').setLogMode(y)
+        self.getAxis('bottom').setLogMode(x, y)
+        self.getAxis('top').setLogMode(x, y)
+        self.getAxis('left').setLogMode(x, y)
+        self.getAxis('right').setLogMode(x, y)
         self.enableAutoRange()
         self.recomputeAverages()
     

--- a/tests/graphicsItems/test_AxisItem.py
+++ b/tests/graphicsItems/test_AxisItem.py
@@ -157,7 +157,21 @@ def test_AxisItem_label_visibility():
        ('left', True, False, False),
     ],
 )
-def test_AxisItem_setLogMode(orientation, x, y, expected):
+def test_AxisItem_setLogMode_two_args(orientation, x, y, expected):
     axis = pg.AxisItem(orientation)
     axis.setLogMode(x, y)
+    assert axis.logMode == expected
+
+@pytest.mark.parametrize(
+    "orientation,log,expected",
+    [
+       ('top', True, True),
+       ('left', True, True),
+       ('top', False, False),
+       ('left', False, False),
+    ],
+)
+def test_AxisItem_setLogMode_one_arg(orientation, log, expected):
+    axis = pg.AxisItem(orientation)
+    axis.setLogMode(log)
     assert axis.logMode == expected

--- a/tests/graphicsItems/test_AxisItem.py
+++ b/tests/graphicsItems/test_AxisItem.py
@@ -1,4 +1,5 @@
 from math import isclose
+import pytest
 
 import pyqtgraph as pg
 
@@ -146,3 +147,17 @@ def test_AxisItem_label_visibility():
     assert axis.labelText == ''
     assert axis.labelUnits == 'V'
     assert axis.label.isVisible()
+
+@pytest.mark.parametrize(
+    "orientation,x,y,expected",
+    [
+       ('top', False, True, False),
+       ('top', True, False, True),
+       ('left', False, True, True),
+       ('left', True, False, False),
+    ],
+)
+def test_AxisItem_setLogMode(orientation, x, y, expected):
+    axis = pg.AxisItem(orientation)
+    axis.setLogMode(x, y)
+    assert axis.logMode == expected


### PR DESCRIPTION
This fix allows the example code from #997 to be run. I also checked that the logAxis.py example looks the same after this change.