### PR TITLE
more convenience methods for color maps and bars

### DIFF
--- a/doc/source/colormap.rst
+++ b/doc/source/colormap.rst
@@ -1,3 +1,5 @@
+.. _apiref_colormap:
+
 Color Maps
 ==========
 
@@ -12,9 +14,14 @@ To provide interactively user-defined color mappings, see
 :class:`~pyqtgraph.GradientEditorItem` combines the editing with a histogram and controls for
 interactively adjusting image levels.
 
+Setting a color map and adding a color bar can be as simple as::
+    
+    plot.addItem( img_item := pg.ImageItem(img_data) )
+    plot.addColorBar( img_item, colorMap='viridis', values=(0, 1) )    ```
+
 ColorMap can also be used a convenient source of colors from a consistent palette or to generate 
-QPen and QBrush objects used to draw lines and fills that are colored according to their values 
-along the horizontal or vertical axis.
+:class:`QPen` and :class:`QBrush` objects used to draw lines and fills that are colored according to 
+their values along the horizontal or vertical axis.
 
 
 Sources for color maps

--- a/doc/source/graphicsItems/imageitem.rst
+++ b/doc/source/graphicsItems/imageitem.rst
@@ -5,7 +5,8 @@ ImageItem
 :class:`~pyqtgraph.ViewBox`, which may itself be part of a :class:`~pyqtgraph.PlotItem`. It is designed
 for rapid updates as needed for a video display. The supplied data is optionally scaled (see 
 :func:`~pyqtgraph.ImageItem.setLevels`) and/or colored according to a
-lookup table (see :func:`~pyqtgraph.ImageItem.setLookupTable`.
+lookup table (see :func:`~pyqtgraph.ImageItem.setColorMap` and 
+:func:`~pyqtgraph.ImageItem.setLookupTable`).
 
 Data is provided as a NumPy array with an ordering of either
 

--- a/pyqtgraph/examples/ColorBarItem.py
+++ b/pyqtgraph/examples/ColorBarItem.py
@@ -23,18 +23,20 @@ class MainWindow(QtWidgets.QMainWindow):
         noisy_data = data * (1 + 0.2 * np.random.random(data.shape) )
         noisy_transposed = noisy_data.transpose()
 
-        #--- add non-interactive image with integrated color -----------------
-        i1 = pg.ImageItem(image=data, colorMap='CET-L9')
+        #--- add non-interactive image with integrated color ------------------
         p1 = gr_wid.addPlot(title="non-interactive")
+        # Basic steps to create a false color image with color bar:
+        i1 = pg.ImageItem(image=data)
         p1.addItem( i1 )
-        i1.addColorBar(values=(0, 30_000), plot=p1, interactive=False)
+        p1.addColorBar( i1, colorMap='CET-L9', values=(0, 30_000)) # , interactive=False)
+        #
         p1.setMouseEnabled( x=False, y=False)
         p1.disableAutoRange()
         p1.hideButtons()
         p1.setRange(xRange=(0,100), yRange=(0,100), padding=0)
         p1.showAxes(True, showValues=(True,False,False,True) )
 
-        #--- add interactive image with integrated horizontal color bar --------------
+        #--- add interactive image with integrated horizontal color bar -------
         i2 = pg.ImageItem(image=noisy_data)
         p2 = gr_wid.addPlot(1,0, 1,1, title="interactive")
         p2.addItem( i2, title='' )
@@ -44,10 +46,10 @@ class MainWindow(QtWidgets.QMainWindow):
         p2.getAxis('bottom').setLabel('bottom axis label')
         p2.getAxis('right').setLabel('right axis label')
 
-        cmap = pg.colormap.get('CET-L4')
+        # cmap = pg.colormap.get('CET-L4')
         bar = pg.ColorBarItem(
             values = (0, 30_000),
-            colorMap=cmap,
+            colorMap='CET-L4',
             label='horizontal color bar',
             limits = (0, None),
             rounding=1000,

--- a/pyqtgraph/examples/ColorBarItem.py
+++ b/pyqtgraph/examples/ColorBarItem.py
@@ -24,26 +24,15 @@ class MainWindow(QtWidgets.QMainWindow):
         noisy_transposed = noisy_data.transpose()
 
         #--- add non-interactive image with integrated color -----------------
-        i1 = pg.ImageItem(image=data)
+        i1 = pg.ImageItem(image=data, colorMap='CET-L9')
         p1 = gr_wid.addPlot(title="non-interactive")
         p1.addItem( i1 )
+        i1.addColorBar(values=(0, 30_000), plot=p1, interactive=False)
         p1.setMouseEnabled( x=False, y=False)
         p1.disableAutoRange()
         p1.hideButtons()
         p1.setRange(xRange=(0,100), yRange=(0,100), padding=0)
-        for key in ['left','right','top','bottom']:
-            p1.showAxis(key)
-            axis = p1.getAxis(key)
-            axis.setZValue(1)
-            if key in ['top', 'right']: 
-                p1.getAxis(key).setStyle( showValues=False )
-
-        cmap = pg.colormap.get('CET-L9')
-        bar = pg.ColorBarItem(
-            interactive=False, values= (0, 30_000), colorMap=cmap,
-            label='vertical fixed color bar'
-        )
-        bar.setImageItem( i1, insert_in=p1 )
+        p1.showAxes(True, showValues=(True,False,False,True) )
 
         #--- add interactive image with integrated horizontal color bar --------------
         i2 = pg.ImageItem(image=noisy_data)

--- a/pyqtgraph/examples/ColorBarItem.py
+++ b/pyqtgraph/examples/ColorBarItem.py
@@ -46,7 +46,6 @@ class MainWindow(QtWidgets.QMainWindow):
         p2.getAxis('bottom').setLabel('bottom axis label')
         p2.getAxis('right').setLabel('right axis label')
 
-        # cmap = pg.colormap.get('CET-L4')
         bar = pg.ColorBarItem(
             values = (0, 30_000),
             colorMap='CET-L4',

--- a/pyqtgraph/graphicsItems/ColorBarItem.py
+++ b/pyqtgraph/graphicsItems/ColorBarItem.py
@@ -155,6 +155,14 @@ class ColorBarItem(PlotItem):
             self.img_list = [ weakref.ref(item) for item in img ]
         except TypeError: # failed to iterate, make a single-item list
             self.img_list = [ weakref.ref( img ) ]
+        if self._colorMap is None: # check if one of the assigned images has a defined color map
+            for img_weakref in self.img_list:
+                img = img_weakref()
+                if img is not None:
+                    img_cm = img.getColorMap()
+                    if img_cm is not None:
+                        self._colorMap = img_cm
+                        break
         if insert_in is not None:
             if self.horizontal:
                 insert_in.layout.addItem( self, 5, 1 ) # insert in layout below bottom axis

--- a/pyqtgraph/graphicsItems/ColorBarItem.py
+++ b/pyqtgraph/graphicsItems/ColorBarItem.py
@@ -9,6 +9,7 @@ from ..Qt import QtCore
 from .ImageItem import ImageItem
 from .LinearRegionItem import LinearRegionItem
 from .PlotItem import PlotItem
+from .. import colormap 
 
 __all__ = ['ColorBarItem']
 
@@ -67,7 +68,7 @@ class ColorBarItem(PlotItem):
             colorMap = cmap
         self.img_list  = [] # list of controlled ImageItems
         self.values    = values
-        self._colorMap = colorMap
+        self._colorMap = None
         self.rounding  = rounding
         self.horizontal = bool( orientation in ('h', 'horizontal') )
 
@@ -115,7 +116,7 @@ class ColorBarItem(PlotItem):
             self.bar.setImage( np.linspace(0, 1, 256).reshape( (1,-1) ) )
             if label is not None: self.getAxis('left').setLabel(label)
         self.addItem(self.bar)
-        if cmap is not None: self.setColorMap(cmap)
+        if colorMap is not None: self.setColorMap(colorMap)
 
         if interactive:
             if self.horizontal:
@@ -186,6 +187,8 @@ class ColorBarItem(PlotItem):
         Sets a ColorMap object to determine the ColorBarItem's look-up table. The same
         look-up table is applied to any assigned ImageItem.
         """
+        if isinstance(colorMap, str):
+            colorMap = colormap.get(colorMap)
         self._colorMap = colorMap
         self._update_items( update_cmap = True )
         

--- a/pyqtgraph/graphicsItems/ColorBarItem.py
+++ b/pyqtgraph/graphicsItems/ColorBarItem.py
@@ -17,8 +17,11 @@ class ColorBarItem(PlotItem):
     """
     **Bases:** :class:`PlotItem <pyqtgraph.PlotItem>`
 
-    :class:`ColorBarItem` is a simpler, compact alternative to :class:`~pyqtgraph.HistogramLUTItem`, 
-    without histogram or the option to adjust the colors of the look-up table.
+    :class:`ColorBarItem` controls the application of a 
+    :ref:`color map <apiref_colormap>` to one (or more) 
+    :class:`~pyqtgraph.ImageItem`. It is a simpler, compact alternative to 
+    :class:`~pyqtgraph.HistogramLUTItem`, without histogram or the 
+    option to adjust the colors of the look-up table.
 
     A labeled axis is displayed directly next to the gradient to help identify values.
     Handles included in the color bar allow for interactive adjustment.

--- a/pyqtgraph/graphicsItems/ColorBarItem.py
+++ b/pyqtgraph/graphicsItems/ColorBarItem.py
@@ -17,16 +17,16 @@ class ColorBarItem(PlotItem):
     """
     **Bases:** :class:`PlotItem <pyqtgraph.PlotItem>`
 
-    ColorBarItem is a simpler, compact alternative to HistogramLUTItem, without histogram
-    or the option to adjust the look-up table.
+    :class:`ColorBarItem` is a simpler, compact alternative to :class:`~pyqtgraph.HistogramLUTItem`, 
+    without histogram or the option to adjust the colors of the look-up table.
 
     A labeled axis is displayed directly next to the gradient to help identify values.
     Handles included in the color bar allow for interactive adjustment.
 
-    A ColorBarItem can be assigned one or more ImageItems that will be displayed according
-    to the selected color map and levels. The ColorBarItem can be used as a separate
-    element in a GraphicsLayout or added to the layout of a PlotItem used to display image
-    data with coordinate axes.
+    A ColorBarItem can be assigned one or more :class:`~pyqtgraph.ImageItem`s that will be displayed 
+    according to the selected color map and levels. The ColorBarItem can be used as a separate
+    element in a :class:`~pyqtgraph.GraphicsLayout` or added to the layout of a 
+    :class:`~pyqtgraph.PlotItem` used to display image data with coordinate axes.
 
     =============================  =============================================
     **Signals:**
@@ -43,20 +43,30 @@ class ColorBarItem(PlotItem):
         """
         Creates a new ColorBarItem.
 
-        ==============  ===========================================================================
-        **Arguments:**
-        values          The range of values as tuple (min, max)
-        width           (default=25) The width of the displayed color bar
-        colorMap        ColorMap object, look-up table is also applied to assigned ImageItem(s)
-        label           (default=None) Label applied to color bar axis
-        interactive     (default=True) Handles are displayed to interactively adjust level range
-        limits          Limits to adjustment range as (low, high) tuple, None disables limit
-        rounding        (default=1) Adjusted range values are rounded to multiples of this values
-        orientation     (default='vertical') 'horizontal' or 'h' gives a horizontal color bar.
-        pen             color of adjustement handles in interactive mode
-        hoverPen        color of adjustement handles when hovered over
-        hoverBrush      color of movable center region when hovered over
-        ==============  ===========================================================================
+        Parameters
+        ----------
+        colorMap: `str` or :class:`~pyqtgraph.ColorMap`
+            Determines the color map displayed and applied to assigned ImageItem(s).
+        values: tuple of float
+            The range of image levels covered by the color bar, as ``(min, max)``.
+        width: float, default=25
+            The width of the displayed color bar.
+        label: str, optional
+            Label applied to the color bar axis.
+        interactive: bool, default=True
+            If `True`, handles are displayed to interactively adjust the level range.
+        limits: `None` or `tuple of float`
+            Limits the adjustment range to `(low, high)`, `None` disables the limit.
+        rounding: float, default=1
+            Adjusted range values are rounded to multiples of this value.
+        orientation: str, default 'vertical'
+            'horizontal' or 'h' gives a horizontal color bar instead of the default vertical bar
+        pen: :class:`Qpen` or argument to :func:`~pyqtgraph.mkPen`
+            Sets the color of adjustment handles in interactive mode.
+        hoverPen: :class:`QPen` or argument to :func:`~pyqtgraph.mkPen`
+            Sets the color of adjustement handles when hovered over.
+        hoverBrush: :class:`QBrush` or argument to :func:`~pyqtgraph.mkBrush`
+            Sets the color of movable center region when hovered over.
         """
         super().__init__()
         if cmap is not None: 
@@ -141,16 +151,19 @@ class ColorBarItem(PlotItem):
 
     def setImageItem(self, img, insert_in=None):
         """
-        assign ImageItem or list of ImageItems to be controlled
+        Assigns an ImageItem or list of ImageItems to be represented and controlled
 
-        ==============  ==========================================================================
-        **Arguments:**
-        image           ImageItem or list of [ImageItem, ImageItem, ...] that will be set to the
-                        color map of the ColorBarItem. In interactive mode, the levels of all
-                        assigned ImageItems will be controlled simultaneously.
-        insert_in       If a PlotItem is given, the color bar is inserted on the right or bottom
-                        of the plot
-        ==============  ==========================================================================
+        Parameters
+        ----------
+        image: :class:`~pyqtgraph.ImageItem` or list of `[ImageItem, ImageItem, ...]`
+            Assigns one or more ImageItems to this ColorBarItem.
+            If a :class:`~pyqtgraph.ColorMap` is defined for ColorBarItem, this will be assigned to the 
+            ImageItems. Otherwise, the ColorBarItem will attempt to retrieve a color map from the ImageItems.
+            In interactive mode, ColorBarItem will control the levels of the assigned ImageItems, 
+            simultaneously if there is more than one.
+        insert_in: :class:`~pyqtgraph.PlotItem`, optional
+            If a PlotItem is given, the color bar is inserted on the right
+            or bottom of the plot, depending on the specified orientation.
         """
         try:
             self.img_list = [ weakref.ref(item) for item in img ]
@@ -184,8 +197,11 @@ class ColorBarItem(PlotItem):
 
     def setColorMap(self, colorMap):
         """
-        Sets a ColorMap object to determine the ColorBarItem's look-up table. The same
+        Sets a color map to determine the ColorBarItem's look-up table. The same
         look-up table is applied to any assigned ImageItem.
+        
+        `colorMap` can be a :class:`~pyqtgraph.ColorMap` or a string argument that is passed to 
+        :func:`colormap.get() <pyqtgraph.colormap.get>`.
         """
         if isinstance(colorMap, str):
             colorMap = colormap.get(colorMap)
@@ -208,15 +224,17 @@ class ColorBarItem(PlotItem):
 
     def setLevels(self, values=None, low=None, high=None ):
         """
-        Sets the displayed range of levels as specified.
+        Sets the displayed range of image levels.
 
-        ==============  ===========================================================================
-        **Arguments:**
-        values          specifies levels as tuple (low, high). Either value can be None to leave
-                        to previous value unchanged. Takes precedence over low and high parameters.
-        low             new low level to be applied to color bar and assigned images
-        high            new high level to be applied to color bar and assigned images
-        ==============  ===========================================================================
+        Parameters
+        ----------
+        values: tuple of float
+            Specifies levels as tuple ``(low, high)``. Either value can be `None` to leave
+            the previous value unchanged. Takes precedence over `low` and `high` parameters.
+        low: float
+            Applies a new low level to color bar and assigned images
+        high: float
+            Applies a new high level to color bar and assigned images
         """
         if values is not None: # values setting takes precendence
             low, high = values
@@ -234,7 +252,7 @@ class ColorBarItem(PlotItem):
         self._update_items()
 
     def levels(self):
-        """ returns the currently set levels as the tuple (low, high). """
+        """ Returns the currently set levels as the tuple ``(low, high)``. """
         return self.values
 
     def _update_items(self, update_cmap=False):

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -139,9 +139,9 @@ class ImageItem(GraphicsObject):
         Parameters
         ----------
             levels: list_like
-                - [`blackLevel`, `whiteLevel`] 
+                - ``[blackLevel, whiteLevel]`` 
                   sets black and white levels for monochrome data and can be used with a lookup table.
-                - [[`minR`, `maxR`], [`minG`, `maxG`], [`minB`, `maxB`]] 
+                - ``[[minR, maxR], [minG, maxG], [minB, maxB]]``
                   sets individual scaling for RGB values. Not compatible with lookup tables.
             update: bool, optional
                 Controls if image immediately updates to reflect the new levels.
@@ -160,7 +160,7 @@ class ImageItem(GraphicsObject):
     def getLevels(self):
         """
         Returns the list representing the current level settings. See :func:`~setLevels`.
-        When ``autoLevels`` is active, the format is [`blackLevel`, `whiteLevel`].
+        When ``autoLevels`` is active, the format is ``[blackLevel, whiteLevel]``.
         """
         return self.levels
         
@@ -170,8 +170,8 @@ class ImageItem(GraphicsObject):
 
         Parameters
         ----------
-        colorMap : `pyqtgraph.ColorMap` or `str`
-            A string argument will be passed to `pyqtgraph.colormap.get()`
+        colorMap : :class:`~pyqtgraph.ColorMap` or `str`
+            A string argument will be passed to :func:`colormap.get() <pyqtgraph.colormap.get>`
         """
         if isinstance(colorMap, colormap.ColorMap):
             self._colorMap = colorMap
@@ -183,35 +183,20 @@ class ImageItem(GraphicsObject):
         
     def getColorMap(self):
         """
-        Returns the assigned color map, or None if not available
+        Returns the assigned :class:`pyqtgraph.ColorMap`, or `None` if not available
         """
         return self._colorMap
         
-    # def addColorBar(self, colorMap=None, plot=None, **kargs):
-    #     """ 
-    #     Convenience method to add a ColorBarItem for this `ImageItem` to the specified plot.
-    #     All additional parameters will be passed on to ColorBarItem.
-    #     """
-    #     if colorMap is not None:
-    #         self.setColorMap(colorMap)
-    #     print('trying to get viewbox')
-    #     vb = self.getViewBox()
-    #     print(vb.getParent())
-    #     # print(self.getViewBox())
-    #     bar = ColorBarItem.ColorBarItem(**kargs)
-    #     bar.setImageItem( self, insert_in=plot )
-    #     return bar
-
     def setLookupTable(self, lut, update=True):
         """
-        Sets lookup table `lut` to use for false color display of a monochrome image. See :func:`makeARGB <pyqtgraph.makeARGB>` for more 
+        Sets lookup table ``lut`` to use for false color display of a monochrome image. See :func:`makeARGB <pyqtgraph.makeARGB>` for more 
         information on how this is used. Optionally, `lut` can be a callable that accepts the current image as an
         argument and returns the lookup table to use.
 
         Ordinarily, this table is supplied by a :class:`~pyqtgraph.HistogramLUTItem`,
         :class:`~pyqtgraph.GradientEditorItem` or :class:`~pyqtgraph.ColorBarItem`.
         
-        Setting `update` to False avoids an immediate image update.
+        Setting ``update = False`` avoids an immediate image update.
         """
         if lut is not self.lut:
             if self._xp is not None:
@@ -239,10 +224,11 @@ class ImageItem(GraphicsObject):
         """
         Controls automatic downsampling for this ImageItem.
 
-        If active is `True`, the image is automatically downsampled to match the
+        If `active` is `True`, the image is automatically downsampled to match the
         screen resolution. This improves performance for large images and
-        reduces aliasing. If autoDownsample is not specified, then ImageItem will
+        reduces aliasing. If `autoDownsample` is not specified, then ImageItem will
         choose whether to downsample the image based on its size.
+        
         `False` disables automatic downsampling.
         """
         self.autoDownsample = active
@@ -265,8 +251,8 @@ class ImageItem(GraphicsObject):
                 Sets a pen to draw to draw an image border. See :func:`~pyqtgraph.ImageItem.setBorder`.
             compositionMode:
                 See :func:`~pyqtgraph.ImageItem.setCompositionMode`
-            colorMap: `pyqtgraph.ColorMap` or str
-                Sets a color map. A string will be passed to `pyqtgraph.colormap.get()`
+            colorMap: :class:`~pyqtgraph.ColorMap` or `str`
+                Sets a color map. A string will be passed to :func:`colormap.get() <pyqtgraph.colormap.get()>`
             lut: array
                 Sets a color lookup table to use when displaying the image.
                 See :func:`~pyqtgraph.ImageItem.setLookupTable`.
@@ -276,7 +262,7 @@ class ImageItem(GraphicsObject):
                 is necessary. See :func:`~pyqtgraph.ImageItem.setLevels`.
             opacity: float, 0.0-1.0
                 Overall opacity for an RGB image.
-            rect: QRectF, QRect or array_like of floats (`x`,`y`,`w`,`h`)
+            rect: :class:`QRectF`, :class:`QRect` or array_like of floats (`x`,`y`,`w`,`h`)
                 Displays the current image within the specified rectangle in plot coordinates.
                 See :func:`~pyqtgraph.ImageItem.setRect`.
             update : bool, optional
@@ -317,8 +303,8 @@ class ImageItem(GraphicsObject):
         setRect(rect) or setRect(x,y,w,h)
         
         Sets translation and scaling of this ImageItem to display the current image within the rectangle given
-        as ``QtCore.QRect`` or ``QtCore.QRectF`` `rect`, or described by parameters `x, y, w, h`, defining starting 
-        position, width and height.
+        as ``rect`` (:class:`QtCore.QRect` or :class:`QtCore.QRectF`), or described by parameters `x, y, w, h`, 
+        defining starting position, width and height.
 
         This method cannot be used before an image is assigned.
         See the :ref:`examples <ImageItem_examples>` for how to manually set transformations.
@@ -357,7 +343,7 @@ class ImageItem(GraphicsObject):
     def setImage(self, image=None, autoLevels=None, **kargs):
         """
         Updates the image displayed by this ImageItem. For more information on how the image
-        is processed before displaying, see :func:`~pyqtgraph.makeARGB>`.
+        is processed before displaying, see :func:`~pyqtgraph.makeARGB`.
         
         For backward compatibility, image data is assumed to be in column-major order (column, row) by default.
         However, most data is stored in row-major order (row, column). It can either be transposed before assignment::
@@ -377,16 +363,16 @@ class ImageItem(GraphicsObject):
             A 3-dimensional array is used to give individual color components. The third dimension must
             be of length 3 (RGB) or 4 (RGBA).
 
-        rect: QRectF, QRect or list_like of floats (`x, y, w, h`), optional
+        rect: QRectF, QRect or list_like of floats ``[x, y, w, h]``, optional
             If given, sets translation and scaling to display the image within the specified rectangle. See 
             :func:`~pyqtgraph.ImageItem.setRect`.
 
         autoLevels: bool, optional
-            If True, ImageItem will automatically select levels based on the maximum and minimum values encountered 
+            If `True`, ImageItem will automatically select levels based on the maximum and minimum values encountered 
             in the data. For performance reasons, this search subsamples the images and may miss individual bright or
             or dark points in the data set.
             
-            If False, the search will be omitted.
+            If `False`, the search will be omitted.
 
             The default is `False` if a ``levels`` keyword argument is given, and `True` otherwise.
             
@@ -908,14 +894,14 @@ class ImageItem(GraphicsObject):
                      targetHistogramSize=500, **kwds):
         """
         Returns `x` and `y` arrays containing the histogram values for the current image.
-        For an explanation of the return format, see numpy.histogram().
+        For an explanation of the return format, see :func:`numpy.histogram()`.
 
         The `step` argument causes pixels to be skipped when computing the histogram to save time.
         If `step` is 'auto', then a step is chosen such that the analyzed data has
         dimensions approximating `targetImageSize` for each axis.
 
         The `bins` argument and any extra keyword arguments are passed to
-        ``self.xp.histogram()``. If `bins` is `auto`, a bin number is automatically
+        :func:`self.xp.histogram()`. If `bins` is `auto`, a bin number is automatically
         chosen based on the image characteristics:
 
           * Integer images will have approximately `targetHistogramSize` bins,
@@ -982,7 +968,7 @@ class ImageItem(GraphicsObject):
     def setPxMode(self, b):
         """
         Sets whether the item ignores transformations and draws directly to screen pixels.
-        If True, the item will not inherit any scale or rotation transformations from its
+        If `True`, the item will not inherit any scale or rotation transformations from its
         parent items, but its position will be transformed as usual.
         (see ``GraphicsItem::ItemIgnoresTransformations`` in the Qt documentation)
         """

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -12,7 +12,6 @@ from ..util.cupy_helper import getCupy
 from .GraphicsObject import GraphicsObject
 from .. import colormap
 from . import ColorBarItem
-# from .ColorBarItem import ColorBarItem
 
 translate = QtCore.QCoreApplication.translate
 
@@ -190,35 +189,14 @@ class ImageItem(GraphicsObject):
         return self._colorMap
         
     def addColorBar(self, colorMap=None, plot=None, **kargs):
-        """ Convenience function to add a ColorBarItem on the right side of the plot """
+        """ 
+        Convenience method to add a ColorBarItem for this `ImageItem` to the specified plot.
+        All additional parameters will be passed on to ColorBarItem.
+        """
         if colorMap is not None:
             self.setColorMap(colorMap)
         bar = ColorBarItem.ColorBarItem(**kargs)
-        bar.setImageItem( self, insert_in=plot,  )
-        
-        # def setImageItem(self, insert_in=None):
-            
-            
-            
-        #         def addColorBar(self, imageItem=None, colorMap=None):
-        # if imageItem is None:
-        #     for item in self.items:
-        #         if isinstance(item, ImageItem):
-        #             print('found an imageitem!')
-        #             imageItem = item
-        #     if imageItem is None:
-        #         raise ValueError("No ImageItem found. Please include 'imageItem' parameter.")
-        # bar = ColorBarItem()
-        # bar.setImageItem(imageItem, insert_in=self)
-
-
-            
-            
-            
-            
-            
-            
-        
+        bar.setImageItem( self, insert_in=plot )
 
     def setLookupTable(self, lut, update=True):
         """

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -197,6 +197,7 @@ class ImageItem(GraphicsObject):
             self.setColorMap(colorMap)
         bar = ColorBarItem.ColorBarItem(**kargs)
         bar.setImageItem( self, insert_in=plot )
+        return bar
 
     def setLookupTable(self, lut, update=True):
         """

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -195,6 +195,10 @@ class ImageItem(GraphicsObject):
         """
         if colorMap is not None:
             self.setColorMap(colorMap)
+        print('trying to get viewbox')
+        vb = self.getViewBox()
+        print(vb.getParent())
+        # print(self.getViewBox())
         bar = ColorBarItem.ColorBarItem(**kargs)
         bar.setImageItem( self, insert_in=plot )
         return bar

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -11,7 +11,6 @@ from ..Qt import QtCore, QtGui, QtWidgets
 from ..util.cupy_helper import getCupy
 from .GraphicsObject import GraphicsObject
 from .. import colormap
-from . import ColorBarItem
 
 translate = QtCore.QCoreApplication.translate
 
@@ -188,20 +187,20 @@ class ImageItem(GraphicsObject):
         """
         return self._colorMap
         
-    def addColorBar(self, colorMap=None, plot=None, **kargs):
-        """ 
-        Convenience method to add a ColorBarItem for this `ImageItem` to the specified plot.
-        All additional parameters will be passed on to ColorBarItem.
-        """
-        if colorMap is not None:
-            self.setColorMap(colorMap)
-        print('trying to get viewbox')
-        vb = self.getViewBox()
-        print(vb.getParent())
-        # print(self.getViewBox())
-        bar = ColorBarItem.ColorBarItem(**kargs)
-        bar.setImageItem( self, insert_in=plot )
-        return bar
+    # def addColorBar(self, colorMap=None, plot=None, **kargs):
+    #     """ 
+    #     Convenience method to add a ColorBarItem for this `ImageItem` to the specified plot.
+    #     All additional parameters will be passed on to ColorBarItem.
+    #     """
+    #     if colorMap is not None:
+    #         self.setColorMap(colorMap)
+    #     print('trying to get viewbox')
+    #     vb = self.getViewBox()
+    #     print(vb.getParent())
+    #     # print(self.getViewBox())
+    #     bar = ColorBarItem.ColorBarItem(**kargs)
+    #     bar.setImageItem( self, insert_in=plot )
+    #     return bar
 
     def setLookupTable(self, lut, update=True):
         """

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -22,6 +22,7 @@ from ..PlotDataItem import PlotDataItem
 from ..ScatterPlotItem import ScatterPlotItem
 from ..ViewBox import ViewBox
 
+
 translate = QtCore.QCoreApplication.translate
 
 ui_template = importlib.import_module(
@@ -344,7 +345,7 @@ class PlotItem(GraphicsWidget):
         
     def setLogMode(self, x=None, y=None):
         """
-        Set log scaling for x and/or y axes.
+        Set log scaling for `x` and/or `y` axes.
         This informs PlotDataItems to transform logarithmically and switches
         the axes to use log ticking. 
         
@@ -520,8 +521,9 @@ class PlotItem(GraphicsWidget):
     def addItem(self, item, *args, **kargs):
         """
         Add a graphics item to the view box. 
-        If the item has plot data (PlotDataItem, PlotCurveItem, ScatterPlotItem), it may
-        be included in analysis performed by the PlotItem.
+        If the item has plot data (:class:`~pyqtgrpah.PlotDataItem`, 
+        :class:`~pyqtgraph.PlotCurveItem`, :class:`~pyqtgraph.ScatterPlotItem`), 
+        it may be included in analysis performed by the PlotItem.
         """
         if item in self.items:
             warnings.warn('Item already added to PlotItem, ignoring.')
@@ -579,7 +581,8 @@ class PlotItem(GraphicsWidget):
         self.addItem(item, *args)
         
     def listDataItems(self):
-        """Return a list of all data items (PlotDataItem, PlotCurveItem, ScatterPlotItem, etc)
+        """Return a list of all data items (:class:`~pyqtgrpah.PlotDataItem`, 
+        :class:`~pyqtgraph.PlotCurveItem`, :class:`~pyqtgraph.ScatterPlotItem`, etc)
         contained in this PlotItem."""
         return self.dataItems[:]
         
@@ -588,16 +591,15 @@ class PlotItem(GraphicsWidget):
             'PlotItem.addCurve is deprecated and will be removed in 0.13. '
             'Use PlotItem.addItem instead.',
             DeprecationWarning, stacklevel=2
-        )    
-
+        )
         self.addItem(c, params)
 
     def addLine(self, x=None, y=None, z=None, **kwds):
         """
-        Create an InfiniteLine and add to the plot. 
+        Create an :class:`~pyqtgraph.InfiniteLine` and add to the plot. 
         
-        If *x* is specified,
-        the line will be vertical. If *y* is specified, the line will be
+        If `x` is specified,
+        the line will be vertical. If `y` is specified, the line will be
         horizontal. All extra keyword arguments are passed to
         :func:`InfiniteLine.__init__() <pyqtgraph.InfiniteLine.__init__>`.
         Returns the item created.
@@ -612,7 +614,7 @@ class PlotItem(GraphicsWidget):
 
     def removeItem(self, item):
         """
-        Remove an item from the internal ViewBox.
+        Remove an item from the PlotItem's :class:`~pyqtgraph.ViewBox`.
         """
         if not item in self.items:
             return
@@ -632,7 +634,7 @@ class PlotItem(GraphicsWidget):
 
     def clear(self):
         """
-        Remove all items from the ViewBox.
+        Remove all items from the PlotItem's :class:`~pyqtgraph.ViewBox`.
         """
         for i in self.items[:]:
             self.removeItem(i)
@@ -644,13 +646,17 @@ class PlotItem(GraphicsWidget):
         self.avgCurves = {}        
     
     def plot(self, *args, **kargs):
+#        **Additional arguments:**
         """
         Add and return a new plot.
         See :func:`PlotDataItem.__init__ <pyqtgraph.PlotDataItem.__init__>` for data arguments
         
-        Extra allowed arguments are:
-            clear    - clear all plots before displaying new data
-            params   - meta-parameters to associate with this data
+        **Additional allowed arguments**
+        
+        ========= =================================================================
+        `clear`   clears all plots before displaying new data
+        `params`  sets meta-parameters to associate with this data
+        ========= =================================================================
         """
         clear = kargs.get('clear', False)
         params = kargs.get('params', None)
@@ -668,14 +674,14 @@ class PlotItem(GraphicsWidget):
 
     def addLegend(self, offset=(30, 30), **kwargs):
         """
-        Create a new :class:`~pyqtgraph.LegendItem` and anchor it over the
-        internal ViewBox. Plots will be automatically displayed in the legend
-        if they are created with the 'name' argument.
+        Create a new :class:`~pyqtgraph.LegendItem` and anchor it over the internal 
+        :class:`~pyqtgraph.ViewBox`. Plots added after this will be automatically 
+        displayed in the legend if they are created with a 'name' argument.
 
-        If a LegendItem has already been created using this method, that
-        item will be returned rather than creating a new one.
+        If a :class:`~pyqtGraph.LegendItem` has already been created using this method, 
+        that item will be returned rather than creating a new one.
 
-        Accepts the same arguments as :meth:`~pyqtgraph.LegendItem`.
+        Accepts the same arguments as :func:`~pyqtgraph.LegendItem.__init__`.
         """
 
         if self.legend is None:
@@ -945,20 +951,26 @@ class PlotItem(GraphicsWidget):
         
         
     def setDownsampling(self, ds=None, auto=None, mode=None):
-        """Change the default downsampling mode for all PlotDataItems managed by this plot.
+        """
+        Changes the default downsampling mode for all :class:`~pyqtgraph.PlotDataItem` managed by this plot.
         
-        =============== =================================================================
+        =============== ====================================================================
         **Arguments:**
         ds              (int) Reduce visible plot samples by this factor, or
+
                         (bool) To enable/disable downsampling without changing the value.
-        auto            (bool) If True, automatically pick *ds* based on visible range
-        mode            'subsample': Downsample by taking the first of N samples.
-                        This method is fastest and least accurate.
+
+        auto            (bool) If `True`, automatically pick ``ds`` based on visible range
+
+        mode            'subsample': Downsample by taking the first of N samples. This 
+                        method is fastest but least accurate.
+
                         'mean': Downsample by taking the mean of N samples.
-                        'peak': Downsample by drawing a saw wave that follows the min
-                        and max of the original data. This method produces the best
-                        visual representation of the data but is slower.
-        =============== =================================================================
+
+                        'peak': Downsample by drawing a saw wave that follows the min and 
+                        max of the original data. This method produces the best visual 
+                        representation of the data but is slower.
+        =============== ====================================================================
         """
         if ds is not None:
             if ds is False:
@@ -1010,8 +1022,8 @@ class PlotItem(GraphicsWidget):
         return ds, auto, method
         
     def setClipToView(self, clip):
-        """Set the default clip-to-view mode for all PlotDataItems managed by this plot.
-        If *clip* is True, then PlotDataItems will attempt to draw only points within the visible
+        """Set the default clip-to-view mode for all :class:`~pyqtgraph.PlotDataItem`s managed by this plot.
+        If *clip* is `True`, then PlotDataItems will attempt to draw only points within the visible
         range of the ViewBox."""
         self.ctrl.clipToViewCheck.setChecked(clip)
         
@@ -1026,16 +1038,17 @@ class PlotItem(GraphicsWidget):
                 curve.show()
     
     def updateDecimation(self):
-        """Reduce or increase number of visible curves depending from Max Traces spinner value
-        if Max Traces is checked in the context menu. Destroy not visible curves if forget traces
-        is checked. This function is called in most cases automaticaly when Max Traces GUI elements
-        are triggered. Also it is auto-called when state of PlotItem is updated, state restored
-        or new items being added/removed.
+        """
+        Reduce or increase number of visible curves according to value set by the `Max Traces` spinner,
+        if `Max Traces` is checked in the context menu. Destroy curves that are not visible if 
+        `forget traces` is checked. In most cases, this function is called automaticaly when the 
+        `Max Traces` GUI elements are triggered. It is also alled when the state of PlotItem is updated,
+        its state is restored, or new items added added/removed.
         
-        This can cause unexpected/conflicting state of curve visibility (or destruction) if curve
-        visibilities are controlled externaly. In case of external control it is adviced to disable
-        the Max Traces checkbox (or context menu) to prevent user from the unexpected
-        curve state change."""
+        This can cause an unexpected or conflicting state of curve visibility (or destruction) if curve
+        visibilities are controlled externally. In the case of external control it is advised to disable
+        the `Max Traces` checkbox (or context menu) to prevent unexpected curve state changes.
+        """
         if not self.ctrl.maxTracesCheck.isChecked():
             return
         else:
@@ -1099,7 +1112,7 @@ class PlotItem(GraphicsWidget):
         """
         Enable or disable the context menu for this PlotItem.
         By default, the ViewBox's context menu will also be affected.
-        (use enableViewBoxMenu=None to leave the ViewBox unchanged)
+        (use ``enableViewBoxMenu=None`` to leave the ViewBox unchanged)
         """
         self._menuEnabled = enableMenu
         if enableViewBoxMenu is None:
@@ -1137,7 +1150,7 @@ class PlotItem(GraphicsWidget):
         
     def setLabel(self, axis, text=None, units=None, unitPrefix=None, **args):
         """
-        Set the label for an axis. Basic HTML formatting is allowed.
+        Sets the label for an axis. Basic HTML formatting is allowed.
         
         ==============  =================================================================
         **Arguments:**
@@ -1156,7 +1169,7 @@ class PlotItem(GraphicsWidget):
         """
         Convenience function allowing multiple labels and/or title to be set in one call.
         Keyword arguments can be 'title', 'left', 'bottom', 'right', or 'top'.
-        Values may be strings or a tuple of arguments to pass to setLabel.
+        Values may be strings or a tuple of arguments to pass to :func:`setLabel`.
         """
         for k,v in kwds.items():
             if k == 'title':

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -688,7 +688,7 @@ class PlotItem(GraphicsWidget):
         Adds a color bar linked to the ImageItem specified by `image`.
         AAdditional parameters will be passed to the `pyqtgraph.ColorBarItem`.
         
-        A call like `plot.addColorBar(img, colorMap='viridis') is a convenient
+        A call like `plot.addColorBar(img, colorMap='viridis')` is a convenient
         method to assign and show a color map.
         """
         from ..ColorBarItem import ColorBarItem # avoid circular import

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -609,7 +609,7 @@ class PlotItem(GraphicsWidget):
         if z is not None:
             line.setZValue(z)
         return line
-        
+
     def removeItem(self, item):
         """
         Remove an item from the internal ViewBox.

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -608,8 +608,8 @@ class PlotItem(GraphicsWidget):
         self.addItem(line)
         if z is not None:
             line.setZValue(z)
-        return line        
-
+        return line
+        
     def removeItem(self, item):
         """
         Remove an item from the internal ViewBox.

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -683,6 +683,19 @@ class PlotItem(GraphicsWidget):
             self.legend.setParentItem(self.vb)
         return self.legend
         
+    def addColorBar(self, image, **kargs):
+        """
+        Adds a color bar linked to the ImageItem specified by `image`.
+        AAdditional parameters will be passed to the `pyqtgraph.ColorBarItem`.
+        
+        A call like `plot.addColorBar(img, colorMap='viridis') is a convenient
+        method to assign and show a color map.
+        """
+        from ..ColorBarItem import ColorBarItem # avoid circular import
+        bar = ColorBarItem(**kargs)
+        bar.setImageItem( image, insert_in=self )
+        return bar
+
     def scatterPlot(self, *args, **kargs):
         if 'pen' in kargs:
             kargs['symbolPen'] = kargs['pen']


### PR DESCRIPTION
This is meant to address #2067.

The `ImageItem` false color options were initially completely designed around control through `HistogramLUTItem`.
This adds a `setColorMap()` method to ImageItem, and the option to use this through a `colorMap` argument during initialization, `setImage()` or `setOpts()`.

The PR also adds the option to create and add a `ColorBarItem` through a new `addColorBar()` method of ImageItem.
This is somewhat inelegant, since the user needs to manually pass a reference to the plot. I could not find a means for the ImageItem to determine its parent. An alternative would have been to include `addColorBar()` as a method of the `PlotItem`, but this results in a circular import.

I have updated the ColorBarItem example to use the new methods for demonstration. The code to add an image with color map and interactive color bar is now down to just
```python
i1 = pg.ImageItem(image=data)
p1.addItem( i1 )
p1.addColorBar( i1, colorMap='CET-L9', values=(0, 30_000))
```
Might close #2067 ...