### PR TITLE
Add some helpful exceptions for invalid inputs to methods

### DIFF
--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -129,6 +129,8 @@ class DockArea(Container, QtWidgets.QWidget, DockDrop):
             new = HContainer(self)
         elif typ == 'tab':
             new = TContainer(self)
+        else:
+            raise ValueError("typ must be one of 'vertical', 'horizontal', or 'tab'")
         return new
         
     def addContainer(self, typ, obj):

--- a/pyqtgraph/flowchart/library/Operators.py
+++ b/pyqtgraph/flowchart/library/Operators.py
@@ -41,8 +41,10 @@ class BinOpNode(CtrlNode):
                 try:
                     fn = getattr(args['A'], name)
                     break
-                except AttributeError:
+                except AttributeError as e:
                     pass
+            else:
+                raise e
         else:
             fn = getattr(args['A'], self.fn)
         out = fn(args['B'])

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -938,6 +938,8 @@ class AxisItem(GraphicsWidget):
             tickStop = bounds.top()
             tickDir = 1
             axis = 1
+        else:
+            raise ValueError("self.orientation must be in ('left', 'right', 'top', 'bottom')")
         #print tickStart, tickStop, span
 
         ## determine size of this item in pixels

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -993,6 +993,8 @@ class PlotItem(GraphicsWidget):
             method = 'mean'
         elif self.ctrl.peakRadio.isChecked():
             method = 'peak'
+        else:
+            raise ValueError("one of the method radios must be selected for: 'subsample', 'mean', or 'peak'.")
         
         return ds, auto, method
         

--- a/pyqtgraph/metaarray/MetaArray.py
+++ b/pyqtgraph/metaarray/MetaArray.py
@@ -413,6 +413,8 @@ class MetaArray(object):
             ind.append(order)
         elif isinstance(axis, str):
             ind = (slice(axis, order),)
+        else:
+            raise TypeError("axis must be type (int, str)")
         return self[tuple(ind)]
   
     def append(self, val, axis):

--- a/pyqtgraph/parametertree/ParameterSystem.py
+++ b/pyqtgraph/parametertree/ParameterSystem.py
@@ -115,6 +115,8 @@ class ParameterSystem(GroupParameter):
             bg = fn.mkBrush('y')
             bold = True
             readonly = False
+        else:
+            raise ValueError("'state' must be one of 'autoSet', 'autoUnset', or 'fixed'")
             
         param.setReadonly(readonly)
         

--- a/pyqtgraph/widgets/DataFilterWidget.py
+++ b/pyqtgraph/widgets/DataFilterWidget.py
@@ -60,6 +60,8 @@ class DataFilterParameter(ptree.types.GroupParameter):
             child = self.addChild(RangeFilterItem(name, self.fields[name]))
         elif mode == 'enum':
             child = self.addChild(EnumFilterItem(name, self.fields[name]))
+        else:
+            raise ValueError("field mode must be 'range' or 'enum'")
         return child
             
     def fieldNames(self):


### PR DESCRIPTION
Raise ValueError/TypeError instead of relying on NameError being raised later on in less helpful contexts to avoid uninitialized variables.