### PR TITLE
avoid redundant assignment of pos=pos

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -2114,11 +2114,9 @@ class PolyLineROI(ROI):
         return h
         
     def segmentClicked(self, segment, ev=None, pos=None): ## pos should be in this item's coordinate system
-        if ev != None:
+        if ev is not None:
             pos = segment.mapToParent(ev.pos())
-        elif pos != None:
-            pos = pos
-        else:
+        elif pos is None:
             raise Exception("Either an event or a position must be given.")
         h1 = segment.handles[0]['item']
         h2 = segment.handles[1]['item']


### PR DESCRIPTION
While I'm at it, I got rid of the equality comparisons to None literal