### PR TITLE
Be lazier about importing h5py

### DIFF
--- a/pyqtgraph/exporters/HDF5Exporter.py
+++ b/pyqtgraph/exporters/HDF5Exporter.py
@@ -1,3 +1,5 @@
+import importlib
+
 import numpy
 
 from .. import PlotItem
@@ -5,11 +7,7 @@ from ..parametertree import Parameter
 from ..Qt import QtCore
 from .Exporter import Exporter
 
-try:
-    import h5py
-    HAVE_HDF5 = True
-except ImportError:
-    HAVE_HDF5 = False
+HAVE_HDF5 = importlib.util.find_spec("h5py") is not None
 
 translate = QtCore.QCoreApplication.translate
 
@@ -37,6 +35,8 @@ class HDF5Exporter(Exporter):
             raise RuntimeError("This exporter requires the h5py package, "
                                "but it was not importable.")
         
+        import h5py
+
         if not isinstance(self.item, PlotItem):
             raise Exception("Must have a PlotItem selected for HDF5 export.")
         


### PR DESCRIPTION
We discovered recently bad interactions between pytables and h5py resulting in the inability to import one after the other had been imported. This takes a step towards pyqtgraph not being a confounding variable in that situation when it doesn't need to be. Note that h5py is still imported in MetaArray, so until that is removed, this doesn't actually solve the issue of h5py being loaded when pyqtgraph is imported, but once metaarray is removed as planned, this is the only remaing library (non-example) code that uses h5py directly.