### PR TITLE
Add a proxy delay to checklist parameter changes via children edits

### DIFF
--- a/pyqtgraph/examples/_paramtreecfg.py
+++ b/pyqtgraph/examples/_paramtreecfg.py
@@ -91,6 +91,11 @@ cfg = {
         'exclusive': {
             'type': 'bool',
             'value': False,
+        },
+        'delay': {
+            'type': 'float',
+            'value': 1.0,
+            'limits': [0, None]
         }
     },
 

--- a/pyqtgraph/examples/parametertree.py
+++ b/pyqtgraph/examples/parametertree.py
@@ -110,11 +110,10 @@ p.sigTreeStateChanged.connect(change)
 def valueChanging(param, value):
     print("Value changing (not finalized): %s %s" % (param, value))
     
-# Too lazy for recursion:
-for child in p.children():
-    child.sigValueChanging.connect(valueChanging)
-    for ch2 in child.children():
-        ch2.sigValueChanging.connect(valueChanging)
+# Only listen for changes of the 'widget' child:
+for child in p.child('Example Parameters'):
+    if 'widget' in child.names:
+        child.child('widget').sigValueChanging.connect(valueChanging)
         
 
 def save():

--- a/pyqtgraph/parametertree/parameterTypes/checklist.py
+++ b/pyqtgraph/parametertree/parameterTypes/checklist.py
@@ -1,5 +1,5 @@
 from ... import functions as fn
-from ...Qt import QtWidgets, QtCore
+from ...Qt import QtWidgets
 from ...SignalProxy import SignalProxy
 from ..ParameterItem import ParameterItem
 from . import BoolParameterItem, SimpleParameter
@@ -151,7 +151,7 @@ class ChecklistParameter(GroupParameter):
             # Also, value calculation will be incorrect until children are added, so make sure to recompute
             self.setValue(value)
 
-        self.coalesceProxy = SignalProxy(self.sigValueChanging, delay=opts.get('delay', 1.0), slot=self._finishChildChanges)
+        self.valChangingProxy = SignalProxy(self.sigValueChanging, delay=opts.get('delay', 1.0), slot=self._finishChildChanges)
 
     def updateLimits(self, _param, limits):
         oldOpts = self.names
@@ -191,7 +191,7 @@ class ChecklistParameter(GroupParameter):
             # self.opts['value'] = self._VALUE_UNSET
             self.updateLimits(None, self.opts.get('limits', []))
         if 'delay' in opts:
-            self.coalesceProxy.setDelay(opts['delay'])
+            self.valChangingProxy.setDelay(opts['delay'])
     
     def value(self):
         vals = [self.forward[p.name()] for p in self.children() if p.value()]


### PR DESCRIPTION
Randomly testing with a touchpad I found 1s proxy delay was usually adequate. Input from others would be nice on this

https://user-images.githubusercontent.com/23620506/141720037-ab4d8c2f-80d5-4cd8-8751-8f98d662f097.mp4

.