### PR TITLE
PlotCurveItem OpenGL : avoid automatic conversion from float64 to float32

### DIFF
--- a/doc/source/config_options.rst
+++ b/doc/source/config_options.rst
@@ -29,7 +29,16 @@ exitCleanup        bool                True               Attempt to work around
 useOpenGL          bool                False              Enable OpenGL in GraphicsView.
 useCupy            bool                False              Use cupy to perform calculations on the GPU. Only currently applies to
                                                           ImageItem and its associated functions.
+useNumba           bool                False              Use numba acceleration where implemented.
 enableExperimental bool                False              Enable experimental features (the curious can search for this key in the code).
+                                                          In combination with useOpenGL, this makes PlotCurveItem use PyOpenGL
+                                                          for curve drawing.
+                                                          
+
+                                                          **Caveats**
+
+                                                            * Only a very limited subset of the full options of PlotCurveItem is implemented.
+                                                            * Single precision is used. This may cause drawing artifacts.
 crashWarning       bool                False              If True, print warnings about situations that may result in a crash.
 ================== =================== ================== ================================================================================
 

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -879,7 +879,7 @@ class PlotCurveItem(GraphicsObject):
 
         try:
             x, y = self.getData()
-            pos = np.empty((len(x), 2))
+            pos = np.empty((len(x), 2), dtype=np.float32)
             pos[:,0] = x
             pos[:,1] = y
             gl.glEnableClientState(gl.GL_VERTEX_ARRAY)
@@ -906,7 +906,7 @@ class PlotCurveItem(GraphicsObject):
                 else:
                     gl.glDisable(gl.GL_LINE_SMOOTH)
 
-                gl.glDrawArrays(gl.GL_LINE_STRIP, 0, int(pos.size / pos.shape[-1]))
+                gl.glDrawArrays(gl.GL_LINE_STRIP, 0, pos.shape[0])
             finally:
                 gl.glDisableClientState(gl.GL_VERTEX_ARRAY)
         finally:


### PR DESCRIPTION
There is an inefficiency in the current PlotCurveItem OpenGL implementation:
1) temporary float64 buffer created for vertices
2) tell PyOpenGL to use it as float32 (thus triggering a float64 - > float32 conversion) 

This PR changes step (1) to use a temporary float32 buffer right from the start.
This gains a few fps with 1,000,000 points: ```examples\PlotSpeedTest.py --opengl --frames 3 --nsamples 1000000```

Alternatively, if it is considered a bug that ```glVertexPointerf``` was used, then that should be changed instead to ```glVertexPointer(2, gl.GL_DOUBLE, 0, pos)```. However, this would then be a change in behavior to use double precision, and in addition, the calls to setting up the stencil should also be changed to double precision.