### PR TITLE
Param tree style, modified

### DIFF
--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -485,9 +485,10 @@ def mkQApp(name=None, style='system'):
 
         QAPP._setStyleSheet = QAPP.setStyleSheet
         QAPP.setStyleSheet = patched_setStyleSheet.__get__(QAPP.setStyleSheet, QtWidgets.QApplication)
-        if style == 'dark':
-            QAPP.setPalette( dark_QPalette() )
-            QAPP.setProperty('darkMode', True )
+    if style == 'dark':
+        print('setting dark palette')
+        QAPP.setPalette( dark_QPalette() )
+        QAPP.setProperty('darkMode', True )
             
 
     if name is not None:

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -404,67 +404,7 @@ if m is not None and list(map(int, m.groups())) < versionReq:
 App = QtWidgets.QApplication
 # subclassing QApplication causes segfaults on PySide{2, 6} / Python 3.8.7+
 
-
-COLORS ={'DS_bg_light' : '#505F69', 'DS_bg_normal' : '#32414B', 'DS_bg_dark' : '#19232D',
-'DS_fg_light' : '#F0F0F0', 'DS_fg_normal' : '#AAAAAA', 'DS_fg_dark' : '#787878',
-'DS_sel_light': '#148CD2', 'DS_sel_normal': '#1464A0', 'DS_sel_dark': '#14506E'}
-
-
-def dark_QPalette():
-    # color definitions roughly match QDarkstyle
-    BLACK      = QtGui.QColor('#000000')
-    BG_LIGHT   = QtGui.QColor('#505F69')
-    BG_NORMAL  = QtGui.QColor('#32414B')
-    BG_DARK    = QtGui.QColor('#19232D')
-    FG_LIGHT   = QtGui.QColor('#F0F0F0')
-    FG_NORMAL  = QtGui.QColor('#AAAAAA')
-    FG_DARK    = QtGui.QColor('#787878')
-    SEL_LIGHT  = QtGui.QColor('#148CD2')
-    SEL_NORMAL = QtGui.QColor('#1464A0')
-    # SEL_DARK   = QtGui.QColor('#14506E')
-    qpal = QtGui.QPalette( QtGui.QColor(BG_DARK) )
-    for ptype in (  QtGui.QPalette.Active,  QtGui.QPalette.Inactive ):
-        qpal.setColor( ptype, QtGui.QPalette.Base      , QtGui.QColor( COLORS['DS_bg_dark'  ] ) )
-        qpal.setColor( ptype, QtGui.QPalette.Window    , QtGui.QColor( COLORS['DS_bg_normal'] ) )
-        qpal.setColor( ptype, QtGui.QPalette.WindowText, QtGui.QColor( COLORS['DS_fg_light' ] ) )
-        qpal.setColor( ptype, QtGui.QPalette.AlternateBase, BG_DARK )
-        qpal.setColor( ptype, QtGui.QPalette.Button, BG_DARK )
-        qpal.setColor( ptype, QtGui.QPalette.ButtonText, FG_LIGHT )
-        qpal.setColor( ptype, QtGui.QPalette.Highlight, SEL_LIGHT )
-        qpal.setColor( ptype, QtGui.QPalette.HighlightedText, BLACK )
-        qpal.setColor( ptype, QtGui.QPalette.Link, SEL_NORMAL )
-        qpal.setColor( ptype, QtGui.QPalette.LinkVisited, FG_NORMAL )
-        qpal.setColor( ptype, QtGui.QPalette.Text, FG_LIGHT )
-        qpal.setColor( ptype, QtGui.QPalette.ToolTipBase, BG_LIGHT )
-        qpal.setColor( ptype, QtGui.QPalette.ToolTipText, FG_LIGHT )
-    qpal.setColor( QtGui.QPalette.Disabled, QtGui.QPalette.Button, BG_NORMAL )
-    qpal.setColor( QtGui.QPalette.Disabled, QtGui.QPalette.ButtonText, FG_DARK )
-    qpal.setColor( QtGui.QPalette.Disabled, QtGui.QPalette.WindowText, FG_DARK )
-    return qpal
-
-
-def _setStyleSheet(styleSheet):
-    """
-    override for QApp.setStylesheet
-    If a stylesheet and a palette are set on the app when the OS is in darkMode
-    remove dark_QPalette and change palette back to the one the user specified users palette
-    """
-    appPalette = QAPP.palette()
-    originalPalette = PALETTE
-    darkPalette = dark_QPalette()
-    darkMode = QAPP.property('darkMode')
-    QAPP._setStyleSheet(styleSheet)
-    if (
-        originalPalette != appPalette
-        and darkMode
-        and appPalette == darkPalette
-    ):
-        QAPP.setPalette(originalPalette)
-
-
 QAPP = None
-PALETTE = None
-
 def mkQApp(name=None):
     """
     Creates new QApplication or returns current instance if existing.
@@ -497,14 +437,8 @@ def mkQApp(name=None):
             QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
 
         QAPP = QtWidgets.QApplication(sys.argv or ["pyqtgraph"])
-        PALETTE = QAPP.palette()
         QAPP.paletteChanged.connect(onPaletteChange)
         QAPP.paletteChanged.emit(QAPP.palette())
-        QAPP._setStyleSheet = QAPP.setStyleSheet
-        QAPP.setStyleSheet = _setStyleSheet
-        if QAPP.property('darkMode'):
-            darkPalette = dark_QPalette()
-            QAPP.setPalette(darkPalette)
 
     if name is not None:
         QAPP.setApplicationName(name)

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -404,7 +404,67 @@ if m is not None and list(map(int, m.groups())) < versionReq:
 App = QtWidgets.QApplication
 # subclassing QApplication causes segfaults on PySide{2, 6} / Python 3.8.7+
 
+
+COLORS ={'DS_bg_light' : '#505F69', 'DS_bg_normal' : '#32414B', 'DS_bg_dark' : '#19232D',
+'DS_fg_light' : '#F0F0F0', 'DS_fg_normal' : '#AAAAAA', 'DS_fg_dark' : '#787878',
+'DS_sel_light': '#148CD2', 'DS_sel_normal': '#1464A0', 'DS_sel_dark': '#14506E'}
+
+
+def dark_QPalette():
+    # color definitions roughly match QDarkstyle
+    BLACK      = QtGui.QColor('#000000')
+    BG_LIGHT   = QtGui.QColor('#505F69')
+    BG_NORMAL  = QtGui.QColor('#32414B')
+    BG_DARK    = QtGui.QColor('#19232D')
+    FG_LIGHT   = QtGui.QColor('#F0F0F0')
+    FG_NORMAL  = QtGui.QColor('#AAAAAA')
+    FG_DARK    = QtGui.QColor('#787878')
+    SEL_LIGHT  = QtGui.QColor('#148CD2')
+    SEL_NORMAL = QtGui.QColor('#1464A0')
+    # SEL_DARK   = QtGui.QColor('#14506E')
+    qpal = QtGui.QPalette( QtGui.QColor(BG_DARK) )
+    for ptype in (  QtGui.QPalette.Active,  QtGui.QPalette.Inactive ):
+        qpal.setColor( ptype, QtGui.QPalette.Base      , QtGui.QColor( COLORS['DS_bg_dark'  ] ) )
+        qpal.setColor( ptype, QtGui.QPalette.Window    , QtGui.QColor( COLORS['DS_bg_normal'] ) )
+        qpal.setColor( ptype, QtGui.QPalette.WindowText, QtGui.QColor( COLORS['DS_fg_light' ] ) )
+        qpal.setColor( ptype, QtGui.QPalette.AlternateBase, BG_DARK )
+        qpal.setColor( ptype, QtGui.QPalette.Button, BG_DARK )
+        qpal.setColor( ptype, QtGui.QPalette.ButtonText, FG_LIGHT )
+        qpal.setColor( ptype, QtGui.QPalette.Highlight, SEL_LIGHT )
+        qpal.setColor( ptype, QtGui.QPalette.HighlightedText, BLACK )
+        qpal.setColor( ptype, QtGui.QPalette.Link, SEL_NORMAL )
+        qpal.setColor( ptype, QtGui.QPalette.LinkVisited, FG_NORMAL )
+        qpal.setColor( ptype, QtGui.QPalette.Text, FG_LIGHT )
+        qpal.setColor( ptype, QtGui.QPalette.ToolTipBase, BG_LIGHT )
+        qpal.setColor( ptype, QtGui.QPalette.ToolTipText, FG_LIGHT )
+    qpal.setColor( QtGui.QPalette.Disabled, QtGui.QPalette.Button, BG_NORMAL )
+    qpal.setColor( QtGui.QPalette.Disabled, QtGui.QPalette.ButtonText, FG_DARK )
+    qpal.setColor( QtGui.QPalette.Disabled, QtGui.QPalette.WindowText, FG_DARK )
+    return qpal
+
+
+def _setStyleSheet(styleSheet):
+    """
+    override for QApp.setStylesheet
+    If a stylesheet and a palette are set on the app when the OS is in darkMode
+    remove dark_QPalette and change palette back to the one the user specified users palette
+    """
+    appPalette = QAPP.palette()
+    originalPalette = PALETTE
+    darkPalette = dark_QPalette()
+    darkMode = QAPP.property('darkMode')
+    QAPP._setStyleSheet(styleSheet)
+    if (
+        originalPalette != appPalette
+        and darkMode
+        and appPalette == darkPalette
+    ):
+        QAPP.setPalette(originalPalette)
+
+
 QAPP = None
+PALETTE = None
+
 def mkQApp(name=None):
     """
     Creates new QApplication or returns current instance if existing.
@@ -415,7 +475,8 @@ def mkQApp(name=None):
     ============== ========================================================
     """
     global QAPP
-    
+    global PALETTE
+
     def onPaletteChange(palette):
         color = palette.base().color().name()
         app = QtWidgets.QApplication.instance()
@@ -434,9 +495,16 @@ def mkQApp(name=None):
         else:  # qt 5.12 and 5.13
             QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
             QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
+
         QAPP = QtWidgets.QApplication(sys.argv or ["pyqtgraph"])
+        PALETTE = QAPP.palette()
         QAPP.paletteChanged.connect(onPaletteChange)
         QAPP.paletteChanged.emit(QAPP.palette())
+        QAPP._setStyleSheet = QAPP.setStyleSheet
+        QAPP.setStyleSheet = _setStyleSheet
+        if QAPP.property('darkMode'):
+            darkPalette = dark_QPalette()
+            QAPP.setPalette(darkPalette)
 
     if name is not None:
         QAPP.setApplicationName(name)

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -484,6 +484,7 @@ def mkQApp(name=None):
                 if palette.base().color().lightnessF() > 0.5:
                     # need to fix light palette background in dark style sheet
                     app.setPalette( dark_QPalette() )
+                    app.setProperty('darkMode', True )
 
         QAPP._setStyleSheet = QAPP.setStyleSheet
         QAPP.setStyleSheet = patched_setStyleSheet.__get__(QAPP.setStyleSheet, QtWidgets.QApplication)

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -435,7 +435,7 @@ def dark_QPalette():
     return qpal
 
 QAPP = None
-def mkQApp(name=None):
+def mkQApp(name=None, style='system'):
     """
     Creates new QApplication or returns current instance if existing.
     
@@ -452,10 +452,6 @@ def mkQApp(name=None):
         color = palette.base().color().name()
         app = QtWidgets.QApplication.instance()
         app.setProperty('darkMode', color.lower() != "#ffffff")
-        print('stylesheet length:', len(app.styleSheet()) )
-        print('------------------------------------------------')
-
-        
 
     QAPP = QtWidgets.QApplication.instance()
     if QAPP is None:
@@ -477,6 +473,7 @@ def mkQApp(name=None):
         
         def patched_setStyleSheet(self, styleSheet):
             QAPP._setStyleSheet(styleSheet) # I would rather call this as self._setStyleSheet, but that does not seem to work
+            # print(styleSheet[:4024])
             if '/* QDarkStyleSheet' in styleSheet[:512]:
                 # print('this is QDarkStyle!')
                 app = QtWidgets.QApplication.instance()
@@ -488,6 +485,10 @@ def mkQApp(name=None):
 
         QAPP._setStyleSheet = QAPP.setStyleSheet
         QAPP.setStyleSheet = patched_setStyleSheet.__get__(QAPP.setStyleSheet, QtWidgets.QApplication)
+        if style == 'dark':
+            QAPP.setPalette( dark_QPalette() )
+            QAPP.setProperty('darkMode', True )
+            
 
     if name is not None:
         QAPP.setApplicationName(name)

--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -544,7 +544,12 @@ class ExampleLoader(QtWidgets.QMainWindow):
         event.accept()
 
 def main():
-    app = pg.mkQApp()
+    # app = pg.mkQApp()
+    
+    import qdarkstyle
+    app = pg.mkQApp("Parameter Tree Example")
+    app.setStyleSheet(qdarkstyle.load_stylesheet())
+    
     loader = ExampleLoader()
     loader.ui.exampleTree.setCurrentIndex(
         loader.ui.exampleTree.model().index(0,0)

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -319,24 +319,30 @@ class GroupParameterItem(ParameterItem):
         self.optsChanged(self.param, self.param.opts)
 
     def updateDepth(self, depth):
-        ## Change item's appearance based on its depth in the tree
-        ## This allows highest-level groups to be displayed more prominently.
-        if depth == 0:
-            for c in [0,1]:
-                self.setBackground(c, QtGui.QBrush(QtGui.QColor(100,100,100)))
-                self.setForeground(c, QtGui.QBrush(QtGui.QColor(220,220,255)))
-                font = self.font(c)
-                font.setBold(True)
+        """
+        Change item's appearance based on its depth in the tree
+        This allows highest-level groups to be displayed more prominently.
+        """
+        app = QtWidgets.QApplication.instance()
+        palette = app.palette()
+        textColor = palette.text().color()
+        backgroundColor = palette.button().color().darker(110)
+        altBackgroundColor = palette.dark().color()
+
+        if app.property('darkMode'):
+            backgroundColor = palette.button().color().lighter(115)
+            altBackgroundColor = palette.light().color().lighter(190)
+
+        for c in [0, 1]:
+            font = self.font(c)
+            font.setBold(True)
+            if depth == 0:
+                backgroundColor = altBackgroundColor
                 font.setPointSize(font.pointSize()+1)
-                self.setFont(c, font)
-        else:
-            for c in [0,1]:
-                self.setBackground(c, QtGui.QBrush(QtGui.QColor(220,220,220)))
-                self.setForeground(c, QtGui.QBrush(QtGui.QColor(50,50,50)))
-                font = self.font(c)
-                font.setBold(True)
-                #font.setPointSize(font.pointSize()+1)
-                self.setFont(c, font)
+
+            self.setBackground(c, backgroundColor)
+            self.setForeground(c, textColor)
+            self.setFont(c, font)
         self.titleChanged()  # sets the size hint for column 0 which is based on the new font
 
     def addClicked(self):

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -1,10 +1,9 @@
 import builtins
 
-from ... import functions as fn
-from ... import icons
-from ...Qt import QtCore, QtWidgets
 from ..Parameter import Parameter
 from ..ParameterItem import ParameterItem
+from ... import functions as fn, icons
+from ...Qt import QtCore, QtGui, QtWidgets
 
 class WidgetParameterItem(ParameterItem):
     """
@@ -304,7 +303,7 @@ class GroupParameterItem(ParameterItem):
                 self.addWidget.clicked.connect(self.addClicked)
             w = QtWidgets.QWidget()
             l = QtWidgets.QHBoxLayout()
-            l.setContentsMargins(0,0,0,0)
+            l.setContentsMargins(0, 0, 0, 0)
             w.setLayout(l)
             l.addWidget(self.addWidget)
             l.addStretch()
@@ -321,11 +320,34 @@ class GroupParameterItem(ParameterItem):
         """
         Change set the item font to bold and increase the font size on outermost groups.
         """
+        app = QtWidgets.QApplication.instance()
+        palette = app.palette()
+        color = palette.background().color()
+        h, s, l = color.hue(), color.saturation(), color.lightness()
+
+        stylesheet =  app.styleSheet()
+        textColor = None
+        if '/* Light Style' in stylesheet or '/* Dark Style' in stylesheet:
+            background = QtGui.QColor(255,255,255,0)
+            altBackground = background
+            textColor = QtGui.QColor('#000000')
+            if '/* Light Style' in stylesheet:
+                textColor = QtGui.QColor('#F0F0F0')
+        elif app.property('darkMode'):
+            background = QtGui.QColor.fromHsl(h, s, l * .6, 255)
+            altBackground = QtGui.QColor.fromHsl(h, s, l * 1.1)
+        else:
+            background = QtGui.QColor.fromHsl(h, s, l)
+            altBackground = QtGui.QColor.fromHsl(h, s, l * .95, 255)
+
         for c in [0, 1]:
             font = self.font(c)
             font.setBold(True)
             if depth == 0:
-                font.setPointSize(font.pointSize()+1)
+                background = altBackground
+                font.setPointSize(font.pointSize() + 1)
+            self.setBackground(c, background)
+            self.setForeground(c, textColor or palette.text().color())
             self.setFont(c, font)
         self.titleChanged()  # sets the size hint for column 0 which is based on the new font
 

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -2,10 +2,9 @@ import builtins
 
 from ... import functions as fn
 from ... import icons
-from ...Qt import QtCore, QtGui, QtWidgets
+from ...Qt import QtCore, QtWidgets
 from ..Parameter import Parameter
 from ..ParameterItem import ParameterItem
-
 
 class WidgetParameterItem(ParameterItem):
     """
@@ -320,35 +319,13 @@ class GroupParameterItem(ParameterItem):
 
     def updateDepth(self, depth):
         """
-        Change item's appearance based on its depth in the tree
-        This allows highest-level groups to be displayed more prominently.
+        Change set the item font to bold and increase the font size on outermost groups.
         """
-        app = QtWidgets.QApplication.instance()
-        palette = app.palette()
-        textColor = palette.text().color()
-        backgroundColor = palette.button().color().darker(110)
-        altBackgroundColor = palette.dark().color()
-
-        # if stylesheet and 'QDarkStyleSheet' in stylesheet:
-        if app.styleSheet(): # Assume the stylesheet is qdarkstyle
-            # #455364 is the background-color of the QHeaderView, #E0E1E3 is lineEdit text from QDarkStyle
-            # lighter/darker are applied to the colors to maintain a good contrast with the item:hover color
-            backgroundColor = QtGui.QColor('#455364').darker(100)
-            altBackgroundColor =  backgroundColor.lighter(130)
-            textColor = QtGui.QColor('#E0E1E3')
-        elif app.property('darkMode'):
-            backgroundColor = palette.button().color().lighter(115)
-            altBackgroundColor = palette.light().color().lighter(190)
-
         for c in [0, 1]:
             font = self.font(c)
             font.setBold(True)
             if depth == 0:
-                backgroundColor = altBackgroundColor
                 font.setPointSize(font.pointSize()+1)
-
-            self.setBackground(c, backgroundColor)
-            self.setForeground(c, textColor)
             self.setFont(c, font)
         self.titleChanged()  # sets the size hint for column 0 which is based on the new font
 

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -329,7 +329,14 @@ class GroupParameterItem(ParameterItem):
         backgroundColor = palette.button().color().darker(110)
         altBackgroundColor = palette.dark().color()
 
-        if app.property('darkMode'):
+        # if stylesheet and 'QDarkStyleSheet' in stylesheet:
+        if app.styleSheet(): # Assume the stylesheet is qdarkstyle
+            # #455364 is the background-color of the QHeaderView, #E0E1E3 is lineEdit text from QDarkStyle
+            # lighter/darker are applied to the colors to maintain a good contrast with the item:hover color
+            backgroundColor = QtGui.QColor('#455364').darker(100)
+            altBackgroundColor =  backgroundColor.lighter(130)
+            textColor = QtGui.QColor('#E0E1E3')
+        elif app.property('darkMode'):
             backgroundColor = palette.button().color().lighter(115)
             altBackgroundColor = palette.light().color().lighter(190)
 

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -322,24 +322,11 @@ class GroupParameterItem(ParameterItem):
         """
         app = QtWidgets.QApplication.instance()
         palette = app.palette()
-        color = palette.window().color()
-        h, s, l = color.hue(), color.saturation(), color.lightness()
-
-        stylesheet =  app.styleSheet()
-        textColor = None
-        if '/* Light Style' in stylesheet or '/* Dark Style' in stylesheet:
-            background = QtGui.QColor(255,255,255,0)
-            altBackground = background
-            textColor = QtGui.QColor('#000000')
-            if '/* Light Style' in stylesheet:
-                textColor = QtGui.QColor('#F0F0F0')
-        elif app.property('darkMode'):
-            background = QtGui.QColor.fromHsl(h, s, l * .6, 255)
-            altBackground = QtGui.QColor.fromHsl(h, s, l * 1.1)
-        else:
-            background = QtGui.QColor.fromHsl(h, s, l)
-            altBackground = QtGui.QColor.fromHsl(h, s, l * .95, 255)
-
+        background = palette.base().color()
+        h, s, l, alpha = background.getHslF()
+        l = 0.5 + (l-0.5) * 0.80 # move closer to gray
+        altBackground = QtGui.QColor.fromHslF(h, s, l)
+        textColor = palette.text().color()
         for c in [0, 1]:
             font = self.font(c)
             font.setBold(True)

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -322,7 +322,7 @@ class GroupParameterItem(ParameterItem):
         """
         app = QtWidgets.QApplication.instance()
         palette = app.palette()
-        color = palette.background().color()
+        color = palette.window().color()
         h, s, l = color.hue(), color.saturation(), color.lightness()
 
         stylesheet =  app.styleSheet()


### PR DESCRIPTION
Modified version of #2101 for visible discussion. 
I hope some of this approach can be merged into #2101, and this PR can be deleted. :)

The idea is not to hardcode any colors, but to always pull from the application palette.

This automatically works on Mac for light/dark mode. (Except -right now- it doesn't allow live switching)
Windows is always on a light palette. This also works there.

The most common way to get dark mode on Windows uses the QDarkStyle style sheet. The code detects if the user specifically applies this stylesheet, but did not provide a matching dark palette. Only in this case, the code sets a dark palette that matches the QDarkStyle color scheme.

Big thanks to @Wubbzi for digging into this and getting all the puzzle pieces nicely lined up on the table!