### PR TITLE
Bugfix: Handle example search failure due to bad regex

### DIFF
--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -325,6 +325,9 @@ class ExampleLoader(QtWidgets.QMainWindow):
             if self.curListener is not None:
                 self.curListener.disconnect()
             self.curListener = textFil.textChanged
+            # In case the regex was invalid before switching to title search,
+            # ensure the "invalid" color is reset
+            self.ui.exampleFilter.setStyleSheet('')
             if searchType == 'Content Search':
                 self.curListener.connect(self.filterByContent)
             else:

--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -372,13 +372,14 @@ class ExampleLoader(QtWidgets.QMainWindow):
         validRegex = True
         try:
             re.compile(text)
-            background = app.palette().background().color()
+            self.ui.exampleFilter.setStyleSheet('')
         except re.error:
             colors = DarkThemeColors if app.property('darkMode') else LightThemeColors
-            background = pg.mkColor(colors.Red)
-            background.setAlpha(100)
+            errorColor = pg.mkColor(colors.Red)
             validRegex = False
-        self.ui.exampleFilter.setStyleSheet(f'background: {pg.mkColor(background).name(QtGui.QColor.HexArgb)}')
+            errorColor.setAlpha(100)
+            # Tuple prints nicely :)
+            self.ui.exampleFilter.setStyleSheet(f'background: rgba{errorColor.getRgb()}')
         if not validRegex:
             return
         checkDict = unnestedDict(utils.examples_)

--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -367,7 +367,20 @@ class ExampleLoader(QtWidgets.QMainWindow):
         self.hl.setDocument(self.ui.codeView.document())
 
     def filterByContent(self, text=None):
-        # Don't filter very short strings
+        # If the new text isn't valid regex, fail early and highlight the search filter red to indicate a problem
+        # to the user
+        validRegex = True
+        try:
+            re.compile(text)
+            background = app.palette().background().color()
+        except re.error:
+            colors = DarkThemeColors if app.property('darkMode') else LightThemeColors
+            background = pg.mkColor(colors.Red)
+            background.setAlpha(100)
+            validRegex = False
+        self.ui.exampleFilter.setStyleSheet(f'background: {pg.mkColor(background).name(QtGui.QColor.HexArgb)}')
+        if not validRegex:
+            return
         checkDict = unnestedDict(utils.examples_)
         self.hl.searchText = text
         # Need to reapply to current document


### PR DESCRIPTION
This fixes an error message when the user is halfway through typing a regex and a `re.error` is raised. The filter box turns red to indicate an issue and no search is performed until the issue is resolved.

Hoping @NilsNemitz can get the palette working instead of manhandling the stylesheet... I had no luck calling `setPalette` directly. 