### PR TITLE
RangeColorMapItem derives from ptree.types.ColorMapParameter

### DIFF
--- a/pyqtgraph/widgets/ColorMapWidget.py
+++ b/pyqtgraph/widgets/ColorMapWidget.py
@@ -186,13 +186,13 @@ class ColorMapParameter(ptree.types.GroupParameter):
             item.restoreState(itemState)
         
     
-class RangeColorMapItem(ptree.types.SimpleParameter):
+class RangeColorMapItem(ptree.types.ColorMapParameter):
     mapType = 'range'
     
     def __init__(self, name, opts):
         self.fieldName = name
         units = opts.get('units', '')
-        ptree.types.SimpleParameter.__init__(self, 
+        ptree.types.ColorMapParameter.__init__(self,
             name=name, autoIncrementName=True, type='colormap', removable=True, renamable=True, 
             children=[
                 #dict(name="Field", type='list', value=name, limits=fields),


### PR DESCRIPTION
prior to PR #1919, there was no ptree.types.ColorMapParameter, and
type "colormap" was handled directly by ptree.types.SimpleParameter.

PR #1919 created ColorMapParameter as a sub-class of SimpleParameter,
and moved colormap specific functionality into ColorMapParameter.
Hence RangeColorMapItem now needs to derive from ColorMapParameter.

This fixes #2070.