### PR TITLE
avoid PyOpenGL automatic array conversion

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -844,7 +844,8 @@ class PlotCurveItem(GraphicsObject):
             gl.glLoadIdentity()
             gl.glOrtho(0, widget.width(), widget.height(), 0, -999999, 999999)
             gl.glMatrixMode(gl.GL_MODELVIEW)
-            gl.glLoadMatrixf(QtGui.QMatrix4x4(self.sceneTransform()).data())
+            mat = QtGui.QMatrix4x4(self.sceneTransform())
+            gl.glLoadMatrixf(np.array(mat.data(), dtype=np.float32))
 
         ## set clipping viewport
         view = self.getViewBox()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -155,7 +155,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
     def setProjection(self, region=None):
         m = self.projectionMatrix(region)
         glMatrixMode(GL_PROJECTION)
-        glLoadMatrixf(m.data())
+        glLoadMatrixf(np.array(m.data(), dtype=np.float32))
 
     def projectionMatrix(self, region=None):
         if region is None:
@@ -183,7 +183,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
     def setModelview(self):
         m = self.viewMatrix()
         glMatrixMode(GL_MODELVIEW)
-        glLoadMatrixf(m.data())
+        glLoadMatrixf(np.array(m.data(), dtype=np.float32))
         
     def viewMatrix(self):
         tr = QtGui.QMatrix4x4()
@@ -267,8 +267,7 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
                 glPushMatrix()
                 try:
                     tr = i.transform()
-                    a = np.array(tr.copyDataTo()).reshape((4,4))
-                    glMultMatrixf(a.transpose())
+                    glMultMatrixf(np.array(tr.data(), dtype=np.float32))
                     self.drawItemTree(i, useItemNames=useItemNames)
                 finally:
                     glMatrixMode(GL_MODELVIEW)

--- a/pyqtgraph/opengl/MeshData.py
+++ b/pyqtgraph/opengl/MeshData.py
@@ -136,12 +136,12 @@ class MeshData(object):
         """
         if indexed is None:
             if verts is not None:
-                self._vertexes = verts
+                self._vertexes = np.ascontiguousarray(verts, dtype=np.float32)
             self._vertexesIndexedByFaces = None
         elif indexed=='faces':
             self._vertexes = None
             if verts is not None:
-                self._vertexesIndexedByFaces = verts
+                self._vertexesIndexedByFaces = np.ascontiguousarray(verts, dtype=np.float32)
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
         
@@ -190,7 +190,7 @@ class MeshData(object):
             return self._faceNormals
         elif indexed == 'faces':
             if self._faceNormalsIndexedByFaces is None:
-                norms = np.empty((self._faceNormals.shape[0], 3, 3))
+                norms = np.empty((self._faceNormals.shape[0], 3, 3), dtype=np.float32)
                 norms[:] = self._faceNormals[:,np.newaxis,:]
                 self._faceNormalsIndexedByFaces = norms
             return self._faceNormalsIndexedByFaces
@@ -207,7 +207,7 @@ class MeshData(object):
         if self._vertexNormals is None:
             faceNorms = self.faceNormals()
             vertFaces = self.vertexFaces()
-            self._vertexNormals = np.empty(self._vertexes.shape, dtype=float)
+            self._vertexNormals = np.empty(self._vertexes.shape, dtype=np.float32)
             for vindex in range(self._vertexes.shape[0]):
                 faces = vertFaces[vindex]
                 if len(faces) == 0:
@@ -247,11 +247,11 @@ class MeshData(object):
         as indexed and should have shape (Nf, 3, 4)
         """
         if indexed is None:
-            self._vertexColors = colors
+            self._vertexColors = np.ascontiguousarray(colors, dtype=np.float32)
             self._vertexColorsIndexedByFaces = None
         elif indexed == 'faces':
             self._vertexColors = None
-            self._vertexColorsIndexedByFaces = colors
+            self._vertexColorsIndexedByFaces = np.ascontiguousarray(colors, dtype=np.float32)
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
         
@@ -280,11 +280,11 @@ class MeshData(object):
         as indexed and should have shape (Nf, 3, 4)
         """
         if indexed is None:
-            self._faceColors = colors
+            self._faceColors = np.ascontiguousarray(colors, dtype=np.float32)
             self._faceColorsIndexedByFaces = None
         elif indexed == 'faces':
             self._faceColors = None
-            self._faceColorsIndexedByFaces = colors
+            self._faceColorsIndexedByFaces = np.ascontiguousarray(colors, dtype=np.float32)
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
         
@@ -332,7 +332,7 @@ class MeshData(object):
                     verts[pt2] = index
                 self._vertexFaces[index].append(i)  # keep track of which vertexes belong to which faces
                 self._faces[i,j] = index
-        self._vertexes = np.array(self._vertexes, dtype=float)
+        self._vertexes = np.array(self._vertexes, dtype=np.float32)
     
     #def _setUnindexedFaces(self, faces, vertexes, vertexColors=None, faceColors=None):
         #self._vertexes = vertexes #[QtGui.QVector3D(*v) for v in vertexes]

--- a/pyqtgraph/opengl/items/GLGraphItem.py
+++ b/pyqtgraph/opengl/items/GLGraphItem.py
@@ -1,4 +1,5 @@
 from OpenGL.GL import *  # noqa
+import numpy as np
 from ... import functions as fn
 from ...Qt import QtCore, QtGui
 from ..GLGraphicsItem import GLGraphicsItem
@@ -88,7 +89,7 @@ class GLGraphItem(GLGraphicsItem):
                 or self.edgeColor is None:
             return None
         verts = self.scatter.pos
-        edges = self.edges.flatten()
+        edges = self.edges.astype(np.uint32).flatten()
         glEnableClientState(GL_VERTEX_ARRAY)
         try:
             glColor4f(*self.edgeColor.getRgbF())

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -51,14 +51,14 @@ class GLImageItem(GLGraphicsItem):
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER)
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER)
         #glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_BORDER)
-        shape = self.data.shape
+        h, w = self.data.shape[:2]
         
         ## Test texture dimensions first
-        glTexImage2D(GL_PROXY_TEXTURE_2D, 0, GL_RGBA, shape[0], shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, None)
+        glTexImage2D(GL_PROXY_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, None)
         if glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_WIDTH) == 0:
-            raise Exception("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % shape[:2])
+            raise Exception("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % (h, w))
         
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, shape[0], shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, self.data.transpose((1,0,2)))
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, self.data)
         glDisable(GL_TEXTURE_2D)
         
         #self.lists = {}
@@ -87,15 +87,16 @@ class GLImageItem(GLGraphicsItem):
         #glEnable( GL_ALPHA_TEST )
         glColor4f(1,1,1,1)
 
+        h, w = self.data.shape[:2]
         glBegin(GL_QUADS)
-        glTexCoord2f(0,0)
-        glVertex3f(0,0,0)
-        glTexCoord2f(1,0)
-        glVertex3f(self.data.shape[0], 0, 0)
-        glTexCoord2f(1,1)
-        glVertex3f(self.data.shape[0], self.data.shape[1], 0)
-        glTexCoord2f(0,1)
-        glVertex3f(0, self.data.shape[1], 0)
+        glTexCoord2f(1, 0)
+        glVertex3f(0, 0, 0)
+        glTexCoord2f(1, 1)
+        glVertex3f(h, 0, 0)
+        glTexCoord2f(0, 1)
+        glVertex3f(h, w, 0)
+        glTexCoord2f(0, 0)
+        glVertex3f(0, w, 0)
         glEnd()
         glDisable(GL_TEXTURE_2D)
                 

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -47,9 +47,16 @@ class GLLinePlotItem(GLGraphicsItem):
             if k not in args:
                 raise Exception('Invalid keyword argument: %s (allowed arguments are %s)' % (k, str(args)))
         self.antialias = False
-        for arg in args:
-            if arg in kwds:
-                setattr(self, arg, kwds[arg])
+        if 'pos' in kwds:
+            pos = kwds.pop('pos')
+            self.pos = np.ascontiguousarray(pos, dtype=np.float32)
+        if 'color' in kwds:
+            color = kwds.pop('color')
+            if isinstance(color, np.ndarray):
+                color = np.ascontiguousarray(color, dtype=np.float32)
+            self.color = color
+        for k, v in kwds.items():
+            setattr(self, k, v)
         self.update()
 
     def paint(self):
@@ -81,9 +88,9 @@ class GLLinePlotItem(GLGraphicsItem):
                 glHint(GL_LINE_SMOOTH_HINT, GL_NICEST)
                 
             if self.mode == 'line_strip':
-                glDrawArrays(GL_LINE_STRIP, 0, int(self.pos.size / self.pos.shape[-1]))
+                glDrawArrays(GL_LINE_STRIP, 0, self.pos.shape[0])
             elif self.mode == 'lines':
-                glDrawArrays(GL_LINES, 0, int(self.pos.size / self.pos.shape[-1]))
+                glDrawArrays(GL_LINES, 0, self.pos.shape[0])
             else:
                 raise Exception("Unknown line mode '%s'. (must be 'lines' or 'line_strip')" % self.mode)
                 

--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -45,10 +45,19 @@ class GLScatterPlotItem(GLGraphicsItem):
             if k not in args:
                 raise Exception('Invalid keyword argument: %s (allowed arguments are %s)' % (k, str(args)))
             
-        args.remove('pxMode')
-        for arg in args:
-            if arg in kwds:
-                setattr(self, arg, kwds[arg])
+        if 'pos' in kwds:
+            pos = kwds.pop('pos')
+            self.pos = np.ascontiguousarray(pos, dtype=np.float32)
+        if 'color' in kwds:
+            color = kwds.pop('color')
+            if isinstance(color, np.ndarray):
+                color = np.ascontiguousarray(color, dtype=np.float32)
+            self.color = color
+        if 'size' in kwds:
+            size = kwds.pop('size')
+            if isinstance(size, np.ndarray):
+                size = np.ascontiguousarray(size, dtype=np.float32)
+            self.size = size
                 
         self.pxMode = kwds.get('pxMode', self.pxMode)
         self.update()
@@ -133,7 +142,7 @@ class GLScatterPlotItem(GLGraphicsItem):
                 
                 if not self.pxMode or isinstance(self.size, np.ndarray):
                     glEnableClientState(GL_NORMAL_ARRAY)
-                    norm = np.empty(pos.shape)
+                    norm = np.zeros(pos.shape, dtype=np.float32)
                     if self.pxMode:
                         norm[...,0] = self.size
                     else:
@@ -148,7 +157,7 @@ class GLScatterPlotItem(GLGraphicsItem):
                 else:
                     glNormal3f(self.size, 0, 0)  ## vertex shader uses norm.x to determine point size
                     #glPointSize(self.size)
-                glDrawArrays(GL_POINTS, 0, int(pos.size / pos.shape[-1]))
+                glDrawArrays(GL_POINTS, 0, pos.shape[0])
             finally:
                 glDisableClientState(GL_NORMAL_ARRAY)
                 glDisableClientState(GL_VERTEX_ARRAY)

--- a/pyqtgraph/opengl/items/GLVolumeItem.py
+++ b/pyqtgraph/opengl/items/GLVolumeItem.py
@@ -59,7 +59,8 @@ class GLVolumeItem(GLGraphicsItem):
         if glGetTexLevelParameteriv(GL_PROXY_TEXTURE_3D, 0, GL_TEXTURE_WIDTH) == 0:
             raise Exception("OpenGL failed to create 3D texture (%dx%dx%d); too large for this hardware." % shape[:3])
         
-        glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, shape[0], shape[1], shape[2], 0, GL_RGBA, GL_UNSIGNED_BYTE, self.data.transpose((2,1,0,3)))
+        data = np.ascontiguousarray(self.data.transpose((2,1,0,3)))
+        glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, shape[0], shape[1], shape[2], 0, GL_RGBA, GL_UNSIGNED_BYTE, data)
         glDisable(GL_TEXTURE_3D)
         
         self.lists = {}

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -4,6 +4,7 @@ try:
     from OpenGL import NullFunctionError
 except ImportError:
     from OpenGL.error import NullFunctionError
+import numpy as np
 import re
 
 ## For centralizing and managing vertex/fragment shader programs.
@@ -322,7 +323,7 @@ class ShaderProgram(object):
                     loc = self.uniform(uniformName)
                     if loc == -1:
                         raise Exception('Could not find uniform variable "%s"' % uniformName)
-                    glUniform1fv(loc, len(data), data)
+                    glUniform1fv(loc, len(data), np.array(data, dtype=np.float32))
                     
                 ### bind buffer data to program blocks
                 #if len(self.blockData) > 0:


### PR DESCRIPTION
Following #2111, this PR tries to eliminate PyOpenGL automatic array conversions in the OpenGL items by making the conversions explicitly. The places where conversion was taking place was discovered by setting ```OpenGL.ERROR_ON_COPY = True``` in the examples and running them.  With this PR, all included OpenGL examples are able to run without error with the above attribute set.

GLImageItem and GLVolumeItem deserve a mention. Pyqtgraph uses Fortran-major axes and thus transposes the texture data before uploading them. GLImageItem was fixed to avoid the transpose by changing the texture coordinate code. The texture coordinate code of GLVolumeItem was too complicated to fix, thus a memory copy is forced.

The script below was used to verify that GLImageItem draws the same before and after this PR.
```python
import pyqtgraph as pg
import pyqtgraph.opengl as gl
import numpy as np
import scipy.misc

pg.mkQApp()

glv = gl.GLViewWidget()
glv.setCameraParams(elevation=90, azimuth=0)
# X points down, Y points right
glv.show()

image = scipy.misc.face()
tex, _ = pg.makeRGBA(image)
glii = gl.GLImageItem(tex)
s = 1/128
glii.scale(s, s, 1)
w, h = tex.shape[:2]    # GLImageItem uses transposed coords?
w *= s
h *= s
glii.translate(-w/2, -h/2, 0)
glv.addItem(glii)

spots = np.array([[-w/2, -h/2, 0, 1, 0, 0, 0.5],
                  [-w/2,  h/2, 0, 0, 1, 0, 0.5],
                  [ w/2,  h/2, 0, 0, 0, 1, 0.5],
                  [ w/2, -h/2, 0, 0, 1, 1, 0.5]])
glspi = gl.GLScatterPlotItem(pos=spots[:,:3], size=50, color=spots[:,3:])
glv.addItem(glspi)

pg.exec()
```

This PR may fix #825.