### PR TITLE
Fix automatic int-casting code for Python 3.10 compatibility

### DIFF
--- a/pyqtgraph/GraphicsScene/exportDialog.py
+++ b/pyqtgraph/GraphicsScene/exportDialog.py
@@ -57,7 +57,9 @@ class ExportDialog(QtWidgets.QWidget):
         if not self.shown:
             self.shown = True
             vcenter = self.scene.getViewWidget().geometry().center()
-            self.setGeometry(vcenter.x()-self.width()/2, vcenter.y()-self.height()/2, self.width(), self.height())
+            self.setGeometry(int(vcenter.x() - self.width() / 2),
+                             int(vcenter.y() - self.height() / 2),
+                             self.width(), self.height())
         
     def updateItemList(self, select=None):
         self.ui.itemTree.clear()

--- a/pyqtgraph/widgets/PenPreviewLabel.py
+++ b/pyqtgraph/widgets/PenPreviewLabel.py
@@ -1,4 +1,4 @@
-from ..Qt import QtWidgets, QtGui
+from ..Qt import QtWidgets, QtGui, QtCore
 from ..functions import mkPen
 
 
@@ -29,5 +29,5 @@ class PenPreviewLabel(QtWidgets.QLabel):
         # No indication of "cosmetic" from just the paint path, so add something extra in that case
         if self.pen.isCosmetic():
             painter.setPen(mkPen('k'))
-            painter.drawText(w * 0.81, 12, 'C')
+            painter.drawText(QtCore.QPointF(w * 0.81, 12), 'C')
         painter.end()


### PR DESCRIPTION
Python 3.10 no longer allows automatically converting some floats to ints, see
the fourth point here:
https://docs.python.org/3/whatsnew/3.10.html#other-language-changes

(I see there's already been a bunch of other Python 3.10 fixes too)