### PR TITLE
Add Python 3.10 to CI - Re-Enable pytest-xdist in CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,9 +3,6 @@ name: codeql
 on: [push, pull_request]
 
 jobs:
-  concurrency: 
-    group: ${{ github.head_ref || github.run_id }}
-    cancel-in-progress: true
   analyze:
     name: analyze
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,6 +3,9 @@ name: codeql
 on: [push, pull_request]
 
 jobs:
+  concurrency: 
+    group: ${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
   analyze:
     name: analyze
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,12 +2,13 @@ name: main
 
 on: [push, pull_request]
 
+concurrency: 
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    concurrency: 
-      group: ${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,13 +5,16 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    concurrency: 
+      group: ${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04 , windows-latest, macos-latest]
         qt-lib: [pyqt, pyside]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - python-version: "3.7"
             qt-lib: "pyqt"
@@ -32,11 +35,19 @@ jobs:
           - python-version: "3.9"
             qt-lib: "pyqt"
             qt-version: "PyQt6"
-            numpy-version: "~=1.21.0"
+            numpy-version: "~=1.22.0"
           - python-version: "3.9"
             qt-lib: "pyside"
             qt-version: "PySide6"
-            numpy-version: "~=1.21.0"
+            numpy-version: "~=1.22.0"
+          - python-version: "3.10"
+            qt-lib: "pyqt"
+            qt-version: "PyQt6"
+            numpy-version: "~=1.22.0"
+          - python-version: "3.10"
+            qt-lib: "pyside"
+            qt-version: "PySide6"
+            numpy-version: "~=1.22.0"
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -65,9 +76,13 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install ${{ matrix.qt-version }} numpy${{ matrix.numpy-version }} scipy pyopengl h5py matplotlib numba
+        python -m pip install ${{ matrix.qt-version }} numpy${{ matrix.numpy-version }} scipy pyopengl h5py matplotlib
         python -m pip install --use-feature=in-tree-build .
         python -m pip install pytest
+    - name: Optionally Install Numba
+      if: matrix.python-version != '3.10'
+      run: |
+        python -m pip install numba
     - name: "Install Linux VirtualDisplay"
       if: runner.os == 'Linux'
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,18 +27,18 @@ jobs:
           - python-version: "3.8"
             qt-lib: "pyqt"
             qt-version: "PyQt5~=5.15.0"
-            numpy-version: "~=1.21.0"
+            numpy-version: "~=1.19.0"
           - python-version: "3.8"
             qt-lib: "pyside"
             qt-version: "PySide2~=5.15.0"
-            numpy-version: "~=1.21.0"
+            numpy-version: "~=1.19.0"
           - python-version: "3.9"
             qt-lib: "pyqt"
-            qt-version: "PyQt6"
+            qt-version: "PyQt6~=6.1.0"
             numpy-version: "~=1.22.0"
           - python-version: "3.9"
             qt-lib: "pyside"
-            qt-version: "PySide6"
+            qt-version: "PySide6~=6.1.0"
             numpy-version: "~=1.22.0"
           - python-version: "3.10"
             qt-lib: "pyqt"
@@ -75,10 +75,8 @@ jobs:
       shell: cmd
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install ${{ matrix.qt-version }} numpy${{ matrix.numpy-version }} scipy pyopengl h5py matplotlib
-        python -m pip install --use-feature=in-tree-build .
-        python -m pip install pytest
+        python -m pip install --upgrade pip
+        python -m pip install ${{ matrix.qt-version }} numpy${{ matrix.numpy-version }} scipy pyopengl h5py matplotlib pytest pytest-xdist .
     - name: Optionally Install Numba
       if: matrix.python-version != '3.10'
       run: |
@@ -117,7 +115,7 @@ jobs:
       run: |
         mkdir $SCREENSHOT_DIR
         pytest tests -v
-        pytest pyqtgraph/examples -v
+        pytest pyqtgraph/examples -v -n auto
       shell: bash
     - name: Upload Screenshots
       uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ This project supports:
 
 * All minor versions of Python released 42 months prior to the project, and at minimum the two latest minor versions.
 * All minor versions of numpy released in the 24 months prior to the project, and at minimum the last three minor versions.
-* All Qt5 versions from 5.12-5.15, and Qt6 6.1
+* All Qt5 versions from 5.12-5.15, and Qt6 6.1+
 
 Currently this means:
 
 * Python 3.7+
-* Qt 5.12-5.15, 6.1
+* Qt 5.12-5.15, 6.1+
 * [PyQt5](https://www.riverbankcomputing.com/software/pyqt/),
   [PyQt6](https://www.riverbankcomputing.com/software/pyqt/),
   [PySide2](https://wiki.qt.io/Qt_for_Python), or
@@ -72,14 +72,14 @@ Qt Bindings Test Matrix
 
 The following table represents the python environments we test in our CI system.  Our CI system uses Ubuntu 20.04, Windows Server 2019, and macOS 10.15 base images.
 
-| Qt-Bindings    | Python 3.7         | Python 3.8         | Python 3.9         |
-| :------------- | :----------------: | :----------------: | :----------------: |
-| PySide2-5.12   | :white_check_mark: | :x:                | :x:                |
-| PyQt5-5.12     | :white_check_mark: |                    | :x:                |
-| PySide2-5.15   |                    | :white_check_mark: |                    |
-| PyQt5-5.15     |                    | :white_check_mark: |                    |
-| PySide6-6.1    |                    |                    | :white_check_mark: |
-| PyQt6-6.1      |                    |                    | :white_check_mark: |
+| Qt-Bindings    | Python 3.7         | Python 3.8         | Python 3.9         | Python 3.10        |
+| :------------- | :----------------: | :----------------: | :----------------: | :----------------: |
+| PySide2-5.12   | :white_check_mark: | :x:                | :x:                | :x:                |
+| PyQt5-5.12     | :white_check_mark: |                    | :x:                | :x:                |
+| PySide2-5.15   |                    | :white_check_mark: |                    |                    |
+| PyQt5-5.15     |                    | :white_check_mark: |                    |                    |
+| PySide6-6.2    |                    |                    | :white_check_mark: | :white_check_mark: |
+| PyQt6-6.2      |                    |                    | :white_check_mark: | :white_check_mark: |
 
 * :x: - Not compatible
 * :white_check_mark: - Tested


### PR DESCRIPTION
This PR adds python 3.10 to our CI suite.  In addition, we use pytest-xdist to speedup our test suite.  Previously we removed pytest-xdist because it made it a bit more difficult to determine which test or example was being problematic in context to segfaults and things like that.   Given our CI has been stable for some time now, I think we can safetly reintroduce pytest-xdist here.

In addition, I remove the automatic upgrade of `wheel` and `setuptools`, as that's not really needed.   I also removed the `python -m pip install --use-feature=in-tree-build .` line as that is now the default, it was generating a warning.

In addition, updating the README accordingly.