### PR TITLE
Add lru cache support to `AxisItem.tickStrings()`

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1094,11 +1094,11 @@ class AxisItem(GraphicsWidget):
             if tickStrings is None:
                 spacing, values = tickLevels[i]
 
-                strings = self.tickStrings(
+                strings = list(self.tickStrings(
                     tuple(values),
                     self.autoSIPrefixScale * self.scale,
                     spacing,
-                )
+                ))
             else:
                 strings = tickStrings[i]
 
@@ -1106,9 +1106,9 @@ class AxisItem(GraphicsWidget):
                 continue
 
             # ignore strings belonging to ticks that were previously ignored
-            # for j in range(len(strings)):
-            #     if tickPositions[i][j] is None:
-            #         strings[j] = None
+            for j in range(len(strings)):
+                if tickPositions[i][j] is None:
+                    strings[j] = None
 
             ## Measure density of text; decide whether to draw this level
             rects = []


### PR DESCRIPTION
This is still very much a WIP/testing patch but on my current use case
(real time updates to a 40k+ datums set at around display rate) results
in approximately a 2x speedup according to the profiler output included
here.

Interested to see my results are not common to other users.

UPDATE:
This is due to the [block i commented](https://github.com/pyqtgraph/pyqtgraph/pull/2160/commits/66700eb39c742063c6800548ec9fcbc1b338df44#diff-1e50558db426ca1859cf7ebfd1472571d8450c94cad8dd07059b080bc0a4f4fdR1108) in 66700eb39c742063c680 which I'm pretty sure we can eventually eliminate (see comments below).

Also I once in a while can get into an error state where I'll see the following error repeatedly:

```python
TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'
    > Entering PriceAxis.generateDrawSpecs
      init: 0.4193 ms
      compute ticks: 0.2095 ms
    < Exiting PriceAxis.generateDrawSpecs, total time: 108.0801 ms
Traceback (most recent call last):
  File "/home/goodboy/repos/pyqtgraph/pyqtgraph/graphicsItems/AxisItem.py", line 652, in paint
    specs = self.generateDrawSpecs(painter)
  File "/home/goodboy/repos/pyqtgraph/pyqtgraph/graphicsItems/AxisItem.py", line 1174, in generateDrawSpecs
    rect = QtCore.QRectF(tickStop+offset, x-(height/2), width, height)
TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'
```