### PR TITLE
`PlotItemOverlay`: an alt approach for #1359

### DIFF
--- a/pyqtgraph/examples/PlotItemOverlay.py
+++ b/pyqtgraph/examples/PlotItemOverlay.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtWidgets
+from pyqtgraph.graphicsItems.AxisItem import AxisItem
+# from pyqtgraph.graphicsItems.PlotItem import PlotItem
+from pyqtgraph.widgets._plotitemoverlay import PlotItemOverlay
+from pyqtgraph.Qt.QtCore import pyqtRemoveInputHook
+
+app = pg.mkQApp()
+pyqtRemoveInputHook()
+mw = QtWidgets.QMainWindow()
+mw.resize(800, 800)
+pg.setConfigOption("background", "black")
+pg.setConfigOption("foreground", "white")
+
+
+def mk_axes(names: list[str] = ['right', 'bottom']):
+    return {name: AxisItem(orientation=name) for name in names}
+
+
+pw = pg.PlotWidget(axisItems=mk_axes())
+mw.setCentralWidget(pw)
+mw.show()
+pw.addLegend(offset=(0, 0))
+pw.setTitle("PlotItem Overlay Example")
+
+plot1 = pw.plotItem
+overlay = PlotItemOverlay(plot1)
+
+# for prints inside `ViewBox`
+plot1.vb.name = 'root'
+
+# XXX: this works now on each individual plot.
+# plot1.enableAutoRange(axis='y')
+# plot1.setAutoVisible(y=True)
+
+f = 2
+data1 = np.sin(np.linspace(0, f * np.pi, num=1000))
+data2 = data1 * 2
+data3 = np.sin(np.linspace(0, f*2 * np.pi, num=500)) * 3
+data4 = np.sin(np.linspace(0, f*4 * np.pi, num=500)) * 4
+
+# Use std plot api for "top" plotitem
+plot1.plot().setData(data1)
+plot1.update()
+plot1.show()
+
+for i, (plot, data) in enumerate((
+    (pg.PlotItem(axisItems=mk_axes(), parent=plot1),
+     data2),
+    (pg.PlotItem(axisItems=mk_axes(), parent=plot1),
+     data3),
+    (pg.PlotItem(axisItems=mk_axes(), parent=plot1),
+     data4),
+)):
+    # TODO: get title stacking in the layout working
+    plot.setTitle(f'Dataset {i}')
+    plot.hideButtons()  # see features notes in overlay module
+    plot.plot().setData(data)
+
+    # XXX: oh look, now this works because we have separate viewboxex B)
+    plot.enableAutoRange(axis='y')
+    plot.setAutoVisible(y=True)
+
+    # XXX: no extra APIs needed ;)
+    overlay.add_plotitem(plot)
+
+    # XXX: for internal viewbox prints/debug
+    plot.vb.name = i
+
+if __name__ == '__main__':
+    pg.exec()

--- a/pyqtgraph/examples/PlotItemOverlay.py
+++ b/pyqtgraph/examples/PlotItemOverlay.py
@@ -18,7 +18,14 @@ def mk_axes(names: list[str] = ['right', 'bottom']):
     return {name: AxisItem(orientation=name) for name in names}
 
 
-pw = pg.PlotWidget(axisItems=mk_axes())
+pw = pg.PlotWidget(
+    axisItems=mk_axes(),
+    # XXX: this is needed here (and below) to avoid
+    # "default visible axes" from being displayed which
+    # not only hurts the overlayed axes performance but
+    # also results in placement of undesired axes..
+    default_axes=[],
+)
 mw.setCentralWidget(pw)
 mw.show()
 pw.addLegend(offset=(0, 0))
@@ -47,11 +54,20 @@ plot1.update()
 plot1.show()
 
 for i, (plot, data) in enumerate((
-    (pg.PlotItem(axisItems=mk_axes(), parent=plot1),
+    (pg.PlotItem(
+        axisItems=mk_axes(),
+        parent=plot1,
+        default_axes=[],),
      data2),
-    (pg.PlotItem(axisItems=mk_axes(), parent=plot1),
+    (pg.PlotItem(
+        axisItems=mk_axes(),
+        parent=plot1,
+        default_axes=[],),
      data3),
-    (pg.PlotItem(axisItems=mk_axes(), parent=plot1),
+    (pg.PlotItem(
+        axisItems=mk_axes(),
+        parent=plot1,
+        default_axes=[],),
      data4),
 )):
     # TODO: get title stacking in the layout working

--- a/pyqtgraph/examples/PlotItemOverlay.py
+++ b/pyqtgraph/examples/PlotItemOverlay.py
@@ -29,6 +29,7 @@ overlay = PlotItemOverlay(plot1)
 
 # for prints inside `ViewBox`
 plot1.vb.name = 'root'
+# plot1.setTitle(f'Dataset root')
 
 # XXX: this works now on each individual plot.
 # plot1.enableAutoRange(axis='y')
@@ -54,7 +55,13 @@ for i, (plot, data) in enumerate((
      data4),
 )):
     # TODO: get title stacking in the layout working
-    plot.setTitle(f'Dataset {i}')
+
+    # NOTE: if we add this it causes mouse wheel zoom
+    # to be offset in a wonky way..
+    # I'm hoping re-stacking labels in the top level layout
+    # will fix this.
+    # plot.setTitle(f'Dataset {i}')
+
     plot.hideButtons()  # see features notes in overlay module
     plot.plot().setData(data)
 

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -13,6 +13,7 @@ import struct
 import sys
 import warnings
 from collections import OrderedDict
+import weakref
 
 import numpy as np
 
@@ -3235,3 +3236,59 @@ class SignalBlock(object):
     def __exit__(self, *args):
         if self.reconnect:
             self.signal.connect(self.slot)
+
+def connect_lambda(bound_signal, self, func, **kwargs):
+    """Convenience function for connecting a function to a signal
+    passing self as argument avoid lambda "leaks".
+    from: `Kovid Goyal <https://riverbankcomputing.com/pipermail/pyqt/2018-July/040604.html>`_
+    Example: connect_lambda(signal, self, lambda self, arg: self.method(arg))
+
+    Saving a rereference to an object inside the
+    object itself or one of it's children creates a
+    reference loop that breaks garbage collection.
+    Method instances (like self.disableAxisAutoRange)
+    store a reference to self.
+    Lambdas and dynamic functions also store references
+    to the objects used inside them.
+    This means that using self in lambdas or dynamic
+    functions and using them as slots will break
+    garbage collection because PySide and PyQt store
+    the slots connected to signals in a way that
+    break garbage collection too.
+
+    Parameters
+    ----------
+    bound_signal : QSignal
+        The signal to connect func to.
+    self : object
+        The object to be passed to the func.
+        It will be wrapped transparently in a weakref
+        to resolve garbage collection issues.
+    func : callable
+        The callable to connect to bound_signal.
+        Should expect at least one parameter: self.
+        The function will be called like this: func(self, *args),
+        args are the parameters passed by the signal.
+    kwargs : dict, optional
+        extra keyword arguments to be passed to the .connect method
+        of the bound_signal.
+
+    Returns
+    -------
+    Connection
+        The newly created Connection QMetaObject
+        returned by the .connect method of the bound_signal.
+    """
+    ref = weakref.ref(self)
+    num_signal_args = func.__code__.co_argcount - 1
+    if num_signal_args < 0:
+        raise TypeError("lambda must take at least one argument")
+
+    def slot(*args):
+        ctx = ref()
+        if ctx is not None:
+            if len(args) != num_signal_args:
+                args = args[:num_signal_args]
+            func(ctx, *args)
+
+    return bound_signal.connect(slot, **kwargs)

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1094,11 +1094,11 @@ class AxisItem(GraphicsWidget):
             if tickStrings is None:
                 spacing, values = tickLevels[i]
 
-                strings = self.tickStrings(
+                strings = list(self.tickStrings(
                     tuple(values),
                     self.autoSIPrefixScale * self.scale,
                     spacing,
-                )
+                ))
             else:
                 strings = tickStrings[i]
 
@@ -1106,9 +1106,9 @@ class AxisItem(GraphicsWidget):
                 continue
 
             # ignore strings belonging to ticks that were previously ignored
-            # for j in range(len(strings)):
-            #     if tickPositions[i][j] is None:
-            #         strings[j] = None
+            for j in range(len(strings)):
+                if tickPositions[i][j] is None:
+                    strings[j] = None
 
             ## Measure density of text; decide whether to draw this level
             rects = []

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -95,6 +95,8 @@ class ViewBox(GraphicsWidget):
     sigStateChanged = QtCore.Signal(object)
     sigTransformChanged = QtCore.Signal(object)
     sigResized = QtCore.Signal(object)
+    sigMouseDragged = QtCore.Signal(object, object)
+    sigMouseWheel = QtCore.Signal(object, object)
 
     ## mouse modes
     PanMode = 3
@@ -1302,16 +1304,10 @@ class ViewBox(GraphicsWidget):
         self._resetTarget()
         self.scaleBy(s, center)
 
-        if axis == ViewBox.XAxis:
-            self.sigXRangeChangedManually.emit(mask)
-        elif axis == ViewBox.YAxis:
-           self.sigYRangeChangedManually.emit(mask)
-        elif axis is None:
-           self.sigXRangeChangedManually.emit(mask)
-           self.sigYRangeChangedManually.emit(mask)
+        if axis is None:
            self.sigMouseWheel.emit(ev, axis)
-        self.sigRangeChangedManually.emit(mask)
 
+        self.sigRangeChangedManually.emit(mask)
         self.maybe_relay(ev)
 
     def mouseClickEvent(self, ev):
@@ -1338,6 +1334,7 @@ class ViewBox(GraphicsWidget):
         ## if axis is specified, event will only affect that axis.
         ## we accept all buttons
 
+        self.sigMouseDragged.emit(ev, axis)
         # print(f'drag: {self.name}')
 
         pos = ev.scenePos()

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -183,7 +183,6 @@ class ViewBox(GraphicsWidget):
         name=None,
         invertX=False,
         defaultPadding=0.02,
-        allow_signal_relay: bool = False,
     ):
         """
         =================  =============================================================
@@ -315,7 +314,6 @@ class ViewBox(GraphicsWidget):
         if name is None:
             self.updateViewLists()
 
-        self.allow_signal_relay: bool = allow_signal_relay
         self.is_beacon: bool = False
 
     def getAspectRatio(self):

--- a/pyqtgraph/widgets/_plotitemoverlay.py
+++ b/pyqtgraph/widgets/_plotitemoverlay.py
@@ -2,11 +2,30 @@ from ..Qt.QtWidgets import QGraphicsGridLayout
 from ..functions import connect_lambda
 # from ..graphicsItems.AxisItem import AxisItem
 # from ..graphicsItems.GraphicsObject import GraphicsObject
-# from ..graphicsItems.PlotDataItem import PlotDataItem
 from ..graphicsItems.PlotItem.PlotItem import PlotItem
 from ..graphicsItems.ViewBox import ViewBox
 from ..Qt.QtCore import QObject, Signal, Qt
 
+# Bugs TODO:
+# - figure out why per-axis drag clicking is halted
+#   after a single handler call - seems like it's a more serious
+#   bug in the depths of the viewbox handlers rat's nest XD
+
+# Unimplemented features TODO:
+# - 'A' (autobtn) should relay to all views
+# - layout unwind and re-pack for 'left' and 'top' axes
+# - add labels to layout if detected in source ``PlotItem``
+
+# UX nice-to-have TODO:
+# - optional "focussed" view box support for view boxes
+#   that have custom input handlers (eg. you might want to
+#   scale the view to some "focussed" data view and have overlayed
+#   viewboxes only respond to relayed events.)
+# - figure out how to deal with menu raise events for multi-viewboxes.
+#   (we might want to add a different menu which specs the name of the
+#   view box currently being handled?
+# - allow selection of a particular view box by interacting with its
+#   axis?
 
 __all__ = ["PlotItemOverlay"]
 
@@ -220,7 +239,7 @@ class PlotItemOverlay:
         ...
 
     # TODO: i guess we need this if you want to detach existing plots
-    # dynamically?
+    # dynamically? XXX: untested as of now.
     def _disconnect_all(
         self,
         plotitem: PlotItem,

--- a/pyqtgraph/widgets/_plotitemoverlay.py
+++ b/pyqtgraph/widgets/_plotitemoverlay.py
@@ -1,0 +1,179 @@
+from ..Qt.QtWidgets import QGraphicsGridLayout
+from ..functions import connect_lambda
+# from ..graphicsItems.AxisItem import AxisItem
+# from ..graphicsItems.GraphicsObject import GraphicsObject
+# from ..graphicsItems.PlotDataItem import PlotDataItem
+from ..graphicsItems.PlotItem.PlotItem import PlotItem
+from ..graphicsItems.ViewBox import ViewBox
+from ..Qt.QtCore import QObject, Signal
+
+
+__all__ = ["PlotItemOverlay"]
+
+# Define the layout "position" indices as to be passed
+# to a ``QtWidgets.QGraphicsGridlayout.addItem()`` call:
+# https://doc.qt.io/qt-5/qgraphicsgridlayout.html#addItem
+# This was pulled from the internals of ``PlotItem.setAxisItem()``.
+_axes_layout_indices: dict[str] = {
+    # row incremented axes
+    'top': (1, 1),
+    'bottom': (3, 1),
+
+    # column incremented axes
+    'left': (2, 0),
+    'right': (2, 2),
+}
+# NOTE: To clarify this indexing, ``PlotItem.__init__()`` makes a grid
+# with dimensions 4x3 and puts the ``ViewBox`` at postiion (2, 1) (aka
+# row=2, col=1) in the grid layout since row (0, 1) is reserved for
+# a title label and row 1 is for any potential "top" axis. Column 1
+# is the "middle" (since 3 columns) and is where the plot/vb is placed.
+
+
+class PlotItemOverlay:
+    '''
+    A composite for managing overlaid ``PlotItem`` instances such that
+    you can make multiple graphics appear on the same graph with
+    separate (non-colliding) axes apply ``ViewBox`` signal broadcasting
+    such that all overlaid items respond to input simultaneously.
+
+    '''
+    def __init__(
+        self,
+        root_plotitem: PlotItem
+    ) -> None:
+        self.root_plotitem: PlotItem = root_plotitem
+        self.overlays: list[PlotItem] = []
+        self._signal_relay: dict[str, Signal] = {}
+
+    @property
+    def layout(self) -> QGraphicsGridLayout:
+        '''
+        Return reference to the "focussed" ``PlotItem``'s grid layout.
+
+        '''
+        return self.root_plotitem.layout
+
+    # Add/Remove API which allows for dynamic mutation
+    # of the overlayed ``PlotItem`` collection.
+    def add_plotitem(
+        self,
+        plotitem: PlotItem,
+
+        # TODO: we could also put the ``ViewBox.XAxis``
+        # style enum here?
+        link_axes: tuple[int] = (0,),
+
+    ) -> None:
+
+        root = self.root_plotitem
+        layout: QGraphicsGridLayout = root.layout
+        self.overlays.append(plotitem)
+
+        vb: ViewBox = plotitem.vb
+        for dim in link_axes:
+            # link x and y axes to new view box such that the top level
+            # viewbox propagates to the root (and whatever other plotitem
+            # overlays that have been added).
+            vb.linkView(dim, root.vb)
+
+        # XXX: when would you ever want the y-axis for overlaid plots to
+        # be linked? Seems like nonsense presuming the whole point of
+        # overlays is disjoint co-domains?
+        # vb.linkView(1, root.vb)
+
+        # make overlaid viewbox impossible to focus since the top
+        # level should handle all input and relay to overlays.
+        # TODO: we will probably want to add a "focus" api such that
+        # a new "top level" ``PlotItem`` can be selected dynamically
+        # (and presumably the axes dynamically sorted to match).
+        vb.setFlag(vb.GraphicsItemFlag.ItemIsFocusable, False)
+
+        # breakpoint()
+        root.vb.setFocus()
+
+        # Add any axes in appropriate sequence to the top level layout
+        # to avoid graphics collision.
+        count = len(self.overlays)
+        assert count
+        try:
+            for name, axis_info in plotitem.axes.items():
+                axis = axis_info['item']
+
+                # plotitem.hideAxis(name)
+
+                # Remove old axis
+                plotitem.layout.removeItem(axis)
+                axis.scene().removeItem(axis)
+
+                # XXX: DON'T unlink it since we the original ``ViewBox``
+                # to still drive it B)
+                # axis.unlinkFromView()
+
+                # if not axis.isVisible():
+                # if name != 'right':
+                #     continue
+
+                if name in ('top', 'bottom'):
+                    i_dim = 0
+                elif name in ('left', 'right'):
+                    i_dim = 1
+
+                # breakpoint()
+                index = list(_axes_layout_indices[name])
+                index[i_dim] = index[i_dim] + count
+                # breakpoint()
+                out = layout.addItem(axis, *index)
+                if out:
+                    breakpoint()
+
+        except Exception as _err:
+            err = _err
+            breakpoint()
+
+        # overlay plot item's view with parent
+        plotitem.setGeometry(self.root_plotitem.vb.sceneBoundingRect())
+        connect_lambda(
+            root.vb.sigResized,
+            plotitem,
+            lambda plotitem,
+            vb: plotitem.setGeometry(vb.sceneBoundingRect())
+        )
+
+        # TODO: move this into ``ViewBox`` as some kind of special
+        # linking method for full view box event relaying.
+        # if link_all_vbs:  # or wtv
+        #     # FROM "https://github.com/pyqtgraph/pyqtgraph/pull/2010" by
+        #     # herodotus77 propagate mouse actions to charts "hidden"
+        #     # behind
+        #     root.vb.sigMouseDragged.connect(vb.mouseDragEvent)
+        #     root.vb.sigMouseWheel.connect(vb.wheelEvent)
+        #     root.vb.sigHistoryChanged.connect(vb.scaleHistory)
+
+    def remove_plotitem(self, plotItem: PlotItem) -> None:
+        '''
+        Remove this ``PlotItem`` from the overlayed set making not shown
+        and unable to accept input.
+
+        '''
+        ...
+
+    def focus_item(self, plotitem: PlotItem) -> PlotItem:
+        '''
+        Apply focus to a contained PlotItem thus making it the "top level"
+        item in the overlay able to accept peripheral's input from the user
+        and responsible for zoom and panning control via its ``ViewBox``.
+
+        '''
+        ...
+
+    def _disconnect_all(self, chart) -> None:
+        '''
+        Disconnects all signals related to this widget for the given chart.
+
+        '''
+        signals = self._signalConnectionsByChart[chart.name]
+        for conn_name, conn in signals.items():
+            if conn is not None:
+                QObject.disconnect(conn)
+                signals[conn_name] = None


### PR DESCRIPTION
This is a competing approach to #1359 for "multi-axis" support.

The main difference is not introducing any new apis or inherited types (`PlotWidget`) and to instead use existing subsystems (with minor internal changes) and a composed `PlotItem` overlay approach which keeps support for custom user defined subtypes (such as `ViewBox`, other `GraphicsObject`, etc.).

---
#### Notes:
- this **is not yet at** feature parity with #1359
  - [x] no `'left'`, `'bottom'` axis layout stacking yet (but this is trivial)
    - prettty sure the [`QGraphicsAnchorLayout`](https://doc.qt.io/qt-5/qgraphicsanchorlayout.html) is the right tool for this job 😉 
  - [x] no label retrieval and layout insertion yet (also trivial)
  - [x] there is a **bug** with click-drag interaction on axes which seems to be something that needs to be fixed in the `ViewBox`-`AxisItem` rats nest of "linked" handlers 😂 
- **yes i know you probably don't like the Python 3.9+ annotations**, we can remove them once we're ready to make the code hard to read and ready to land 😉 

---
#### Improvements over #1359
- each plot item keeps it's own `ViewBox` which means multiple implementations can be use together (or passed in by the user)
- no ad-hoc rerouting of interaction signals (where possible) to some singleton view
- [linkable axes controls](https://github.com/pyqtgraph/pyqtgraph/pull/2162/files#diff-da1deb0e90c1b92d20e3158b950bc6b59cce99510e741d3fd3c768ff436d7d50R83) for either x, y or both

The current issues there last I checked were:
- [ ] initial autorange is not correct
- [ ] multiple signals received by the charts in the back when interacting with the top level one making them move more than expected
  - figured this out! turns out you just have to ignore calls to any handler that was a broadcasted call from some source `ViewBox`, the details of why this is an issue is gets fairly involved:
    - using `ViewBox.linkView()` does it's own set of signal/slot-broadcasting configuration which can result in handlers being called       **twice**, which in this case **is true** since [`ViewBox.linkView()`](https://github.com/pyqtgraph/pyqtgraph/blob/master/pyqtgraph/graphicsItems/ViewBox/ViewBox.py#L1000) will [**also call `.setXRange()`**](https://github.com/pyqtgraph/pyqtgraph/blob/master/pyqtgraph/graphicsItems/ViewBox/ViewBox.py#L1098).. 

Afaict both of these are solved in this approach. Minus unimplemented features, the only bug here is the axis click-drag support which seems to be an internal bug to do with signal relaying.

The trick for overlaying view box code was definitely used from #1359 which you'll see commented.

See the [list of out-standings in the module](https://github.com/pyqtgraph/pyqtgraph/pull/2162/files#diff-da1deb0e90c1b92d20e3158b950bc6b59cce99510e741d3fd3c768ff436d7d50R9) for more details.


---
#### Changes to `ViewBox` and `PlotItem`
I will make comments alongside the code below. 
 
 ---
Very interested to get a detailed discussion on this approach 🏄🏼 😂 🥸 
ping @j9ac9k @outofculture @pijyoi 
