### PR TITLE
lazy create the rectangle selection item

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -205,6 +205,7 @@ class ViewBox(GraphicsWidget):
         self.borderRect.setPen(self.border)
 
         self.reScaleBox = None
+        self._add_rectangle_selection()
 
         ## show target rect for debugging
         self.target = QtWidgets.QGraphicsRectItem(0, 0, 1, 1)
@@ -347,7 +348,12 @@ class ViewBox(GraphicsWidget):
         if mode not in [ViewBox.PanMode, ViewBox.RectMode]:
             raise Exception("Mode must be ViewBox.PanMode or ViewBox.RectMode")
         self.state['mouseMode'] = mode
-        if self.reScaleBox is None and mode == ViewBox.RectMode:
+        self._add_rectangle_selection()
+
+        self.sigStateChanged.emit(self)
+
+    def _add_rectangle_selection(self):
+        if self.reScaleBox is None and self.state['mouseMode'] == ViewBox.RectMode:
             ## Make scale box that is shown when dragging on the view
             self.rbScaleBox = QtWidgets.QGraphicsRectItem(0, 0, 1, 1)
             self.rbScaleBox.setPen(fn.mkPen((255, 255, 100), width=1))
@@ -355,8 +361,6 @@ class ViewBox(GraphicsWidget):
             self.rbScaleBox.setZValue(1e9)
             self.rbScaleBox.hide()
             self.addItem(self.rbScaleBox, ignoreBounds=True)
-
-        self.sigStateChanged.emit(self)
 
     def setLeftButtonAction(self, mode='rect'):  ## for backward compatibility
         if mode.lower() == 'rect':

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -204,13 +204,7 @@ class ViewBox(GraphicsWidget):
         self.borderRect.setZValue(1e3)
         self.borderRect.setPen(self.border)
 
-        ## Make scale box that is shown when dragging on the view
-        self.rbScaleBox = QtWidgets.QGraphicsRectItem(0, 0, 1, 1)
-        self.rbScaleBox.setPen(fn.mkPen((255,255,100), width=1))
-        self.rbScaleBox.setBrush(fn.mkBrush(255,255,0,100))
-        self.rbScaleBox.setZValue(1e9)
-        self.rbScaleBox.hide()
-        self.addItem(self.rbScaleBox, ignoreBounds=True)
+        self.reScaleBox = None
 
         ## show target rect for debugging
         self.target = QtWidgets.QGraphicsRectItem(0, 0, 1, 1)
@@ -353,6 +347,15 @@ class ViewBox(GraphicsWidget):
         if mode not in [ViewBox.PanMode, ViewBox.RectMode]:
             raise Exception("Mode must be ViewBox.PanMode or ViewBox.RectMode")
         self.state['mouseMode'] = mode
+        if self.reScaleBox is None and mode == ViewBox.RectMode:
+            ## Make scale box that is shown when dragging on the view
+            self.rbScaleBox = QtWidgets.QGraphicsRectItem(0, 0, 1, 1)
+            self.rbScaleBox.setPen(fn.mkPen((255, 255, 100), width=1))
+            self.rbScaleBox.setBrush(fn.mkBrush(255, 255, 0, 100))
+            self.rbScaleBox.setZValue(1e9)
+            self.rbScaleBox.hide()
+            self.addItem(self.rbScaleBox, ignoreBounds=True)
+
         self.sigStateChanged.emit(self)
 
     def setLeftButtonAction(self, mode='rect'):  ## for backward compatibility

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -204,7 +204,7 @@ class ViewBox(GraphicsWidget):
         self.borderRect.setZValue(1e3)
         self.borderRect.setPen(self.border)
 
-        self.reScaleBox = None
+        self.rbScaleBox = None
         self._add_rectangle_selection()
 
         ## show target rect for debugging
@@ -353,7 +353,7 @@ class ViewBox(GraphicsWidget):
         self.sigStateChanged.emit(self)
 
     def _add_rectangle_selection(self):
-        if self.reScaleBox is None and self.state['mouseMode'] == ViewBox.RectMode:
+        if self.rbScaleBox is None and self.state['mouseMode'] == ViewBox.RectMode:
             ## Make scale box that is shown when dragging on the view
             self.rbScaleBox = QtWidgets.QGraphicsRectItem(0, 0, 1, 1)
             self.rbScaleBox.setPen(fn.mkPen((255, 255, 100), width=1))


### PR DESCRIPTION
In the current implementation for each ViewBox there will be a rectangle selection item. If the mouse mode is set to PanMode then this rectangle is unused.

With this PR the rectangle is only created if it is really needed.