### PR TITLE
Fix formatting on minimum value of GradientLegend.

### DIFF
--- a/pyqtgraph/graphicsItems/GradientLegend.py
+++ b/pyqtgraph/graphicsItems/GradientLegend.py
@@ -42,7 +42,7 @@ class GradientLegend(UIGraphicsItem):
             g.setColorAt(x, colors[i])
         self.setGradient(g)
         if 'labels' not in kargs:
-            self.setLabels({str(minVal/10.): 0, str(maxVal): 1})
+            self.setLabels({str(minVal): 0, str(maxVal): 1})
         else:
             self.setLabels({kargs['labels'][0]:0, kargs['labels'][1]:1})
         


### PR DESCRIPTION
The GradientLegend has a bug with the minimum label being divided by 10 and converted from int to float.