### PR TITLE
Used the power of `blockIfUnchanged` decorator

### DIFF
--- a/pyqtgraph/widgets/ComboBox.py
+++ b/pyqtgraph/widgets/ComboBox.py
@@ -106,19 +106,9 @@ class ComboBox(QtWidgets.QComboBox):
         If a dict is given, then the keys are used to populate the combo box
         and the values will be used for both value() and setValue().
         """
-        prevVal = self.value()
-        
-        self.blockSignals(True)
-        try:
-            self.clear()
-            self.addItems(items)
-        finally:
-            self.blockSignals(False)
-            
-        # only emit if we were not able to re-set the original value
-        if self.value() != prevVal:
-            self.currentIndexChanged.emit(self.currentIndex())
-        
+        self.clear()
+        self.addItems(items)
+
     def items(self):
         return self.items.copy()
         


### PR DESCRIPTION
If the signals are blocked externally, keep the state. Before the patch, the block got released unconditionally. There has been a `blockIfUnchanged` decorator for this, but its code has been re-used with a logical error, so the decorator (although used) couldn't have worked.