### PR TITLE
[Bugfix] Update import in parametertree.py example

### DIFF
--- a/pyqtgraph/examples/parametertree.py
+++ b/pyqtgraph/examples/parametertree.py
@@ -9,7 +9,7 @@ as well as some customized parameter types
 # This contains information about the options for each parameter so they can be directly
 # inserted into the example parameter tree. To create your own parameters, simply follow
 # the guidelines demonstrated by other parameters created here.
-from _buildParamTypes import makeAllParamTypes
+from pyqtgraph.examples.buildParamTypes import makeAllParamTypes
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtWidgets


### PR DESCRIPTION
Change relative import to absolute import. The relative import currently breaks running the example in the runner.