### PR TITLE
Introduce API option to control whether lines are drawn as segmented lines

### DIFF
--- a/doc/source/config_options.rst
+++ b/doc/source/config_options.rst
@@ -40,6 +40,10 @@ enableExperimental bool                False              Enable experimental fe
                                                             * Only a very limited subset of the full options of PlotCurveItem is implemented.
                                                             * Single precision is used. This may cause drawing artifacts.
 crashWarning       bool                False              If True, print warnings about situations that may result in a crash.
+segmentedLineMode  str                 'auto'             For 'on', lines are always plotted in segments. For 'off', lines are never 
+                                                          plotted in segments. For 'auto', whether lines are plotted in segments is 
+                                                          automatically decided based on pen poperties and whether anti-aliasing is 
+                                                          enabled. 
 ================== =================== ================== ================================================================================
 
 

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -54,7 +54,11 @@ CONFIG_OPTIONS = {
                                  # change in the future.
     'useCupy': False,  # When True, attempt to use cupy ( currently only with ImageItem and related functions )
     'useNumba': False, # When True, use numba
-} 
+    'segmentedLineMode': 'auto',  # segmented line mode, controls if lines are plotted in segments or continuous
+                                  # 'auto': whether lines are plotted in segments is automatically decided using pen properties and whether anti-aliasing is enabled
+                                  # 'on': lines are always plotted in segments
+                                  # 'off': lines are never plotted in segments
+}
 
 
 def setConfigOption(opt, value):
@@ -62,6 +66,8 @@ def setConfigOption(opt, value):
         raise KeyError('Unknown configuration option "%s"' % opt)
     if opt == 'imageAxisOrder' and value not in ('row-major', 'col-major'):
         raise ValueError('imageAxisOrder must be either "row-major" or "col-major"')
+    if opt == 'segmentedLineMode' and value not in ('auto', 'on', 'off'):
+        raise ValueError('segmentedLineMode must be "auto", "on" or "off"')
     CONFIG_OPTIONS[opt] = value
 
 def setConfigOptions(**opts):

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -56,8 +56,8 @@ CONFIG_OPTIONS = {
     'useNumba': False, # When True, use numba
     'segmentedLineMode': 'auto',  # segmented line mode, controls if lines are plotted in segments or continuous
                                   # 'auto': whether lines are plotted in segments is automatically decided using pen properties and whether anti-aliasing is enabled
-                                  # 'on': lines are always plotted in segments
-                                  # 'off': lines are never plotted in segments
+                                  # 'on' or True: lines are always plotted in segments
+                                  # 'off' or False: lines are never plotted in segments
 }
 
 

--- a/pyqtgraph/examples/PlotSpeedTest.py
+++ b/pyqtgraph/examples/PlotSpeedTest.py
@@ -132,12 +132,16 @@ def onPenChanged(param, pen):
 def onFillChanged(param, enable):
     curve.setFillLevel(0.0 if enable else None)
 
+def onSegmentedLineModeChanged(param, mode):
+    curve.setSegmentedLineMode(mode)
+
 params.child('sigopts').sigTreeStateChanged.connect(makeData)
 params.child('useOpenGL').sigValueChanged.connect(onUseOpenGLChanged)
 params.child('enableExperimental').sigValueChanged.connect(onEnableExperimentalChanged)
 params.child('pen').sigValueChanged.connect(onPenChanged)
 params.child('fill').sigValueChanged.connect(onFillChanged)
 params.child('plotMethod').sigValueChanged.connect(curve.setMethod)
+params.child('segmentedLineMode').sigValueChanged.connect(onSegmentedLineModeChanged)
 params.sigTreeStateChanged.connect(resetTimings)
 
 makeData()
@@ -146,7 +150,7 @@ fpsLastUpdate = perf_counter()
 def update():
     global curve, data, ptr, elapsed, fpsLastUpdate
 
-    options = ['antialias', 'connect', 'skipFiniteCheck', 'segmentedLineMode']
+    options = ['antialias', 'connect', 'skipFiniteCheck']
     kwds = { k : params[k] for k in options }
     if kwds['connect'] == 'array':
         kwds['connect'] = connect_array

--- a/pyqtgraph/examples/PlotSpeedTest.py
+++ b/pyqtgraph/examples/PlotSpeedTest.py
@@ -80,7 +80,8 @@ children = [
     dict(name='connect', type='list', limits=['all', 'pairs', 'finite', 'array'], value='all'),
     dict(name='fill', type='bool', value=False),
     dict(name='skipFiniteCheck', type='bool', value=False),
-    dict(name='plotMethod', title='Plot Method', type='list', limits=['pyqtgraph', 'drawPolyline'])
+    dict(name='plotMethod', title='Plot Method', type='list', limits=['pyqtgraph', 'drawPolyline']),
+    dict(name='segmentedLineMode', title='Segmented lines', type='list', limits=['auto', 'on', 'off'], value='auto'),
 ]
 
 params = ptree.Parameter.create(name='Parameters', type='group', children=children)
@@ -145,7 +146,7 @@ fpsLastUpdate = perf_counter()
 def update():
     global curve, data, ptr, elapsed, fpsLastUpdate
 
-    options = ['antialias', 'connect', 'skipFiniteCheck']
+    options = ['antialias', 'connect', 'skipFiniteCheck', 'segmentedLineMode']
     kwds = { k : params[k] for k in options }
     if kwds['connect'] == 'array':
         kwds['connect'] = connect_array

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -637,12 +637,12 @@ class PlotCurveItem(GraphicsObject):
                ``'auto'`` (default) segmented lines are drawn if the pen's width > 1, pen style is a
                solid line, the pen color is opaque and anti-aliasing is not enabled.
 
-               ``'on'`` or ``True`` lines are always drawn as segmented lines
+               ``'on'`` lines are always drawn as segmented lines
 
-               ``'off'`` or ``False`` lines are never drawn as segmented lines, i.e. the drawing
+               ``'off'`` lines are never drawn as segmented lines, i.e. the drawing
                method with continuous lines is used
         """
-        if mode not in ('auto', 'on', 'off', True, False):
+        if mode not in ('auto', 'on', 'off'):
             raise ValueError(f'segmentedLineMode must be "auto", "on" or "off", got {mode} instead')
         self.opts['segmentedLineMode'] = mode
         self.invalidateBounds()
@@ -650,9 +650,9 @@ class PlotCurveItem(GraphicsObject):
 
     def _shouldUseDrawLineSegments(self, pen):
         mode = self.opts['segmentedLineMode']
-        if mode in ('on', True):
+        if mode in ('on'):
             return True
-        if mode in ('off', False):
+        if mode in ('off'):
             return False
         return (
             pen.widthF() > 1.0

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -424,49 +424,51 @@ class PlotCurveItem(GraphicsObject):
 
     def setData(self, *args, **kargs):
         """
-        =============== =================================================================
+        ================= =================================================================
         **Arguments:**
-        x, y            (numpy arrays) Data to display
-        pen             Pen to use when drawing. Any single argument accepted by
-                        :func:`mkPen <pyqtgraph.mkPen>` is allowed.
-        shadowPen       Pen for drawing behind the primary pen. Usually this
-                        is used to emphasize the curve by providing a
-                        high-contrast border. Any single argument accepted by
-                        :func:`mkPen <pyqtgraph.mkPen>` is allowed.
-        fillLevel       (float or None) Fill the area under the curve to
-                        the specified value.
-        fillOutline     (bool) If True, an outline surrounding the `fillLevel`
-                        area is drawn.
-        brush           Brush to use when filling. Any single argument accepted
-                        by :func:`mkBrush <pyqtgraph.mkBrush>` is allowed.
-        antialias       (bool) Whether to use antialiasing when drawing. This
-                        is disabled by default because it decreases performance.
-        stepMode        (str or None) If 'center', a step is drawn using the `x`
-                        values as boundaries and the given `y` values are
-                        associated to the mid-points between the boundaries of
-                        each step. This is commonly used when drawing
-                        histograms. Note that in this case, ``len(x) == len(y) + 1``
+        x, y              (numpy arrays) Data to display
+        pen               Pen to use when drawing. Any single argument accepted by
+                          :func:`mkPen <pyqtgraph.mkPen>` is allowed.
+        shadowPen         Pen for drawing behind the primary pen. Usually this
+                          is used to emphasize the curve by providing a
+                          high-contrast border. Any single argument accepted by
+                          :func:`mkPen <pyqtgraph.mkPen>` is allowed.
+        fillLevel         (float or None) Fill the area under the curve to
+                          the specified value.
+        fillOutline       (bool) If True, an outline surrounding the `fillLevel`
+                          area is drawn.
+        brush             Brush to use when filling. Any single argument accepted
+                          by :func:`mkBrush <pyqtgraph.mkBrush>` is allowed.
+        antialias         (bool) Whether to use antialiasing when drawing. This
+                          is disabled by default because it decreases performance.
+        stepMode          (str or None) If 'center', a step is drawn using the `x`
+                          values as boundaries and the given `y` values are
+                          associated to the mid-points between the boundaries of
+                          each step. This is commonly used when drawing
+                          histograms. Note that in this case, ``len(x) == len(y) + 1``
                         
-                        If 'left' or 'right', the step is drawn assuming that
-                        the `y` value is associated to the left or right boundary,
-                        respectively. In this case ``len(x) == len(y)``
-                        If not passed or an empty string or `None` is passed, the
-                        step mode is not enabled.
-        connect         Argument specifying how vertexes should be connected
-                        by line segments. 
+                          If 'left' or 'right', the step is drawn assuming that
+                          the `y` value is associated to the left or right boundary,
+                          respectively. In this case ``len(x) == len(y)``
+                          If not passed or an empty string or `None` is passed, the
+                          step mode is not enabled.
+        connect           Argument specifying how vertexes should be connected
+                          by line segments. 
                         
                             | 'all' (default) indicates full connection. 
                             | 'pairs' draws one separate line segment for each two points given.
                             | 'finite' omits segments attached to `NaN` or `Inf` values. 
                             | For any other connectivity, specify an array of boolean values.
-        compositionMode See :func:`setCompositionMode
-                        <pyqtgraph.PlotCurveItem.setCompositionMode>`.
-        skipFiniteCheck (bool, defaults to `False`) Optimization flag that can
-                        speed up plotting by not checking and compensating for
-                        `NaN` values.  If set to `True`, and `NaN` values exist, the
-                        data may not be displayed or the plot may take a
-                        significant performance hit.
-        =============== =================================================================
+        compositionMode   See :func:`setCompositionMode
+                          <pyqtgraph.PlotCurveItem.setCompositionMode>`.
+        skipFiniteCheck   (bool, defaults to `False`) Optimization flag that can
+                          speed up plotting by not checking and compensating for
+                          `NaN` values.  If set to `True`, and `NaN` values exist, the
+                          data may not be displayed or the plot may take a
+                          significant performance hit.
+        segmentedLineMode See :func:`setSegmentedLineMode
+                          <pyqtgraph.PlotCurveItem.setSegmentedLineMode>`.
+        ================= =================================================================
 
         If non-keyword arguments are used, they will be interpreted as
         ``setData(y)`` for a single argument and ``setData(x, y)`` for two
@@ -559,6 +561,8 @@ class PlotCurveItem(GraphicsObject):
             self.opts['antialias'] = kargs['antialias']
         if 'skipFiniteCheck' in kargs:
             self.opts['skipFiniteCheck'] = kargs['skipFiniteCheck']
+        if 'segmentedLineMode' in kargs:
+            self.setSegmentedLineMode(kargs['segmentedLineMode'])
 
         profiler('set')
         self.update()
@@ -634,11 +638,8 @@ class PlotCurveItem(GraphicsObject):
         Parameters
         ----------
         mode : str
-               ``'auto'`` (default) segmented lines are drawn based upon the pen's width, style
-               and alpha as well whether anti-aliasing is enabled. See
-               :func:`_shouldUseDrawLineSegments
-               <pyqtgraph.PlotCurveItem._shouldUseDrawLineSegments>` for more details on the
-               criteria.
+               ``'auto'`` (default) segmented lines are drawn if the pen's width > 1, pen style is a
+               solid line, the pen color is opaque and anti-aliasing is not enabled.
 
                ``'on'`` lines are always drawn as segmented lines
 
@@ -646,7 +647,7 @@ class PlotCurveItem(GraphicsObject):
                continuous lines is used
         """
         if mode not in ('auto', 'on', 'off'):
-            raise ValueError('segmentedLineMode must be "auto", "on" or "off"')
+            raise ValueError(f'segmentedLineMode must be "auto", "on" or "off", got {mode} instead')
         self.opts['segmentedLineMode'] = mode
         self.invalidateBounds()
         self.update()

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -424,51 +424,49 @@ class PlotCurveItem(GraphicsObject):
 
     def setData(self, *args, **kargs):
         """
-        ================= =================================================================
+        =============== =================================================================
         **Arguments:**
-        x, y              (numpy arrays) Data to display
-        pen               Pen to use when drawing. Any single argument accepted by
-                          :func:`mkPen <pyqtgraph.mkPen>` is allowed.
-        shadowPen         Pen for drawing behind the primary pen. Usually this
-                          is used to emphasize the curve by providing a
-                          high-contrast border. Any single argument accepted by
-                          :func:`mkPen <pyqtgraph.mkPen>` is allowed.
-        fillLevel         (float or None) Fill the area under the curve to
-                          the specified value.
-        fillOutline       (bool) If True, an outline surrounding the `fillLevel`
-                          area is drawn.
-        brush             Brush to use when filling. Any single argument accepted
-                          by :func:`mkBrush <pyqtgraph.mkBrush>` is allowed.
-        antialias         (bool) Whether to use antialiasing when drawing. This
-                          is disabled by default because it decreases performance.
-        stepMode          (str or None) If 'center', a step is drawn using the `x`
-                          values as boundaries and the given `y` values are
-                          associated to the mid-points between the boundaries of
-                          each step. This is commonly used when drawing
-                          histograms. Note that in this case, ``len(x) == len(y) + 1``
+        x, y            (numpy arrays) Data to display
+        pen             Pen to use when drawing. Any single argument accepted by
+                        :func:`mkPen <pyqtgraph.mkPen>` is allowed.
+        shadowPen       Pen for drawing behind the primary pen. Usually this
+                        is used to emphasize the curve by providing a
+                        high-contrast border. Any single argument accepted by
+                        :func:`mkPen <pyqtgraph.mkPen>` is allowed.
+        fillLevel       (float or None) Fill the area under the curve to
+                        the specified value.
+        fillOutline     (bool) If True, an outline surrounding the `fillLevel`
+                        area is drawn.
+        brush           Brush to use when filling. Any single argument accepted
+                        by :func:`mkBrush <pyqtgraph.mkBrush>` is allowed.
+        antialias       (bool) Whether to use antialiasing when drawing. This
+                        is disabled by default because it decreases performance.
+        stepMode        (str or None) If 'center', a step is drawn using the `x`
+                        values as boundaries and the given `y` values are
+                        associated to the mid-points between the boundaries of
+                        each step. This is commonly used when drawing
+                        histograms. Note that in this case, ``len(x) == len(y) + 1``
                         
-                          If 'left' or 'right', the step is drawn assuming that
-                          the `y` value is associated to the left or right boundary,
-                          respectively. In this case ``len(x) == len(y)``
-                          If not passed or an empty string or `None` is passed, the
-                          step mode is not enabled.
-        connect           Argument specifying how vertexes should be connected
-                          by line segments. 
+                        If 'left' or 'right', the step is drawn assuming that
+                        the `y` value is associated to the left or right boundary,
+                        respectively. In this case ``len(x) == len(y)``
+                        If not passed or an empty string or `None` is passed, the
+                        step mode is not enabled.
+        connect         Argument specifying how vertexes should be connected
+                        by line segments. 
                         
                             | 'all' (default) indicates full connection. 
                             | 'pairs' draws one separate line segment for each two points given.
                             | 'finite' omits segments attached to `NaN` or `Inf` values. 
                             | For any other connectivity, specify an array of boolean values.
-        compositionMode   See :func:`setCompositionMode
-                          <pyqtgraph.PlotCurveItem.setCompositionMode>`.
-        skipFiniteCheck   (bool, defaults to `False`) Optimization flag that can
-                          speed up plotting by not checking and compensating for
-                          `NaN` values.  If set to `True`, and `NaN` values exist, the
-                          data may not be displayed or the plot may take a
-                          significant performance hit.
-        segmentedLineMode See :func:`setSegmentedLineMode
-                          <pyqtgraph.PlotCurveItem.setSegmentedLineMode>`.
-        ================= =================================================================
+        compositionMode See :func:`setCompositionMode
+                        <pyqtgraph.PlotCurveItem.setCompositionMode>`.
+        skipFiniteCheck (bool, defaults to `False`) Optimization flag that can
+                        speed up plotting by not checking and compensating for
+                        `NaN` values.  If set to `True`, and `NaN` values exist, the
+                        data may not be displayed or the plot may take a
+                        significant performance hit.
+        =============== =================================================================
 
         If non-keyword arguments are used, they will be interpreted as
         ``setData(y)`` for a single argument and ``setData(x, y)`` for two
@@ -561,8 +559,6 @@ class PlotCurveItem(GraphicsObject):
             self.opts['antialias'] = kargs['antialias']
         if 'skipFiniteCheck' in kargs:
             self.opts['skipFiniteCheck'] = kargs['skipFiniteCheck']
-        if 'segmentedLineMode' in kargs:
-            self.setSegmentedLineMode(kargs['segmentedLineMode'])
 
         profiler('set')
         self.update()

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -637,12 +637,12 @@ class PlotCurveItem(GraphicsObject):
                ``'auto'`` (default) segmented lines are drawn if the pen's width > 1, pen style is a
                solid line, the pen color is opaque and anti-aliasing is not enabled.
 
-               ``'on'`` lines are always drawn as segmented lines
+               ``'on'`` or ``True`` lines are always drawn as segmented lines
 
-               ``'off'`` lines are never drawn as segmented lines, i.e. the drawing method with
-               continuous lines is used
+               ``'off'`` or ``False`` lines are never drawn as segmented lines, i.e. the drawing
+               method with continuous lines is used
         """
-        if mode not in ('auto', 'on', 'off'):
+        if mode not in ('auto', 'on', 'off', True, False):
             raise ValueError(f'segmentedLineMode must be "auto", "on" or "off", got {mode} instead')
         self.opts['segmentedLineMode'] = mode
         self.invalidateBounds()
@@ -650,9 +650,9 @@ class PlotCurveItem(GraphicsObject):
 
     def _shouldUseDrawLineSegments(self, pen):
         mode = self.opts['segmentedLineMode']
-        if mode == 'on':
+        if mode in ('on', True):
             return True
-        if mode == 'off':
+        if mode in ('off', False):
             return False
         return (
             pen.widthF() > 1.0

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -151,7 +151,8 @@ class PlotCurveItem(GraphicsObject):
             'connect': 'all',
             'mouseWidth': 8, # width of shape responding to mouse click
             'compositionMode': None,
-            'skipFiniteCheck': False
+            'skipFiniteCheck': False,
+            'segmentedLineMode': getConfigOption('segmentedLineMode'),
         }
         if 'pen' not in kargs:
             self.opts['pen'] = fn.mkPen('w')
@@ -624,7 +625,38 @@ class PlotCurveItem(GraphicsObject):
 
         return self.path
 
+    def setSegmentedLineMode(self, mode):
+        """
+        Sets the mode that decides whether or not lines are drawn as segmented lines. Drawing lines
+        as segmented lines is more performant than the standard drawing method with continuous
+        lines.
+
+        Parameters
+        ----------
+        mode : str
+               ``'auto'`` (default) segmented lines are drawn based upon the pen's width, style
+               and alpha as well whether anti-aliasing is enabled. See
+               :func:`_shouldUseDrawLineSegments
+               <pyqtgraph.PlotCurveItem._shouldUseDrawLineSegments>` for more details on the
+               criteria.
+
+               ``'on'`` lines are always drawn as segmented lines
+
+               ``'off'`` lines are never drawn as segmented lines, i.e. the drawing method with
+               continuous lines is used
+        """
+        if mode not in ('auto', 'on', 'off'):
+            raise ValueError('segmentedLineMode must be "auto", "on" or "off"')
+        self.opts['segmentedLineMode'] = mode
+        self.invalidateBounds()
+        self.update()
+
     def _shouldUseDrawLineSegments(self, pen):
+        mode = self.opts['segmentedLineMode']
+        if mode == 'on':
+            return True
+        if mode == 'off':
+            return False
         return (
             pen.widthF() > 1.0
             # non-solid pen styles need single polyline to be effective
@@ -634,6 +666,9 @@ class PlotCurveItem(GraphicsObject):
             and pen.isSolid()   # pen.brush().style() == Qt.BrushStyle.SolidPattern
             # ends of adjacent line segments overlapping is visible when not opaque
             and pen.color().alphaF() == 1.0
+            # anti-aliasing introduces transparent pixels and therefore also causes visible overlaps
+            # for adjacent line segments
+            and not self.opts['antialias']
         )
 
     def _getLineSegments(self):


### PR DESCRIPTION
This PR proposes an API interface for the segmented line drawing method introduced in  PR #2011 (as discussed in issue #2178).

The commit features the following:
- Adds a global options to set mode for drawing segmented lines
- Mode can be 'auto' (use existing method),  'on' (always draw segmented lines), 'off' (never draw segmented lines)
- Global option can be overridden for given ``PlotCurveItem`` instance using setter method
- **[optional]** Added activation of anti-aliasing as criterion to decide whether to draw segmented lines in 'auto' mode (specifically [these lines](https://github.com/swvanbuuren/pyqtgraph/blob/segmented-lines-api-option/pyqtgraph/graphicsItems/PlotCurveItem.py#L669-L671))

I would like to emphasize that the last point is still under debate and can be left out if required.