### PR TITLE
Reverted to real data to export CSV correctly

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -1065,12 +1065,11 @@ class PlotDataItem(GraphicsObject):
 
     def getData(self):
         """
-        Returns the displayed data as the tuple (`xData`, `yData`) after mapping and data reduction.         
+        Returns the data as the tuple (`xData`, `yData`).
         """
-        dataset = self.getDisplayDataset()
-        if dataset is None:
+        if self._dataset is None:
             return (None, None)
-        return dataset.x, dataset.y
+        return self._dataset.x, self._dataset.y
 
     # compatbility method for access to dataRect for full dataset:
     def dataRect(self):


### PR DESCRIPTION
When the axes are in log mode, what's saved is log10 of values instead of real data. The view should _never alter_ the data to export.

Please check how the change can affect other code. I haven't found anything.

Please check other item types that have their own `getData()` function implementations. I don't have time for that right now.