### PR TITLE
Apply the log mode to the displayed dataset, export the mapped one

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -12,6 +12,7 @@ from .ScatterPlotItem import ScatterPlotItem
 
 __all__ = ['PlotDataItem']
 
+
 class PlotDataset(object):
     """
     :orphan:
@@ -19,67 +20,71 @@ class PlotDataset(object):
 
     Holds collected information for a plotable dataset. 
     Numpy arrays containing x and y coordinates are available as ``dataset.x`` and ``dataset.y``.
-    
-    After a search has been performed, typically during a call to :func:`dataRect() <pyqtgraph.PlotDataset.dataRect>`, 
-    ``dataset.containsNonfinite`` is `True` if any coordinate values are nonfinite (e.g. NaN or inf) or `False` if all 
+
+    After a search has been performed, typically during a call to :func:`dataRect() <pyqtgraph.PlotDataset.dataRect>`,
+    ``dataset.containsNonfinite`` is `True` if any coordinate values are nonfinite (e.g. NaN or inf) or `False` if all
     values are finite. If no search has been performed yet, ``dataset.containsNonfinite`` is `None`.
 
-    For internal use in :class:`PlotDataItem <pyqtgraph.PlotDataItem>`, this class should not be instantiated when no data is available. 
+    For internal use in :class:`PlotDataItem <pyqtgraph.PlotDataItem>`, this class should not be instantiated when no data is available.
     """
+
     def __init__(self, x, y):
-        """ 
+        """
         Parameters
         ----------
         x: array
-            x coordinates of data points. 
+            x coordinates of data points.
         y: array
-            y coordinates of data points. 
+            y coordinates of data points.
         """
         super().__init__()
         self.x = x
         self.y = y
         self._dataRect = None
         self.containsNonfinite = None
-        
+
     def _updateDataRect(self):
-        """ 
-        Finds bounds of plotable data and stores them as ``dataset._dataRect``, 
+        """
+        Finds bounds of plotable data and stores them as ``dataset._dataRect``,
         stores information about the presence of nonfinite data points.
             """
         if self.y is None or self.x is None:
             return None
-        if self.containsNonfinite is False: # all points are directly usable.
-            ymin = np.min( self.y ) # find minimum of all values
-            ymax = np.max( self.y ) # find maximum of all values
-            xmin = np.min( self.x ) # find minimum of all values
-            xmax = np.max( self.x ) # find maximum of all values
-        else: # This may contain NaN values and infinites.
-            selection = np.isfinite(self.y)    # We are looking for the bounds of the plottable data set. Infinite and Nan are ignored. 
-            all_y_are_finite = selection.all() # False if all values are finite, True if there are any non-finites
+        if self.containsNonfinite is False:  # all points are directly usable.
+            ymin = np.min(self.y)  # find minimum of all values
+            ymax = np.max(self.y)  # find maximum of all values
+            xmin = np.min(self.x)  # find minimum of all values
+            xmax = np.max(self.x)  # find maximum of all values
+        else:  # This may contain NaN values and infinites.
+            selection = np.isfinite(
+                self.y)  # We are looking for the bounds of the plottable data set. Infinite and Nan are ignored.
+            all_y_are_finite = selection.all()  # False if all values are finite, True if there are any non-finites
             try:
-                ymin = np.min( self.y[selection] ) # find minimum of all finite values
-                ymax = np.max( self.y[selection] ) # find maximum of all finite values
-            except ValueError: # is raised when there are no finite values
+                ymin = np.min(self.y[selection])  # find minimum of all finite values
+                ymax = np.max(self.y[selection])  # find maximum of all finite values
+            except ValueError:  # is raised when there are no finite values
                 ymin = np.nan
                 ymax = np.nan
-            selection = np.isfinite(self.x) # We are looking for the bounds of the plottable data set. Infinite and Nan are ignored. 
-            all_x_are_finite = selection.all() # False if all values are finite, True if there are any non-finites
+            selection = np.isfinite(
+                self.x)  # We are looking for the bounds of the plottable data set. Infinite and Nan are ignored.
+            all_x_are_finite = selection.all()  # False if all values are finite, True if there are any non-finites
             try:
-                xmin = np.min( self.x[selection] ) # find minimum of all finite values
-                xmax = np.max( self.x[selection] ) # find maximum of all finite values
-            except ValueError: # is raised when there are no finite values
+                xmin = np.min(self.x[selection])  # find minimum of all finite values
+                xmax = np.max(self.x[selection])  # find maximum of all finite values
+            except ValueError:  # is raised when there are no finite values
                 xmin = np.nan
                 xmax = np.nan
-            self.containsNonfinite = not (all_x_are_finite and all_y_are_finite) # This always yields a definite True/False answer
-        self._dataRect = QtCore.QRectF( QtCore.QPointF(xmin,ymin), QtCore.QPointF(xmax,ymax) )
-        
+            self.containsNonfinite = not (
+                        all_x_are_finite and all_y_are_finite)  # This always yields a definite True/False answer
+        self._dataRect = QtCore.QRectF(QtCore.QPointF(xmin, ymin), QtCore.QPointF(xmax, ymax))
+
     def dataRect(self):
         """
         Returns a bounding rectangle (as :class:`QtCore.QRectF`) for the finite subset of data.
-        If there is an active mapping function, such as logarithmic scaling, then bounds represent the mapped data. 
+        If there is an active mapping function, such as logarithmic scaling, then bounds represent the mapped data.
         Will return `None` if there is no data or if all values (`x` or `y`) are NaN.
         """
-        if self._dataRect is None: 
+        if self._dataRect is None:
             self._updateDataRect()
         return self._dataRect
 
@@ -88,7 +93,7 @@ class PlotDataset(object):
         Applies a logarithmic mapping transformation (base 10) if requested for the respective axis.
         This replaces the internal data. Values of ``-inf`` resulting from zeros in the original dataset are
         replaced by ``np.NaN``.
-        
+
         Parameters
         ----------
         logmode: tuple or list of two bool
@@ -99,9 +104,9 @@ class PlotDataset(object):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
                 self.x = np.log10(self.x)
-            nonfinites = ~np.isfinite( self.x )
+            nonfinites = ~np.isfinite(self.x)
             if nonfinites.any():
-                self.x[nonfinites] = np.nan # set all non-finite values to NaN
+                self.x[nonfinites] = np.nan  # set all non-finite values to NaN
                 self.containsNonfinite = True
             else:
                 all_x_finite = True
@@ -110,21 +115,22 @@ class PlotDataset(object):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
                 self.y = np.log10(self.y)
-            nonfinites = ~np.isfinite( self.y )
+            nonfinites = ~np.isfinite(self.y)
             if nonfinites.any():
-                self.y[nonfinites] = np.nan # set all non-finite values to NaN
+                self.y[nonfinites] = np.nan  # set all non-finite values to NaN
                 self.containsNonfinite = True
             else:
                 all_y_finite = True
-        if all_x_finite and all_y_finite: 
-            self.containsNonfinite = False # mark as False only if both axes were checked.
-        
+        if all_x_finite and all_y_finite:
+            self.containsNonfinite = False  # mark as False only if both axes were checked.
+
+
 class PlotDataItem(GraphicsObject):
     """
     **Bases:** :class:`GraphicsObject <pyqtgraph.GraphicsObject>`
 
     :class:`PlotDataItem` provides a unified interface for displaying plot curves, scatter plots, or both.
-    It also contains methods to transform or decimate the original data before it is displayed. 
+    It also contains methods to transform or decimate the original data before it is displayed.
 
     As pyqtgraph's standard plotting object, ``plot()`` methods such as :func:`pyqtgraph.plot` and
     :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>` create instances of :class:`PlotDataItem`.
@@ -149,7 +155,7 @@ class PlotDataItem(GraphicsObject):
     sigPointsClicked = QtCore.Signal(object, object, object)
     sigPointsHovered = QtCore.Signal(object, object, object)
 
-#        **(x,y data only)**
+    #        **(x,y data only)**
 
     def __init__(self, *args, **kargs):
         """
@@ -174,43 +180,43 @@ class PlotDataItem(GraphicsObject):
             PlotDataItem(list-of-dicts)  ``[{'x': x, 'y': y, ...},   ...]``
             PlotDataItem(dict-of-lists)  ``{'x': [...], 'y': [...],  ...}``
             ============================ ===============================================
-        
+
         **Line style keyword arguments:**
 
             ============ ==============================================================================
             connect      Specifies how / whether vertexes should be connected. See below for details.
             pen          Pen to use for drawing the lines between points.
                          Default is solid grey, 1px width. Use None to disable line drawing.
-                         May be a ``QPen`` or any single argument accepted by 
+                         May be a ``QPen`` or any single argument accepted by
                          :func:`mkPen() <pyqtgraph.mkPen>`
             shadowPen    Pen for secondary line to draw behind the primary line. Disabled by default.
-                         May be a ``QPen`` or any single argument accepted by 
+                         May be a ``QPen`` or any single argument accepted by
                          :func:`mkPen() <pyqtgraph.mkPen>`
             fillLevel    If specified, the area between the curve and fillLevel is filled.
             fillOutline  (bool) If True, an outline surrounding the *fillLevel* area is drawn.
-            fillBrush    Fill to use in the *fillLevel* area. May be any single argument accepted by 
+            fillBrush    Fill to use in the *fillLevel* area. May be any single argument accepted by
                          :func:`mkBrush() <pyqtgraph.mkBrush>`
             stepMode     (str or None) If specified and not None, a stepped curve is drawn.
                          For 'left' the specified points each describe the left edge of a step.
-                         For 'right', they describe the right edge. 
+                         For 'right', they describe the right edge.
                          For 'center', the x coordinates specify the location of the step boundaries.
                          This mode is commonly used for histograms. Note that it requires an additional
                          x value, such that len(x) = len(y) + 1 .
 
             ============ ==============================================================================
-        
+
         ``connect`` supports the following arguments:
-        
-        - 'all' connects all points.  
+
+        - 'all' connects all points.
         - 'pairs' generates lines between every other point.
-        - 'finite' creates a break when a nonfinite points is encountered. 
+        - 'finite' creates a break when a nonfinite points is encountered.
         - If an ndarray is passed, it should contain `N` int32 values of 0 or 1.
           Values of 1 indicate that the respective point will be connected to the next.
         - In the default 'auto' mode, PlotDataItem will normally use 'all', but if any
           nonfinite data points are detected, it will automatically switch to 'finite'.
-          
+
         See :func:`arrayToQPath() <pyqtgraph.arrayToQPath>` for more details.
-        
+
         **Point style keyword arguments:**  (see :func:`ScatterPlotItem.setData() <pyqtgraph.ScatterPlotItem.setData>` for more information)
 
             ============ ======================================================
@@ -219,7 +225,7 @@ class PlotDataItem(GraphicsObject):
             symbolPen    Outline pen for drawing points, or a list of pens, one
                          per point. May be any single argument accepted by
                          :func:`mkPen() <pyqtgraph.mkPen>`.
-            symbolBrush  Brush for filling points, or a list of brushes, one 
+            symbolBrush  Brush for filling points, or a list of brushes, one
                          per point. May be any single argument accepted by
                          :func:`mkBrush() <pyqtgraph.mkBrush>`.
             symbolSize   Diameter of symbols, or list of diameters.
@@ -227,11 +233,11 @@ class PlotDataItem(GraphicsObject):
                          pixels. If False, then symbolSize is
                          specified in data coordinates.
             ============ ======================================================
-            
+
         Any symbol recognized by :class:`ScatterPlotItem <pyqtgraph.ScatterPlotItem>` can be specified,
         including 'o' (circle), 's' (square), 't', 't1', 't2', 't3' (triangles of different orientation),
         'd' (diamond), '+' (plus sign), 'x' (x mark), 'p' (pentagon), 'h' (hexagon) and 'star'.
-        
+
         Symbols can also be directly given in the form of a :class:`QtGui.QPainterPath` instance.
 
         **Optimization keyword arguments:**
@@ -255,19 +261,19 @@ class PlotDataItem(GraphicsObject):
                               :class:`ViewBox` is plotted. This can improve performance when plotting
                               very large data sets where only a fraction of the data is visible
                               at any time.
-            dynamicRangeLimit (float or `None`) Limit off-screen y positions of data points. 
+            dynamicRangeLimit (float or `None`) Limit off-screen y positions of data points.
                               `None` disables the limiting. This can increase performance but may
                               cause plots to disappear at high levels of magnification.
-                              The default of 1e6 limits data to approximately 1,000,000 times the 
+                              The default of 1e6 limits data to approximately 1,000,000 times the
                               :class:`ViewBox` height.
             dynamicRangeHyst  (float) Permits changes in vertical zoom up to the given hysteresis
                               factor (the default is 3.0) before the limit calculation is repeated.
-            skipFiniteCheck   (bool, default `False`) Optimization flag that can speed up plotting by not 
-                              checking and compensating for NaN values.  If set to `True`, and NaN 
+            skipFiniteCheck   (bool, default `False`) Optimization flag that can speed up plotting by not
+                              checking and compensating for NaN values.  If set to `True`, and NaN
                               values exist, unpredictable behavior will occur. The data may not be
                               displayed or the plot may take a significant performance hit.
-                              
-                              In the default 'auto' connect mode, `PlotDataItem` will apply this 
+
+                              In the default 'auto' connect mode, `PlotDataItem` will apply this
                               setting automatically.
             ================= =======================================================================
 
@@ -278,17 +284,17 @@ class PlotDataItem(GraphicsObject):
             ==========   ================================================
 
         **Notes on performance:**
-        
+
         Plotting lines with the default single-pixel width is the fastest available option. For such lines,
         translucent colors (`alpha` < 1) do not result in a significant slowdown.
-        
+
         Wider lines increase the complexity due to the overlap of individual line segments. Translucent colors
         require merging the entire plot into a single entity before the alpha value can be applied. For plots with more
         than a few hundred points, this can result in excessive slowdown.
 
         Since version 0.12.4, this slowdown is automatically avoided by an algorithm that draws line segments
         separately for fully opaque lines. Setting `alpha` < 1 reverts to the previous, slower drawing method.
-        
+
         For lines with a width of more than 4 pixels, :func:`pyqtgraph.mkPen() <pyqtgraph.mkPen>` will automatically
         create a ``QPen`` with `Qt.PenCapStyle.RoundCap` to ensure a smooth connection of line segments. This incurs a
         small performance penalty.
@@ -298,9 +304,9 @@ class PlotDataItem(GraphicsObject):
         self.setFlag(self.GraphicsItemFlag.ItemHasNoContents)
         # Original data, mapped data, and data processed for display is now all held in PlotDataset objects.
         # The convention throughout PlotDataItem is that a PlotDataset is only instantiated if valid data is available.
-        self._dataset        = None # will hold a PlotDataset for the original data
-        self._datasetMapped  = None # will hold a PlotDataset for data after mapping transforms (e.g. log scale)
-        self._datasetDisplay = None # will hold a PlotDataset for data downsampled and limited for display
+        self._dataset = None  # will hold a PlotDataset for the original data
+        self._datasetMapped = None  # will hold a PlotDataset for data after mapping transforms (e.g. log scale)
+        self._datasetDisplay = None  # will hold a PlotDataset for data downsampled and limited for display
         self.curve = PlotCurveItem()
         self.scatter = ScatterPlotItem()
         self.curve.setParentItem(self)
@@ -309,22 +315,22 @@ class PlotDataItem(GraphicsObject):
         self.curve.sigClicked.connect(self.curveClicked)
         self.scatter.sigClicked.connect(self.scatterClicked)
         self.scatter.sigHovered.connect(self.scatterHovered)
-        
+
         # self._xViewRangeWasChanged = False
         # self._yViewRangeWasChanged = False
         # self._styleWasChanged = True # force initial update
-        
+
         # update-required notifications are handled through properties to allow future management through
         # the QDynamicPropertyChangeEvent sent on any change.
         self.setProperty('xViewRangeWasChanged', False)
         self.setProperty('yViewRangeWasChanged', False)
-        self.setProperty('styleWasChanged', True) # force initial update
+        self.setProperty('styleWasChanged', True)  # force initial update
 
-        self._drlLastClip = (0.0, 0.0) # holds last clipping points of dynamic range limiter
-        #self.clear()
+        self._drlLastClip = (0.0, 0.0)  # holds last clipping points of dynamic range limiter
+        # self.clear()
         self.opts = {
-            'connect': 'auto', # defaults to 'all', unless overridden to 'finite' for log-scaling
-            'skipFiniteCheck': False, 
+            'connect': 'auto',  # defaults to 'all', unless overridden to 'finite' for log-scaling
+            'skipFiniteCheck': False,
             'fftMode': False,
             'logMode': [False, False],
             'derivativeMode': False,
@@ -332,7 +338,7 @@ class PlotDataItem(GraphicsObject):
             'alphaHint': 1.0,
             'alphaMode': False,
 
-            'pen': (200,200,200),
+            'pen': (200, 200, 200),
             'shadowPen': None,
             'fillLevel': None,
             'fillOutline': False,
@@ -341,7 +347,7 @@ class PlotDataItem(GraphicsObject):
 
             'symbol': None,
             'symbolSize': 10,
-            'symbolPen': (200,200,200),
+            'symbolPen': (200, 200, 200),
             'symbolBrush': (50, 50, 150),
             'pxMode': True,
 
@@ -359,13 +365,13 @@ class PlotDataItem(GraphicsObject):
         }
         self.setCurveClickable(kargs.get('clickable', False))
         self.setData(*args, **kargs)
-    
+
     # Compatibility with direct property access to previous xData and yData structures:
     @property
     def xData(self):
         if self._dataset is None: return None
         return self._dataset.x
-        
+
     @property
     def yData(self):
         if self._dataset is None: return None
@@ -405,33 +411,33 @@ class PlotDataItem(GraphicsObject):
         self.opts['alphaHint'] = alpha
         self.opts['alphaMode'] = auto
         self.setOpacity(alpha)
-        #self.update()
+        # self.update()
 
     def setFftMode(self, state):
         """
         ``state = True`` enables mapping the data by a fast Fourier transform.
         If the `x` values are not equidistant, the data set is resampled at
-        equal intervals. 
+        equal intervals.
         """
         if self.opts['fftMode'] == state:
             return
         self.opts['fftMode'] = state
-        self._datasetMapped  = None
+        self._datasetMapped = None
         self._datasetDisplay = None
         self.updateItems(styleUpdate=False)
         self.informViewBoundsChanged()
 
     def setLogMode(self, xState, yState):
         """
-        When log mode is enabled for the respective axis by setting ``xState`` or 
+        When log mode is enabled for the respective axis by setting ``xState`` or
         ``yState`` to `True`, a mapping according to ``mapped = np.log10( value )``
-        is applied to the data. For negative or zero values, this results in a 
+        is applied to the data. For negative or zero values, this results in a
         `NaN` value.
         """
         if self.opts['logMode'] == [xState, yState]:
             return
         self.opts['logMode'] = [xState, yState]
-        self._datasetMapped  = None  # invalidate mapped data
+        self._datasetMapped = None  # invalidate mapped data
         self._datasetDisplay = None  # invalidate display data
         self.updateItems(styleUpdate=False)
         self.informViewBoundsChanged()
@@ -439,28 +445,28 @@ class PlotDataItem(GraphicsObject):
     def setDerivativeMode(self, state):
         """
         ``state = True`` enables derivative mode, where a mapping according to
-        ``y_mapped = dy / dx`` is applied, with `dx` and `dy` representing the 
+        ``y_mapped = dy / dx`` is applied, with `dx` and `dy` representing the
         differences between adjacent `x` and `y` values.
         """
         if self.opts['derivativeMode'] == state:
             return
         self.opts['derivativeMode'] = state
-        self._datasetMapped  = None  # invalidate mapped data
+        self._datasetMapped = None  # invalidate mapped data
         self._datasetDisplay = None  # invalidate display data
         self.updateItems(styleUpdate=False)
         self.informViewBoundsChanged()
 
     def setPhasemapMode(self, state):
         """
-        ``state = True`` enables phase map mode, where a mapping 
+        ``state = True`` enables phase map mode, where a mapping
         according to ``x_mappped = y`` and ``y_mapped = dy / dx``
-        is applied, plotting the numerical derivative of the data over the 
+        is applied, plotting the numerical derivative of the data over the
         original `y` values.
         """
         if self.opts['phasemapMode'] == state:
             return
         self.opts['phasemapMode'] = state
-        self._datasetMapped  = None  # invalidate mapped data
+        self._datasetMapped = None  # invalidate mapped data
         self._datasetDisplay = None  # invalidate display data
         self.updateItems(styleUpdate=False)
         self.informViewBoundsChanged()
@@ -479,23 +485,23 @@ class PlotDataItem(GraphicsObject):
     def setPen(self, *args, **kargs):
         """
         Sets the pen used to draw lines between points.
-        The argument can be a :class:`QtGui.QPen` or any combination of arguments accepted by 
+        The argument can be a :class:`QtGui.QPen` or any combination of arguments accepted by
         :func:`pyqtgraph.mkPen() <pyqtgraph.mkPen>`.
         """
         pen = fn.mkPen(*args, **kargs)
         self.opts['pen'] = pen
-        #self.curve.setPen(pen)
-        #for c in self.curves:
-            #c.setPen(pen)
-        #self.update()
+        # self.curve.setPen(pen)
+        # for c in self.curves:
+        # c.setPen(pen)
+        # self.update()
         self.updateItems(styleUpdate=True)
 
     def setShadowPen(self, *args, **kargs):
         """
         Sets the shadow pen used to draw lines between points (this is for enhancing contrast or
-        emphasizing data). This line is drawn behind the primary pen and should generally be assigned 
+        emphasizing data). This line is drawn behind the primary pen and should generally be assigned
         greater width than the primary pen.
-        The argument can be a :class:`QtGui.QPen` or any combination of arguments accepted by 
+        The argument can be a :class:`QtGui.QPen` or any combination of arguments accepted by
         :func:`pyqtgraph.mkPen() <pyqtgraph.mkPen>`.
         """
         if args[0] is None:
@@ -503,13 +509,13 @@ class PlotDataItem(GraphicsObject):
         else:
             pen = fn.mkPen(*args, **kargs)
         self.opts['shadowPen'] = pen
-        #for c in self.curves:
-            #c.setPen(pen)
-        #self.update()
+        # for c in self.curves:
+        # c.setPen(pen)
+        # self.update()
         self.updateItems(styleUpdate=True)
 
     def setFillBrush(self, *args, **kargs):
-        """ 
+        """
         Sets the :class:`QtGui.QBrush` used to fill the area under the curve.
         See :func:`mkBrush() <pyqtgraph.functions.mkBrush>`) for arguments.
         """
@@ -530,8 +536,8 @@ class PlotDataItem(GraphicsObject):
 
     def setFillLevel(self, level):
         """
-        Enables filling the area under the curve towards the value specified by 
-        `level`. `None` disables the filling. 
+        Enables filling the area under the curve towards the value specified by
+        `level`. `None` disables the filling.
         """
         if self.opts['fillLevel'] == level:
             return
@@ -539,18 +545,18 @@ class PlotDataItem(GraphicsObject):
         self.updateItems(styleUpdate=True)
 
     def setSymbol(self, symbol):
-        """ `symbol` can be any string recognized by 
+        """ `symbol` can be any string recognized by
         :class:`ScatterPlotItem <pyqtgraph.ScatterPlotItem>` or a list that
         specifies a symbol for each point.
         """
         if self.opts['symbol'] == symbol:
             return
         self.opts['symbol'] = symbol
-        #self.scatter.setSymbol(symbol)
+        # self.scatter.setSymbol(symbol)
         self.updateItems(styleUpdate=True)
 
     def setSymbolPen(self, *args, **kargs):
-        """ 
+        """
         Sets the :class:`QtGui.QPen` used to draw symbol outlines.
         See :func:`mkPen() <pyqtgraph.functions.mkPen>`) for arguments.
         """
@@ -558,7 +564,7 @@ class PlotDataItem(GraphicsObject):
         if self.opts['symbolPen'] == pen:
             return
         self.opts['symbolPen'] = pen
-        #self.scatter.setSymbolPen(pen)
+        # self.scatter.setSymbolPen(pen)
         self.updateItems(styleUpdate=True)
 
     def setSymbolBrush(self, *args, **kargs):
@@ -570,7 +576,7 @@ class PlotDataItem(GraphicsObject):
         if self.opts['symbolBrush'] == brush:
             return
         self.opts['symbolBrush'] = brush
-        #self.scatter.setSymbolBrush(brush)
+        # self.scatter.setSymbolBrush(brush)
         self.updateItems(styleUpdate=True)
 
     def setSymbolSize(self, size):
@@ -580,7 +586,7 @@ class PlotDataItem(GraphicsObject):
         if self.opts['symbolSize'] == size:
             return
         self.opts['symbolSize'] = size
-        #self.scatter.setSymbolSize(symbolSize)
+        # self.scatter.setSymbolSize(symbolSize)
         self.updateItems(styleUpdate=True)
 
     def setDownsampling(self, ds=None, auto=None, method=None):
@@ -617,7 +623,7 @@ class PlotDataItem(GraphicsObject):
                 self.opts['downsampleMethod'] = method
 
         if changed:
-            self._datasetMapped  = None  # invalidata mapped data
+            self._datasetMapped = None  # invalidata mapped data
             self._datasetDisplay = None  # invalidate display data
             self.updateItems(styleUpdate=False)
 
@@ -635,7 +641,7 @@ class PlotDataItem(GraphicsObject):
     def setDynamicRangeLimit(self, limit=1e06, hysteresis=3.):
         """
         Limit the off-screen positions of data points at large magnification
-        This avoids errors with plots not displaying because their visibility is incorrectly determined. 
+        This avoids errors with plots not displaying because their visibility is incorrectly determined.
         The default setting repositions far-off points to be within ±10^6 times the viewport height.
 
         =============== ================================================================
@@ -645,40 +651,40 @@ class PlotDataItem(GraphicsObject):
                         All values are relative to the viewport height.
                         'None' disables the check for a minimal increase in performance.
                         Default is 1E+06.
-                        
+
         hysteresis      (float) Hysteresis factor that controls how much change
                         in zoom level (vertical height) is allowed before recalculating
                         Default is 3.0
         =============== ================================================================
         """
-        if hysteresis < 1.0: 
+        if hysteresis < 1.0:
             hysteresis = 1.0
-        self.opts['dynamicRangeHyst']  = hysteresis
+        self.opts['dynamicRangeHyst'] = hysteresis
 
         if limit == self.opts['dynamicRangeLimit']:
-            return # avoid update if there is no change
-        self.opts['dynamicRangeLimit'] = limit # can be None
+            return  # avoid update if there is no change
+        self.opts['dynamicRangeLimit'] = limit  # can be None
         self._datasetDisplay = None  # invalidate display data
 
         self.updateItems(styleUpdate=False)
-        
+
     def setSkipFiniteCheck(self, skipFiniteCheck):
         """
         When it is known that the plot data passed to ``PlotDataItem`` contains only finite numerical values,
-        the ``skipFiniteCheck`` property can help speed up plotting. If this flag is set and the data contains 
+        the ``skipFiniteCheck`` property can help speed up plotting. If this flag is set and the data contains
         any non-finite values (such as `NaN` or `Inf`), unpredictable behavior will occur. The data might not
         be plotted, or there migth be significant performance impact.
-        
+
         In the default 'auto' connect mode, ``PlotDataItem`` will apply this setting automatically.
         """
-        self.opts['skipFiniteCheck']  = bool(skipFiniteCheck)
+        self.opts['skipFiniteCheck'] = bool(skipFiniteCheck)
 
     def setData(self, *args, **kargs):
         """
         Clear any data displayed by this item and display new data.
         See :func:`__init__() <pyqtgraph.PlotDataItem.__init__>` for details; it accepts the same arguments.
         """
-        #self.clear()
+        # self.clear()
         if kargs.get("stepMode", None) is True:
             warnings.warn(
                 'stepMode=True is deprecated and will result in an error after October 2022. Use stepMode="center" instead.',
@@ -689,7 +695,7 @@ class PlotDataItem(GraphicsObject):
                 'The decimate keyword has been deprecated. It has no effect and may result in an error in releases after October 2022. ',
                 DeprecationWarning, stacklevel=2
             )
-        
+
         if 'identical' in kargs.keys():
             warnings.warn(
                 'The identical keyword has been deprecated. It has no effect may result in an error in releases after October 2022. ',
@@ -706,18 +712,18 @@ class PlotDataItem(GraphicsObject):
             elif dt == 'listOfValues':
                 y = np.array(data)
             elif dt == 'Nx2array':
-                x = data[:,0]
-                y = data[:,1]
+                x = data[:, 0]
+                y = data[:, 1]
             elif dt == 'recarray' or dt == 'dictOfLists':
                 if 'x' in data:
                     x = np.array(data['x'])
                 if 'y' in data:
                     y = np.array(data['y'])
-            elif dt ==  'listOfDicts':
+            elif dt == 'listOfDicts':
                 if 'x' in data[0]:
-                    x = np.array([d.get('x',None) for d in data])
+                    x = np.array([d.get('x', None) for d in data])
                 if 'y' in data[0]:
-                    y = np.array([d.get('y',None) for d in data])
+                    y = np.array([d.get('y', None) for d in data])
                 for k in ['data', 'symbolSize', 'symbolPen', 'symbolBrush', 'symbolShape']:
                     if k in data:
                         kargs[k] = [d.get(k, None) for d in data]
@@ -731,9 +737,11 @@ class PlotDataItem(GraphicsObject):
             seq = ('listOfValues', 'MetaArray', 'empty')
             dtyp = dataType(args[0]), dataType(args[1])
             if dtyp[0] not in seq or dtyp[1] not in seq:
-                raise Exception('When passing two unnamed arguments, both must be a list or array of values. (got %s, %s)' % (str(type(args[0])), str(type(args[1]))))
+                raise Exception(
+                    'When passing two unnamed arguments, both must be a list or array of values. (got %s, %s)' % (
+                    str(type(args[0])), str(type(args[1]))))
             if not isinstance(args[0], np.ndarray):
-                #x = np.array(args[0])
+                # x = np.array(args[0])
                 if dtyp[0] == 'MetaArray':
                     x = args[0].asarray()
                 else:
@@ -741,7 +749,7 @@ class PlotDataItem(GraphicsObject):
             else:
                 x = args[0].view(np.ndarray)
             if not isinstance(args[1], np.ndarray):
-                #y = np.array(args[1])
+                # y = np.array(args[1])
                 if dtyp[1] == 'MetaArray':
                     y = args[1].asarray()
                 else:
@@ -769,13 +777,13 @@ class PlotDataItem(GraphicsObject):
         if 'connect' in kargs:
             self.opts['connect'] = kargs['connect']
             self.setProperty('styleWasChanged', True)
-            
+
         if 'skipFiniteCheck' in kargs:
             self.opts['skipFiniteCheck'] = kargs['skipFiniteCheck']
 
         ## if symbol pen/brush are given with no previously set symbol, then assume symbol is 'o'
         if 'symbol' not in kargs and ('symbolPen' in kargs or 'symbolBrush' in kargs or 'symbolSize' in kargs):
-            if self.opts['symbol'] is None: 
+            if self.opts['symbol'] is None:
                 kargs['symbol'] = 'o'
 
         if 'brush' in kargs:
@@ -785,30 +793,30 @@ class PlotDataItem(GraphicsObject):
             if k in kargs:
                 self.opts[k] = kargs[k]
                 self.setProperty('styleWasChanged', True)
-        #curveArgs = {}
-        #for k in ['pen', 'shadowPen', 'fillLevel', 'brush']:
-            #if k in kargs:
-                #self.opts[k] = kargs[k]
-            #curveArgs[k] = self.opts[k]
+        # curveArgs = {}
+        # for k in ['pen', 'shadowPen', 'fillLevel', 'brush']:
+        # if k in kargs:
+        # self.opts[k] = kargs[k]
+        # curveArgs[k] = self.opts[k]
 
-        #scatterArgs = {}
-        #for k,v in [('symbolPen','pen'), ('symbolBrush','brush'), ('symbol','symbol')]:
-            #if k in kargs:
-                #self.opts[k] = kargs[k]
-            #scatterArgs[v] = self.opts[k]
+        # scatterArgs = {}
+        # for k,v in [('symbolPen','pen'), ('symbolBrush','brush'), ('symbol','symbol')]:
+        # if k in kargs:
+        # self.opts[k] = kargs[k]
+        # scatterArgs[v] = self.opts[k]
 
-        if y is None or len(y) == 0: # empty data is represented as None
+        if y is None or len(y) == 0:  # empty data is represented as None
             yData = None
-        else: # actual data is represented by ndarray
+        else:  # actual data is represented by ndarray
             if not isinstance(y, np.ndarray):
                 y = np.array(y)
             yData = y.view(np.ndarray)
             if x is None:
                 x = np.arange(len(y))
-                
-        if x is None or len(x)==0: # empty data is represented as None
+
+        if x is None or len(x) == 0:  # empty data is represented as None
             xData = None
-        else: # actual data is represented by ndarray
+        else:  # actual data is represented by ndarray
             if not isinstance(x, np.ndarray):
                 x = np.array(x)
             xData = x.view(np.ndarray)  # one last check to make sure there are no MetaArrays getting by
@@ -816,14 +824,14 @@ class PlotDataItem(GraphicsObject):
         if xData is None or yData is None:
             self._dataset = None
         else:
-            self._dataset = PlotDataset( xData, yData )
-        self._datasetMapped  = None  # invalidata mapped data , will be generated in getData() / getDisplayDataset()
+            self._dataset = PlotDataset(xData, yData)
+        self._datasetMapped = None  # invalidata mapped data , will be generated in getData() / getDisplayDataset()
         self._datasetDisplay = None  # invalidate display data, will be generated in getData() / getDisplayDataset()
 
         profiler('set data')
 
-        self.updateItems( styleUpdate = self.property('styleWasChanged') )
-        self.setProperty('styleWasChanged', False) # items have been updated
+        self.updateItems(styleUpdate=self.property('styleWasChanged'))
+        self.setProperty('styleWasChanged', False)  # items have been updated
         profiler('update items')
 
         self.informViewBoundsChanged()
@@ -835,16 +843,16 @@ class PlotDataItem(GraphicsObject):
         # override styleUpdate request and always enforce update until we have a better solution for
         # - ScatterPlotItem losing per-point style information
         # - PlotDataItem performing multiple unnecessary setData calls on initialization
-        styleUpdate=True
-        
+        styleUpdate = True
+
         curveArgs = {}
         scatterArgs = {}
 
-        if styleUpdate: # repeat style arguments only when changed
+        if styleUpdate:  # repeat style arguments only when changed
             for k, v in [
-                ('pen','pen'),
-                ('shadowPen','shadowPen'),
-                ('fillLevel','fillLevel'),
+                ('pen', 'pen'),
+                ('shadowPen', 'shadowPen'),
+                ('fillLevel', 'fillLevel'),
                 ('fillOutline', 'fillOutline'),
                 ('fillBrush', 'brush'),
                 ('antialias', 'antialias'),
@@ -856,9 +864,9 @@ class PlotDataItem(GraphicsObject):
                     curveArgs[v] = self.opts[k]
 
             for k, v in [
-                ('symbolPen','pen'),
-                ('symbolBrush','brush'),
-                ('symbol','symbol'),
+                ('symbolPen', 'pen'),
+                ('symbolBrush', 'brush'),
+                ('symbol', 'symbol'),
                 ('symbolSize', 'size'),
                 ('data', 'data'),
                 ('pxMode', 'pxMode'),
@@ -868,60 +876,61 @@ class PlotDataItem(GraphicsObject):
                     scatterArgs[v] = self.opts[k]
 
         dataset = self.getDisplayDataset()
-        if dataset is None: # then we have nothing to show
+        if dataset is None:  # then we have nothing to show
             self.curve.hide()
             self.scatter.hide()
             return
 
         x = dataset.x
         y = dataset.y
-        #scatterArgs['mask'] = self.dataMask
-        if(
-            self.opts['pen'] is not None 
-            or (self.opts['fillBrush'] is not None and self.opts['fillLevel'] is not None)
-            ): # draw if visible...
+        # scatterArgs['mask'] = self.dataMask
+        if (
+                self.opts['pen'] is not None
+                or (self.opts['fillBrush'] is not None and self.opts['fillLevel'] is not None)
+        ):  # draw if visible...
             # auto-switch to indicate non-finite values as interruptions in the curve:
-            if isinstance(curveArgs['connect'], str) and curveArgs['connect'] == 'auto': # connect can also take a boolean array
+            if isinstance(curveArgs['connect'], str) and curveArgs[
+                'connect'] == 'auto':  # connect can also take a boolean array
                 if dataset.containsNonfinite is None:
-                    curveArgs['connect'] = 'all' # this is faster, but silently connects the curve across any non-finite values
+                    curveArgs[
+                        'connect'] = 'all'  # this is faster, but silently connects the curve across any non-finite values
                 else:
                     if dataset.containsNonfinite:
                         curveArgs['connect'] = 'finite'
                     else:
-                        curveArgs['connect'] = 'all' # all points can be connected, and no further check is needed.
+                        curveArgs['connect'] = 'all'  # all points can be connected, and no further check is needed.
                         curveArgs['skipFiniteCheck'] = True
             self.curve.setData(x=x, y=y, **curveArgs)
             self.curve.show()
-        else: # ...hide if not.
+        else:  # ...hide if not.
             self.curve.hide()
 
-        if self.opts['symbol'] is not None: # draw if visible...
+        if self.opts['symbol'] is not None:  # draw if visible...
             ## check against `True` too for backwards compatibility
             if self.opts.get('stepMode', False) in ("center", True):
-                x = 0.5 * (x[:-1] + x[1:])                
+                x = 0.5 * (x[:-1] + x[1:])
             self.scatter.setData(x=x, y=y, **scatterArgs)
             self.scatter.show()
-        else: # ...hide if not.
+        else:  # ...hide if not.
             self.scatter.hide()
-
 
     def getDisplayDataset(self):
         """
-        Returns a :class:`PlotDataset <pyqtgraph.PlotDataset>` object that contains data suitable for display 
+        Returns a :class:`PlotDataset <pyqtgraph.PlotDataset>` object that contains data suitable for display
         (after mapping and data reduction) as ``dataset.x`` and ``dataset.y``.
         Intended for internal use.
         """
         if self._dataset is None:
             return None
         # Return cached processed dataset if available and still valid:
-        if( self._datasetDisplay is not None and
-            not (self.property('xViewRangeWasChanged') and self.opts['clipToView']) and
-            not (self.property('xViewRangeWasChanged') and self.opts['autoDownsample']) and
-            not (self.property('yViewRangeWasChanged') and self.opts['dynamicRangeLimit'] is not None)
+        if (self._datasetDisplay is not None and
+                not (self.property('xViewRangeWasChanged') and self.opts['clipToView']) and
+                not (self.property('xViewRangeWasChanged') and self.opts['autoDownsample']) and
+                not (self.property('yViewRangeWasChanged') and self.opts['dynamicRangeLimit'] is not None)
         ):
             return self._datasetDisplay
-        
-        # Apply data mapping functions if mapped dataset is not yet available: 
+
+        # Apply data mapping functions if mapped dataset is not yet available:
         if self._datasetMapped is None:
             x = self._dataset.x
             y = self._dataset.y
@@ -931,27 +940,24 @@ class PlotDataItem(GraphicsObject):
                 x = x.astype(np.uint8)
 
             if self.opts['fftMode']:
-                x,y = self._fourierTransform(x, y)
+                x, y = self._fourierTransform(x, y)
                 # Ignore the first bin for fft data if we have a logx scale
                 if self.opts['logMode'][0]:
-                    x=x[1:]
-                    y=y[1:]
+                    x = x[1:]
+                    y = y[1:]
 
             if self.opts['derivativeMode']:  # plot dV/dt
-                y = np.diff(self._dataset.y)/np.diff(self._dataset.x)
+                y = np.diff(self._dataset.y) / np.diff(self._dataset.x)
                 x = x[:-1]
             if self.opts['phasemapMode']:  # plot dV/dt vs V
                 x = self._dataset.y[:-1]
-                y = np.diff(self._dataset.y)/np.diff(self._dataset.x)
+                y = np.diff(self._dataset.y) / np.diff(self._dataset.x)
 
-            dataset = PlotDataset(x,y)
+            dataset = PlotDataset(x, y)
             dataset.containsNonfinite = self._dataset.containsNonfinite
-            
-            if True in self.opts['logMode']:
-                dataset.applyLogMapping( self.opts['logMode'] ) # Apply log scaling for x and/or y axis
 
             self._datasetMapped = dataset
-        
+
         # apply processing that affects the on-screen display of data:
         x = self._datasetMapped.x
         y = self._datasetMapped.y
@@ -961,7 +967,7 @@ class PlotDataItem(GraphicsObject):
         if view is None:
             view_range = None
         else:
-            view_range = view.viewRect() # this is always up-to-date
+            view_range = view.viewRect()  # this is always up-to-date
         if view_range is None:
             view_range = self.viewRect()
 
@@ -972,18 +978,18 @@ class PlotDataItem(GraphicsObject):
         if self.opts['autoDownsample']:
             # this option presumes that x-values have uniform spacing
             if view_range is not None and len(x) > 1:
-                dx = float(x[-1]-x[0]) / (len(x)-1)
+                dx = float(x[-1] - x[0]) / (len(x) - 1)
                 if dx != 0.0:
-                    x0 = (view_range.left()-x[0]) / dx
-                    x1 = (view_range.right()-x[0]) / dx
+                    x0 = (view_range.left() - x[0]) / dx
+                    x1 = (view_range.right() - x[0]) / dx
                     width = self.getViewBox().width()
                     if width != 0.0:
-                        ds = int(max(1, int((x1-x0) / (width*self.opts['autoDownsampleFactor']))))
+                        ds = int(max(1, int((x1 - x0) / (width * self.opts['autoDownsampleFactor']))))
                     ## downsampling is expensive; delay until after clipping.
 
         if self.opts['clipToView']:
             if view is None or view.autoRangeEnabled()[0]:
-                pass # no ViewBox to clip to, or view will autoscale to data range.
+                pass  # no ViewBox to clip to, or view will autoscale to data range.
             else:
                 # clip-to-view always presumes that x-values are in increasing order
                 if view_range is not None and len(x) > 1:
@@ -991,7 +997,7 @@ class PlotDataItem(GraphicsObject):
                     # since we want the curve to go to the edge of the screen, we need to preserve
                     # one down-sampled point on the left and one of the right, so we extend the interval
                     x0 = np.searchsorted(x, view_range.left()) - ds
-                    x0 = fn.clip_scalar(x0, 0, len(x)) # workaround
+                    x0 = fn.clip_scalar(x0, 0, len(x))  # workaround
                     # x0 = np.clip(x0, 0, len(x))
 
                     x1 = np.searchsorted(x, view_range.right()) + ds
@@ -1006,20 +1012,20 @@ class PlotDataItem(GraphicsObject):
                 y = y[::ds]
             elif self.opts['downsampleMethod'] == 'mean':
                 n = len(x) // ds
-                stx = ds//2 # start of x-values; try to select a somewhat centered point
-                x = x[stx:stx+n*ds:ds] 
-                y = y[:n*ds].reshape(n,ds).mean(axis=1)
+                stx = ds // 2  # start of x-values; try to select a somewhat centered point
+                x = x[stx:stx + n * ds:ds]
+                y = y[:n * ds].reshape(n, ds).mean(axis=1)
             elif self.opts['downsampleMethod'] == 'peak':
                 n = len(x) // ds
-                x1 = np.empty((n,2))
-                stx = ds//2 # start of x-values; try to select a somewhat centered point
-                x1[:] = x[stx:stx+n*ds:ds,np.newaxis]
-                x = x1.reshape(n*2)
-                y1 = np.empty((n,2))
-                y2 = y[:n*ds].reshape((n, ds))
-                y1[:,0] = y2.max(axis=1)
-                y1[:,1] = y2.min(axis=1)
-                y = y1.reshape(n*2)
+                x1 = np.empty((n, 2))
+                stx = ds // 2  # start of x-values; try to select a somewhat centered point
+                x1[:] = x[stx:stx + n * ds:ds, np.newaxis]
+                x = x1.reshape(n * 2)
+                y1 = np.empty((n, 2))
+                y2 = y[:n * ds].reshape((n, ds))
+                y1[:, 0] = y2.max(axis=1)
+                y1[:, 1] = y2.min(axis=1)
+                y = y1.reshape(n * 2)
 
         if self.opts['dynamicRangeLimit'] is not None:
             if view_range is not None:
@@ -1027,36 +1033,40 @@ class PlotDataItem(GraphicsObject):
                 if data_range is not None:
                     view_height = view_range.height()
                     limit = self.opts['dynamicRangeLimit']
-                    hyst  = self.opts['dynamicRangeHyst']
+                    hyst = self.opts['dynamicRangeHyst']
                     # never clip data if it fits into +/- (extended) limit * view height
-                    if ( # note that "bottom" is the larger number, and "top" is the smaller one.
-                        view_height > 0                                # never clip if the view does not show anything and would cause division by zero
-                        and not data_range.bottom() < view_range.top() # never clip if all data is too small to see
-                        and not data_range.top() > view_range.bottom() # never clip if all data is too large to see
-                        and data_range.height() > 2 * hyst * limit * view_height
+                    if (  # note that "bottom" is the larger number, and "top" is the smaller one.
+                            view_height > 0  # never clip if the view does not show anything and would cause division by zero
+                            and not data_range.bottom() < view_range.top()  # never clip if all data is too small to see
+                            and not data_range.top() > view_range.bottom()  # never clip if all data is too large to see
+                            and data_range.height() > 2 * hyst * limit * view_height
                     ):
                         cache_is_good = False
                         # check if cached display data can be reused:
-                        if self._datasetDisplay is not None: # top is minimum value, bottom is maximum value
+                        if self._datasetDisplay is not None:  # top is minimum value, bottom is maximum value
                             # how many multiples of the current view height does the clipped plot extend to the top and bottom?
-                            top_exc =-(self._drlLastClip[0]-view_range.bottom()) / view_height
-                            bot_exc = (self._drlLastClip[1]-view_range.top()   ) / view_height
+                            top_exc = -(self._drlLastClip[0] - view_range.bottom()) / view_height
+                            bot_exc = (self._drlLastClip[1] - view_range.top()) / view_height
                             # print(top_exc, bot_exc, hyst)
-                            if (    top_exc >= limit / hyst and top_exc <= limit * hyst
-                                and bot_exc >= limit / hyst and bot_exc <= limit * hyst ):
+                            if (top_exc >= limit / hyst and top_exc <= limit * hyst
+                                    and bot_exc >= limit / hyst and bot_exc <= limit * hyst):
                                 # restore cached values
                                 x = self._datasetDisplay.x
                                 y = self._datasetDisplay.y
                                 cache_is_good = True
                         if not cache_is_good:
                             min_val = view_range.bottom() - limit * view_height
-                            max_val = view_range.top()    + limit * view_height
+                            max_val = view_range.top() + limit * view_height
                             # print('alloc:', end='')
                             # workaround for slowdown from numpy deprecation issues in 1.17 to 1.20+ :
                             # y = np.clip(y, a_min=min_val, a_max=max_val)
                             y = fn.clip_array(y, min_val, max_val)
                             self._drlLastClip = (min_val, max_val)
-        self._datasetDisplay = PlotDataset( x,y )
+        self._datasetDisplay = PlotDataset(x, y)
+
+        if True in self.opts['logMode']:
+            self._datasetDisplay.applyLogMapping(self.opts['logMode'])  # Apply log scaling for x and/or y axis
+
         self._datasetDisplay.containsNonfinite = containsNonfinite
         self.setProperty('xViewRangeWasChanged', False)
         self.setProperty('yViewRangeWasChanged', False)
@@ -1065,9 +1075,9 @@ class PlotDataItem(GraphicsObject):
 
     def getData(self):
         """
-        Returns the displayed data as the tuple (`xData`, `yData`) after mapping and data reduction.         
+        Returns the displayed data as the tuple (`xData`, `yData`) after mapping and data reduction.
         """
-        dataset = self.getDisplayDataset()
+        dataset = self._datasetMapped
         if dataset is None:
             return (None, None)
         return dataset.x, dataset.y
@@ -1109,7 +1119,7 @@ class PlotDataItem(GraphicsObject):
             range = [
                 r2[0] if range[0] is None else (range[0] if r2[0] is None else min(r2[0], range[0])),
                 r2[1] if range[1] is None else (range[1] if r2[1] is None else min(r2[1], range[1]))
-                ]
+            ]
         return range
 
     def pixelPadding(self):
@@ -1125,8 +1135,8 @@ class PlotDataItem(GraphicsObject):
         return pad
 
     def clear(self):
-        self._dataset        = None
-        self._datasetMapped  = None
+        self._dataset = None
+        self._datasetMapped = None
         self._datasetDisplay = None
         self.curve.clear()
         self.scatter.clear()
@@ -1150,16 +1160,16 @@ class PlotDataItem(GraphicsObject):
     # has already been invalidated. However, responding here will make PlotDataItem
     # update curve and scatter later than intended.
     #   super().viewTransformChanged() # this invalidates the viewRect() cache!
-        
+
     def viewRangeChanged(self, vb=None, ranges=None, changed=None):
-        # view range has changed; re-plot if needed 
+        # view range has changed; re-plot if needed
         update_needed = False
-        if changed is None or changed[0]: 
+        if changed is None or changed[0]:
             # if ranges is not None:
             #     print('hor:', ranges[0])
             self.setProperty('xViewRangeWasChanged', True)
-            if( self.opts['clipToView']
-                or self.opts['autoDownsample']
+            if (self.opts['clipToView']
+                    or self.opts['autoDownsample']
             ):
                 self._datasetDisplay = None
                 update_needed = True
@@ -1177,18 +1187,19 @@ class PlotDataItem(GraphicsObject):
         ## Perform Fourier transform. If x values are not sampled uniformly,
         ## then use np.interp to resample before taking fft.
         dx = np.diff(x)
-        uniform = not np.any(np.abs(dx-dx[0]) > (abs(dx[0]) / 1000.))
+        uniform = not np.any(np.abs(dx - dx[0]) > (abs(dx[0]) / 1000.))
         if not uniform:
             x2 = np.linspace(x[0], x[-1], len(x))
             y = np.interp(x2, x, y)
             x = x2
         n = y.size
         f = np.fft.rfft(y) / n
-        d = float(x[-1]-x[0]) / (len(x)-1)
+        d = float(x[-1] - x[0]) / (len(x) - 1)
         x = np.fft.rfftfreq(n, d)
         y = np.abs(f)
         return x, y
-        
+
+
 # helper functions:
 def dataType(obj):
     if hasattr(obj, '__len__') and len(obj) == 0:
@@ -1217,4 +1228,5 @@ def dataType(obj):
 
 
 def isSequence(obj):
-    return hasattr(obj, '__iter__') or isinstance(obj, np.ndarray) or (hasattr(obj, 'implements') and obj.implements('MetaArray'))
+    return hasattr(obj, '__iter__') or isinstance(obj, np.ndarray) or (
+                hasattr(obj, 'implements') and obj.implements('MetaArray'))


### PR DESCRIPTION
My next try to export the actual data plotted in log mode.

I believe that the log mode is something of displaying, not of the actual data. So, I moved the `applyLogMapping` function call down to `self._datasetDisplay`.

Next, I return the data saved into `self._datasetMapped` in `PlotDataItem.getData` function. It's a kind of expected behavior when it comes to returning the data, not the position of screen points.

I realize that it better be two tiny commits.