### PR TITLE
implementing SpinBox prefix

### DIFF
--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -149,7 +149,7 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
                        
                          * *value* - the unscaled value of the spin box
                          * *prefix* - the prefix string
-                         * *prefixGap* - a single space if a suffix is present, or an empty
+                         * *prefixGap* - a single space if a prefix is present, or an empty
                            string otherwise
                          * *suffix* - the suffix string
                          * *scaledValue* - the scaled value to use when an SI prefix is present

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -78,6 +78,7 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
             'int': False, ## Set True to force value to be integer
             'finite': True,
             
+            'prefix': '', ## string to be prepended to spin box value
             'suffix': '',
             'siPrefix': False,   ## Set to True to display numbers with SI prefix (ie, 100pA instead of 1e-10A)
             
@@ -87,7 +88,7 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
             
             'decimals': 6,
             
-            'format': "{scaledValue:.{decimals}g}{suffixGap}{siPrefix}{suffix}",
+            'format': "{prefix}{scaledValue:.{decimals}g}{suffixGap}{siPrefix}{suffix}",
             'regex': fn.FLOAT_REGEX,
             'evalFunc': decimal.Decimal,
             
@@ -124,6 +125,7 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
                        the value represents a dimensionless quantity that might span many
                        orders of magnitude, such as a Reynolds number, an SI
                        prefix is allowed with no suffix. Default is False.
+        prefix         (str) String to be prepended to the spin box value. Default is an empty string.
         step           (float) The size of a single step. This is used when clicking the up/
                        down arrows, when rolling the mouse wheel, or when pressing 
                        keyboard arrows while the widget has keyboard focus. Note that
@@ -450,6 +452,7 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
         # get the number of decimal places to print
         decimals = self.opts['decimals']
         suffix = self.opts['suffix']
+        prefix = self.opts['prefix']
 
         # format the string 
         val = self.value()
@@ -461,11 +464,11 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
                 (s, p) = fn.siScale(prev)
             else:
                 (s, p) = fn.siScale(val)
-            parts = {'value': val, 'suffix': suffix, 'decimals': decimals, 'siPrefix': p, 'scaledValue': s*val}
+            parts = {'value': val, 'suffix': suffix, 'decimals': decimals, 'siPrefix': p, 'scaledValue': s*val, 'prefix':prefix}
 
         else:
             # no SI prefix /suffix requested; scale is 1
-            parts = {'value': val, 'suffix': suffix, 'decimals': decimals, 'siPrefix': '', 'scaledValue': val}
+            parts = {'value': val, 'suffix': suffix, 'decimals': decimals, 'siPrefix': '', 'scaledValue': val, 'prefix':prefix}
 
         parts['suffixGap'] = '' if (parts['suffix'] == '' and parts['siPrefix'] == '') else ' '
         
@@ -524,6 +527,11 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
     def interpret(self):
         """Return value of text or False if text is invalid."""
         strn = self.lineEdit().text()
+        # strip prefix
+        try:
+            strn = strn.removeprefix(self.opts['prefix'])
+        except AttributeError:
+            strn = strn[len(self.opts['prefix']):]
         
         # tokenize into numerical value, si prefix, and suffix
         try:

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -88,7 +88,7 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
             
             'decimals': 6,
             
-            'format': "{prefix}{scaledValue:.{decimals}g}{suffixGap}{siPrefix}{suffix}",
+            'format': "{prefix}{prefixGap}{scaledValue:.{decimals}g}{suffixGap}{siPrefix}{suffix}",
             'regex': fn.FLOAT_REGEX,
             'evalFunc': decimal.Decimal,
             
@@ -148,6 +148,9 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
                        done with ``str.format()`` and makes use of several arguments:
                        
                          * *value* - the unscaled value of the spin box
+                         * *prefix* - the prefix string
+                         * *prefixGap* - a single space if a suffix is present, or an empty
+                           string otherwise
                          * *suffix* - the suffix string
                          * *scaledValue* - the scaled value to use when an SI prefix is present
                          * *siPrefix* - the SI prefix string (if any), or an empty string if
@@ -219,7 +222,7 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
                 self.opts['minStep'] = ms
 
             if 'format' not in opts:
-                self.opts['format'] = "{value:d}{suffixGap}{suffix}"
+                self.opts['format'] = "{prefix}{prefixGap}{value:d}{suffixGap}{suffix}"
 
         if self.opts['dec']:
             if self.opts.get('minStep') is None:
@@ -470,6 +473,7 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
             # no SI prefix /suffix requested; scale is 1
             parts = {'value': val, 'suffix': suffix, 'decimals': decimals, 'siPrefix': '', 'scaledValue': val, 'prefix':prefix}
 
+        parts['prefixGap'] = '' if parts['prefix'] == '' else ' '
         parts['suffixGap'] = '' if (parts['suffix'] == '' and parts['siPrefix'] == '') else ' '
         
         return self.opts['format'].format(**parts)

--- a/tests/widgets/test_spinbox.py
+++ b/tests/widgets/test_spinbox.py
@@ -24,6 +24,7 @@ def test_SpinBox_defaults():
     (1.45e-3, '1.45 mPSI', dict(int=False, decimals=6, suffix='PSI', siPrefix=True)),
     (-2500.3427, '$-2500.34', dict(int=False, format='${value:0.02f}')),
     (1000, '1 k', dict(siPrefix=True, suffix="")),
+    (1.45e-9, 'i = 1.45e-09 A', dict(int=False, decimals=6, suffix='A', siPrefix=False, prefix='i =')),
 ])
 def test_SpinBox_formatting(value, expected_text, opts):
     sb = pg.SpinBox(**opts)
@@ -31,7 +32,6 @@ def test_SpinBox_formatting(value, expected_text, opts):
 
     assert sb.value() == value
     assert sb.text() == expected_text
-
 
 @pytest.mark.parametrize("suffix", ["", "V"])
 def test_SpinBox_gui_set_value(suffix):


### PR DESCRIPTION
Although SpinBox has a `setPrefix` method, displaying the contents with a prefix wasn't implemented.

These changes include 'prefix' in `opts` and add it to the 'format' string (and remove it when validating).