### PR TITLE
Add an option to makeARGB to disable masking NaNs

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1353,7 +1353,7 @@ def makeRGBA(*args, **kwds):
     return makeARGB(*args, **kwds)
 
 
-def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False, output=None):
+def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False, maskNans=True, output=None):
     """
     Convert an array of values into an ARGB array suitable for building QImages,
     OpenGL textures, etc.
@@ -1391,6 +1391,7 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False, output=None
                    The default is False, which returns in ARGB order for use with QImage 
                    (Note that 'ARGB' is a term used by the Qt documentation; the *actual* order 
                    is BGRA).
+    maskNans       Enable or disable masking NaNs as transparent.
     ============== ==================================================================================
     """
     cp = getCupy()
@@ -1446,7 +1447,7 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False, output=None
 
     # awkward, but fastest numpy native nan evaluation
     nanMask = None
-    if data.dtype.kind == 'f' and xp.isnan(data.min()):
+    if maskNans and data.dtype.kind == 'f' and xp.isnan(data.min()):
         nanMask = xp.isnan(data)
         if data.ndim > 2:
             nanMask = xp.any(nanMask, axis=-1)

--- a/tests/test_makeARGB.py
+++ b/tests/test_makeARGB.py
@@ -4488,6 +4488,10 @@ def test_makeARGB_with_human_readable_code():
     assert im2[3, 5, 3] == 0  # nan pixel is transparent
     assert im2[0, 0, 3] == 255  # doesn't affect other pixels
 
+    # With masking nans disabled, the nan pixel shouldn't be transparent
+    im2, alpha = _makeARGB(im1, levels=(0, 1), maskNans=False)
+    assert im2[3, 5, 3] == 255
+
     # 3d RGB input image, any color channel of a pixel is nan
     im1 = np.ones((10, 12, 3))
     im1[3, 5, 1] = np.nan


### PR DESCRIPTION
Sometimes it's useful for NaNs not to be masked by transparent pixels.

(originally written by @cammilleCC)