### PR TITLE
improve GraphicsWidget paint speed by caching the bounding rect and the path used by the shape method

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsWidget.py
+++ b/pyqtgraph/graphicsItems/GraphicsWidget.py
@@ -18,6 +18,7 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
 
         # cache bouding rect and geometry
         self._br = self._geometry = None
+        self._path = None
         
         ## done by GraphicsItem init
         #GraphicsScene.registerObject(self)  ## workaround for pyqt bug in graphicsscene.items()
@@ -50,6 +51,8 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
     def boundingRect(self):
         geometry = self.geometry()
         if geometry != self._geometry:
+            self._path = None
+            
             br = self.mapRectFromParent(geometry).normalized()
             self._br = br
             self._geometry = geometry
@@ -58,9 +61,13 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
 
         #print "bounds:", br
         return br
-        
+
     def shape(self):  ## No idea why this is necessary, but rotated items do not receive clicks otherwise.
-        p = QtGui.QPainterPath()
-        p.addRect(self.boundingRect())
-        #print "shape:", p.boundingRect()
+        p = self._path
+        if p is None:
+            p = QtGui.QPainterPath()
+            p.addRect(self.boundingRect())
+            self._path = p
+
+        # print "shape:", p.boundingRect()
         return p

--- a/pyqtgraph/graphicsItems/GraphicsWidget.py
+++ b/pyqtgraph/graphicsItems/GraphicsWidget.py
@@ -65,9 +65,7 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
     def shape(self):  ## No idea why this is necessary, but rotated items do not receive clicks otherwise.
         p = self._path
         if p is None:
-            p = QtGui.QPainterPath()
+            self._path = p = QtGui.QPainterPath()
             p.addRect(self.boundingRect())
-            self._path = p
 
-        # print "shape:", p.boundingRect()
         return p

--- a/pyqtgraph/graphicsItems/GraphicsWidget.py
+++ b/pyqtgraph/graphicsItems/GraphicsWidget.py
@@ -15,6 +15,9 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
         """
         QtWidgets.QGraphicsWidget.__init__(self, *args, **kargs)
         GraphicsItem.__init__(self)
+
+        # cache bouding rect and geometry
+        self._br = self._geometry = None
         
         ## done by GraphicsItem init
         #GraphicsScene.registerObject(self)  ## workaround for pyqt bug in graphicsscene.items()
@@ -45,7 +48,14 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
         return self.geometry().width()
 
     def boundingRect(self):
-        br = self.mapRectFromParent(self.geometry()).normalized()
+        geometry = self.geometry()
+        if geometry != self._geometry:
+            br = self.mapRectFromParent().normalized()
+            self._br = br
+            self._geometry = geometry
+        else:
+            br = self._br
+
         #print "bounds:", br
         return br
         

--- a/pyqtgraph/graphicsItems/GraphicsWidget.py
+++ b/pyqtgraph/graphicsItems/GraphicsWidget.py
@@ -17,8 +17,8 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
         GraphicsItem.__init__(self)
 
         # cache bouding rect and geometry
-        self._br = self._geometry = None
-        self._path = None
+        self._boundingRectCache = self._previousGeometry = None
+        self._painterPathCache = None
         
         ## done by GraphicsItem init
         #GraphicsScene.registerObject(self)  ## workaround for pyqt bug in graphicsscene.items()
@@ -50,22 +50,21 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
 
     def boundingRect(self):
         geometry = self.geometry()
-        if geometry != self._geometry:
-            self._path = None
+        if geometry != self._previousGeometry:
+            self._painterPathCache = None
             
             br = self.mapRectFromParent(geometry).normalized()
-            self._br = br
-            self._geometry = geometry
+            self._boundingRectCache = br
+            self._previousGeometry = geometry
         else:
-            br = self._br
+            br = self._boundingRectCache
 
-        #print "bounds:", br
         return br
 
     def shape(self):  ## No idea why this is necessary, but rotated items do not receive clicks otherwise.
-        p = self._path
+        p = self._painterPathCache
         if p is None:
-            self._path = p = QtGui.QPainterPath()
+            self._painterPathCache = p = QtGui.QPainterPath()
             p.addRect(self.boundingRect())
 
         return p

--- a/pyqtgraph/graphicsItems/GraphicsWidget.py
+++ b/pyqtgraph/graphicsItems/GraphicsWidget.py
@@ -50,7 +50,7 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
     def boundingRect(self):
         geometry = self.geometry()
         if geometry != self._geometry:
-            br = self.mapRectFromParent().normalized()
+            br = self.mapRectFromParent(geometry).normalized()
             self._br = br
             self._geometry = geometry
         else:


### PR DESCRIPTION
By caching the bounding rect the painting is increased significantly. On a live updating plot with ~160 curves the timings show the following:

#### With this patch 0.95 us/call
![image](https://user-images.githubusercontent.com/20952040/153834091-418ab5d9-1839-4073-9435-cb3d3b1c3ccc.png)

#### Without 1.99 us/call
![image](https://user-images.githubusercontent.com/20952040/153834894-568e5453-a2fc-4c0d-86de-848fb7c17d10.png)

Overall the painting speed went from 43.5ms/frame to 39.3ms/frame 
