### PR TITLE
Have version number reflect development release

### DIFF
--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -3,7 +3,7 @@ PyQtGraph - Scientific Graphics and GUI Library for Python
 www.pyqtgraph.org
 """
 
-__version__ = '0.12.4'
+__version__ = '0.12.4.dev0'
 
 ### import all the goodies and add some helper functions for easy CLI use
 


### PR DESCRIPTION
To better reflect that the current `master` branch does not reflect a current release, we append `.dev0` to `__version__`.