### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@ setupOpts = dict(
     long_description=DESCRIPTION,
     license =  'MIT',
     url='http://www.pyqtgraph.org',
+    project_urls={
+        'Source': 'https://github.com/pyqtgraph/pyqtgraph',
+    },
     author='Luke Campagnola',
     author_email='luke.campagnola@gmail.com',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setupOpts = dict(
     license =  'MIT',
     url='http://www.pyqtgraph.org',
     project_urls={
+        'Documentation': 'https://pyqtgraph.readthedocs.io',
         'Source': 'https://github.com/pyqtgraph/pyqtgraph',
     },
     author='Luke Campagnola',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)