### PR TITLE
Remove old Qt workarounds

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -5,17 +5,10 @@ from time import perf_counter, perf_counter_ns
 from .. import debug as debug
 from .. import getConfigOption
 from ..Point import Point
-from ..Qt import QT_LIB, QtCore, QtGui, QtWidgets, isQObjectAlive
+from ..Qt import QtCore, QtGui, QtWidgets, isQObjectAlive
 from .mouseEvents import HoverEvent, MouseClickEvent, MouseDragEvent
 
 getMillis = lambda: perf_counter_ns() // 10 ** 6
-
-
-if QT_LIB.startswith('PyQt'):
-    from ..Qt import sip
-    HAVE_SIP = True
-else:
-    HAVE_SIP = False
 
 
 __all__ = ['GraphicsScene']
@@ -404,18 +397,6 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
         self.sigItemRemoved.emit(item)
         return ret
         
-    def items(self, *args):
-        items = QtWidgets.QGraphicsScene.items(self, *args)
-        return self.translateGraphicsItems(items)
-    
-    def selectedItems(self, *args):
-        items = QtWidgets.QGraphicsScene.selectedItems(self, *args)
-        return self.translateGraphicsItems(items)
-
-    def itemAt(self, *args):
-        item = QtWidgets.QGraphicsScene.itemAt(self, *args)
-        return self.translateGraphicsItem(item)
-
     def itemsNearEvent(self, event, selMode=QtCore.Qt.ItemSelectionMode.IntersectsItemShape, sortOrder=QtCore.Qt.SortOrder.DescendingOrder, hoverable=False):
         """
         Return an iterator that iterates first through the items that directly intersect point (in Z order)
@@ -478,20 +459,6 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
     def getViewWidget(self):
         return self.views()[0]
     
-    #def getViewWidget(self, widget):
-        ### same pyqt bug -- mouseEvent.widget() doesn't give us the original python object.
-        ### [[doesn't seem to work correctly]]
-        #if HAVE_SIP and isinstance(self, sip.wrapper):
-            #addr = sip.unwrapinstance(sip.cast(widget, QtWidgets.QWidget))
-            ##print "convert", widget, addr
-            #for v in self.views():
-                #addr2 = sip.unwrapinstance(sip.cast(v, QtWidgets.QWidget))
-                ##print "   check:", v, addr2
-                #if addr2 == addr:
-                    #return v
-        #else:
-            #return widget
-
     def addParentContextMenus(self, item, menu, event):
         """
         Can be called by any item in the scene to expand its context menu to include parent context menus.
@@ -557,19 +524,3 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
             from . import exportDialog
             self.exportDialog = exportDialog.ExportDialog(self)
         self.exportDialog.show(self.contextMenuItem)
-
-    @staticmethod
-    def translateGraphicsItem(item):
-        # This function is intended as a workaround for a problem with older
-        # versions of PyQt (< 4.9?), where methods returning 'QGraphicsItem *'
-        # lose the type of the QGraphicsObject subclasses and instead return
-        # generic QGraphicsItem wrappers.
-        if HAVE_SIP and isinstance(item, sip.wrapper):
-            obj = item.toGraphicsObject()
-            if obj is not None:
-                item = obj
-        return item
-
-    @staticmethod
-    def translateGraphicsItems(items):
-        return list(map(GraphicsScene.translateGraphicsItem, items))

--- a/pyqtgraph/Vector.py
+++ b/pyqtgraph/Vector.py
@@ -51,15 +51,6 @@ class Vector(QtGui.QVector3D):
     def __len__(self):
         return 3
 
-    def __add__(self, b):
-        # workaround for pyside bug. see https://bugs.launchpad.net/pyqtgraph/+bug/1223173
-        if QT_LIB == 'PySide' and isinstance(b, QtGui.QVector3D):
-            b = Vector(b)
-        return QtGui.QVector3D.__add__(self, b)
-    
-    #def __reduce__(self):
-        #return (Point, (self.x(), self.y()))
-        
     def __getitem__(self, i):
         if i == 0:
             return self.x()

--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -408,8 +408,7 @@ class GraphicsItem(object):
         return self.mapToView(self.mapFromParent(self.pos()))
     
     def parentItem(self):
-        ## PyQt bug -- some items are returned incorrectly.
-        return GraphicsScene.translateGraphicsItem(self._qtBaseClass.parentItem(self))
+        return self._qtBaseClass.parentItem(self)
         
     def setParentItem(self, parent):
         ## Workaround for Qt bug: https://bugreports.qt-project.org/browse/QTBUG-18616
@@ -420,8 +419,7 @@ class GraphicsItem(object):
         return self._qtBaseClass.setParentItem(self, parent)
     
     def childItems(self):
-        ## PyQt bug -- some child items are returned incorrectly.
-        return list(map(GraphicsScene.translateGraphicsItem, self._qtBaseClass.childItems(self)))
+        return self._qtBaseClass.childItems(self)
 
 
     def sceneTransform(self):

--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -152,10 +152,7 @@ class GraphicsItem(object):
         if view is None:
             return None
         if hasattr(view, 'implements') and view.implements('ViewBox'):
-            tr = self.itemTransform(view.innerSceneItem())
-            if isinstance(tr, tuple):
-                tr = tr[0]   ## difference between pyside and pyqt
-            return tr
+            return self.itemTransform(view.innerSceneItem())[0]
         else:
             return self.sceneTransform()
             #return self.deviceTransform(view.viewportTransform())
@@ -439,9 +436,7 @@ class GraphicsItem(object):
         if relativeItem is None:
             relativeItem = self.parentItem()
 
-        tr = self.itemTransform(relativeItem)
-        if isinstance(tr, tuple):  ## difference between pyside and pyqt
-            tr = tr[0]
+        tr = self.itemTransform(relativeItem)[0]
         vec = tr.map(QtCore.QLineF(0,0,1,0))
         return vec.angleTo(QtCore.QLineF(vec.p1(), vec.p1()+QtCore.QPointF(1,0)))
         

--- a/pyqtgraph/graphicsItems/GraphicsObject.py
+++ b/pyqtgraph/graphicsItems/GraphicsObject.py
@@ -1,7 +1,4 @@
-from ..Qt import QT_LIB, QtWidgets
-
-if QT_LIB.startswith('PyQt'):
-    from ..Qt import sip
+from ..Qt import QtWidgets
 
 from .GraphicsItem import GraphicsItem
 
@@ -38,9 +35,4 @@ class GraphicsObject(GraphicsItem, QtWidgets.QGraphicsObject):
             if inform_view_on_change and change in [self.GraphicsItemChange.ItemPositionHasChanged, self.GraphicsItemChange.ItemTransformHasChanged]:
                 self.informViewBoundsChanged()
             
-        ## workaround for pyqt bug:
-        ## http://www.riverbankcomputing.com/pipermail/pyqt/2012-August/031818.html
-        if QT_LIB == 'PyQt5' and change == self.GraphicsItemChange.ItemParentChange and isinstance(ret, QtWidgets.QGraphicsItem):
-            ret = sip.cast(ret, QtWidgets.QGraphicsItem)
-
         return ret

--- a/pyqtgraph/graphicsItems/GraphicsObject.py
+++ b/pyqtgraph/graphicsItems/GraphicsObject.py
@@ -1,4 +1,4 @@
-from ..Qt import QtWidgets
+from ..Qt import QtCore, QtWidgets, QT_LIB
 
 from .GraphicsItem import GraphicsItem
 
@@ -19,12 +19,12 @@ class GraphicsObject(GraphicsItem, QtWidgets.QGraphicsObject):
     def itemChange(self, change, value):
         ret = super().itemChange(change, value)
         if change in [self.GraphicsItemChange.ItemParentHasChanged, self.GraphicsItemChange.ItemSceneHasChanged]:
-            import types
-            if isinstance(self.parentChanged, types.MethodType):
-                self.parentChanged()
-            else:
+            if QT_LIB == 'PySide6' and QtCore.__version_info__ == (6, 2, 2):
                 # workaround PySide6 6.2.2 issue https://bugreports.qt.io/browse/PYSIDE-1730
+                # note that the bug exists also in PySide6 6.2.2.1 / Qt 6.2.2
                 getattr(self.__class__, 'parentChanged')(self)
+            else:
+                self.parentChanged()
         try:
             inform_view_on_change = self.__inform_view_on_changes
         except AttributeError:

--- a/pyqtgraph/graphicsItems/UIGraphicsItem.py
+++ b/pyqtgraph/graphicsItems/UIGraphicsItem.py
@@ -1,8 +1,5 @@
-from ..Qt import QT_LIB, QtCore, QtGui, QtWidgets
+from ..Qt import QtCore, QtGui
 from .GraphicsObject import GraphicsObject
-
-if QT_LIB.startswith('PyQt'):
-    from ..Qt import sip
 
 __all__ = ['UIGraphicsItem']
 class UIGraphicsItem(GraphicsObject):
@@ -47,11 +44,6 @@ class UIGraphicsItem(GraphicsObject):
     def itemChange(self, change, value):
         ret = GraphicsObject.itemChange(self, change, value)
             
-        ## workaround for pyqt bug:
-        ## http://www.riverbankcomputing.com/pipermail/pyqt/2012-August/031818.html
-        if QT_LIB == 'PyQt5' and change == self.GraphicsItemChange.ItemParentChange and isinstance(ret, QtWidgets.QGraphicsItem):
-            ret = sip.cast(ret, QtWidgets.QGraphicsItem)
-        
         if change == self.GraphicsItemChange.ItemScenePositionHasChanged:
             self.setNewBounds()
         return ret

--- a/pyqtgraph/multiprocess/bootstrap.py
+++ b/pyqtgraph/multiprocess/bootstrap.py
@@ -26,15 +26,6 @@ if __name__ == '__main__':
                 sys.path.pop()
             sys.path.extend(path)
 
-    pyqtapis = opts.pop('pyqtapis', None)
-    if pyqtapis is not None:
-        try:
-            from PyQt5 import sip
-        except ImportError:
-            import sip
-            for k,v in pyqtapis.items():
-                sip.setapi(k, v)
-        
     qt_lib = opts.pop('qt_lib', None)
     if qt_lib is not None:
         globals()[qt_lib] = importlib.import_module(qt_lib)

--- a/pyqtgraph/multiprocess/bootstrap.py
+++ b/pyqtgraph/multiprocess/bootstrap.py
@@ -7,12 +7,8 @@ import sys
 if __name__ == '__main__':
     if hasattr(os, 'setpgrp'):
         os.setpgrp()  ## prevents signals (notably keyboard interrupt) being forwarded from parent to this process
-    if sys.version[0] == '3':
-        #name, port, authkey, ppid, targetStr, path, pyside = pickle.load(sys.stdin.buffer)
-        opts = pickle.load(sys.stdin.buffer)
-    else:
-        #name, port, authkey, ppid, targetStr, path, pyside = pickle.load(sys.stdin)
-        opts = pickle.load(sys.stdin)
+    #name, port, authkey, ppid, targetStr, path, pyside = pickle.load(sys.stdin.buffer)
+    opts = pickle.load(sys.stdin.buffer)
     #print "key:",  ' '.join([str(ord(x)) for x in authkey])
     path = opts.pop('path', None)
     if path is not None:

--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -6,11 +6,7 @@ import signal
 import subprocess
 import sys
 import time
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from ..Qt import QT_LIB, mkQApp
 from ..util import cprint  # color printing for debugging

--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -73,8 +73,9 @@ class Process(RemoteEventHandler):
                         for a python bug: http://bugs.python.org/issue3905
                         but has the side effect that child output is significantly
                         delayed relative to the parent output.
-        pyqtapis        Optional dictionary of PyQt API version numbers to set before
-                        importing pyqtgraph in the remote process.
+        pyqtapis        Formerly optional dictionary of PyQt API version numbers to set
+                        before importing pyqtgraph in the remote process.
+                        No longer has any effect.
         ==============  =============================================================
         """
         if target is None:
@@ -156,7 +157,6 @@ class Process(RemoteEventHandler):
             path=sysPath, 
             qt_lib=QT_LIB,
             debug=procDebug,
-            pyqtapis=pyqtapis,
             )
         pickle.dump(data, self.proc.stdin)
         self.proc.stdin.close()

--- a/pyqtgraph/multiprocess/remoteproxy.py
+++ b/pyqtgraph/multiprocess/remoteproxy.py
@@ -5,15 +5,10 @@ import time
 import traceback
 import warnings
 import weakref
+import builtins
+import pickle
 
 import numpy as np
-
-try:
-    import __builtin__ as builtins
-    import cPickle as pickle
-except ImportError:
-    import builtins
-    import pickle
 
 # color printing for debugging
 from ..util import cprint

--- a/pyqtgraph/multiprocess/remoteproxy.py
+++ b/pyqtgraph/multiprocess/remoteproxy.py
@@ -78,12 +78,11 @@ class RemoteEventHandler(object):
             'returnType': 'auto',    ## 'proxy', 'value', 'auto'
             'autoProxy': False,      ## bool
             'deferGetattr': False,   ## True, False
-            'noProxyTypes': [ type(None), str, int, float, tuple, list, dict, LocalObjectProxy, ObjectProxy ],
+            'noProxyTypes': [
+                type(None), str, bytes, int, float, tuple, list, dict,
+                LocalObjectProxy, ObjectProxy,
+            ],
         }
-        if int(sys.version[0]) < 3:
-            self.proxyOptions['noProxyTypes'].append(unicode)
-        else:
-            self.proxyOptions['noProxyTypes'].append(bytes)
         
         self.optsLock = threading.RLock()
         

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -101,11 +101,6 @@ class GraphicsView(QtWidgets.QGraphicsView):
         self.sceneObj = GraphicsScene(parent=self)
         self.setScene(self.sceneObj)
         
-        ## Workaround for PySide crash
-        ## This ensures that the scene will outlive the view.
-        if QT_LIB == 'PySide':
-            self.sceneObj._view_ref_workaround = self
-        
         ## by default we set up a central widget with a grid layout.
         ## this can be replaced if needed.
         self.centralWidget = None

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -510,23 +510,12 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
         
         self.errorBox.setVisible(not self.textValid)
         
-        ## support 2 different pyqt APIs. Bleh.
-        if hasattr(QtCore, 'QString'):
-            return (ret, pos)
-        else:
-            return (ret, strn, pos)
+        return (ret, strn, pos)
         
     def fixup(self, strn):
         # fixup is called when the spinbox loses focus with an invalid or intermediate string
         self.updateText()
-
-        # support both PyQt APIs (for Python 2 and 3 respectively)
-        # http://pyqt.sourceforge.net/Docs/PyQt4/python_v3.html#qvalidator
-        try:
-            strn.clear()
-            strn.append(self.lineEdit().text())
-        except AttributeError:
-            return self.lineEdit().text()
+        return self.lineEdit().text()
 
     def interpret(self):
         """Return value of text or False if text is invalid."""

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -58,13 +58,11 @@ def test_types():
 
     # int
     types = ['int0', 'int', 'float', 'bigfloat', 'npfloat', 'npint', 'bool']
-    inttyps = int if sys.version[0] >= '3' else (int, long) 
-    check_param_types(param.child('int'), inttyps, int, 0, all_objs, types)
+    check_param_types(param.child('int'), int, int, 0, all_objs, types)
     
     # str  (should be able to make a string out of any type)
     types = all_objs.keys()
-    strtyp = str if sys.version[0] >= '3' else unicode
-    check_param_types(param.child('str'), strtyp, str, '', all_objs, types)
+    check_param_types(param.child('str'), str, str, '', all_objs, types)
     
     # bool  (should be able to make a boolean out of any type?)
     types = all_objs.keys()


### PR DESCRIPTION
Remove workarounds for old versions of Qt.
Some old Python 2 compatibility code also removed.