### PR TITLE
remove border QGraphicsRectItem from scene

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsLayout.py
+++ b/pyqtgraph/graphicsItems/GraphicsLayout.py
@@ -165,7 +165,8 @@ class GraphicsLayout(GraphicsWidget):
         del self.items[item]
 
         item.geometryChanged.disconnect(self._updateItemBorder)
-        del self.itemBorders[item]
+        itemBorder = self.itemBorders.pop(item)
+        self.scene().removeItem(itemBorder)
 
         self.update()
     


### PR DESCRIPTION
This fixes issue #2173 where the QGraphicsRectItem representing the border for the item is leaked when the item is removed.
This fix can be tested with the MWE given in #2173