### PR TITLE
Fix GLImageItem regression

### DIFF
--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -1,4 +1,5 @@
 from OpenGL.GL import *  # noqa
+import numpy as np
 from ..GLGraphicsItem import GLGraphicsItem
 
 __all__ = ['GLImageItem']
@@ -58,7 +59,8 @@ class GLImageItem(GLGraphicsItem):
         if glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_WIDTH) == 0:
             raise Exception("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % shape[:2])
         
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, shape[0], shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, self.data.transpose((1,0,2)))
+        data = np.ascontiguousarray(self.data.transpose((1,0,2)))
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, shape[0], shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, data)
         glDisable(GL_TEXTURE_2D)
         
         #self.lists = {}

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -51,14 +51,14 @@ class GLImageItem(GLGraphicsItem):
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER)
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER)
         #glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_BORDER)
-        h, w = self.data.shape[:2]
+        shape = self.data.shape
         
         ## Test texture dimensions first
-        glTexImage2D(GL_PROXY_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, None)
+        glTexImage2D(GL_PROXY_TEXTURE_2D, 0, GL_RGBA, shape[0], shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, None)
         if glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_WIDTH) == 0:
-            raise Exception("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % (h, w))
+            raise Exception("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % shape[:2])
         
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, self.data)
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, shape[0], shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, self.data.transpose((1,0,2)))
         glDisable(GL_TEXTURE_2D)
         
         #self.lists = {}
@@ -87,16 +87,15 @@ class GLImageItem(GLGraphicsItem):
         #glEnable( GL_ALPHA_TEST )
         glColor4f(1,1,1,1)
 
-        h, w = self.data.shape[:2]
         glBegin(GL_QUADS)
-        glTexCoord2f(1, 0)
-        glVertex3f(0, 0, 0)
-        glTexCoord2f(1, 1)
-        glVertex3f(h, 0, 0)
-        glTexCoord2f(0, 1)
-        glVertex3f(h, w, 0)
-        glTexCoord2f(0, 0)
-        glVertex3f(0, w, 0)
+        glTexCoord2f(0,0)
+        glVertex3f(0,0,0)
+        glTexCoord2f(1,0)
+        glVertex3f(self.data.shape[0], 0, 0)
+        glTexCoord2f(1,1)
+        glVertex3f(self.data.shape[0], self.data.shape[1], 0)
+        glTexCoord2f(0,1)
+        glVertex3f(0, self.data.shape[1], 0)
         glEnd()
         glDisable(GL_TEXTURE_2D)
                 


### PR DESCRIPTION
#2131 caused a regression to GLImageItem as reported in #2230.
This PR reverts the offending commit 36b2e49cd3b0ba38a2169e8cb3b2d2d7c8b5e619 and applies only the cast to contiguous array operation that was intended in #2131.