### PR TITLE
Apply the log mode to the displayed dataset, export the mapped one [3]

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -946,10 +946,6 @@ class PlotDataItem(GraphicsObject):
 
             dataset = PlotDataset(x,y)
             dataset.containsNonfinite = self._dataset.containsNonfinite
-            
-            if True in self.opts['logMode']:
-                dataset.applyLogMapping( self.opts['logMode'] ) # Apply log scaling for x and/or y axis
-
             self._datasetMapped = dataset
         
         # apply processing that affects the on-screen display of data:
@@ -1057,6 +1053,8 @@ class PlotDataItem(GraphicsObject):
                             y = fn.clip_array(y, min_val, max_val)
                             self._drlLastClip = (min_val, max_val)
         self._datasetDisplay = PlotDataset( x,y )
+        if True in self.opts['logMode']:
+            self._datasetDisplay.applyLogMapping(self.opts['logMode'])  # Apply log scaling for x and/or y axis
         self._datasetDisplay.containsNonfinite = containsNonfinite
         self.setProperty('xViewRangeWasChanged', False)
         self.setProperty('yViewRangeWasChanged', False)
@@ -1067,7 +1065,7 @@ class PlotDataItem(GraphicsObject):
         """
         Returns the displayed data as the tuple (`xData`, `yData`) after mapping and data reduction.         
         """
-        dataset = self.getDisplayDataset()
+        dataset = self._datasetMapped
         if dataset is None:
             return (None, None)
         return dataset.x, dataset.y

--- a/tests/graphicsItems/test_PlotDataItem.py
+++ b/tests/graphicsItems/test_PlotDataItem.py
@@ -35,7 +35,7 @@ def test_fft():
 
     pd.setLogMode(True, False)
     x, y = pd.getData()
-    assert abs(x[np.argmax(y)] - np.log10(f)) < 0.01
+    assert abs(np.log10(x[np.argmax(y)] / f)) < 0.01
 
 def test_setData():
     pdi = pg.PlotDataItem()
@@ -154,24 +154,24 @@ def test_clipping():
     c.setClipToView(True)
     for x_min in range(-200, 2**10 - 100, 100):
         x_max = x_min + 100
-        w.setXRange(x_min, x_max, padding=0)
-        xDisp, _ = c.getData()
+        w.setXRange(2**x_min, 2**x_max, padding=0)
+        xDisp = c.getDisplayDataset().x
         # vr = c.viewRect()
         if len(xDisp) > 3: # check that all points except the first and last are on screen
-            assert( xDisp[ 1] >= x_min and xDisp[ 1] <= x_max )
-            assert( xDisp[-2] >= x_min and xDisp[-2] <= x_max )
+            assert( xDisp[ 1] >= 2**x_min and xDisp[ 1] <= 2**x_max )
+            assert( xDisp[-2] >= 2**x_min and xDisp[-2] <= 2**x_max )
 
     c.setDownsampling(ds=1) # disable downsampling
     for x_min in range(-200, 2**10 - 100, 100):
         x_max = x_min + 100
-        w.setXRange(x_min, x_max, padding=0)
-        xDisp, _ = c.getData()
+        w.setXRange(2**x_min, 2**x_max, padding=0)
+        xDisp = c.getDisplayDataset().x
         # vr = c.viewRect() # this tends to be out of data, so we check against the range that we set
         if len(xDisp) > 3: # check that all points except the first and last are on screen
-            assert( xDisp[ 0] == x[ 0] or xDisp[ 0] < x_min ) # first point should be unchanged, or off-screen
-            assert( xDisp[ 1] >= x_min and xDisp[ 1] <= x_max )
-            assert( xDisp[-2] >= x_min and xDisp[-2] <= x_max )
-            assert( xDisp[-1] == x[-1] or xDisp[-1] > x_max ) # last point should be unchanged, or off-screen
+            assert( xDisp[ 0] == x[ 0] or xDisp[ 0] < 2**x_min ) # first point should be unchanged, or off-screen
+            assert( xDisp[ 1] >= 2**x_min and xDisp[ 1] <= 2**x_max )
+            assert( xDisp[-2] >= 2**x_min and xDisp[-2] <= 2**x_max )
+            assert( xDisp[-1] == x[-1] or xDisp[-1] > 2**x_max ) # last point should be unchanged, or off-screen
 
     c.setData(x=np.zeros_like(y), y=y) # test zero width data set:
     # test center and expected number of remaining data points
@@ -180,7 +180,7 @@ def test_clipping():
         # when all elelemts are on-screen, all should be kept
         # and the code should not crash for zero separation
         w.setXRange( center-50, center+50, padding=0 )
-        xDisp, yDisp = c.getData()
+        xDisp, yDisp = c.getDisplayDataset().x, c.getDisplayDataset().y
         assert len(xDisp) == num
         assert len(yDisp) == num
 


### PR DESCRIPTION
My 3rd try to export the actual data plotted in log mode. That's what https://github.com/pyqtgraph/pyqtgraph/pull/2188 should have been. This time I changed the tests to match my perspective.

I believe that the log mode is something of displaying, not of the actual data. So, I moved the `applyLogMapping` function call down to `self._datasetDisplay`.

Next, I return the data saved into `self._datasetMapped` in `PlotDataItem.getData` function. It's a kind of expected behavior when it comes to returning the data, not the position of screen points.

The tests should respect the actual data, too.