### PR TITLE
Added opts to InfiniteLine so it can be included in Legend

### DIFF
--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -3,6 +3,7 @@ from math import atan2, degrees
 import numpy as np
 
 from .. import functions as fn
+from .. import getConfigOption
 from ..Point import Point
 from ..Qt import QtCore, QtGui
 from .GraphicsItem import GraphicsItem
@@ -72,6 +73,21 @@ class InfiniteLine(GraphicsObject):
         self._name = name
 
         GraphicsObject.__init__(self)
+
+        self.opts = {
+            'shadowPen': None,
+            'fillLevel': None,
+            'fillOutline': False,
+            'brush': None,
+            'stepMode': None,
+            'name': name,
+            'antialias': getConfigOption('antialias'),
+            'connect': 'all',
+            'mouseWidth': 8, # width of shape responding to mouse click
+            'compositionMode': None,
+            'skipFiniteCheck': False,
+            'pen': pen
+        }
 
         if bounds is None:              ## allowed value boundaries for orthogonal lines
             self.maxRange = [None, None]


### PR DESCRIPTION
I was in a situation where I needed to be able to add an InfiniteLine item to a graph legend, but was unable to. Perhaps this was a design choice, but I changed InfiniteLine to now have the opts component needed for Legend to create an item out of it.