### PR TITLE
Fixes for API changes in Qt

### DIFF
--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -517,7 +517,7 @@ class ExampleLoader(QtWidgets.QMainWindow):
 
     def keyPressEvent(self, event):
         ret = super().keyPressEvent(event)
-        if not QtCore.Qt.KeyboardModifier.ControlModifier & event.modifiers():
+        if int(QtCore.Qt.KeyboardModifier.ControlModifier) & int(event.modifiers()):
             return ret
         key = event.key()
         Key = QtCore.Qt.Key

--- a/pyqtgraph/exporters/HDF5Exporter.py
+++ b/pyqtgraph/exporters/HDF5Exporter.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 
 import numpy
 

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -728,7 +728,7 @@ class ROI(GraphicsObject):
                 hover=True
                 
             for btn in [QtCore.Qt.MouseButton.LeftButton, QtCore.Qt.MouseButton.RightButton, QtCore.Qt.MouseButton.MiddleButton]:
-                if (self.acceptedMouseButtons() & btn) and ev.acceptClicks(btn):
+                if (int(self.acceptedMouseButtons()) & btn) and ev.acceptClicks(btn):
                     hover=True
             if self.contextMenuEnabled():
                 ev.acceptClicks(QtCore.Qt.MouseButton.RightButton)
@@ -814,7 +814,7 @@ class ROI(GraphicsObject):
             if ev.button() == QtCore.Qt.MouseButton.RightButton and self.contextMenuEnabled():
                 self.raiseContextMenu(ev)
                 ev.accept()
-            elif ev.button() & self.acceptedMouseButtons():
+            elif ev.button() & int(self.acceptedMouseButtons()):
                 ev.accept()
                 self.sigClicked.emit(self, ev)
             else:
@@ -1385,9 +1385,9 @@ class Handle(UIGraphicsItem):
     def setDeletable(self, b):
         self.deletable = b
         if b:
-            self.setAcceptedMouseButtons(self.acceptedMouseButtons() | QtCore.Qt.MouseButton.RightButton)
+            self.setAcceptedMouseButtons(int(self.acceptedMouseButtons()) | QtCore.Qt.MouseButton.RightButton)
         else:
-            self.setAcceptedMouseButtons(self.acceptedMouseButtons() & ~QtCore.Qt.MouseButton.RightButton)
+            self.setAcceptedMouseButtons(int(self.acceptedMouseButtons()) & ~QtCore.Qt.MouseButton.RightButton)
 
     def removeClicked(self):
         self.sigRemoveRequested.emit(self)
@@ -1398,7 +1398,7 @@ class Handle(UIGraphicsItem):
             if ev.acceptDrags(QtCore.Qt.MouseButton.LeftButton):
                 hover=True
             for btn in [QtCore.Qt.MouseButton.LeftButton, QtCore.Qt.MouseButton.RightButton, QtCore.Qt.MouseButton.MiddleButton]:
-                if (self.acceptedMouseButtons() & btn) and ev.acceptClicks(btn):
+                if (int(self.acceptedMouseButtons()) & btn) and ev.acceptClicks(btn):
                     hover=True
                     
         if hover:
@@ -1424,7 +1424,7 @@ class Handle(UIGraphicsItem):
                 self.isMoving = False  ## prevents any further motion
                 self.movePoint(self.startPos, finish=True)
                 ev.accept()
-            elif ev.button() & self.acceptedMouseButtons():
+            elif ev.button() & int(self.acceptedMouseButtons()):
                 ev.accept()
                 if ev.button() == QtCore.Qt.MouseButton.RightButton and self.deletable:
                     self.raiseContextMenu(ev)
@@ -1448,7 +1448,7 @@ class Handle(UIGraphicsItem):
         removeAllowed = all(r.checkRemoveHandle(self) for r in self.rois)
         self.removeAction.setEnabled(removeAllowed)
         pos = ev.screenPos()
-        menu.popup(QtCore.QPoint(pos.x(), pos.y()))    
+        menu.popup(QtCore.QPoint(int(pos.x()), int(pos.y())))
 
     def mouseDragEvent(self, ev):
         if ev.button() != QtCore.Qt.MouseButton.LeftButton:


### PR DESCRIPTION
In my most recent environment (PyQt5 5.12.3 Qt 5.12.9), I started seeing errors in comparisons between MouseButton and MouseButtons (we used to be able to use `&` to determine whether a MouseButton was included in a MouseButtons, but now this generates `TypeError: unsupported operand type(s) for &: 'MouseButton' and 'MouseButtons'`).

This PR fixes a few instances of this comparison, plus a similar comparison between KeyboardModifier and KeyboardModifiers. 

Also snuck in a fix for the HDF5 exporter; seems like importlib.util is no longer imported by default.