### PR TITLE
Fix UFuncTypeError when plotting integer data on windows

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1218,9 +1218,10 @@ def clip_array(arr, vmin, vmax, out=None):
         return np.core.umath.maximum(arr, vmin, out=out)
     elif _win32_clip_workaround_needed:
         if out is None:
-            out = np.empty_like(arr)
+            out = np.empty(arr.shape, dtype=np.find_common_type([arr.dtype], [type(vmax)]))
         out = np.core.umath.minimum(arr, vmax, out=out)
         return np.core.umath.maximum(out, vmin, out=out)
+
     else:
         return np.core.umath.clip(arr, vmin, vmax, out=out)
 


### PR DESCRIPTION
When plotting integer arrays on windows, I ran into the following:
```
  File "pyqtgraph\pyqtgraph\graphicsItems\PlotDataItem.py", line 1057, in getDisplayDataset
    y = fn.clip_array(y, min_val, max_val)
  File "pyqtgraph\pyqtgraph\functions.py", line 1223, in clip_array
    out = np.core.umath.minimum(arr, vmax, out=out)
numpy.core._exceptions.UFuncTypeError: Cannot cast ufunc 'minimum' output from dtype('float64') to dtype('int32') with casting rule 'same_kind'
```
This is because we are asking (on ine 1223) for the minimum of an integer array and a float scalar, but the output array has already been allocated as integer. The fix here instead asks numpy to select a compatible dtype between the two.

