### PR TITLE
test enum using : "enums & enum"

### DIFF
--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -517,7 +517,7 @@ class ExampleLoader(QtWidgets.QMainWindow):
 
     def keyPressEvent(self, event):
         ret = super().keyPressEvent(event)
-        if not QtCore.Qt.KeyboardModifier.ControlModifier & event.modifiers():
+        if not (event.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier):
             return ret
         key = event.key()
         Key = QtCore.Qt.Key

--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -516,9 +516,9 @@ class ExampleLoader(QtWidgets.QMainWindow):
         self.loadFile(edited=True)
 
     def keyPressEvent(self, event):
-        ret = super().keyPressEvent(event)
+        super().keyPressEvent(event)
         if not (event.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier):
-            return ret
+            return
         key = event.key()
         Key = QtCore.Qt.Key
 
@@ -529,7 +529,7 @@ class ExampleLoader(QtWidgets.QMainWindow):
             return
 
         if key not in [Key.Key_Plus, Key.Key_Minus, Key.Key_Underscore, Key.Key_Equal, Key.Key_0]:
-            return ret
+            return
         font = self.ui.codeView.font()
         oldSize = font.pointSize()
         if key == Key.Key_Plus or key == Key.Key_Equal:

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -797,28 +797,17 @@ class ROI(GraphicsObject):
         self.mouseDragHandler.mouseDragEvent(ev)
 
     def mouseClickEvent(self, ev):
-        with warnings.catch_warnings():
-            # warning present on pyqt5 5.12 + python 3.8
-            warnings.filterwarnings(
-                "ignore",
-                message=(
-                    ".*Implicit conversion to integers using __int__ is "
-                    "deprecated, and may be removed in a future version of "
-                    "Python."
-                ),
-                category=DeprecationWarning
-            )
-            if ev.button() == QtCore.Qt.MouseButton.RightButton and self.isMoving:
-                ev.accept()
-                self.cancelMove()
-            if ev.button() == QtCore.Qt.MouseButton.RightButton and self.contextMenuEnabled():
-                self.raiseContextMenu(ev)
-                ev.accept()
-            elif ev.button() & self.acceptedMouseButtons():
-                ev.accept()
-                self.sigClicked.emit(self, ev)
-            else:
-                ev.ignore()
+        if ev.button() == QtCore.Qt.MouseButton.RightButton and self.isMoving:
+            ev.accept()
+            self.cancelMove()
+        if ev.button() == QtCore.Qt.MouseButton.RightButton and self.contextMenuEnabled():
+            self.raiseContextMenu(ev)
+            ev.accept()
+        elif self.acceptedMouseButtons() & ev.button():
+            ev.accept()
+            self.sigClicked.emit(self, ev)
+        else:
+            ev.ignore()
 
     def _moveStarted(self):
         self.isMoving = True
@@ -1408,29 +1397,18 @@ class Handle(UIGraphicsItem):
         self.update()
 
     def mouseClickEvent(self, ev):
-        with warnings.catch_warnings():
-            # warning present on pyqt5 5.12 + python 3.8
-            warnings.filterwarnings(
-                "ignore",
-                message=(
-                    ".*Implicit conversion to integers using __int__ is "
-                    "deprecated, and may be removed in a future version of "
-                    "Python."
-                ),
-                category=DeprecationWarning
-            )
-            ## right-click cancels drag
-            if ev.button() == QtCore.Qt.MouseButton.RightButton and self.isMoving:
-                self.isMoving = False  ## prevents any further motion
-                self.movePoint(self.startPos, finish=True)
-                ev.accept()
-            elif ev.button() & self.acceptedMouseButtons():
-                ev.accept()
-                if ev.button() == QtCore.Qt.MouseButton.RightButton and self.deletable:
-                    self.raiseContextMenu(ev)
-                self.sigClicked.emit(self, ev)
-            else:
-                ev.ignore()        
+        ## right-click cancels drag
+        if ev.button() == QtCore.Qt.MouseButton.RightButton and self.isMoving:
+            self.isMoving = False  ## prevents any further motion
+            self.movePoint(self.startPos, finish=True)
+            ev.accept()
+        elif self.acceptedMouseButtons() & ev.button():
+            ev.accept()
+            if ev.button() == QtCore.Qt.MouseButton.RightButton and self.deletable:
+                self.raiseContextMenu(ev)
+            self.sigClicked.emit(self, ev)
+        else:
+            ev.ignore()
                 
     def buildMenu(self):
         menu = QtWidgets.QMenu()


### PR DESCRIPTION
It appears that some warnings for PyQt5 5.12 and Python 3.8 were being deliberately masked.
These masked warnings seem to be the source of trouble that #2248 was attempting to fix.

This PR attempts to fix the underlying issue and allows us to remove the masked warnings.
The fix is by changing `enum & enums` to `enums & enum`.
On PyQt5 5.12, `enum` is an integer and thus does the `&` operation by coercing the rhs to an integer, which is deprecated or no longer allowed with newer Python.

@campagnola , could you test whether this fixes the issue in #2248?
