### PR TITLE
Avoid all-NaNs warning

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -991,8 +991,8 @@ class ScatterPlotItem(GraphicsObject):
         return self._maxSpotPxWidth*0.7072
 
     def boundingRect(self):
-        (xmn, xmx) = self.dataBounds(ax=0)
-        (ymn, ymx) = self.dataBounds(ax=1)
+        (xmn, xmx) = self.dataBounds(ax=0) or (None, None)
+        (ymn, ymx) = self.dataBounds(ax=1) or (None, None)
         if xmn is None or xmx is None:
             xmn = 0
             xmx = 0

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -955,7 +955,7 @@ class ScatterPlotItem(GraphicsObject):
 
         #self.prepareGeometryChange()
         if self.data is None or len(self.data) == 0:
-            return (None, None)
+            return self.bounds[ax]
 
         if ax == 0:
             d = self.data['x']
@@ -972,16 +972,19 @@ class ScatterPlotItem(GraphicsObject):
             d2 = d2[mask]
 
             if d.size == 0:
-                return (None, None)
+                return self.bounds[ax]
 
         if frac >= 1.0:
-            self.bounds[ax] = (np.nanmin(d) - self._maxSpotWidth*0.7072, np.nanmax(d) + self._maxSpotWidth*0.7072)
+            if not np.all(np.isnan(d)):
+                self.bounds[ax] = (np.nanmin(d) - self._maxSpotWidth*0.7072, np.nanmax(d) + self._maxSpotWidth*0.7072)
             return self.bounds[ax]
         elif frac <= 0.0:
             raise Exception("Value for parameter 'frac' must be > 0. (got %s)" % str(frac))
         else:
             mask = np.isfinite(d)
             d = d[mask]
+            if d.size == 0:  # nothing to show
+                return self.bounds[ax]
             return np.percentile(d, [50 * (1 - frac), 50 * (1 + frac)])
 
     def pixelPadding(self):


### PR DESCRIPTION
I'm uncertain whether the way is the best. If the data becomes all-NaNs, the bounds don't change, like if the plot is waiting for data.

With the fix, lines like `RuntimeWarning: All-NaN slice encountered ...` don't appear if the data consists of only NaNs.

And please make your mind up to whether `ScatterPlotItem.bounds` is a tuple or a list. I'd rather make it a tuple everywhere.