### PR TITLE
Make auto downsample factor calculation more robust

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -977,11 +977,9 @@ class PlotDataItem(GraphicsObject):
             if view_range is not None and len(finite_x) > 1:
                 dx = float(finite_x[-1]-finite_x[0]) / (len(finite_x)-1)
                 if dx != 0.0:
-                    x0 = (view_range.left()-finite_x[0]) / dx
-                    x1 = (view_range.right()-finite_x[0]) / dx
                     width = self.getViewBox().width()
                     if width != 0.0:  # autoDownsampleFactor _should_ be > 1.0
-                        ds_float = max(1.0, (x1 - x0) / (width * self.opts['autoDownsampleFactor']))
+                        ds_float = max(1.0, abs(view_range.width() / dx / (width * self.opts['autoDownsampleFactor'])))
                         if math.isfinite(ds_float):
                             ds = int(ds_float)
                     ## downsampling is expensive; delay until after clipping.

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -979,8 +979,10 @@ class PlotDataItem(GraphicsObject):
                     x0 = (view_range.left()-finite_x[0]) / dx
                     x1 = (view_range.right()-finite_x[0]) / dx
                     width = self.getViewBox().width()
-                    if width*self.opts['autoDownsampleFactor'] != 0.0 and np.isfinite(x1-x0):
-                        ds = int(max(1, int((x1-x0) / (width*self.opts['autoDownsampleFactor']))))
+                    if width * self.opts['autoDownsampleFactor'] != 0.0:
+                        ds_float = max(1.0, (x1 - x0) / (width * self.opts['autoDownsampleFactor']))
+                        if np.isfinite(ds_float):
+                            ds = int(ds_float)
                     ## downsampling is expensive; delay until after clipping.
 
         if self.opts['clipToView']:

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -971,13 +971,15 @@ class PlotDataItem(GraphicsObject):
 
         if self.opts['autoDownsample']:
             # this option presumes that x-values have uniform spacing
-            if view_range is not None and len(x) > 1:
-                dx = float(x[-1]-x[0]) / (len(x)-1)
+
+            finite_x = x[np.isfinite(x)]  # ignore infinite and nan values
+            if view_range is not None and len(finite_x) > 1:
+                dx = float(finite_x[-1]-finite_x[0]) / (len(finite_x)-1)
                 if dx != 0.0:
-                    x0 = (view_range.left()-x[0]) / dx
-                    x1 = (view_range.right()-x[0]) / dx
+                    x0 = (view_range.left()-finite_x[0]) / dx
+                    x1 = (view_range.right()-finite_x[0]) / dx
                     width = self.getViewBox().width()
-                    if width != 0.0:
+                    if width*self.opts['autoDownsampleFactor'] != 0.0 and np.isfinite(x1-x0):
                         ds = int(max(1, int((x1-x0) / (width*self.opts['autoDownsampleFactor']))))
                     ## downsampling is expensive; delay until after clipping.
 

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 
 import numpy as np
@@ -979,9 +980,9 @@ class PlotDataItem(GraphicsObject):
                     x0 = (view_range.left()-finite_x[0]) / dx
                     x1 = (view_range.right()-finite_x[0]) / dx
                     width = self.getViewBox().width()
-                    if width * self.opts['autoDownsampleFactor'] != 0.0:
+                    if width != 0.0:  # autoDownsampleFactor _should_ be > 1.0
                         ds_float = max(1.0, (x1 - x0) / (width * self.opts['autoDownsampleFactor']))
-                        if np.isfinite(ds_float):
+                        if math.isfinite(ds_float):
                             ds = int(ds_float)
                     ## downsampling is expensive; delay until after clipping.
 


### PR DESCRIPTION
The proposed changes enable ignoring the infinite and NaN values of `x` and avoiding a division by zero if `self.opts['autoDownsampleFactor'] == 0`.