### PR TITLE
Expose useCache ScatterPlotItem option from plot method

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -237,6 +237,9 @@ class PlotDataItem(GraphicsObject):
         **Optimization keyword arguments:**
 
             ================= =======================================================================
+            useCache          (bool) By default, generated point graphics items are cached to
+                              improve performance. Setting this to False can improve image quality
+                              in certain situations.
             antialias         (bool) By default, antialiasing is disabled to improve performance.
                               Note that in some cases (in particular, when ``pxMode=True``), points
                               will be rendered antialiased even if this is set to `False`.
@@ -344,11 +347,11 @@ class PlotDataItem(GraphicsObject):
             'symbolPen': (200,200,200),
             'symbolBrush': (50, 50, 150),
             'pxMode': True,
-            'useCache': True,
 
             'antialias': getConfigOption('antialias'),
             'pointMode': None,
 
+            'useCache': True,
             'downsample': 1,
             'autoDownsample': False,
             'downsampleMethod': 'peak',

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -344,6 +344,7 @@ class PlotDataItem(GraphicsObject):
             'symbolPen': (200,200,200),
             'symbolBrush': (50, 50, 150),
             'pxMode': True,
+            'useCache': True,
 
             'antialias': getConfigOption('antialias'),
             'pointMode': None,
@@ -862,7 +863,8 @@ class PlotDataItem(GraphicsObject):
                 ('symbolSize', 'size'),
                 ('data', 'data'),
                 ('pxMode', 'pxMode'),
-                ('antialias', 'antialias')
+                ('antialias', 'antialias'),
+                ('useCache', 'useCache')
             ]:
                 if k in self.opts:
                     scatterArgs[v] = self.opts[k]

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -483,6 +483,9 @@ class ScatterPlotItem(GraphicsObject):
         *hoverSize*            A single size to use for hovered spots. Set to -1 to keep size unchanged. Default is -1.
         *hoverPen*             A single pen to use for hovered spots. Set to None to keep pen unchanged. Default is None.
         *hoverBrush*           A single brush to use for hovered spots. Set to None to keep brush unchanged. Default is None.
+        *useCache*             (bool) By default, generated point graphics items are cached to
+                               improve performance. Setting this to False can improve image quality
+                               in certain situations.
         *antialias*            Whether to draw symbols with antialiasing. Note that if pxMode is True, symbols are
                                always rendered with antialiasing (since the rendered symbols can be cached, this
                                incurs very little performance cost)

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -597,6 +597,8 @@ class ScatterPlotItem(GraphicsObject):
             self.opts['hoverable'] = bool(kargs['hoverable'])
         if 'tip' in kargs:
             self.opts['tip'] = kargs['tip']
+        if 'useCache' in kargs:
+            self.opts['useCache'] = kargs['useCache']
 
         ## Set any extra parameters provided in keyword arguments
         for k in ['pen', 'brush', 'symbol', 'size']:


### PR DESCRIPTION
When "printing" a pyqtgraph object to a PDF, plots with `pxMode` set to `True` had their symbols rendered as rasters, rather than maintaining their vector format. Plots with `pxMode` set to `False` rendered to PDF correctly.

This pull request fixes that issue by using the same `QPicture` painting method for `pxMode=True` that was already being used for `pxMode=False`. With this change, both plots with `pxMode=True` and `False` render nicely to PDF output, allowing smooth resizing.

NOTE: This pull request also eliminates the `if ... useCache` section of the `pxMode=True` paint block. I _think_ that with the QPicture being cached, this is no longer needed, but testing is in order :-)