### PR TITLE
Avoid import error in HDF5 exporter

### DIFF
--- a/pyqtgraph/exporters/HDF5Exporter.py
+++ b/pyqtgraph/exporters/HDF5Exporter.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 
 import numpy
 


### PR DESCRIPTION
`importlib.util` is no longer imported by default with `importlib`; this has led to an import error in the HDF5 exporter.