### PR TITLE
add support for PySide6 6.3.0 QOverrideCursorGuard

### DIFF
--- a/pyqtgraph/widgets/BusyCursor.py
+++ b/pyqtgraph/widgets/BusyCursor.py
@@ -18,10 +18,15 @@ def BusyCursor():
     """
     app = QtCore.QCoreApplication.instance()
     in_gui_thread = (app is not None) and (QtCore.QThread.currentThread() == app.thread())
+    need_cleanup = in_gui_thread
     try:
         if in_gui_thread:
-            QtWidgets.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
+            guard = QtWidgets.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.WaitCursor))
+            if hasattr(QtGui, 'QOverrideCursorGuard') and isinstance(guard, QtGui.QOverrideCursorGuard):
+                # on PySide6 6.3.0, setOverrideCursor() returns a QOverrideCursorGuard context manager
+                # object that calls restoreOverrideCursor() for us
+                need_cleanup = False
         yield
     finally:
-        if in_gui_thread:
+        if need_cleanup:
             QtWidgets.QApplication.restoreOverrideCursor()


### PR DESCRIPTION
This fixes `BusyCursor` such that `test_busycursor.py` passes for PySide6 6.3.0.

A similar fix would be required for `ProgressDialog` which also makes use of `setOverrideCursor()`. Not being familiar with the workings of `ProgressDialog`, this PR limits itself to `BusyCursor` only.