### PR TITLE
Keep relative coordinates for free-moving handles on ROIs

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -839,7 +839,7 @@ class ROI(GraphicsObject):
         h = self.handles[index]
         p0 = self.mapToParent(h['pos'] * self.state['size'])
         p1 = Point(pos)
-        
+
         if coords == 'parent':
             pass
         elif coords == 'scene':
@@ -861,7 +861,8 @@ class ROI(GraphicsObject):
         elif h['type'] == 'f':
             newPos = self.mapFromParent(p1)
             h['item'].setPos(newPos)
-            h['pos'] = newPos
+            h["pos"] = self._mapToScaledRelativePosition(newPos)
+
             self.freeHandleMoved = True
             
         elif h['type'] == 's':
@@ -959,7 +960,7 @@ class ROI(GraphicsObject):
             
             if h['type'] == 'rf':
                 h['item'].setPos(self.mapFromScene(p1))  ## changes ROI coordinates of handle
-                h['pos'] = self.mapFromParent(p1)
+                h["pos"] = self._mapToScaledRelativePosition(self.mapFromParent(p1))
                 
         elif h['type'] == 'sr':
             try:
@@ -1004,7 +1005,16 @@ class ROI(GraphicsObject):
             self.setState(newState, update=False)
         
         self.stateChanged(finish=finish)
-    
+
+    def _mapToScaledRelativePosition(self, pos):
+        bound = self.boundingRect()
+        size = bound.size()
+        center = bound.center()
+        p = QtCore.QPointF(pos) - center
+        xrel = p.x() / size.width() + 0.5
+        yrel = p.y() / size.height() + 0.5
+        return Point(xrel, yrel)
+
     def stateChanged(self, finish=True):
         """Process changes to the state of the ROI.
         If there are any changes, then the positions of handles are updated accordingly

--- a/tests/graphicsItems/test_ROI.py
+++ b/tests/graphicsItems/test_ROI.py
@@ -272,3 +272,25 @@ def test_LineROI_coords(p1, p2):
         got = lineroi.mapSceneToParent(scenepos)
         assert math.isclose(got.x(), expected[0])
         assert math.isclose(got.y(), expected[1])
+
+
+def _assert_point_match(a, b):
+    if not math.isclose(a[0], b[0]) or not math.isclose(a[1], b[1]):
+        raise AssertionError(f"({a[0]:.17g}, {a[1]:.17g}) should equal ({b[0]:.17g}, {b[1]:.17g})")
+
+
+def test_FreeHandle_move_coords():
+    pw = pg.plot()
+
+    roi = pg.LineROI([0, 0], [10, 10], width=0.5, pen="r")
+    pw.addItem(roi)
+
+    h = roi.addFreeHandle([0.5, 0.5])
+    idx = roi.indexOfHandle(h)
+    hinfo = roi.handles[idx]
+    roi.movePoint(h, [0, 0])
+    _assert_point_match(hinfo["pos"], [0, 0.5])
+    roi.movePoint(h, [5, 5])
+    _assert_point_match(hinfo["pos"], [0.5, 0.5])
+    roi.movePoint(h, [5, 10])
+    _assert_point_match(hinfo["pos"], [0.75, 0.5 + math.sqrt(50)])


### PR DESCRIPTION
Fixes #2265 and adds a test. Thanks, @msdubrovin!