### PR TITLE
Added possibility to use custom dock labels

### DIFF
--- a/pyqtgraph/dockarea/__init__.py
+++ b/pyqtgraph/dockarea/__init__.py
@@ -1,2 +1,2 @@
-from .Dock import Dock
+from .Dock import Dock, DockLabel
 from .DockArea import DockArea


### PR DESCRIPTION
Changing the style of dock labels is currently very limited, only font size can be adjusted (i.e colors etc cannot be adjusted). To allow more customization of the labels, this pull request:

1. Includes `DockLabel` class to `dockarea` module so it could be imported and customized by subclassing
2. Added `label` argument to `Dock` class so that custom label can be specified.

There are no breaking changes, only one extra parameter (`label`) for `Dock` class.

Example:
```python
from pyqtgraph.dockarea import Dock, DockLabel

class CustomDockLabel(DockLabel):
    def updateStyle(self):
        ...

label = CustomDockLabel("name")
dock = Dock("name", label=label)

```