### PR TITLE
#2283 delete limitation by rectangle width

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -1197,8 +1197,6 @@ class ROI(GraphicsObject):
         arguments.
         """
         br = self.boundingRect()
-        if br.width() > 1000:
-            raise Exception()
         if returnMappedCoords:
             sliced, mappedCoords = ROI.getArrayRegion(
                 self, data, img, axes, returnMappedCoords, fromBoundingRect=True, **kwds)

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -1196,7 +1196,6 @@ class ROI(GraphicsObject):
         See :meth:`~pyqtgraph.ROI.getArrayRegion` for a description of the
         arguments.
         """
-        br = self.boundingRect()
         if returnMappedCoords:
             sliced, mappedCoords = ROI.getArrayRegion(
                 self, data, img, axes, returnMappedCoords, fromBoundingRect=True, **kwds)


### PR DESCRIPTION
Deleted strange exception for region of ROI with width of its containing rectangle more than 1000 that was discussed in Issue #2283 