### PR TITLE
avoid double __init__ of DockDrop

### DIFF
--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -1,6 +1,6 @@
 import warnings
 
-from ..Qt import QtCore, QtGui, QtWidgets
+from ..Qt import QT_LIB, QtCore, QtGui, QtWidgets
 from ..widgets.VerticalLabel import VerticalLabel
 from .DockDrop import DockDrop
 
@@ -11,8 +11,12 @@ class Dock(QtWidgets.QWidget, DockDrop):
     sigClosed = QtCore.Signal(object)
 
     def __init__(self, name, area=None, size=(10, 10), widget=None, hideTitle=False, autoOrientation=True, label=None, **kargs):
-        QtWidgets.QWidget.__init__(self)
-        DockDrop.__init__(self)
+        allowedAreas = None
+        if QT_LIB.startswith('PyQt'):
+            QtWidgets.QWidget.__init__(self, allowedAreas=allowedAreas)
+        else:
+            QtWidgets.QWidget.__init__(self)
+            DockDrop.__init__(self, allowedAreas=allowedAreas)
         self._container = None
         self._name = name
         self.area = area

--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -1,6 +1,6 @@
 import weakref
 
-from ..Qt import QtWidgets
+from ..Qt import QT_LIB, QtWidgets
 from .Container import Container, HContainer, TContainer, VContainer
 from .Dock import Dock
 from .DockDrop import DockDrop
@@ -9,8 +9,12 @@ from .DockDrop import DockDrop
 class DockArea(Container, QtWidgets.QWidget, DockDrop):
     def __init__(self, parent=None, temporary=False, home=None):
         Container.__init__(self, self)
-        QtWidgets.QWidget.__init__(self, parent=parent)
-        DockDrop.__init__(self, allowedAreas=['left', 'right', 'top', 'bottom'])
+        allowedAreas=['left', 'right', 'top', 'bottom']
+        if QT_LIB.startswith('PyQt'):
+            QtWidgets.QWidget.__init__(self, parent=parent, allowedAreas=allowedAreas)
+        else:
+            QtWidgets.QWidget.__init__(self, parent=parent)
+            DockDrop.__init__(self, allowedAreas=allowedAreas)
         self.layout = QtWidgets.QVBoxLayout()
         self.layout.setContentsMargins(0,0,0,0)
         self.layout.setSpacing(0)


### PR DESCRIPTION
The `DockDrop` class has its `__init__` method being called twice on PyQt{5, 6}.

According to the following references, PyQt{5,6} (but not PyQt4) added cooperative inheritance.
Besides minor changes, `DockDrop` was last modified in 2012. i.e. the code was written based on PyQt4 behavior.
https://docs.huihoo.com/pyqt/PyQt5/pyqt4_differences.html#cooperative-multi-inheritance
https://doc.bccnsoft.com/docs/PyQt5/multiinheritance.html
https://www.riverbankcomputing.com/pipermail/pyqt/2017-January/038650.html

This PR avoids the double `__init__` by differentiating between PyQt{5,6} and PySide{2,6}.
PySide{2,6} do not support cooperative inheritance. i.e. They have PyQt4 behavior.

An attempt was made to use `DockDrop` by composition instead of inheritance, thus avoiding all this trouble. But it turned out that there is quite a bit of coupling present. e.g. there is an assumption that a `DockDrop` instance *is* a `QWidget`.