### PR TITLE
Update tox for currently supported configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
     -   id: check-added-large-files
         args: ['--maxkb=100']

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,16 @@
 [tox]
 envlist = 
     ; qt 5.15.x
-    py{37,38,39}-{pyqt5,pyside2}_515
+    py{38,39,310}-{pyqt5,pyside2}_515
 
-    ; qt 5.12.x
-    py{37}-{pyqt5,pyside2}_512
     ; py38-pyside2_512 doesn't work due to PYSIDE-1140
     py38-pyqt5_512 
 
-    ; qt 6
-    py{37,38,39}-{pyqt6,pyside6}
+    ; qt 6.2
+    py{38,39,310}-{pyqt6,pyside6}_62
+
+    ; qt 6-newest
+    py{38,39,310}-{pyqt6,pyside6}
 
 [base]
 deps =
@@ -25,10 +26,12 @@ passenv = DISPLAY XAUTHORITY, PYTHON_VERSION
 setenv = PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command
 deps=
     {[base]deps}
-    pyside2_512: pyside2==5.12.6
-    pyqt5_512: pyqt5==5.12.3
+    pyqt5_512: pyqt5~=5.12.0
     pyside2_515: pyside2
     pyqt5_515: pyqt5
+    pyqt6_62: pyqt6~=6.2.0
+    pyqt6_62: PyQt6-Qt6~=6.2.0
+    pyside6_62: pyside6~=6.2.0
     pyqt6: pyqt6
     pyside6: pyside6
 


### PR DESCRIPTION
When deprecating python 3.7 support, I did not update `tox.ini`, this PR addresses that, and also updated `.pre-commit-config.yaml` with a version bump.