### PR TITLE
Update LabelItem to allow transparency in the text

### DIFF
--- a/pyqtgraph/graphicsItems/LabelItem.py
+++ b/pyqtgraph/graphicsItems/LabelItem.py
@@ -1,6 +1,6 @@
 from .. import functions as fn
 from .. import getConfigOption
-from ..Qt import QtCore, QtWidgets
+from ..Qt import QtCore, QtWidgets, QtGui
 from .GraphicsWidget import GraphicsWidget
 from .GraphicsWidgetAnchor import GraphicsWidgetAnchor
 
@@ -55,7 +55,7 @@ class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
         if color is None:
             color = getConfigOption('foreground')
         color = fn.mkColor(color)
-        optlist.append('color: ' + color.name())
+        optlist.append('color: ' + color.name(QtGui.QColor.HexArgb))
         if 'size' in opts:
             optlist.append('font-size: ' + opts['size'])
         if 'bold' in opts and opts['bold'] in [True, False]:

--- a/pyqtgraph/graphicsItems/LabelItem.py
+++ b/pyqtgraph/graphicsItems/LabelItem.py
@@ -55,7 +55,7 @@ class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
         if color is None:
             color = getConfigOption('foreground')
         color = fn.mkColor(color)
-        optlist.append('color: ' + color.name(QtGui.QColor.HexArgb))
+        optlist.append('color: ' + color.name(QtGui.QColor.NameFormat.HexArgb))
         if 'size' in opts:
             optlist.append('font-size: ' + opts['size'])
         if 'bold' in opts and opts['bold'] in [True, False]:


### PR DESCRIPTION
Use the QColor.HexArgb NameFormat when retrieving the name of the color in setText to allow text with transparency