### PR TITLE
Issue #2203 Potential Fix: Disabled FlowchartCtrlWidget.nodeRenamed o…

### DIFF
--- a/pyqtgraph/flowchart/Flowchart.py
+++ b/pyqtgraph/flowchart/Flowchart.py
@@ -219,7 +219,8 @@ class Flowchart(Node):
     def nodeRenamed(self, node, oldName):
         del self._nodes[oldName]
         self._nodes[node.name()] = node
-        self.widget().nodeRenamed(node, oldName)
+        if node is not self.inputNode and node is not self.outputNode:
+            self.widget().nodeRenamed(node, oldName)
         self.sigChartChanged.emit(self, 'rename', node)
         
     def arrangeNodes(self):


### PR DESCRIPTION
…n Input/Output node

In [FlowechartCtrlWidget.nodeRenamed](https://github.com/pyqtgraph/pyqtgraph/blob/master/pyqtgraph/flowchart/Flowchart.py#L698), the `items` dictionary is being used, but the Input and Output nodes are not added to `items` due to the if statement at [line 195](https://github.com/pyqtgraph/pyqtgraph/blob/master/pyqtgraph/flowchart/Flowchart.py#L195). I added the logic of excluding the Input and Output nodes to [Flowchart.nodeRenamed](https://github.com/pyqtgraph/pyqtgraph/blob/master/pyqtgraph/flowchart/Flowchart.py#L222).

This maintains current functionality according to issue #2203, unclear if this is expected functionality.