### PR TITLE
GridItem: Fix pen for usage of dash-pattern

### DIFF
--- a/pyqtgraph/graphicsItems/GridItem.py
+++ b/pyqtgraph/graphicsItems/GridItem.py
@@ -163,11 +163,7 @@ class GridItem(UIGraphicsItem):
 
                 bx = (ax+1) % 2
                 for x in range(0, int(nl[ax])):
-                    linePen.setCosmetic(False)
-                    if ax == 0:
-                        linePen.setWidthF(self.pixelWidth())
-                    else:
-                        linePen.setWidthF(self.pixelHeight())
+                    linePen.setCosmetic(True)
                     p.setPen(linePen)
                     p1 = np.array([0.,0.])
                     p2 = np.array([0.,0.])


### PR DESCRIPTION
Hi, I wanted to use a custom dash-pattern for the grid. Currently this doesn't work, the drawn dash pattern changes with the zoom of the plot.
See the attached screenshot showing different vertical and horizontal grid lines, due to the different ranges set at the end of the example.
```
...
app = mkQApp("Grid bug demo")
plot = PlotWidget()
plot.show()

grid = GridItem()
grid.setPen(dash=[4,4,8,4])
plot.addItem(grid)

plot.setXRange(min=0.0, max=10.0)
plot.setYRange(min=0.0, max=1.0)
```
![grafik](https://user-images.githubusercontent.com/36670201/169067427-ac9b60ee-e486-4e24-9277-395aa5f1936b.png)
