### PR TITLE
Address #2303 unapplied pen parameter constructor options

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes/pen.py
+++ b/pyqtgraph/parametertree/parameterTypes/pen.py
@@ -46,6 +46,8 @@ class PenParameter(GroupParameter):
         if 'children' in opts:
             raise KeyError('Cannot set "children" argument in Pen Parameter opts')
         super().__init__(**opts, children=list(children))
+        # Handles optiosn like "width", "color", etc.
+        self.applyOptsToPen(**opts)
         self.valChangingProxy = SignalProxy(self.sigValueChanging, delay=1.0, slot=self._childrenFinishedChanging)
 
     def _childrenFinishedChanging(self, paramAndValue):

--- a/pyqtgraph/parametertree/parameterTypes/pen.py
+++ b/pyqtgraph/parametertree/parameterTypes/pen.py
@@ -41,13 +41,11 @@ class PenParameter(GroupParameter):
     itemClass = PenParameterItem
 
     def __init__(self, **opts):
-        self.pen = fn.mkPen()
+        self.pen = fn.mkPen(**opts)
         children = self._makeChildren(self.pen)
         if 'children' in opts:
             raise KeyError('Cannot set "children" argument in Pen Parameter opts')
         super().__init__(**opts, children=list(children))
-        # Handles optiosn like "width", "color", etc.
-        self.applyOptsToPen(**opts)
         self.valChangingProxy = SignalProxy(self.sigValueChanging, delay=1.0, slot=self._childrenFinishedChanging)
 
     def _childrenFinishedChanging(self, paramAndValue):

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -165,7 +165,7 @@ def test_data_race():
 
 def test_pen_settings():
     # Option from constructor
-    p = pt.Parameter.create(name='test', type='pen', width=5)
+    p = pt.Parameter.create(name='test', type='pen', width=5, additionalname='test')
     assert p.pen.width() == 5
     # Opts from dynamic update
     p.setOpts(width=3)

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -162,3 +162,14 @@ def test_data_race():
     p.sigValueChanged.connect(override)
     pi.widget.setValue(2)
     assert p.value() == pi.widget.value() == 1
+
+def test_pen_settings():
+    # Option from constructor
+    p = pt.Parameter.create(name='test', type='pen', width=5)
+    assert p.pen.width() == 5
+    # Opts from dynamic update
+    p.setOpts(width=3)
+    assert p.pen.width() == 3
+    # Opts from changing child
+    p["width"] = 10
+    assert p.pen.width() == 10


### PR DESCRIPTION
Fixes #2303 

Initial pen options specified in `**opts` were ignored in the pen parameter constructure. These can just be passed directly to the initialized pen.