### PR TITLE
ScatterPlotItem point masking fix

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -1079,7 +1079,7 @@ class ScatterPlotItem(GraphicsObject):
 
         if self.opts['pxMode'] is True:
             # Cull points that are outside view
-            viewMask = self._maskAt(self.getViewBox().viewRect())
+            viewMask = self._maskAt(self.viewRect())
 
             # Map points using painter's world transform so they are drawn with pixel-valued sizes
             pts = np.vstack([self.data['x'], self.data['y']])


### PR DESCRIPTION
If `ScatterPlotItem` is transformed by `item.setTransform(...)` then it starts to act weird (e.g. symbols partly disappearing when zooming in).
Discovered that scatter points are incorrectly filtered by untransformed view box (`self.getViewBox().viewRect()`), however, view box in the local coordinate system of the item (`self.viewRect()`) should be used instead (as data is given in the  local coordinate system of the item).