### PR TITLE
Make parameter tree read-only values selectable and copiable

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -230,7 +230,7 @@ class WidgetParameterItem(ParameterItem):
         if 'readonly' in opts:
             self.updateDefaultBtn()
 
-            if opts["readonly"]:
+            if opts['readonly']:
                 self.displayLabel.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
             else:
                 self.displayLabel.setTextInteractionFlags(QtCore.Qt.LinksAccessibleByMouse)

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -229,6 +229,12 @@ class WidgetParameterItem(ParameterItem):
 
         if 'readonly' in opts:
             self.updateDefaultBtn()
+
+            if opts["readonly"]:
+                self.displayLabel.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+            else:
+                self.displayLabel.setTextInteractionFlags(QtCore.Qt.LinksAccessibleByMouse)
+
             if hasattr(self.widget, 'setReadOnly'):
                 self.widget.setReadOnly(opts['readonly'])
             else:

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -231,9 +231,9 @@ class WidgetParameterItem(ParameterItem):
             self.updateDefaultBtn()
 
             if opts['readonly']:
-                self.displayLabel.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+                self.displayLabel.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
             else:
-                self.displayLabel.setTextInteractionFlags(QtCore.Qt.LinksAccessibleByMouse)
+                self.displayLabel.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.LinksAccessibleByMouse)
 
             if hasattr(self.widget, 'setReadOnly'):
                 self.widget.setReadOnly(opts['readonly'])


### PR DESCRIPTION
If `ParameterTree` is used with read-only parameters then it makes sense that it would be possible to select and copy the value of the parameter. Right now the value is not selectable or copiable in any way.