### PR TITLE
test_PlotCurveItem: unset skipFiniteCheck for next test

### DIFF
--- a/tests/graphicsItems/test_PlotCurveItem.py
+++ b/tests/graphicsItems/test_PlotCurveItem.py
@@ -29,6 +29,7 @@ def test_PlotCurveItem():
 
     c.setData(data, connect='finite', skipFiniteCheck=True)
     assertImageApproved(p, 'plotcurveitem/connectfinite', "Plot curve with finite points connected using QPolygonF.")
+    c.setSkipFiniteCheck(False)
     
     c.setData(data, connect=np.array([1,1,1,0,1,1,0,0,1,0,0,0,1,1,0,0]))
     assertImageApproved(p, 'plotcurveitem/connectarray', "Plot curve with connection array.")


### PR DESCRIPTION
`test_PlotCurveItem.py` has a bug as follows:

At the time (8997cfa07c7a0ff4209f60702b028a81f46e14ca) of the addition of the 2nd last test with `skipFiniteCheck=True`, `skipFiniteCheck` was not a sticky option. Thus, the last test automatically reverts to `skipFiniteCheck=False`.

Since the other options of `PlotCurveItem` were sticky in nature, for consistency, 21d77dbea5225fcce448df2f9149174e877db472 changed `skipFiniteCheck`  to also be a sticky option. This made the last test to be run with `skipFiniteCheck=True` even though it was intended to be executed with `skipFiniteCheck=False`.

Note: With the bug, a blank image actually gets generated for the last test but due to the low number of "on" pixels in the reference image, it passes the tolerance test.
