### PR TITLE
Enhance testing for creating parameters from saved states

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes/calendar.py
+++ b/pyqtgraph/parametertree/parameterTypes/calendar.py
@@ -51,5 +51,6 @@ class CalendarParameter(Parameter):
     def saveState(self, filter=None):
         state = super().saveState(filter)
         fmt = self._interpretFormat()
-        state['value'] = state['value'].toString(fmt)
+        if state['value'] is not None:
+            state['value'] = state['value'].toString(fmt)
         return state

--- a/pyqtgraph/parametertree/parameterTypes/checklist.py
+++ b/pyqtgraph/parametertree/parameterTypes/checklist.py
@@ -136,6 +136,11 @@ class ChecklistParameter(GroupParameter):
     itemClass = ChecklistParameterItem
 
     def __init__(self, **opts):
+        # Child options are populated through values, not explicit "children"
+        if 'children' in opts:
+            raise ValueError(
+                "Cannot pass 'children' to ChecklistParameter. Pass a 'value' key only."
+            )
         self.targetValue = None
         limits = opts.setdefault('limits', [])
         self.forward, self.reverse = ListParameter.mapping(limits)
@@ -225,3 +230,27 @@ class ChecklistParameter(GroupParameter):
             checked = chParam.name() in names
             chParam.setValue(checked, self._onChildChanging)
         super().setValue(self.childrenValue(), blockSignal)
+
+    def saveState(self, filter=None):
+        # Unlike the normal GroupParameter, child states shouldn't be separately
+        # preserved
+        state = super().saveState(filter)
+        state.pop("children", None)
+        return state
+
+    def restoreState(
+        self,
+        state,
+        recursive=True,
+        addChildren=True,
+        removeChildren=True,
+        blockSignals=True
+    ):
+        # Child management shouldn't happen through state
+        return super().restoreState(
+            state,
+            recursive,
+            addChildren=False,
+            removeChildren=False,
+            blockSignals=blockSignals
+        )

--- a/pyqtgraph/parametertree/parameterTypes/checklist.py
+++ b/pyqtgraph/parametertree/parameterTypes/checklist.py
@@ -187,8 +187,13 @@ class ChecklistParameter(GroupParameter):
         else:
             return vals
 
-    def _onChildChanging(self, _ch, _val):
-        self.sigValueChanging.emit(self, self.childrenValue())
+    def _onChildChanging(self, child, value):
+        # When exclusive, ensure only this value is True
+        if self.opts['exclusive'] and value:
+            value = self.forward[child.name()]
+        else:
+            value = self.childrenValue()
+        self.sigValueChanging.emit(self, value)
 
     def updateLimits(self, _param, limits):
         oldOpts = self.names
@@ -216,11 +221,8 @@ class ChecklistParameter(GroupParameter):
 
     def _finishChildChanges(self, paramAndValue):
         param, value = paramAndValue
-        if self.opts['exclusive']:
-            val = self.reverse[0][self.reverse[1].index(param.name())]
-            return self.setValue(val)
         # Interpret value, fire sigValueChanged
-        return self.setValue(self.childrenValue())
+        return self.setValue(value)
 
     def optsChanged(self, param, opts):
         if 'exclusive' in opts:

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -173,3 +173,11 @@ def test_pen_settings():
     # Opts from changing child
     p["width"] = 10
     assert p.pen.width() == 10
+
+
+def test_recreate_from_savestate():
+    from pyqtgraph.examples import _buildParamTypes
+    created = _buildParamTypes.makeAllParamTypes()
+    state = created.saveState()
+    created2 = pt.Parameter.create(**state)
+    assert pg.eq(state, created2.saveState())


### PR DESCRIPTION
Before this PR, parameters like e.g. checklist would save states that couldn't reproduce their parameter layout. Fix this for the specific fail types of checklist and calendar while ensuring all other parameter types can successfully recreate themselves.

During testing, a few other issues with checklists came up  and were resolved, so the branch name is a bit of a misnomer now
- [x] `exclusive` checklists now propagate changing values correctly
- [x] `Clear All`, `Select All`, and default buttons now force changes even when there is a pending proxy signal