### PR TITLE
access QPainterPathPrivate for faster arrayToQPath

### DIFF
--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -396,6 +396,8 @@ if QT_LIB in [PYQT5, PYQT6]:
     compat.unwrapinstance = sip.unwrapinstance
     compat.voidptr = sip.voidptr
 
+from . import internals
+
 # USE_XXX variables are deprecated
 USE_PYSIDE = QT_LIB == PYSIDE
 USE_PYQT4 = QT_LIB == PYQT4

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -147,7 +147,7 @@ def _copy_attrs(src, dst):
         if not hasattr(dst, o):
             setattr(dst, o, getattr(src, o))
 
-from . import QtCore, QtGui, QtWidgets
+from . import QtCore, QtGui, QtWidgets, compat
 
 if QT_LIB == PYQT5:
     # We're using PyQt5 which has a different structure so we're going to use a shim to
@@ -368,6 +368,9 @@ if QT_LIB in [PYSIDE2, PYSIDE6]:
                     QtWidgets.QApplication.processEvents()
             QtTest.QTest.qWait = qWait
 
+    compat.wrapinstance = shiboken.wrapInstance
+    compat.unwrapinstance = lambda x : shiboken.getCppPointer(x)[0]
+    compat.voidptr = shiboken.VoidPtr
 
 # Common to PyQt5 and PyQt6
 if QT_LIB in [PYQT5, PYQT6]:
@@ -388,6 +391,10 @@ if QT_LIB in [PYQT5, PYQT6]:
     loadUiType = uic.loadUiType
 
     QtCore.Signal = QtCore.pyqtSignal
+
+    compat.wrapinstance = sip.wrapinstance
+    compat.unwrapinstance = sip.unwrapinstance
+    compat.voidptr = sip.voidptr
 
 # USE_XXX variables are deprecated
 USE_PYSIDE = QT_LIB == PYSIDE

--- a/pyqtgraph/Qt/internals.py
+++ b/pyqtgraph/Qt/internals.py
@@ -1,0 +1,71 @@
+import ctypes
+import numpy as np
+from . import QT_LIB
+from . import compat
+
+__all__ = ["get_qpainterpath_element_array"]
+
+class QArrayDataQt5(ctypes.Structure):
+    _fields_ = [
+        ("ref", ctypes.c_int),
+        ("size", ctypes.c_int),
+        ("alloc", ctypes.c_uint, 31),
+        ("offset", ctypes.c_ssize_t),
+    ]
+
+class QPainterPathPrivateQt5(ctypes.Structure):
+    _fields_ = [
+        ("ref", ctypes.c_int),
+        ("adata", ctypes.POINTER(QArrayDataQt5)),
+    ]
+
+class QArrayDataQt6(ctypes.Structure):
+    _fields_ = [
+        ("ref", ctypes.c_int),
+        ("flags", ctypes.c_uint),
+        ("alloc", ctypes.c_ssize_t),
+    ]
+
+class QPainterPathPrivateQt6(ctypes.Structure):
+    _fields_ = [
+        ("ref", ctypes.c_int),
+        ("adata", ctypes.POINTER(QArrayDataQt6)),
+        ("data", ctypes.c_void_p),
+        ("size", ctypes.c_ssize_t),
+    ]
+
+def get_qpainterpath_element_array(qpath, nelems=None):
+    writable = nelems is not None
+    if writable:
+        qpath.reserve(nelems)
+
+    itemsize = 24
+    dtype = dict(names=['x','y','c'], formats=['f8', 'f8', 'i4'], itemsize=itemsize)
+
+    ptr0 = compat.unwrapinstance(qpath)
+    pte_cp = ctypes.c_void_p.from_address(ptr0)
+    if not pte_cp:
+        return np.zeros(0, dtype=dtype)
+
+    # _cp : ctypes pointer
+    # _ci : ctypes instance
+    if QT_LIB in ['PyQt5', 'PySide2']:
+        PTR = ctypes.POINTER(QPainterPathPrivateQt5)
+        pte_ci = ctypes.cast(pte_cp, PTR).contents
+        size_ci = pte_ci.adata[0]
+        eptr = ctypes.addressof(size_ci) + size_ci.offset
+    elif QT_LIB in ['PyQt6', 'PySide6']:
+        PTR = ctypes.POINTER(QPainterPathPrivateQt6)
+        pte_ci = ctypes.cast(pte_cp, PTR).contents
+        size_ci = pte_ci
+        eptr = pte_ci.data
+    else:
+        raise NotImplementedError
+
+    if writable:
+        size_ci.size = nelems
+    else:
+        nelems = size_ci.size
+
+    vp = compat.voidptr(eptr, itemsize*nelems, writable)
+    return np.frombuffer(vp, dtype=dtype)

--- a/tests/test_qpainterpathprivate.py
+++ b/tests/test_qpainterpathprivate.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
+
+
+def test_qpainterpathprivate_read():
+    x0, y0 = 100, 200
+    size = 100
+
+    qpath = QtGui.QPainterPath()
+    qpath.moveTo(x0, y0)
+    for idx in range(1, size):
+        qpath.lineTo(x0 + idx, y0 + idx)
+
+    memory = pg.Qt.internals.get_qpainterpath_element_array(qpath)
+    assert len(memory) == size
+    assert np.all(memory['x'] == np.arange(x0, x0 + size))
+    assert np.all(memory['y'] == np.arange(y0, y0 + size))
+    assert memory['c'][0] == 0
+    assert np.all(memory['c'][1:] == 1)
+
+
+@pytest.mark.skipif(
+    not hasattr(QtGui.QPainterPath, 'reserve'),
+    reason="needs Qt version >= 5.13"
+)
+def test_qpainterpathprivate_write():
+    x0, y0 = 100, 200
+    size = 100
+
+    qpath0 = QtGui.QPainterPath()
+    qpath0.moveTo(x0, y0)
+    for idx in range(1, size):
+        qpath0.lineTo(x0 + idx, y0 + idx)
+
+    qpath1 = QtGui.QPainterPath()
+    memory = pg.Qt.internals.get_qpainterpath_element_array(qpath1, size)
+    assert len(memory) == size
+
+    memory['x'] = np.arange(x0, x0 + size)
+    memory['y'] = np.arange(y0, y0 + size)
+    memory['c'][:1] = 0
+    memory['c'][1:] = 1
+    assert qpath0 == qpath1


### PR DESCRIPTION
This PR allows populating `QPainterPath` without having to go through the serialization / deserialization steps.
Where the serialization / deserialization could still be considered a public API (although the binary serialized format is not publicly documented), this method clearly strays into the Qt private internals.

To see this in action, run `PlotSpeedTest.py` and switch to 'array' (or 'pairs') mode. Then toggle the `enableExperimental` checkbox to activate this new method.
On my system, this brings `array`'s performance on par with `all`'s performance. (This raises the possibility of making all `connect` kinds be implemented simply in terms of `array`)

Obviously, the Qt library is free to change its internal private implementation at any time, which would break this method.

Not tested on 32-bit systems. The ctypes used should be correct on both 32-bit / 64-bit though.