### PR TITLE
add support for PySide6's usage of Python Enums

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes/qtenum.py
+++ b/pyqtgraph/parametertree/parameterTypes/qtenum.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from ...Qt import QT_LIB, QtCore
 from .list import ListParameter
 
@@ -50,7 +51,10 @@ class QtEnumParameter(ListParameter):
 
     def _getAllowedEnums(self, enum):
         """Pyside provides a dict for easy evaluation"""
-        if 'PySide' in QT_LIB:
+        if issubclass(enum, Enum):
+            # PyQt6 and PySide6 (opt-in in 6.3.1) use python enums
+            vals = {e.name: e for e in enum}
+        elif 'PySide' in QT_LIB:
             vals = enum.values
         elif 'PyQt5' in QT_LIB:
             vals = {}
@@ -58,8 +62,6 @@ class QtEnumParameter(ListParameter):
                 value = getattr(self.searchObj, key)
                 if isinstance(value, enum):
                     vals[key] = value
-        elif 'PyQt6' in QT_LIB:
-            vals = {e.name: e for e in enum}
         else:
             raise RuntimeError(f'Cannot find associated enum values for qt lib {QT_LIB}')
         # Remove "M<enum>" since it's not a real option


### PR DESCRIPTION
PySide6 is moving to implement Qt enums as Python Enums (like PyQt6).
in PySide6 6.3.1, it is opt-in by setting environment variable `PYSIDE63_OPTION_PYTHON_ENUM=1`

This PR adds the support by changing the previously PyQt6-specific codepaths to become Python-Enum-specific codepaths. The older implementation of enums on PySide6 continues to work.