### PR TITLE
test PyQt version before using sip.array

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -40,7 +40,14 @@ _have_native_drawlines_array = Qt.QT_LIB.startswith('PySide') and have_native_dr
 
 class LineSegments:
     def __init__(self):
-        self.use_sip_array = Qt.QT_LIB.startswith('PyQt') and hasattr(Qt.sip, 'array')
+        self.use_sip_array = (
+            Qt.QT_LIB.startswith('PyQt') and
+            hasattr(Qt.sip, 'array') and
+            (
+                (0x60301 <= QtCore.PYQT_VERSION) or
+                (0x50f07 <= QtCore.PYQT_VERSION < 0x60000)
+            )
+        )
         self.use_native_drawlines = Qt.QT_LIB.startswith('PySide') and _have_native_drawlines_array
         self.alloc(0)
 

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -145,7 +145,14 @@ def _mkBrush(*args, **kwargs):
 
 class PixmapFragments:
     def __init__(self):
-        self.use_sip_array = Qt.QT_LIB.startswith('PyQt') and hasattr(Qt.sip, 'array')
+        self.use_sip_array = (
+            Qt.QT_LIB.startswith('PyQt') and
+            hasattr(Qt.sip, 'array') and
+            (
+                (0x60301 <= QtCore.PYQT_VERSION) or
+                (0x50f07 <= QtCore.PYQT_VERSION < 0x60000)
+            )
+        )
         self.alloc(0)
 
     def alloc(self, size):


### PR DESCRIPTION
it is not sufficient to test for presence of sip.array.
newer versions of PyQt[56]-sip with sip.array can be mixed with older PyQt[56] that doesn't have support.

In particular, a fresh installation of PyQt5 5.12.x (that doesn't have support for sip.array) would pull in the newer PyQt5-sip 12.11.0 with sip.array.