### PR TITLE
Update CI Config

### DIFF
--- a/.github/workflows/etc/environment-pyqt.yml
+++ b/.github/workflows/etc/environment-pyqt.yml
@@ -8,6 +8,4 @@ dependencies:
   - nomkl
   - scipy
   - pyopengl
-  - pytest
-  - pytest-xdist
   - pip

--- a/.github/workflows/etc/environment-pyqt.yml
+++ b/.github/workflows/etc/environment-pyqt.yml
@@ -1,0 +1,11 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - pyqt
+  - numpy
+  - scipy
+  - pyopengl
+  - pytest
+  - pytest-xdist
+  - pip

--- a/.github/workflows/etc/environment-pyqt.yml
+++ b/.github/workflows/etc/environment-pyqt.yml
@@ -3,7 +3,9 @@ channels:
   - conda-forge
 dependencies:
   - pyqt
+  - qt-main
   - numpy
+  - nomkl
   - scipy
   - pyopengl
   - pytest

--- a/.github/workflows/etc/environment-pyside.yml
+++ b/.github/workflows/etc/environment-pyside.yml
@@ -3,7 +3,9 @@ channels:
   - conda-forge
 dependencies:
   - pyside2
+  - qt-main
   - numpy
+  - nomkl
   - scipy
   - pyopengl
   - pytest

--- a/.github/workflows/etc/environment-pyside.yml
+++ b/.github/workflows/etc/environment-pyside.yml
@@ -8,6 +8,4 @@ dependencies:
   - nomkl
   - scipy
   - pyopengl
-  - pytest
-  - pytest-xdist
   - pip

--- a/.github/workflows/etc/environment-pyside.yml
+++ b/.github/workflows/etc/environment-pyside.yml
@@ -1,9 +1,7 @@
 name: test
 channels:
   - conda-forge
-  - defaults
 dependencies:
-  - python=3.8
   - pyside2
   - numpy
   - scipy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
             qt-version: "PyQt6"
           - python-version: "3.10"
             qt-lib: "pyside"
-            qt-version: "PySide6"
+            qt-version: "PySide6-Essentials"
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,6 +157,8 @@ jobs:
           environment-file: ${{ matrix.environment-file }}
           auto-update-conda: false
           python-version: "3.8"
+      - name: "Install Test Framework"
+        run: pip install pytest pytest-xdist
       - name: "Install Windows-Mesa OpenGL DLL"
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,37 +134,29 @@ jobs:
   test-conda:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        qt-lib: [pyqt, pyside]
+        include:
+          - qt-lib: pyqt
+            environment-file: .github/workflows/etc/environment-pyqt.yml
+          - qt-lib: pyside
+            environment-file: .github/workflows/etc/environment-pyside.yml
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: "latest"
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          environment-file: ${{ matrix.environment-file }}
           auto-update-conda: false
-          channels: conda-forge,defaults
-          channel-priority: true
           python-version: "3.8"
-          use-only-tar-bz2: true
-      - name: Get Date
-        id: get-date
-        run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')"
-        shell: bash
-      - name: Cache Conda env
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CONDA }}/envs
-          key: conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ hashFiles('.github/workflows/etc/environment.yml') }}-${{ env.CACHE_NUMBER }}
-        env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
-          CACHE_NUMBER: 0
-        id: cache
-      - name: Update environment
-        run: conda env update -n test -f .github/workflows/etc/environment.yml
-        if: steps.cache.outputs.cache-hit != 'true'
       - name: "Install Windows-Mesa OpenGL DLL"
         if: runner.os == 'Windows'
         run: |
@@ -199,7 +191,6 @@ jobs:
             libxcb-xinerama0 \
             libopengl0
           pip install pytest-xvfb
-        shell: bash -l {0}
       - name: 'Debug Info'
         run: |
           echo python location: `which python`
@@ -210,7 +201,6 @@ jobs:
           pip list
           echo pyqtgraph system info
           python -c "import pyqtgraph as pg; pg.systemInfo()"
-        shell: bash -l {0}
         env:
           QT_DEBUG_PLUGINS: 1
       - name: 'XVFB Display Info'
@@ -218,19 +208,16 @@ jobs:
           xvfb-run --server-args="-screen 0, 1920x1200x24 -ac +extension GLX +render -noreset" python -m pyqtgraph.util.glinfo
           xvfb-run --server-args="-screen 0, 1920x1200x24 -ac +extension GLX +render -noreset" python -m pyqtgraph.util.get_resolution
         if: runner.os == 'Linux'
-        shell: bash -l {0}
       - name: 'Display Info'
         run: |
           python -m pyqtgraph.util.glinfo
           python -m pyqtgraph.util.get_resolution
         if: runner.os != 'Linux'
-        shell: bash -l {0}
       - name: Run Tests
         run: |
           mkdir $SCREENSHOT_DIR
           pytest tests -v
           pytest pyqtgraph/examples -v -n 2
-        shell: bash -l {0}
         env:
           SCREENSHOT_DIR: ./screenshots
 

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,22 +1,22 @@
 # numpy based on python version and NEP-29 requirements
 numpy; python_version == '3.10'
 numpy==1.21.5; python_version == '3.9'
-numpy==1.19.5; python_version == '3.8'
+numpy==1.20.3; python_version == '3.8'
 
 # image testing
-scipy==1.8.0
+scipy==1.8.1
 
 # optional high performance paths
-numba==0.55.1; python_version == '3.9'
+numba==0.55.2; python_version == '3.9'
 
 # optional 3D
 pyopengl==3.1.6
 
 # supplimental tools
-matplotlib==3.5.1
-h5py==3.6.0
+matplotlib==3.5.2
+h5py==3.7.0
 
 # testing
-pytest==7.1.0
+pytest==7.1.2
 pytest-xdist==2.5.0
 pytest-xvfb==2.0.0; sys_platform == 'linux'

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ class Install(install.install):
     """
     def run(self):
         global path, version, initVersion, forcedVersion, installVersion
-        
+
         name = self.config_vars['dist_name']
         path = os.path.join(self.install_libbase, 'pyqtgraph')
         if os.path.exists(path):
@@ -122,7 +122,7 @@ setup(
         'style': helpers.StyleCommand
     },
     packages=find_namespace_packages(include=['pyqtgraph', 'pyqtgraph.*']),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     package_dir={"pyqtgraph": "pyqtgraph"},
     package_data={
         'pyqtgraph.examples': ['optics/*.gz', 'relativity/presets/*.cfg'],
@@ -134,7 +134,7 @@ setup(
         ],
     },
     install_requires = [
-        'numpy>=1.19.0',
+        'numpy>=1.20.0',
     ],
     **setupOpts
 )


### PR DESCRIPTION
This PR does a number of small changes

* Expands conda based pipelines to test both pyqt5 and pyside2 bindings
* Uses mambaforge instead of miniconda (much faster environment resolution)
* On conda configs, explicitly state qt-main to not download qt-webengine
* On conda configs install pytest via pip (hopefully have slightly faster dependency resolution)
* On pip, use pyside6-essentials for the current pyside6 pipeline
* Bump required numpy version to 1.20 per NEP-29
* Add dependabot config file to keep our github actions config up to date.