### PR TITLE
No need to run CI on depandabot branch push events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: main
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore: "dependabot/**"
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
@@ -236,6 +241,7 @@ jobs:
         run: |
           python -m pip install setuptools wheel
           python setup.py bdist_wheel
+  
   analyze:
     name: analyze
     runs-on: ubuntu-latest


### PR DESCRIPTION
On the dependabot branch push events, the CI would run, but the codeql-analyze job would fail with the following error:

> Error: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.

Afterl looking at the workflow [here](https://github.com/actions/upload-artifact/actions/runs/943194932/workflow), I think the same run critiera can be applied to our CI:

```yaml
on:
  push:
    branches-ignore: "dependabot/**"
  pull_request:
    paths-ignore:
      - '**.md'
```
