### PR TITLE
Grab latest patch versions of numpy for specified minor version

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,7 +1,7 @@
 # numpy based on python version and NEP-29 requirements
 numpy; python_version == '3.10'
-numpy==1.21.5; python_version == '3.9'
-numpy==1.20.3; python_version == '3.8'
+numpy~=1.21.0; python_version == '3.9'
+numpy~=1.20.0; python_version == '3.8'
 
 # image testing
 scipy==1.8.1


### PR DESCRIPTION
Likely won't impact anything given that numpy isn't releasing new patches for 1.20 and 1.21; but still this ensures the latest patch version is grabbed for the specified minor version.