### PR TITLE
BusyCursor and QPainter fixes for PyPy

### DIFF
--- a/pyqtgraph/dockarea/DockDrop.py
+++ b/pyqtgraph/dockarea/DockDrop.py
@@ -131,3 +131,4 @@ class DropAreaOverlay(QtWidgets.QWidget):
         p.setBrush(QtGui.QBrush(QtGui.QColor(100, 100, 255, 50)))
         p.setPen(QtGui.QPen(QtGui.QColor(50, 50, 150), 3))
         p.drawRect(rgn)
+        p.end()

--- a/pyqtgraph/widgets/JoystickButton.py
+++ b/pyqtgraph/widgets/JoystickButton.py
@@ -79,6 +79,7 @@ class JoystickButton(QtWidgets.QPushButton):
             6,
             6
         )
+        p.end()
         
     def resizeEvent(self, ev):
         self.setState(*self.state)


### PR DESCRIPTION
1) #2263 added a hasty fix for the addition of `QOverrideCursorGuard`. That fix doesn't work on PyPy. A more proper fix is implemented here.

2) QPainter.end() needs to be called when painting is done.

In both of these cases, the issue has to do with the CPython implementation relying on the objects getting destructed when their refcnt drops to zero.

The fixes here are not specific to PyPy per se, but rather, the issues they fix are exposed when run under PyPy.