### PR TITLE
Add helpful comment about transformation order

### DIFF
--- a/doc/source/images/gen_example_imageitem_transform.py
+++ b/doc/source/images/gen_example_imageitem_transform.py
@@ -17,6 +17,7 @@ class MainWindow(pg.GraphicsLayoutWidget):
         # Example: Transformed display of ImageItem
 
         tr = QtGui.QTransform()  # prepare ImageItem transformation:
+        #Order of transforms are important here, you might want the other way around. 
         tr.scale(6.0, 3.0)       # scale horizontal and vertical axes
         tr.translate(-1.5, -1.5) # move 3x3 image to locate center at axis origin
 


### PR DESCRIPTION
Transformation operations are non-commutable. I spent ages trying to convert old code that used the .scale and .setPos and was acting strangely. In my case I needed to call translate first and then scale.