### PR TITLE
fix: super().__init__ does not need self

### DIFF
--- a/pyqtgraph/graphicsItems/TargetItem.py
+++ b/pyqtgraph/graphicsItems/TargetItem.py
@@ -78,7 +78,7 @@ class TargetItem(UIGraphicsItem):
             A dict of keyword arguments to use when constructing the text
             label. See :class:`TargetLabel` and :class:`~pyqtgraph.TextItem`
         """
-        super().__init__(self)
+        super().__init__()
         self.movable = movable
         self.moving = False
         self._label = None


### PR DESCRIPTION
`super().__init__(self)` results in a call to `UIGraphicsItem.__init__(self, bounds=self, parent=None)`

UIGraphicsItem expects `"bounds"` to be a `QRectF` and assigns it to `"self._bounds"`.
(`"self._bounds"` ends up not being used at all, but that's another issue...)

At worst, the bug here causes a cyclic reference.