### PR TITLE
fixed mouse move event position updates

### DIFF
--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -371,7 +371,7 @@ class GraphicsView(QtGui.QGraphicsView):
     def mouseMoveEvent(self, ev):
         if self.lastMousePos is None:
             self.lastMousePos = Point(ev.pos())
-        delta = Point(ev.pos() - QtCore.QPoint(*self.lastMousePos))
+        delta = Point(ev.pos() - QtCore.QPoint(int(self.lastMousePos.x()), int(self.lastMousePos.y())))
         self.lastMousePos = Point(ev.pos())
 
         QtGui.QGraphicsView.mouseMoveEvent(self, ev)


### PR DESCRIPTION
It was giving an error shown as below:
```
Traceback (most recent call last):
  File "/media/bryan/Disk/PROJECTS/GPR/viewer_test/venv/lib/python3.10/site-packages/pyqtgraph/widgets/GraphicsView.py", line 374, in mouseMoveEvent
    delta = Point(ev.pos() - QtCore.QPoint(*self.lastMousePos))
TypeError: arguments did not match any overloaded call:
  QPoint(): too many arguments
  QPoint(int, int): argument 1 has unexpected type 'float'
  QPoint(QPoint): argument 1 has unexpected type 'float'

```

it seems like `QPoint()` is getting `float` params. The issues is fixed