### PR TITLE
remove legend items manually from scene

### DIFF
--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -268,6 +268,18 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         except IndexError:
             return None
 
+    def _removeItemFromLayout(self, *args):
+        for item in args:
+            self.layout.removeItem(item)
+            item.close()
+            # Normally, the item is automatically removed from
+            # its scene when it gets destroyed.
+            # this doesn't happen on current versions of
+            # PySide (5.15.x, 6.3.x) and results in a leak.
+            scene = item.scene()
+            if scene:
+                scene.removeItem(item)
+
     def removeItem(self, item):
         """Removes one item from the legend.
 
@@ -279,20 +291,14 @@ class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
         for sample, label in self.items:
             if sample.item is item or label.text == item:
                 self.items.remove((sample, label))  # remove from itemlist
-                self.layout.removeItem(sample)  # remove from layout
-                sample.close()  # remove from drawing
-                self.layout.removeItem(label)
-                label.close()
-                self.updateSize()  # redraq box
+                self._removeItemFromLayout(sample, label)
+                self.updateSize()  # redraw box
                 return  # return after first match
 
     def clear(self):
         """Remove all items from the legend."""
         for sample, label in self.items:
-            self.layout.removeItem(sample)
-            sample.close()
-            self.layout.removeItem(label)
-            label.close()
+            self._removeItemFromLayout(sample, label)
 
         self.items = []
         self.updateSize()


### PR DESCRIPTION
On PySide{2,6}, these items persist in the scene, causing a leak. Details and test-cases are found in #2348.

Fixes #2348
