### PR TITLE
Fix GraphicsScene.itemsNearEvent and setClickRadius

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -396,66 +396,77 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
         ret = QtWidgets.QGraphicsScene.removeItem(self, item)
         self.sigItemRemoved.emit(item)
         return ret
-        
-    def itemsNearEvent(self, event, selMode=QtCore.Qt.ItemSelectionMode.IntersectsItemShape, sortOrder=QtCore.Qt.SortOrder.DescendingOrder, hoverable=False):
+
+    def itemsNearEvent(
+        self,
+        event,
+        selMode=QtCore.Qt.ItemSelectionMode.IntersectsItemShape,
+        sortOrder=QtCore.Qt.SortOrder.DescendingOrder,
+        hoverable=False,
+    ):
         """
         Return an iterator that iterates first through the items that directly intersect point (in Z order)
         followed by any other items that are within the scene's click radius.
         """
-        #tr = self.getViewWidget(event.widget()).transform()
         view = self.views()[0]
         tr = view.viewportTransform()
-        
-        if hasattr(event, 'buttonDownScenePos'):
+
+        if hasattr(event, "buttonDownScenePos"):
             point = event.buttonDownScenePos()
         else:
             point = event.scenePos()
 
-        items = self.items(point, selMode, sortOrder, tr)
-        
-        ## remove items whose shape does not contain point (scene.items() apparently sucks at this)
-        items2 = []
-        for item in items:
-            if hoverable and not hasattr(item, 'hoverEvent'):
-                continue
-            if item.scene() is not self:
-                continue
-            shape = item.shape() # Note: default shape() returns boundingRect()
-            if shape is None:
-                continue
-            if shape.contains(item.mapFromScene(point)):
-                items2.append(item)
-        
         ## Sort by descending Z-order (don't trust scene.itms() to do this either)
         ## use 'absolute' z value, which is the sum of all item/parent ZValues
         def absZValue(item):
             if item is None:
                 return 0
             return item.zValue() + absZValue(item.parentItem())
-        
-        items2.sort(key=absZValue, reverse=True)
-        
-        return items2
 
-        #seen = set()
-        #r = self._clickRadius
-        #rect = view.mapToScene(QtCore.QRect(0, 0, 2*r, 2*r)).boundingRect()
-        #w = rect.width()
-        #h = rect.height()
-        #rgn = QtCore.QRectF(point.x()-w, point.y()-h, 2*w, 2*h)
-        #self.searchRect.setRect(rgn)
-        
-        #for item in items:
-            ##seen.add(item)
+        ## Get items, which directly are at the given point (sorted by z-value)
+        items_at_point = self.items(point, selMode, sortOrder, tr)
+        items_at_point.sort(key=absZValue, reverse=True)
 
-            #shape = item.mapToScene(item.shape())
-            #if not shape.contains(point):
-                #continue
-            #yield item
-        #for item in self.items(rgn, selMode, sortOrder, tr):
-            ##if item not in seen:
-            #yield item
-        
+        ## Get items, which are within the click radius around the given point (sorted by z-value)
+        r = self._clickRadius
+        items_within_radius = []
+        rgn = None
+        if r > 0.0:
+            rect = view.mapToScene(QtCore.QRect(0, 0, 2 * r, 2 * r)).boundingRect()
+            w = rect.width()
+            h = rect.height()
+            rgn = QtCore.QRectF(point.x() - w / 2, point.y() - h / 2, w, h)
+            items_within_radius = self.items(rgn, selMode, sortOrder, tr)
+            items_within_radius.sort(key=absZValue, reverse=True)
+            # Remove items, which are already in the other list
+            for item in items_at_point:
+                if item in items_within_radius:
+                    items_within_radius.remove(item)
+
+        ## Put both groups of items together, but in the correct order
+        ## The items directly at the given point shall have higher priority
+        all_items = items_at_point + items_within_radius
+
+        ## Remove items, which we don't want, due to several reasons
+        selected_items = []
+        for item in all_items:
+            if hoverable and not hasattr(item, "hoverEvent"):
+                continue
+            if item.scene() is not self:
+                continue
+            shape = item.shape()  # Note: default shape() returns boundingRect()
+            if shape is None:
+                continue
+            # Remove items whose shape does not contain point or region
+            # (scene.items() apparently sucks at this)
+            if (
+                rgn is not None
+                and shape.intersects(item.mapFromScene(rgn).boundingRect())
+            ) or shape.contains(item.mapFromScene(point)):
+                selected_items.append(item)
+
+        return selected_items
+
     def getViewWidget(self):
         return self.views()[0]
     

--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -301,14 +301,11 @@ class InfiniteLine(GraphicsObject):
         if vr is None:
             return QtCore.QRectF()
         
-        ## add a 4-pixel radius around the line for mouse interaction.
-        
         px = self.pixelLength(direction=Point(1,0), ortho=True)  ## get pixel length orthogonal to the line
         if px is None:
             px = 0
         pw = max(self.pen.width() / 2, self.hoverPen.width() / 2)
-        w = max(4, self._maxMarkerSize + pw) + 1
-        w = w * px
+        w = (self._maxMarkerSize + pw + 1) * px
         br = QtCore.QRectF(vr)
         br.setBottom(-w)
         br.setTop(w)

--- a/tests/graphicsItems/test_InfiniteLine.py
+++ b/tests/graphicsItems/test_InfiniteLine.py
@@ -46,7 +46,7 @@ def test_InfiniteLine():
     pos = oline.mapToScene(pg.Point(2, 0))
     assert br.containsPoint(pos, QtCore.Qt.FillRule.OddEvenFill)
     px = pg.Point(-0.5, -1.0 / 3**0.5)
-    assert br.containsPoint(pos + 2 * px, QtCore.Qt.FillRule.OddEvenFill)
+    assert br.containsPoint(pos + 1 * px, QtCore.Qt.FillRule.OddEvenFill)
     assert not br.containsPoint(pos + 3 * px, QtCore.Qt.FillRule.OddEvenFill)
     plt.close()
 

--- a/tests/graphicsItems/test_InfiniteLine.py
+++ b/tests/graphicsItems/test_InfiniteLine.py
@@ -46,8 +46,8 @@ def test_InfiniteLine():
     pos = oline.mapToScene(pg.Point(2, 0))
     assert br.containsPoint(pos, QtCore.Qt.FillRule.OddEvenFill)
     px = pg.Point(-0.5, -1.0 / 3**0.5)
-    assert br.containsPoint(pos + 5 * px, QtCore.Qt.FillRule.OddEvenFill)
-    assert not br.containsPoint(pos + 7 * px, QtCore.Qt.FillRule.OddEvenFill)
+    assert br.containsPoint(pos + 2 * px, QtCore.Qt.FillRule.OddEvenFill)
+    assert not br.containsPoint(pos + 3 * px, QtCore.Qt.FillRule.OddEvenFill)
     plt.close()
 
 def test_mouseInteraction():


### PR DESCRIPTION
There is an issue with the mapping of mouse cursor position to the items which shall get mouse events.
It's about the case, when the cursor position is not directly intersecting with the item, but is quite near to it. 
For the `InfiniteLine` there exists some code, solving this, which I would say is rather a workaround. But actually, this should and can be solved within `GraphicsScene.itemsNearEvent()`. 
See also `GraphicsScene.setClickRadius()`, which doesn't have any effect currently.

### MWE with description of resulting problems

```python
import pyqtgraph as pg

app = pg.mkQApp()
plot = pg.PlotWidget()
plot.show()

plot.setXRange(min=-1.0, max=+1.0)

plot.scene().setClickRadius(20)  # Has no effect

region1 = pg.LinearRegionItem()
region1.setRegion((0.1, 0.13))
region1.setBrush(pg.mkBrush("blue"))
region1.setHoverBrush(pg.mkBrush("magenta"))
for line in region1.lines:
    line.setPen(pg.mkPen(color="yellow", width=2))
    line.setHoverPen(pg.mkPen("#00ff00", width=2))
plot.addItem(region1)

region2 = pg.LinearRegionItem()
region2.setRegion((0.5, 0.502))
region2.setBrush(pg.mkBrush("red"))
region2.setHoverBrush(pg.mkBrush("magenta"))
for line in region2.lines:
    line.setVisible(False)
plot.addItem(region2)

if __name__ == '__main__':
    pg.exec()
```

If you run the mwe, the blue `region1` should have a width of around 10 pixel and the red `region2` should appear with a width of 1 pixel. This works for me with the default window size and zoom.
In this case I see the following two problems:

1. Moving the **blue `region1`** via **mouse dragging is impossible**, because it's too small. Either the left or the right line gets hovered (and dragged if clicked), but never the area in between. But, I would say this should be possible for an area which is roughly 6 px wide.

2. Moving the **red `region2`** via **mouse dragging is impossible** neither works the hovering.

### Reason

`GraphicsScene.itemsNearEvent()` returns only the items which directly intersect with the position of the event, e.g. the mouse cursor position in this case. See also the docstring, which describes the desired behaviour in my opinion.
Usually, this problem isn't observed, since for the `InfiniteLine`, there exists a workaround, which simply makes the bounding rect a 4 px wide line, see InfiniteLine.py line 304 and 310 (https://github.com/pyqtgraph/pyqtgraph/blob/8be2d6a88edc1e26b1f6f85c47a72c400db9a28b/pyqtgraph/graphicsItems/InfiniteLine.py#L304,L310).

### Resolution

In the present PR, I removed the workaround in InfiniteLine.py and reworked `GraphicsScene.itemsNearEvent()` and reactivated commented code, such that the click radius is considered and the behaviour is as described in the docstring.