### PR TITLE
Fix flickering, when panning/scrolling in a fully zoomed-out view

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1622,8 +1622,13 @@ class ViewBox(GraphicsWidget):
                     changed[0] = True
                 viewRange[0] = rangeX
 
-
-        changed = [(viewRange[i][0] != self.state['viewRange'][i][0]) or (viewRange[i][1] != self.state['viewRange'][i][1]) for i in (0,1)]
+        # Consider only as 'changed' if the differences are larger than floating point inaccuracies
+        thresholds = [(viewRange[axis][1] - viewRange[axis][0]) * 1.0e-9 for axis in (0,1)]
+        changed = [
+            (abs(viewRange[axis][0] - self.state["viewRange"][axis][0]) > thresholds[axis])
+            or (abs(viewRange[axis][1] - self.state["viewRange"][axis][1]) > thresholds[axis])
+            for axis in (0, 1)
+        ]
         self.state['viewRange'] = viewRange
 
         if any(changed):

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1622,7 +1622,9 @@ class ViewBox(GraphicsWidget):
                     changed[0] = True
                 viewRange[0] = rangeX
 
-        # Consider only as 'changed' if the differences are larger than floating point inaccuracies
+        # Consider only as 'changed' if the differences are larger than floating point inaccuracies,
+        # which regularly appear in magnitude of around 1e-15. Therefore, 1e-9 as factor was chosen
+        # more or less arbitrarily.
         thresholds = [(viewRange[axis][1] - viewRange[axis][0]) * 1.0e-9 for axis in (0,1)]
         changed = [
             (abs(viewRange[axis][0] - self.state["viewRange"][axis][0]) > thresholds[axis])


### PR DESCRIPTION
If a `ViewBox` is fully zoomed out (i.e. the current view range equals to the limits), it's still possible to pan the view. 
The values by which the views range changes are extremely small (less than 1e-14), but still this is source of at least some imperfections. Issues I observed are that the `ViewBox.sigRangeChanged` is emitted and that plot or axis might flicker.

### Fix

In `ViewBox.updateViewRange` the desired view range values are compared with the current view range values and if they differ, the `ViewBox.sigRangeChanged` is emitted.
To solve the issue, I replaced the direct comparison of the view-range-values with a threshold based comparison.
So only if the difference between new and old values relative to the total visible span exceeds a value of 1.0e-9 it's considered as a actual change.

### mwe to reproduce the problem

To reproduce the problems, run the mwe below and follow these steps:
1. The view should already be fully zoomed-out but you can ensure it trying to further zoom-out.
2. Now click'n'drag and try to pan the view a few times to the left and a few times to the right.
You'll observe that the "0"- and "1"-tick-labels at the x-axis sometimes (dis)appear, depending on which direction you tried to pan the view.
Further, the printed x-range shows values like 
`x-range: [3.41740524767431e-16, 1.0]` or `x-range: [0.0, 0.9999999999999996]`.

```{python}
import pyqtgraph as pg

app = pg.mkQApp()
plot = pg.PlotWidget()
plot.show()

plot.setMouseEnabled(x=True, y=False)
plot.setLimits(xMin=0.0, xMax=1.0, maxXRange=1.0)
plot.setXRange(min=0.0, max=1.0, padding=0.0)

def print_x_range(plotwidget,view_range):
    print(f"x-range: {view_range[0]}")

plot.sigRangeChanged.connect(print_x_range)

if __name__ == '__main__':
    pg.exec()
```
