### PR TITLE
remove QFileDialog PyQt4 compatibility code

### DIFF
--- a/pyqtgraph/examples/relativity/relativity.py
+++ b/pyqtgraph/examples/relativity/relativity.py
@@ -162,21 +162,17 @@ class RelativityGUI(QtWidgets.QWidget):
         self.setAnimation(self.params['Animate'])
         
     def save(self):
-        filename = pg.QtWidgets.QFileDialog.getSaveFileName(self, "Save State..", "untitled.cfg", "Config Files (*.cfg)")
-        if isinstance(filename, tuple):
-            filename = filename[0]  # Qt4/5 API difference
-        if filename == '':
+        filename, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Save State..", "untitled.cfg", "Config Files (*.cfg)")
+        if not filename:
             return
         state = self.params.saveState()
-        configfile.writeConfigFile(state, str(filename)) 
+        configfile.writeConfigFile(state, filename)
         
     def load(self):
-        filename = pg.QtWidgets.QFileDialog.getOpenFileName(self, "Save State..", "", "Config Files (*.cfg)")
-        if isinstance(filename, tuple):
-            filename = filename[0]  # Qt4/5 API difference
-        if filename == '':
+        filename, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Save State..", "", "Config Files (*.cfg)")
+        if not filename:
             return
-        state = configfile.readConfigFile(str(filename)) 
+        state = configfile.readConfigFile(filename)
         self.loadState(state)
         
     def loadPreset(self, param, preset):

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -819,12 +819,10 @@ class ImageView(QtWidgets.QWidget):
             self.imageItem.save(fileName)
             
     def exportClicked(self):
-        fileName = QtWidgets.QFileDialog.getSaveFileName()
-        if isinstance(fileName, tuple):
-            fileName = fileName[0]  # Qt4/5 API difference
-        if fileName == '':
+        fileName, _ = QtWidgets.QFileDialog.getSaveFileName()
+        if not fileName:
             return
-        self.export(str(fileName))
+        self.export(fileName)
         
     def buildMenu(self):
         self.menu = QtWidgets.QMenu()

--- a/pyqtgraph/widgets/TableWidget.py
+++ b/pyqtgraph/widgets/TableWidget.py
@@ -349,15 +349,13 @@ class TableWidget(QtWidgets.QTableWidget):
         self.save(self.serialize(useSelection=False))
 
     def save(self, data):
-        fileName = QtWidgets.QFileDialog.getSaveFileName(
+        fileName, _ = QtWidgets.QFileDialog.getSaveFileName(
             self,
             f"{translate('TableWidget', 'Save As')}...",
             "",
             f"{translate('TableWidget', 'Tab-separated values')} (*.tsv)"
         )
-        if isinstance(fileName, tuple):
-            fileName = fileName[0]  # Qt4/5 API difference
-        if fileName == '':
+        if not fileName:
             return
         with open(fileName, 'w') as fd:
             fd.write(data)


### PR DESCRIPTION
PyQt4 had two separate APIs:
1) QFileDialog.getOpenFileName() -> filename
2) QFileDialog.getOpenFileNameAndFilter() -> (filename, selectedfilter)

Other bindings (including PySide1) have this API:
* QFileDialog.getOpenFileName() -> (filename, selectedfilter)

This PR simplifies the code by removing the support for PyQt4.