### PR TITLE
map pyqtgraph symbols to a matplotlib equivalent

### DIFF
--- a/pyqtgraph/exporters/Matplotlib.py
+++ b/pyqtgraph/exporters/Matplotlib.py
@@ -27,7 +27,29 @@ The advantage is that there is less to do to get an exported file cleaned and re
 publication. Fonts are not vectorized (outlined), and window colors are white.
 
 """
-    
+
+
+_symbol_pg_to_mpl = {
+    'o'           : 'o',    # circle
+    's'           : 's',    # square
+    't'           : 'v',    # triangle_down
+    't1'          : '^',    # triangle_up
+    't2'          : '>',    # triangle_right
+    't3'          : '<',    # triangle_left
+    'd'           : 'd',    # thin_diamond
+    '+'           : 'P',    # plus (filled)
+    'x'           : 'X',    # x (filled)
+    'p'           : 'p',    # pentagon
+    'h'           : 'h',    # hexagon1
+    'star'        : '*',    # star
+    'arrow_up'    : 6,      # caretup
+    'arrow_right' : 5,      # caretright
+    'arrow_down'  : 7,      # caretdown
+    'arrow_left'  : 4,      # caretleft
+    'crosshair'   : 'o',    # circle
+}
+
+
 class MatplotlibExporter(Exporter):
     Name = "Matplotlib Window"
     windows = []
@@ -96,8 +118,7 @@ class MatplotlibExporter(Exporter):
                 linestyle = '-'
             color = pen.color().getRgbF()
             symbol = opts['symbol']
-            if symbol == 't':
-                symbol = '^'
+            symbol = _symbol_pg_to_mpl.get(symbol, "")
             symbolPen = fn.mkPen(opts['symbolPen'])
             symbolBrush = fn.mkBrush(opts['symbolBrush'])
             markeredgecolor = symbolPen.color().getRgbF()


### PR DESCRIPTION
This PR maps all the pyqtgraph scatterplot symbols to some matplotlib equivalent such that the `Symbols.py` example can export something to Matplotlib:

master:
![before](https://user-images.githubusercontent.com/2657027/184525210-897831c4-0527-4da9-8c85-2509730469ef.png)

this PR:
![image](https://user-images.githubusercontent.com/2657027/184524965-183be6e2-3c6c-4115-8ea1-70c504acb299.png)
