### PR TITLE
`getHistogramRange` for `HistogramLUTItem`

### DIFF
--- a/pyqtgraph/graphicsItems/HistogramLUTItem.py
+++ b/pyqtgraph/graphicsItems/HistogramLUTItem.py
@@ -254,13 +254,20 @@ class HistogramLUTItem(GraphicsWidget):
                 p.drawLine(gradRect.topRight(), gradRect.bottomRight())
 
     def setHistogramRange(self, mn, mx, padding=0.1):
-        """Set the Y range on the histogram plot. This disables auto-scaling."""
+        """Set the X/Y range on the histogram plot, depending on the orientation. This disables auto-scaling."""
         if self.orientation == 'vertical':
             self.vb.enableAutoRange(self.vb.YAxis, False)
             self.vb.setYRange(mn, mx, padding)
         else:
             self.vb.enableAutoRange(self.vb.XAxis, False)
             self.vb.setXRange(mn, mx, padding)
+
+    def getHistogramRange(self):
+        """Returns range on the histogram plot."""
+        if self.orientation == 'vertical':
+            return self.vb.viewRange()[1]
+        else:
+            return self.vb.viewRange()[0]
 
     def autoHistogramRange(self):
         """Enable auto-scaling on the histogram plot."""


### PR DESCRIPTION
`pyqtgraph.HistogramLUTItem` already had the setter `setHistogramRange`, but was missing the getter `getHistogramRange`. I added it.