### PR TITLE
remove MatplotlibWidget from pg namespace

### DIFF
--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -289,9 +289,6 @@ from .widgets.TreeWidget import *
 from .widgets.ValueLabel import *
 from .widgets.VerticalLabel import *
 
-# Wrapped to prevent matplotlib becoming a hard dependency.
-if spec := importlib.util.find_spec('matplotlib') is not None:
-    from .widgets.MatplotlibWidget import *
 
 ##############################################################
 ## PyQt and PySide both are prone to crashing on exit. 

--- a/tests/widgets/test_matplotlibwidget.py
+++ b/tests/widgets/test_matplotlibwidget.py
@@ -11,11 +11,13 @@ import numpy as np
 
 pytest.importorskip("matplotlib")
 
+from pyqtgraph.widgets.MatplotlibWidget import MatplotlibWidget
+
 pg.mkQApp()
 
 default_parent = None
-default_figsize = pg.MatplotlibWidget.figsize_default
-default_dpi = pg.MatplotlibWidget.dpi_default
+default_figsize = MatplotlibWidget.figsize_default
+default_dpi = MatplotlibWidget.dpi_default
 
 
 def assert_widget_fields(mplw, parent, figsize, dpi):
@@ -31,7 +33,7 @@ def test_init_with_qwidget_arguments():
     """
     win = QtWidgets.QMainWindow()
 
-    mplw = pg.MatplotlibWidget(win)
+    mplw = MatplotlibWidget(win)
 
     assert_widget_fields(mplw, win, default_figsize, default_dpi)
 
@@ -43,13 +45,13 @@ def test_init_with_matplotlib_arguments():
     """
     figsize = (1.0, 3.0)
     dpi = 256
-    mplw = pg.MatplotlibWidget(figsize, dpi)
+    mplw = MatplotlibWidget(figsize, dpi)
 
     assert_widget_fields(mplw, default_parent, figsize, dpi)
 
 
 def test_init_with_no_arguments():
-    mplw = pg.MatplotlibWidget()
+    mplw = MatplotlibWidget()
 
     assert_widget_fields(mplw, default_parent, default_figsize, default_dpi)
 
@@ -66,20 +68,20 @@ def test_init_sanity():
     assert figsize != default_figsize
     assert dpi != default_dpi
 
-    mplw = pg.MatplotlibWidget(parent, figsize=figsize)
+    mplw = MatplotlibWidget(parent, figsize=figsize)
     assert_widget_fields(mplw, parent, figsize, default_dpi)
 
-    mplw = pg.MatplotlibWidget(parent, dpi=dpi)
+    mplw = MatplotlibWidget(parent, dpi=dpi)
     assert_widget_fields(mplw, parent, default_figsize, dpi)
 
-    mplw = pg.MatplotlibWidget(parent, figsize, dpi)
+    mplw = MatplotlibWidget(parent, figsize, dpi)
     assert_widget_fields(mplw, parent, figsize, dpi)
 
-    mplw = pg.MatplotlibWidget(figsize, dpi)
+    mplw = MatplotlibWidget(figsize, dpi)
     assert_widget_fields(mplw, default_parent, figsize, dpi)
 
-    mplw = pg.MatplotlibWidget(figsize, dpi, parent)
+    mplw = MatplotlibWidget(figsize, dpi, parent)
     assert_widget_fields(mplw, parent, figsize, dpi)
 
-    mplw = pg.MatplotlibWidget(dpi=dpi, parent=parent)
+    mplw = MatplotlibWidget(dpi=dpi, parent=parent)
     assert_widget_fields(mplw, parent, default_figsize, dpi)


### PR DESCRIPTION
This PR partially undoes #2366, specifically its import of `MatplotlibWidget` into the `pg` namespace.
Firstly, it adds unnecessary overhead to the import of `pyqtgraph` for users who do not use the Matplotlib Exporter functionality.
Secondly, this import seems to be causing the segfault in one of the CI pipelines (Python 3.9.13 / Linux / PySide2 5.15) for the not-yet-merged #2318.