### PR TITLE
Fix InfiniteLine bounding rect calculation

### DIFF
--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -301,7 +301,8 @@ class InfiniteLine(GraphicsObject):
         if vr is None:
             return QtCore.QRectF()
         
-        px = self.pixelLength(direction=Point(1,0), ortho=True)  ## get pixel length orthogonal to the line
+        # get pixel length orthogonal to the line
+        px = self.pixelLength(direction=Point(0, 1))
         if px is None:
             px = 0
         pw = max(self.pen.width() / 2, self.hoverPen.width() / 2)

--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -300,11 +300,12 @@ class InfiniteLine(GraphicsObject):
         vr = self.viewRect()  # bounds of containing ViewBox mapped to local coords.
         if vr is None:
             return QtCore.QRectF()
-        
-        # get pixel length orthogonal to the line
-        px = self.pixelLength(direction=Point(0, 1))
-        if px is None:
-            px = 0
+
+        # compute the pixel size orthogonal to the line
+        # this is more complicated than it seems, maybe it can be simplified
+        _, ortho = self.pixelVectors(direction=Point(1, 0))
+        px = 0 if ortho is None else ortho.y()
+
         pw = max(self.pen.width() / 2, self.hoverPen.width() / 2)
         w = (self._maxMarkerSize + pw + 1) * px
         br = QtCore.QRectF(vr)


### PR DESCRIPTION
Fixes #1878 

Sometimes the smallest changes need the most explanation...

`InfiniteLine` previously used `GraphicsItem.pixelLength(Point(0, 1), ortho=True)` to compute the size of 1 pixel in the direction orthogonal to the line, in the item's coordinate system. I'm not sure why the current version requests pixel length orthogonal to the direction along the line rather than via the orthogonal direction directly - I'm still suspicious that I'm missing something.

I haven't figured out yet if `pixelVectors` does what it should or not. It'd be worth taking a closer look at it as I vaguely recall some bounding rect type issues with ROIs which also use it.

### Demonstration

Without the proposed change, zooming on say the y axis causes the blue bounding rect to change "width", when it should hug the line with a small ~constant buffer.

Notice also the red and green lines stay parallel and orthogonal to the infinite line. If you change it to `pixelVectors(pg.Point(0, 1))`, this is no longer the case.

It's also strange that if you directly plot `Point(0, 1)` and `Point(1, 0)`, `Point(0, 1)` doesn't really do what you'd expect. I'm not sure what to make of that.

```python
import pyqtgraph as pg


class InfLine(pg.InfiniteLine):

    def paint(self, p, *args):
        tr = p.transform()

        # bounding rect in blue
        p.setPen(pg.mkPen("b", width=1))
        p.drawRect(self.boundingRect())

        super().paint(p, args)

        # draw pixelVectors
        p.setTransform(tr)
        normV, orthoV = self.pixelVectors(pg.Point(1, 0))  # try pg.Point(0, 1)
        print(normV, orthoV)
        p.setPen(pg.mkPen("r"))
        # p.drawLine(pg.Point(0, 0), pg.Point(1, 0))
        p.drawLine(pg.Point(0, 0), 10*normV)
        p.setPen(pg.mkPen("g"))
        # p.drawLine(pg.Point(0, 0), pg.Point(0, 1))
        p.drawLine(pg.Point(0, 0), 10*orthoV)


app = pg.mkQApp()

plt = pg.plot()
plt.setXRange(-10, 10)
plt.setYRange(-10, 10)
plt.resize(600, 600)
plt.showGrid(x=True, y=True)

oline = InfLine(angle=30)
plt.addItem(oline)

app.exec()
```