### PR TITLE
Bugfix: `interact` on decorated method that uses `self`.

### DIFF
--- a/doc/source/parametertree/interactiveparameters.rst
+++ b/doc/source/parametertree/interactiveparameters.rst
@@ -73,24 +73,24 @@ code below is functionally equivalent to above):
 There are several caveats, but this is one of the most common scenarios
 for function interaction.
 
-``runOpts``
-^^^^^^^^^^^
+``runOptions``
+^^^^^^^^^^^^^^
 
 Often, an ``interact``-ed function shouldn't run until multiple
 parameter values are changed. Or, the function should be run every time
 a value is *changing*, not just changed. In these cases, modify the
-``runOpts`` parameter.
+``runOptions`` parameter.
 
 .. code:: python
 
-    from pyqtgraph.parametertree import interact, RunOpts
+    from pyqtgraph.parametertree import interact, RunOptions
 
     # Will add a button named "Run". When clicked, the function will run
-    params = interact(a, runOpts=RunOpts.ON_ACTION)
+    params = interact(a, runOptions=RunOptions.ON_ACTION)
     # Will run on any `sigValueChanging` signal
-    params = interact(a, runOpts=RunOpts.ON_CHANGING)
+    params = interact(a, runOptions=RunOptions.ON_CHANGING)
     # Runs on `sigValueChanged` or when "Run" is pressed
-    params = interact(a, runOpts=[RunOpts.ON_CHANGED, RunOpts.ON_ACTION])
+    params = interact(a, runOptions=[RunOptions.ON_CHANGED, RunOptions.ON_ACTION])
     # Any combination of RUN_* options can be used
 
 The default run behavior can also be modified. If several functions are
@@ -100,13 +100,13 @@ use the provided context manager:
 .. code:: python
 
     from pyqtgraph.parametertree import interact
-    # `runOpts` can be set to any combination of options as demonstrated above, too
-    with interact.optsContext(runOpts=RunOpts.ON_ACTION):
-        # All will have `runOpts` set to ON_ACTION
+    # `runOptions` can be set to any combination of options as demonstrated above, too
+    with interact.optsContext(runOptions=RunOptions.ON_ACTION):
+        # All will have `runOptions` set to ON_ACTION
         p1 = interact(aFunc)
         p2 = interact(bFunc)
         p3 = interact(cFunc)
-    # After the context, `runOpts` is back to the previous default
+    # After the context, `runOptions` is back to the previous default
 
 If the default for all interaction should be changed, you can directly
 call ``interactDefaults.setOpts`` (but be warned - anyone who imports your
@@ -119,9 +119,9 @@ resetting afterward:
 
     from pyqtgraph.parametertree import Interactor
     myInteractor = Interactor()
-    oldOpts = myInteractor.setOpts(runOpts=RunOpts.ON_ACTION)
+    oldOpts = myInteractor.setOpts(runOptions=RunOptions.ON_ACTION)
     # Can also directly create interactor with these opts:
-    # myInteractor = Interactor(runOpts=RunOpts.ON_ACTION)
+    # myInteractor = Interactor(runOptions=RunOptions.ON_ACTION)
 
     # ... do some things...
     # Unset option
@@ -367,13 +367,13 @@ and ``reconnect()`` methods, and object accessors to ``closures`` arguments.
 
 .. code:: python
 
-    from pyqtgraph.parametertree import InteractiveFunction, interact, Parameter, RunOpts
+    from pyqtgraph.parametertree import InteractiveFunction, interact, Parameter, RunOptions
 
     def myfunc(a=5):
         print(a)
 
     useFunc = InteractiveFunction(myfunc)
-    param = interact(useFunc, runOpts=RunOpts.ON_CHANGED)
+    param = interact(useFunc, runOptions=RunOptions.ON_CHANGED)
     param['a'] = 6
     # Will print 6
     useFunc.disconnect()
@@ -388,7 +388,7 @@ can use ``InteractiveFunction`` like a decorator:
 
 .. code:: python
 
-    from pyqtgraph.parametertree import InteractiveFunction, interact, Parameter, RunOpts
+    from pyqtgraph.parametertree import InteractiveFunction, interact, Parameter, RunOptions
 
     @InteractiveFunction
     def myfunc(a=5):
@@ -396,7 +396,7 @@ can use ``InteractiveFunction`` like a decorator:
 
     # myfunc is now an InteractiveFunction that can be used as above
     # Also, calling `myfunc` will preserve parameter arguments
-    param = interact(myfunc, RunOpts.ON_ACTION)
+    param = interact(myfunc, RunOptions.ON_ACTION)
     param['a'] = 6
 
     myfunc()

--- a/pyqtgraph/examples/InteractiveParameter.py
+++ b/pyqtgraph/examples/InteractiveParameter.py
@@ -5,7 +5,7 @@ from pyqtgraph.Qt import QtWidgets
 from pyqtgraph.parametertree import (
     Parameter,
     ParameterTree,
-    RunOpts,
+    RunOptions,
     InteractiveFunction,
     Interactor,
 )
@@ -60,7 +60,7 @@ def ignoredAParam(a=10, b=20):
     return a * b
 
 
-@interactor.decorate(runOpts=RunOpts.ON_ACTION)
+@interactor.decorate(runOptions=RunOptions.ON_ACTION)
 @printResult
 def runOnButton(a=10, b=20):
     return a + b
@@ -91,7 +91,7 @@ with interactor.optsContext(titleFormat=str.upper):
 
 
 @interactor.decorate(
-    runOpts=(RunOpts.ON_CHANGED, RunOpts.ON_ACTION),
+    runOptions=(RunOptions.ON_CHANGED, RunOptions.ON_ACTION),
     a={"type": "list", "limits": [5, 10, 20]},
 )
 @printResult

--- a/pyqtgraph/parametertree/__init__.py
+++ b/pyqtgraph/parametertree/__init__.py
@@ -3,4 +3,4 @@ from .Parameter import Parameter, registerParameterItemType, registerParameterTy
 from .ParameterItem import ParameterItem
 from .ParameterSystem import ParameterSystem, SystemSolver
 from .ParameterTree import ParameterTree
-from .interactive import RunOpts, interact, InteractiveFunction, Interactor
+from .interactive import RunOptions, interact, InteractiveFunction, Interactor

--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -7,9 +7,11 @@ from . import Parameter
 from .. import functions as fn
 
 
-class RunOpts:
-    class PARAM_UNSET:
-        """Sentinel value for detecting parameters with unset values"""
+class PARAM_UNSET:
+    """Sentinel value for detecting parameters with unset values"""
+
+
+class RunOptions:
 
     ON_ACTION = "action"
     """
@@ -197,14 +199,21 @@ class InteractiveFunction:
 
 
 class Interactor:
-    runOpts = RunOpts.ON_CHANGED
+    runOptions = RunOptions.ON_CHANGED
     parent = None
     titleFormat = None
     nest = True
     existOk = True
     runActionTemplate = dict(type="action", defaultName="Run")
 
-    _optNames = ["runOpts", "parent", "titleFormat", "nest", "existOk", "runActionTemplate"]
+    _optNames = [
+        "runOptions",
+        "parent",
+        "titleFormat",
+        "nest",
+        "existOk",
+        "runActionTemplate",
+    ]
 
     def __init__(self, **kwargs):
         """
@@ -265,11 +274,11 @@ class Interactor:
         function,
         *,
         ignores=None,
-        runOpts=RunOpts.PARAM_UNSET,
-        parent=RunOpts.PARAM_UNSET,
-        titleFormat=RunOpts.PARAM_UNSET,
-        nest=RunOpts.PARAM_UNSET,
-        existOk=RunOpts.PARAM_UNSET,
+        runOptions=PARAM_UNSET,
+        parent=PARAM_UNSET,
+        titleFormat=PARAM_UNSET,
+        nest=PARAM_UNSET,
+        existOk=PARAM_UNSET,
         **overrides,
     ):
         """
@@ -287,7 +296,7 @@ class Interactor:
         function: Callable
             function with which to interact. Can also be a :class:`InteractiveFunction`,
             if a reference to the bound signals is required.
-        runOpts: ``GroupParameter.<RUN_ACTION, CHANGED, or CHANGING>`` value
+        runOptions: ``GroupParameter.<RUN_ACTION, CHANGED, or CHANGING>`` value
             How the function should be run, i.e. when pressing an action, on
             sigValueChanged, and/or on sigValueChanging
         ignores: Sequence
@@ -318,13 +327,11 @@ class Interactor:
         locs = locals()
         # Everything until action template
         opts = {
-            kk: locs[kk]
-            for kk in self._optNames[:-1]
-            if locs[kk] is not RunOpts.PARAM_UNSET
+            kk: locs[kk] for kk in self._optNames[:-1] if locs[kk] is not PARAM_UNSET
         }
         oldOpts = self.setOpts(**opts)
         # Delete explicitly since correct values are now ``self`` attributes
-        del runOpts, titleFormat, nest, existOk, parent
+        del runOptions, titleFormat, nest, existOk, parent
 
         function = self._toInteractiveFunction(function)
         funcDict = self.functionToParameterDict(function.function, **overrides)
@@ -342,13 +349,13 @@ class Interactor:
         recycleNames = set(ignores) & set(chNames)
         for name in recycleNames:
             value = children[chNames.index(name)]["value"]
-            if name not in function.extra and value is not RunOpts.PARAM_UNSET:
+            if name not in function.extra and value is not PARAM_UNSET:
                 function.extra[name] = value
 
         missingChildren = [
             ch["name"]
             for ch in children
-            if ch["value"] is RunOpts.PARAM_UNSET
+            if ch["value"] is PARAM_UNSET
             and ch["name"] not in function.closures
             and ch["name"] not in function.extra
         ]
@@ -368,7 +375,7 @@ class Interactor:
         function.hookupParameters(useParams)
         # If no top-level parent and no nesting, return the list of child parameters
         ret = funcGroup or useParams
-        if RunOpts.ON_ACTION in self.runOpts:
+        if RunOptions.ON_ACTION in self.runOptions:
             # Add an extra action child which can activate the function
             action = self._makeRunAction(self.nest, funcDict.get("tip"), function)
             # Return just the action if no other params were allowed
@@ -460,9 +467,9 @@ class Interactor:
             child = Parameter.create(**childOpts)
         else:
             child = funcGroup.addChild(childOpts, existOk=self.existOk)
-        if RunOpts.ON_CHANGED in self.runOpts:
+        if RunOptions.ON_CHANGED in self.runOptions:
             child.sigValueChanged.connect(interactiveFunc.runFromChangedOrChanging)
-        if RunOpts.ON_CHANGING in self.runOpts:
+        if RunOptions.ON_CHANGING in self.runOptions:
             child.sigValueChanging.connect(interactiveFunc.runFromChangedOrChanging)
         return child
 
@@ -556,7 +563,7 @@ class Interactor:
         pgDict["name"] = name
         # Required function arguments with any override specifications can still be
         # unfilled at this point
-        pgDict.setdefault("value", RunOpts.PARAM_UNSET)
+        pgDict.setdefault("value", PARAM_UNSET)
 
         # Anywhere a title is specified should take precedence over the default factory
         if self.titleFormat is not None:

--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -326,11 +326,11 @@ class Interactor:
         # Delete explicitly since correct values are now ``self`` attributes
         del runOpts, titleFormat, nest, existOk, parent
 
-        funcDict = self.functionToParameterDict(function, **overrides)
+        function = self._toInteractiveFunction(function)
+        funcDict = self.functionToParameterDict(function.function, **overrides)
         children = funcDict.pop("children", [])  # type: list[dict]
         chNames = [ch["name"] for ch in children]
         funcGroup = self._resolveFunctionGroup(funcDict)
-        function = self._toInteractiveFunction(function)
 
         # Values can't come both from closures and overrides/params, so ensure they don't
         # get created

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -388,6 +388,13 @@ def test_class_interact():
     parent = Parameter.create(name="parent", type="group")
     interactor = Interactor(parent=parent, nest=False)
 
+    def outside_class_deco(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return wrapper
+
     class A:
         def a(self, x=5):
             return x
@@ -396,9 +403,16 @@ def test_class_interact():
         def b(cls, y=5):
             return y
 
+        @outside_class_deco
+        def c(self, z=5):
+            return z
+
     a = A()
     ai = interactor.decorate()(a.a)
     assert ai() == a.a()
 
     bi = interactor.decorate()(A.b)
     assert bi() == A.b()
+
+    ci = interactor.decorate()(a.c)
+    assert ci() == a.c()

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -2,7 +2,12 @@ import pytest
 from functools import wraps
 from pyqtgraph.parametertree import Parameter
 from pyqtgraph.parametertree.parameterTypes import GroupParameter as GP
-from pyqtgraph.parametertree import RunOpts, InteractiveFunction, Interactor, interact
+from pyqtgraph.parametertree import (
+    RunOptions,
+    InteractiveFunction,
+    Interactor,
+    interact,
+)
 
 
 def test_parameter_hasdefault():
@@ -65,7 +70,7 @@ def test_unpack_parameter():
 
 
 def test_interact():
-    interactor = Interactor(runOpts=RunOpts.ON_ACTION)
+    interactor = Interactor(runOptions=RunOptions.ON_ACTION)
     value = None
 
     def retain(func):
@@ -106,7 +111,11 @@ def test_interact():
     assert value == (10, 5)
 
     host = interactor(
-        a, x=10, y=50, ignores=["x"], runOpts=(RunOpts.ON_CHANGED, RunOpts.ON_CHANGING)
+        a,
+        x=10,
+        y=50,
+        ignores=["x"],
+        runOptions=(RunOptions.ON_CHANGED, RunOptions.ON_CHANGING),
     )
     for child in "x", "Run":
         assert child not in host.names
@@ -127,7 +136,7 @@ def test_interact():
         assert host.title() == "Group only"
         assert [p.title() is None for p in host]
 
-    with interactor.optsContext(runOpts=RunOpts.ON_CHANGED):
+    with interactor.optsContext(runOptions=RunOptions.ON_CHANGED):
         host = interactor(a, x=5)
         host["y"] = 20
         assert value == (5, 20)
@@ -156,7 +165,7 @@ def test_interact():
     host.child("a", "Run").activate()
     assert value == 5
 
-    @interactor.decorate(nest=False, runOpts=RunOpts.ON_CHANGED)
+    @interactor.decorate(nest=False, runOptions=RunOptions.ON_CHANGED)
     @retain
     def b(y=6):
         return y
@@ -173,7 +182,7 @@ def test_interact():
     def override(**kwargs):
         return raw(**kwargs)
 
-    host = interactor(wraps(raw)(override), runOpts=RunOpts.ON_CHANGED)
+    host = interactor(wraps(raw)(override), runOptions=RunOptions.ON_CHANGED)
     assert "x" in host.names
     host["x"] = 100
     assert value == 100
@@ -183,7 +192,7 @@ def test_run():
     def a():
         """"""
 
-    interactor = Interactor(runOpts=RunOpts.ON_ACTION)
+    interactor = Interactor(runOptions=RunOptions.ON_ACTION)
 
     defaultRunBtn = Parameter.create(**interactor.runActionTemplate, name="Run")
     btn = interactor(a)
@@ -201,6 +210,7 @@ def test_run():
     test2 = interactor(a, nest=False)
     assert not test2.parent()
 
+
 def test_no_func_group():
     def inner(a=5, b=6):
         return a + b
@@ -215,7 +225,7 @@ def test_tips():
 
     interactor = Interactor()
 
-    btn = interactor(a, runOpts=RunOpts.ON_ACTION)
+    btn = interactor(a, runOptions=RunOptions.ON_ACTION)
     assert btn.opts["tip"] == a.__doc__
 
     def a2(x=5):
@@ -227,7 +237,7 @@ def test_tips():
         followed by more text won't result in a tooltip
         """
 
-    param = interactor(a2, runOpts=RunOpts.ON_ACTION)
+    param = interactor(a2, runOptions=RunOptions.ON_ACTION)
     assert param.opts["tip"] == a2.__doc__ and param.type() == "group"
 
     param = interactor(a3)
@@ -243,7 +253,7 @@ def test_interactiveFunc():
         return a
 
     interactive = InteractiveFunction(myfunc)
-    host = interact(interactive, runOpts=[])
+    host = interact(interactive, runOptions=[])
 
     host["a"] = 7
     assert interactive.runFromAction() == 7
@@ -354,6 +364,7 @@ def test_update_non_param_kwarg():
     def a(x=3, **kwargs):
         RetainVal.a = sum(kwargs.values()) + x
         return RetainVal.a
+
     a.parametersNeedRunKwargs = True
 
     host = interact(a)
@@ -372,10 +383,12 @@ def test_update_non_param_kwarg():
     # But the cache should still be up-to-date
     assert a() == 5
 
+
 def test_hookup_extra_params():
     @InteractiveFunction
     def a(x=5, **kwargs):
         return x + sum(kwargs.values())
+
     interact(a)
 
     p2 = Parameter.create(name="p2", type="int", value=3)


### PR DESCRIPTION
The modified example in `tests/parametertree` used to fail before this PR. A result of #2404 was that `inspect.signature` no longer realized that `self` was a bound variable in class-defined, outside-decorated functions. Fix this simply by calling `functionToParameterDict` on the original function, rather than the interactive version.

Also expands `runOpts` to `runOptions` to remain in keeping with fully-expanded argument names elsewhere. `setOpts` and related terms are now the only non-expanded items, since they match the already-present `Parameter` API