### PR TITLE
Fix doubling labels in DateAxisItem

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -820,7 +820,11 @@ class AxisItem(GraphicsWidget):
             ## remove any ticks that were present in higher levels
             ## we assume here that if the difference between a tick value and a previously seen tick value
             ## is less than spacing/100, then they are 'equal' and we can ignore the new tick.
-            values = list(filter(lambda x: np.all(np.abs(allValues-x) > spacing/self.scale*0.01), values))
+            close = np.any(
+                np.isclose(allValues, values[:, np.newaxis], rtol=0, atol=spacing/self.scale*0.01)
+                , axis=-1
+            )
+            values = values[~close]
             allValues = np.concatenate([allValues, values])
             ticks.append((spacing/self.scale, values))
 

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -826,7 +826,7 @@ class AxisItem(GraphicsWidget):
             )
             values = values[~close]
             allValues = np.concatenate([allValues, values])
-            ticks.append((spacing/self.scale, values))
+            ticks.append((spacing/self.scale, values.tolist()))
 
         if self.logMode:
             return self.logTickValues(minVal, maxVal, size, ticks)

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -170,7 +170,6 @@ class ZoomLevel:
             # remove any ticks that were present in higher levels
             # we assume here that if the difference between a tick value and a previously seen tick value
             # is less than min-spacing/100, then they are 'equal' and we can ignore the new tick.
-            ticks = np.array(ticks)
             close = np.any(
                 np.isclose(allTicks, ticks[:, np.newaxis], rtol=0, atol=minSpc * 0.01),
                 axis=-1,

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -170,9 +170,14 @@ class ZoomLevel:
             # remove any ticks that were present in higher levels
             # we assume here that if the difference between a tick value and a previously seen tick value
             # is less than min-spacing/100, then they are 'equal' and we can ignore the new tick.
-            tick_list = list(filter(lambda x: np.all(np.abs(allTicks-x) > minSpc*0.01), ticks))
-            allTicks = np.concatenate([allTicks, tick_list])
-            valueSpecs.append((spec.spacing, tick_list))
+            ticks = np.array(ticks)
+            close = np.any(
+                np.isclose(allTicks, ticks[:, np.newaxis], rtol=0, atol=minSpc * 0.01),
+                axis=-1,
+            )
+            ticks = ticks[~close]
+            allTicks = np.concatenate([allTicks, ticks])
+            valueSpecs.append((spec.spacing, ticks))
             # if we're skipping ticks on the current level there's no point in
             # producing lower level ticks
             if skipFactor > 1:

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -176,7 +176,7 @@ class ZoomLevel:
             )
             ticks = ticks[~close]
             allTicks = np.concatenate([allTicks, ticks])
-            valueSpecs.append((spec.spacing, ticks))
+            valueSpecs.append((spec.spacing, ticks.tolist()))
             # if we're skipping ticks on the current level there's no point in
             # producing lower level ticks
             if skipFactor > 1:

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -157,7 +157,7 @@ class ZoomLevel:
         # minSpc indicates the minimum spacing (in seconds) between two ticks
         # to fullfill the maxTicksPerPt constraint of the DateAxisItem at the
         # current zoom level. This is used for auto skipping ticks.
-        allTicks = []
+        allTicks = np.array([])
         valueSpecs = []
         # back-project (minVal maxVal) to UTC, compute ticks then offset to
         # back to local time again
@@ -170,8 +170,8 @@ class ZoomLevel:
             # remove any ticks that were present in higher levels
             # we assume here that if the difference between a tick value and a previously seen tick value
             # is less than min-spacing/100, then they are 'equal' and we can ignore the new tick.
-            tick_list = list(filter(lambda x: np.all(np.abs(np.array(allTicks)-x) > minSpc*0.01), ticks))
-            allTicks.extend(tick_list)
+            tick_list = list(filter(lambda x: np.all(np.abs(allTicks-x) > minSpc*0.01), ticks))
+            allTicks = np.concatenate([allTicks, tick_list])
             valueSpecs.append((spec.spacing, tick_list))
             # if we're skipping ticks on the current level there's no point in
             # producing lower level ticks

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -168,7 +168,9 @@ class ZoomLevel:
             # reposition tick labels to local time coordinates
             ticks += self.utcOffset
             # remove any ticks that were present in higher levels
-            tick_list = [x for x in ticks.tolist() if x not in allTicks]
+            # we assume here that if the difference between a tick value and a previously seen tick value
+            # is less than min-spacing/100, then they are 'equal' and we can ignore the new tick.
+            tick_list = list(filter(lambda x: np.all(np.abs(np.array(allTicks)-x) > minSpc*0.01), ticks))
             allTicks.extend(tick_list)
             valueSpecs.append((spec.spacing, tick_list))
             # if we're skipping ticks on the current level there's no point in


### PR DESCRIPTION
### In short
* Due to floating point errors, comparison for equality sometimes fails to detect doubling values. Use approximative comparison instead. Code is copied from AxisItem.tickValues().

### In detail

In some situations `DateAxisItem` draws two different tick labels (of different levels) for the same value. See the following screenshot, where "60.0" and "02:01:00" are drawn. "60.0" should be skipped and only "02:01:00" should be drawn.
This can be reproduced, using the `DateAxisItem` example, simply zoom in like in the screenshot. There, the visible range is something between 0.01s and 0.004s. It seems to happen at each full minute. Note, that the occurence depends also on the minimum axis value, meaning it may be necessary to pan the axis a bit to the left or right always keeping the full minute within the visible range.

![grafik](https://user-images.githubusercontent.com/36670201/189619056-3a98ddfc-bf62-4bbb-b7eb-d5e511cf26f3.png)