### PR TITLE
Promote interactive `Run` action to group level

### DIFF
--- a/pyqtgraph/examples/_buildParamTypes.py
+++ b/pyqtgraph/examples/_buildParamTypes.py
@@ -88,7 +88,11 @@ def makeAllParamTypes():
         btn = Parameter.create(name=f'{name} All', type='action')
         btn.sigActivated.connect(activate)
         params.insertChild(0, btn)
-    missing = set(PARAM_TYPES).difference(_encounteredTypes)
+    missing = [
+        typ
+        for typ in set(PARAM_TYPES).difference(_encounteredTypes)
+        if not typ.startswith("_")
+    ]
     if missing:
         raise RuntimeError(f'{missing} parameters are not represented')
     return params

--- a/pyqtgraph/examples/_paramtreecfg.py
+++ b/pyqtgraph/examples/_paramtreecfg.py
@@ -132,6 +132,18 @@ cfg = {
         }
     },
 
+    'action': {
+        'shortcut': {
+            'type': 'str',
+            'value': "Ctrl+Shift+P",
+        },
+        'icon': {
+            'type': 'file',
+            'value': None,
+            'nameFilter': "Images (*.png *.jpg *.bmp *.jpeg *.svg)",
+        },
+    },
+
     'calendar': {
         'format': {
             'type': 'str',
@@ -186,7 +198,6 @@ cfg = {
         'bool': False,
         'colormap': None,
         'progress': 50,
-        'action': None,
         'font': 'Inter',
     }
 }

--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -361,6 +361,10 @@ class Interactor:
             and ch["name"] not in function.extra
         ]
         if missingChildren:
+            # setOpts will not be called due to the value error, so reset here.
+            # This only matters to restore Interactor state in an outer try-except
+            # block
+            self.setOpts(**oldOpts)
             raise ValueError(
                 f"Cannot interact with `{function}` since it has required parameters "
                 f"{missingChildren} with no default or closure values provided."

--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -4,7 +4,7 @@ import inspect
 import pydoc
 
 from . import Parameter
-from .parameterTypes import FunctionGroupParameter
+from .parameterTypes import ActionGroup
 from .. import functions as fn
 
 
@@ -483,7 +483,7 @@ class Interactor:
         return child
 
     def _resolveRunAction(self, interactiveFunction, functionGroup, functionTip):
-        if isinstance(functionGroup, FunctionGroupParameter):
+        if isinstance(functionGroup, ActionGroup):
             functionGroup.setButtonOpts(visible=True)
             child = None
         else:
@@ -514,7 +514,7 @@ class Interactor:
         children = []
         name = function.__name__
         btnOpts = dict(**self._makePopulatedActionTemplate(name), visible=False)
-        out = dict(name=name, type="functiongroup", children=children, button=btnOpts)
+        out = dict(name=name, type="_actiongroup", children=children, button=btnOpts)
         if self.titleFormat is not None:
             out["title"] = self._nameToTitle(name, forwardStringTitle=True)
 

--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -39,6 +39,10 @@ class InteractiveFunction:
     can provide an external scope for accessing the hooked up parameter signals.
     """
 
+    # Attributes below are populated by `update_wrapper` but aren't detected by linters
+    __name__: str
+    __qualname__: str
+
     def __init__(self, function, *, closures=None, **extra):
         """
         Wraps a callable function in a way that forwards Parameter arguments as keywords
@@ -207,7 +211,7 @@ class Interactor:
     existOk = True
     runActionTemplate = dict(type="action", defaultName="Run")
 
-    _optNames = [
+    _optionNames = [
         "runOptions",
         "parent",
         "titleFormat",
@@ -328,7 +332,7 @@ class Interactor:
         locs = locals()
         # Everything until action template
         opts = {
-            kk: locs[kk] for kk in self._optNames[:-1] if locs[kk] is not PARAM_UNSET
+            kk: locs[kk] for kk in self._optionNames[:-1] if locs[kk] is not PARAM_UNSET
         }
         oldOpts = self.setOpts(**opts)
         # Delete explicitly since correct values are now ``self`` attributes
@@ -380,9 +384,7 @@ class Interactor:
         function.hookupParameters(useParams)
         if RunOptions.ON_ACTION in self.runOptions:
             # Add an extra action child which can activate the function
-            action = self._resolveRunAction(
-                function, funcGroup, funcDict.get("tip")
-            )
+            action = self._resolveRunAction(function, funcGroup, funcDict.get("tip"))
             if action:
                 useParams.append(action)
         retValue = funcGroup if self.nest else useParams
@@ -413,7 +415,7 @@ class Interactor:
 
         return decorator
 
-    def _nameToTitle(self, name, forwardStrTitle=False):
+    def _nameToTitle(self, name, forwardStringTitle=False):
         """
         Converts a function name to a title based on ``self.titleFormat``.
 
@@ -421,7 +423,7 @@ class Interactor:
         ----------
         name: str
             Name of the function
-        forwardStrTitle: bool
+        forwardStringTitle: bool
             If ``self.titleFormat`` is a string and ``forwardStrTitle`` is True,
             ``self.titleFormat`` will be used as the title. Otherwise, if
             ``self.titleFormat`` is *None*, the name will be returned unchanged.
@@ -430,7 +432,7 @@ class Interactor:
         """
         titleFormat = self.titleFormat
         isString = isinstance(titleFormat, str)
-        if titleFormat is None or (isString and not forwardStrTitle):
+        if titleFormat is None or (isString and not forwardStringTitle):
             return name
         elif isString:
             return titleFormat
@@ -467,15 +469,17 @@ class Interactor:
             refOwner.interactiveRefs = [interactive]
         return interactive
 
-    def resolveAndHookupParameterChild(self, funcGroup, childOpts, interactiveFunc):
-        if not funcGroup:
+    def resolveAndHookupParameterChild(
+        self, functionGroup, childOpts, interactiveFunction
+    ):
+        if not functionGroup:
             child = Parameter.create(**childOpts)
         else:
-            child = funcGroup.addChild(childOpts, existOk=self.existOk)
+            child = functionGroup.addChild(childOpts, existOk=self.existOk)
         if RunOptions.ON_CHANGED in self.runOptions:
-            child.sigValueChanged.connect(interactiveFunc.runFromChangedOrChanging)
+            child.sigValueChanged.connect(interactiveFunction.runFromChangedOrChanging)
         if RunOptions.ON_CHANGING in self.runOptions:
-            child.sigValueChanging.connect(interactiveFunc.runFromChangedOrChanging)
+            child.sigValueChanging.connect(interactiveFunction.runFromChangedOrChanging)
         return child
 
     def _resolveRunAction(self, interactiveFunction, functionGroup, functionTip):
@@ -598,7 +602,7 @@ class Interactor:
         return str(self)
 
     def getOpts(self):
-        return {attr: getattr(self, attr) for attr in self._optNames}
+        return {attr: getattr(self, attr) for attr in self._optionNames}
 
 
 interact = Interactor()

--- a/pyqtgraph/parametertree/parameterTypes/__init__.py
+++ b/pyqtgraph/parametertree/parameterTypes/__init__.py
@@ -1,5 +1,6 @@
 from ..Parameter import registerParameterItemType, registerParameterType
 from .action import ActionParameter, ActionParameterItem
+from .actiongroup import ActionGroup, ActionGroupParameterItem
 from .basetypes import (
     GroupParameter,
     GroupParameterItem,
@@ -12,7 +13,6 @@ from .checklist import ChecklistParameter, ChecklistParameterItem
 from .color import ColorParameter, ColorParameterItem
 from .colormap import ColorMapParameter, ColorMapParameterItem
 from .file import FileParameter, FileParameterItem
-from .functiongroup import FunctionGroupParameter, FunctionGroupParameterItem
 from .font import FontParameter, FontParameterItem
 from .list import ListParameter, ListParameterItem
 from .numeric import NumericParameterItem
@@ -28,8 +28,9 @@ registerParameterItemType('float', NumericParameterItem, SimpleParameter, overri
 registerParameterItemType('int',   NumericParameterItem, SimpleParameter, override=True)
 registerParameterItemType('str',   StrParameterItem,     SimpleParameter, override=True)
 
-registerParameterType('group',         GroupParameter,         override=True)
-registerParameterType('functiongroup', FunctionGroupParameter, override=True)
+registerParameterType('group',         GroupParameter, override=True)
+# Keep actiongroup private for now, mainly useful for Interactor but not externally
+registerParameterType('_actiongroup',  ActionGroup,    override=True)
 
 registerParameterType('action',    ActionParameter,      override=True)
 registerParameterType('calendar',  CalendarParameter,    override=True)

--- a/pyqtgraph/parametertree/parameterTypes/__init__.py
+++ b/pyqtgraph/parametertree/parameterTypes/__init__.py
@@ -12,6 +12,7 @@ from .checklist import ChecklistParameter, ChecklistParameterItem
 from .color import ColorParameter, ColorParameterItem
 from .colormap import ColorMapParameter, ColorMapParameterItem
 from .file import FileParameter, FileParameterItem
+from .functiongroup import FunctionGroupParameter, FunctionGroupParameterItem
 from .font import FontParameter, FontParameterItem
 from .list import ListParameter, ListParameterItem
 from .numeric import NumericParameterItem
@@ -27,7 +28,8 @@ registerParameterItemType('float', NumericParameterItem, SimpleParameter, overri
 registerParameterItemType('int',   NumericParameterItem, SimpleParameter, override=True)
 registerParameterItemType('str',   StrParameterItem,     SimpleParameter, override=True)
 
-registerParameterType('group', GroupParameter, override=True)
+registerParameterType('group',         GroupParameter,         override=True)
+registerParameterType('functiongroup', FunctionGroupParameter, override=True)
 
 registerParameterType('action',    ActionParameter,      override=True)
 registerParameterType('calendar',  CalendarParameter,    override=True)

--- a/pyqtgraph/parametertree/parameterTypes/action.py
+++ b/pyqtgraph/parametertree/parameterTypes/action.py
@@ -1,10 +1,12 @@
-from ...Qt import QtCore, QtWidgets
+from ...Qt import QtCore, QtWidgets, QtGui
 from ..Parameter import Parameter
 from ..ParameterItem import ParameterItem
 
 
 class ParameterControlledButton(QtWidgets.QPushButton):
-    settableAttributes = {"title", "tip", "icon", "shortcut", "enabled", "visible"}
+    settableAttributes = {
+        "title", "tip", "icon", "shortcut", "enabled", "visible"
+    }
 
     def __init__(self, parameter=None, parent=None):
         super().__init__(parent)
@@ -18,7 +20,7 @@ class ParameterControlledButton(QtWidgets.QPushButton):
     def updateOpts(self, param, opts):
         # Of the attributes that can be set on a QPushButton, only the text
         # and tooltip attributes are different from standard pushbutton names
-        nameMap = dict(title="text", tip="tooltip")
+        nameMap = dict(title="text", tip="toolTip")
         # Special case: "title" could be none, in which case make it something
         # readable by the simple copy-paste logic later
         opts = opts.copy()
@@ -27,13 +29,19 @@ class ParameterControlledButton(QtWidgets.QPushButton):
         if "title" in opts and opts["title"] is None:
             opts["title"] = param.title()
 
+        # Another special case: icons should be loaded from data before
+        # being passed to the button
+        if "icon" in opts:
+            opts["icon"] = QtGui.QIcon(opts["icon"])
+
         for attr in self.settableAttributes.intersection(opts):
-            buttonAttr = nameMap.get(attr, attr).title()
-            setter = getattr(self, f"set{buttonAttr}")
+            buttonAttr = nameMap.get(attr, attr)
+            capitalized = buttonAttr[0].upper() + buttonAttr[1:]
+            setter = getattr(self, f"set{capitalized}")
             setter(opts[attr])
 
     def onNameChange(self, param, name):
-        self.updateOpts(param, title=param.title())
+        self.updateOpts(param, dict(title=param.title()))
 
 
 class ActionParameterItem(ParameterItem):
@@ -67,6 +75,17 @@ class ActionParameter(Parameter):
     """Used for displaying a button within the tree.
 
     ``sigActivated(self)`` is emitted when the button is clicked.
+
+    ============== ============================================================
+    **Options:**
+    icon           Icon to display in the button. Can be any argument accepted
+                   by :func:`QtGui.QIcon <pyqtgraph.QtGui.QIcon>`
+    shortcut       Key sequence to use as a shortcut for the button. Note that
+                   this shortcut is associated with spawned parameters, i.e.
+                   the shortcut will only work when this parameter has an item
+                   in a tree that is visible. Can be set to any string accepted
+                   by :func:`QtGui.QKeySequence <pyqtgraph.QtGui.QKeySequence>`
+    ============== ============================================================
     """
     itemClass = ActionParameterItem
     sigActivated = QtCore.Signal(object)

--- a/pyqtgraph/parametertree/parameterTypes/action.py
+++ b/pyqtgraph/parametertree/parameterTypes/action.py
@@ -72,20 +72,21 @@ class ActionParameterItem(ParameterItem):
 
 
 class ActionParameter(Parameter):
-    """Used for displaying a button within the tree.
+    """
+    Used for displaying a button within the tree.
 
     ``sigActivated(self)`` is emitted when the button is clicked.
 
-    ============== ============================================================
-    **Options:**
-    icon           Icon to display in the button. Can be any argument accepted
-                   by :func:`QtGui.QIcon <pyqtgraph.QtGui.QIcon>`
-    shortcut       Key sequence to use as a shortcut for the button. Note that
-                   this shortcut is associated with spawned parameters, i.e.
-                   the shortcut will only work when this parameter has an item
-                   in a tree that is visible. Can be set to any string accepted
-                   by :func:`QtGui.QKeySequence <pyqtgraph.QtGui.QKeySequence>`
-    ============== ============================================================
+    Parameters
+    ----------
+    icon: str
+        Icon to display in the button. Can be any argument accepted
+        by :class:`QIcon <QtGui.QIcon>`.
+    shortcut: str
+        Key sequence to use as a shortcut for the button. Note that this shortcut is
+        associated with spawned parameters, i.e. the shortcut will only work when this
+        parameter has an item in a tree that is visible. Can be set to any string
+        accepted by :class:`QKeySequence <QtGui.QKeySequence>`.
     """
     itemClass = ActionParameterItem
     sigActivated = QtCore.Signal(object)

--- a/pyqtgraph/parametertree/parameterTypes/actiongroup.py
+++ b/pyqtgraph/parametertree/parameterTypes/actiongroup.py
@@ -5,7 +5,7 @@ from ..ParameterItem import ParameterItem
 from ...Qt import QtCore
 
 
-class FunctionGroupParameterItem(GroupParameterItem):
+class ActionGroupParameterItem(GroupParameterItem):
     """
     Wraps a :class:`GroupParameterItem` to manage ``bool`` parameter children. Also provides convenience buttons to
     select or clear all values at once. Note these conveniences are disabled when ``exclusive`` is *True*.
@@ -34,8 +34,8 @@ class FunctionGroupParameterItem(GroupParameterItem):
         super().optsChanged(param, opts)
 
 
-class FunctionGroupParameter(GroupParameter):
-    itemClass = FunctionGroupParameterItem
+class ActionGroup(GroupParameter):
+    itemClass = ActionGroupParameterItem
 
     sigActivated = QtCore.Signal()
 

--- a/pyqtgraph/parametertree/parameterTypes/actiongroup.py
+++ b/pyqtgraph/parametertree/parameterTypes/actiongroup.py
@@ -21,10 +21,7 @@ class ActionGroupParameterItem(GroupParameterItem):
         tw = self.treeWidget()
         if tw is None:
             return
-        if self.button:
-            tw.setItemWidget(self, 1, self.button)
-        elif tw.itemWidget(self, 1) is not None:
-            tw.removeItemWidget(self, 1)
+        tw.setItemWidget(self, 1, self.button)
 
     def optsChanged(self, param, opts):
         if "button" in opts:

--- a/pyqtgraph/parametertree/parameterTypes/functiongroup.py
+++ b/pyqtgraph/parametertree/parameterTypes/functiongroup.py
@@ -1,0 +1,56 @@
+from ...Qt import QtCore
+from .action import ParameterControlledButton
+from .basetypes import GroupParameter, GroupParameterItem
+from ..ParameterItem import ParameterItem
+from ...Qt import QtCore
+
+
+class FunctionGroupParameterItem(GroupParameterItem):
+    """
+    Wraps a :class:`GroupParameterItem` to manage ``bool`` parameter children. Also provides convenience buttons to
+    select or clear all values at once. Note these conveniences are disabled when ``exclusive`` is *True*.
+    """
+
+    def __init__(self, param, depth):
+        self.button = ParameterControlledButton()
+        super().__init__(param, depth)
+        self.button.clicked.connect(param.activate)
+
+    def treeWidgetChanged(self):
+        ParameterItem.treeWidgetChanged(self)
+        tw = self.treeWidget()
+        if tw is None:
+            return
+        if self.button:
+            tw.setItemWidget(self, 1, self.button)
+        elif tw.itemWidget(self, 1) is not None:
+            tw.removeItemWidget(self, 1)
+
+    def optsChanged(self, param, opts):
+        if "button" in opts:
+            buttonOpts = opts["button"] or dict(visible=False)
+            self.button.updateOpts(param, buttonOpts)
+            self.treeWidgetChanged()
+        super().optsChanged(param, opts)
+
+
+class FunctionGroupParameter(GroupParameter):
+    itemClass = FunctionGroupParameterItem
+
+    sigActivated = QtCore.Signal()
+
+    def __init__(self, **opts):
+        opts.setdefault("button", {})
+        super().__init__(**opts)
+
+    def activate(self):
+        self.sigActivated.emit()
+
+    def setButtonOpts(self, **opts):
+        """
+        Update individual button options without replacing the entire
+        button definition.
+        """
+        buttonOpts = self.opts.get("button", {}).copy()
+        buttonOpts.update(opts)
+        self.setOpts(button=buttonOpts)

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -430,3 +430,13 @@ def test_class_interact():
 
     ci = interactor.decorate()(a.c)
     assert ci() == a.c()
+
+
+def test_args_interact():
+
+    @interact.decorate()
+    def a(*args):
+        """"""
+
+    assert not (a.parameters or a.extra)
+    a()

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -230,7 +230,7 @@ def test_tips():
     interactor = Interactor()
 
     group = interactor(a, runOptions=RunOptions.ON_ACTION)
-    assert group.opts["tip"] == a.__doc__ and group.type() == "functiongroup"
+    assert group.opts["tip"] == a.__doc__ and group.type() == "_actiongroup"
 
     params = interactor(a, runOptions=RunOptions.ON_ACTION, nest=False)
     assert len(params) == 1 and params[0].opts["tip"] == a.__doc__


### PR DESCRIPTION
Much less screen real estate is required if an `interactive` parameter's "Run" button is associated with the group rather than as a subchild (similar to the `pen` parameter):
![image](https://user-images.githubusercontent.com/23620506/189905154-631b94eb-5810-4a59-9179-afc2e12482de.png)
A very nice additional benefit is being able to run the function even when all parameters are not expanded:
![image](https://user-images.githubusercontent.com/23620506/189905381-d1cce334-d074-4075-b06a-0a7eb0124710.png)

Because "Run" buttons would no longer clutter a parameter and make unnecessary children, there is minimal drawback to making `[RunOptions.ON_CHANGED, RunOptions.ON_ACTION]` the default instead of `RunOptions.ON_CHANGED`.

To facilitate this change, minor refactoring of `action`'s button meant more of its options (`icon`, `shortcut`, other button properties as desired) could be exposed as parameter `opts`.

**Note:** The current `shortcut` behavior means an action only listens to the shortcut when any of its items are visible. So if a tree is hidden (or no parameter items were spawned), the shortcut doesn't work. There are many other ways of implementing parameter shortcuts, but this is the most pain-free (doesn't require the user to specify a widget parent in `opts`, doesn't depend on shortcut parent's life cycle). If this behavior is unintuitive, my next plan would be to force the user to provide a `shortcutParent` (or something similar) if `shortcut` is specified. This is the widget whose focus determines whether the shortcut will be listening. The downside is if this object is deleted, it can lead to confusing behavior. However, it would allow the shortcut to be tied to the parameter itself, rather than an instantiated button. _(I could also simply remove `shortcut` from the list of available options, but I find it useful enough)_

- [x] TODO: Update `ActionParameter` docs to incorporate new options once the discussion regarding `shortcut` is settled.