### PR TITLE
Add iterations argparse argument to benchmarks

### DIFF
--- a/pyqtgraph/examples/MultiPlotSpeedTest.py
+++ b/pyqtgraph/examples/MultiPlotSpeedTest.py
@@ -2,12 +2,21 @@
 """
 Test the speed of rapidly updating multiple plot curves
 """
+import argparse
+import itertools
 
 import numpy as np
+from utils import FrameCounter
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore
-from utils import FrameCounter
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--iterations', default=float('inf'), type=float,
+    help="Number of iterations to run before exiting"
+)
+args = parser.parse_args()
+iterations_counter = itertools.count()
 
 # pg.setConfigOptions(useOpenGL=True)
 app = pg.mkQApp("MultiPlot Speed Test")
@@ -37,7 +46,10 @@ data = np.random.normal(size=(nPlots*23,nSamples))
 ptr = 0
 def update():
     global ptr
-
+    if next(iterations_counter) > args.iterations:
+        timer.stop()
+        app.quit()
+        return None
     for i in range(nPlots):
         curves[i].setData(data[(ptr+i)%data.shape[0]])
 

--- a/pyqtgraph/examples/RemoteSpeedTest.py
+++ b/pyqtgraph/examples/RemoteSpeedTest.py
@@ -10,12 +10,21 @@ between the two cases. IF you have a multi-core CPU, it should be obvious that t
 remote case is much faster.
 """
 
+import argparse
+import itertools
+
 import numpy as np
+from utils import FrameCounter
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtWidgets
 
-from utils import FrameCounter
+parser = argparse.ArgumentParser()
+parser.add_argument('--iterations', default=float('inf'), type=float,
+    help="Number of iterations to run before exiting"
+)
+args = parser.parse_args()
+iterations_counter = itertools.count()
 
 app = pg.mkQApp()
 
@@ -46,6 +55,11 @@ rplt._setProxyOptions(deferGetattr=True)  ## speeds up access to rplt.plot
 view.setCentralItem(rplt)
 
 def update():
+    if next(iterations_counter) > args.iterations:
+        timer.stop()
+        app.quit()
+        return None
+
     data = np.random.normal(size=(10000,50)).sum(axis=1)
     data += 5 * np.sin(np.linspace(0, 10, data.shape[0]))
     

--- a/pyqtgraph/examples/ScatterPlotSpeedTest.py
+++ b/pyqtgraph/examples/ScatterPlotSpeedTest.py
@@ -5,15 +5,25 @@ For testing rapid updates of ScatterPlotItem under various conditions.
 (Scatter plots are still rather slow to draw; expect about 20fps)
 """
 
-import numpy as np
-import pyqtgraph as pg
-from pyqtgraph.Qt import QtCore, QtWidgets
-import pyqtgraph.parametertree as ptree
+import argparse
+import itertools
 import re
 
+import numpy as np
 from utils import FrameCounter
 
+import pyqtgraph as pg
+import pyqtgraph.parametertree as ptree
+from pyqtgraph.Qt import QtCore, QtWidgets
+
 translate = QtCore.QCoreApplication.translate
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--iterations', default=float('inf'), type=float,
+    help="Number of iterations to run before exiting"
+)
+args = parser.parse_args()
+iterations_counter = itertools.count()
 
 app = pg.mkQApp()
 
@@ -29,6 +39,7 @@ splitter.show()
 
 data = {}
 item = pg.ScatterPlotItem()
+
 hoverBrush = pg.mkBrush("y")
 ptr = 0
 timer = QtCore.QTimer()
@@ -37,7 +48,7 @@ def fmt(name):
     replace = r"\1 \2"
     name = re.sub(r"(\w)([A-Z])", replace, name)
     name = name.replace("_", " ")
-    return translate("ScatterPlot", name.title().strip() + ":    ")
+    return translate("ScatterPlot", f"{name.title().strip()}:    ")
 
 
 interactor = ptree.Interactor(
@@ -96,6 +107,11 @@ def getData(randomize=False):
 )
 def update(mode="Reuse Item"):
     global ptr
+
+    if next(iterations_counter) > args.iterations:
+        timer.stop()
+        app.quit()
+        return None
     if mode == "New Item":
         mkItem()
     elif mode == "Reuse Item":
@@ -110,7 +126,6 @@ def update(mode="Reuse Item"):
         item.pointsAt(new.pos())
         old.resetBrush()  # reset old's brush before setting new's to better simulate hovering
         new.setBrush(hoverBrush)
-
     ptr += 1
     framecnt.update()
 
@@ -121,7 +136,6 @@ def pausePlot(paused=False):
         timer.stop()
     else:
         timer.start()
-
 
 mkDataAndItem()
 timer.timeout.connect(update)

--- a/pyqtgraph/examples/VideoSpeedTest.py
+++ b/pyqtgraph/examples/VideoSpeedTest.py
@@ -6,14 +6,14 @@ is used by the view widget
 """
 
 import argparse
+import itertools
 import sys
 
 import numpy as np
+from utils import FrameCounter
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui, QtWidgets
-
-from utils import FrameCounter
 
 pg.setConfigOption('imageAxisOrder', 'row-major')
 
@@ -48,7 +48,11 @@ parser.add_argument('--levels', default=None, type=lambda s: tuple([float(x) for
 parser.add_argument('--lut', default=False, action='store_true', help="Use color lookup table")
 parser.add_argument('--lut-alpha', default=False, action='store_true', help="Use alpha color lookup table", dest='lut_alpha')
 parser.add_argument('--size', default='512x512', type=lambda s: tuple([int(x) for x in s.split('x')]), help="WxH image dimensions default='512x512'")
+parser.add_argument('--iterations', default=float('inf'), type=float,
+    help="Number of iterations to run before exiting"
+)
 args = parser.parse_args(sys.argv[1:])
+iterations_counter = itertools.count()
 
 if RawImageGLWidget is not None:
     # don't limit frame rate to vsync
@@ -244,6 +248,12 @@ ui.numbaCheck.toggled.connect(noticeNumbaCheck)
 ptr = 0
 def update():
     global ptr
+    if next(iterations_counter) > args.iterations:
+        # cleanly close down benchmark
+        timer.stop()
+        app.quit()
+        return None
+
     if ui.lutCheck.isChecked():
         useLut = LUT
     else:


### PR DESCRIPTION
Add `--iterations` argument to the benchmark examples allowing the benchmark to exit on its own cleanly after `n` updates.  This is useful for profilers which need the application to exit before computing results.


EDIT: Below was the original PR post, decided to walk back the scope of this PR by scrapping the changes to try and compute the `setData` + `paint` duration

Add functionality to allow for the benchmark to stop after a specific number of iterations.  By default, will run indefinitely as it currently does, however, if an iteration argument is passed with a numerical value, the update timer will stop, and the example will exit cleanly.

~~This is my first attempt at using QSignalMapper, while I would normally use `self.sender()`, the update method is a function, not a method, where `self` is not an argument being passed in.~~

QEventLoop to block the python code until the paint function finishes.  This should provide for a far more accurate duration calculation than `QApplication.processEvents()`

Redo the FPS calculation to take into account the entirety of the Qt EventLoop, not just the call to paint.  