### PR TITLE
Add GLTextItem to docs

### DIFF
--- a/doc/source/3dgraphics/gltextitem.rst
+++ b/doc/source/3dgraphics/gltextitem.rst
@@ -1,0 +1,7 @@
+GLTextItem
+==========
+
+.. autoclass:: pyqtgraph.opengl.GLTextItem
+    :members:
+
+    .. automethod:: pyqtgraph.opengl.GLTextItem.__init__

--- a/doc/source/3dgraphics/index.rst
+++ b/doc/source/3dgraphics/index.rst
@@ -28,4 +28,5 @@ Contents:
     glaxisitem
     glgraphicsitem
     glscatterplotitem
+    gltextitem
     meshdata


### PR DESCRIPTION
Fixes #2037.

Google did not give me the suggestion to use GLTextItem when trying to find a way to get text in a 3D scene. Documentation didn't help either. After an hour or two I ended up in #2037 with great happiness. Thought I should fix it to help anyone else in the same situation.

This is my first contribution ever to an open source project. Even if this is a miniscule change, please tell me if I am doing something wrong.

