### PR TITLE
deprecate GraphicsObject::parentChanged method

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -452,13 +452,16 @@ class GraphicsItem(object):
                 #print "   --> ", ch2.scene()
             #self.setChildScene(ch2)
 
-    def parentChanged(self):
+    def changeParent(self):
         """Called when the item's parent has changed. 
         This method handles connecting / disconnecting from ViewBox signals
         to make sure viewRangeChanged works properly. It should generally be 
         extended, not overridden."""
         self._updateView()
-        
+
+    def parentChanged(self):
+        # deprecated version of changeParent()
+        GraphicsItem.changeParent(self)
 
     def _updateView(self):
         ## called to see whether this item has a new view to connect to

--- a/pyqtgraph/graphicsItems/GraphicsObject.py
+++ b/pyqtgraph/graphicsItems/GraphicsObject.py
@@ -1,3 +1,4 @@
+import warnings
 from ..Qt import QT_LIB, QtCore, QtWidgets
 from .GraphicsItem import GraphicsItem
 
@@ -18,12 +19,21 @@ class GraphicsObject(GraphicsItem, QtWidgets.QGraphicsObject):
     def itemChange(self, change, value):
         ret = super().itemChange(change, value)
         if change in [self.GraphicsItemChange.ItemParentHasChanged, self.GraphicsItemChange.ItemSceneHasChanged]:
-            if QT_LIB == 'PySide6' and QtCore.__version_info__ == (6, 2, 2):
-                # workaround PySide6 6.2.2 issue https://bugreports.qt.io/browse/PYSIDE-1730
-                # note that the bug exists also in PySide6 6.2.2.1 / Qt 6.2.2
-                getattr(self.__class__, 'parentChanged')(self)
+            if self.__class__.__dict__.get('parentChanged') is not None:
+                # user's GraphicsObject subclass has a parentChanged() method
+                warnings.warn(
+                    "parentChanged() is deprecated and will be removed in the future. "
+                    "Use changeParent() instead.",
+                    DeprecationWarning, stacklevel=2
+                )
+                if QT_LIB == 'PySide6' and QtCore.__version_info__ == (6, 2, 2):
+                    # workaround PySide6 6.2.2 issue https://bugreports.qt.io/browse/PYSIDE-1730
+                    # note that the bug exists also in PySide6 6.2.2.1 / Qt 6.2.2
+                    getattr(self.__class__, 'parentChanged')(self)
+                else:
+                    self.parentChanged()
             else:
-                self.parentChanged()
+                self.changeParent()
         try:
             inform_view_on_change = self.__inform_view_on_changes
         except AttributeError:

--- a/pyqtgraph/graphicsItems/ScaleBar.py
+++ b/pyqtgraph/graphicsItems/ScaleBar.py
@@ -36,7 +36,7 @@ class ScaleBar(GraphicsObject, GraphicsWidgetAnchor):
         self.text = TextItem(text=fn.siFormat(size, suffix=suffix), anchor=(0.5,1))
         self.text.setParentItem(self)
 
-    def parentChanged(self):
+    def changeParent(self):
         view = self.parentItem()
         if view is None:
             return


### PR DESCRIPTION
QGraphicsObject has a signal named `parentChanged`.
Although Qt bindings "permit" a method name to be the same as a Qt signal name, it may not be a good idea to make use of this "feature".
This "feature" has been broken before: #2132
It also relies on the inheritance order of the parent classes of `GraphicsObject`.

This PR renames the method name while emitting a deprecation warning if it detects that the old name is being used by user sub-classes.

One way to test out this PR is to modify `examples/customGraphicsItem.py`.
By adding the following method:
```python
def parentChanged(self):
    super().parentChanged()
```
We can verify that running this example with `python -Wdefault` emits a deprecation warning.
