### PR TITLE
Fix missing import in Flowchart.py

### DIFF
--- a/pyqtgraph/flowchart/Flowchart.py
+++ b/pyqtgraph/flowchart/Flowchart.py
@@ -2,6 +2,7 @@ __init__ = ["Flowchart", "FlowchartGraphicsItem", "FlowchartNode"]
 
 import importlib
 from collections import OrderedDict
+import os
 
 from .. import DataTreeWidget, FileDialog
 from ..Qt import QT_LIB, QtCore, QtWidgets


### PR DESCRIPTION
A missing import in `Flowchart.py` causes the following errors when updating fileNameLabel on the flowchart widget:

```
Traceback (most recent call last):
  File "venv/lib/python3.10/site-packages/pyqtgraph/flowchart/Flowchart.py", line 686, in setCurrentFile
    self.ui.fileNameLabel.setText("<b>%s</b>" % os.path.split(self.currentFileName)[1])
NameError: name 'os' is not defined
Traceback (most recent call last):
  File "venv/lib/python3.10/site-packages/pyqtgraph/flowchart/Flowchart.py", line 657, in fileSaved
    self.setCurrentFile(fileName)
  File "venv/lib/python3.10/site-packages/pyqtgraph/flowchart/Flowchart.py", line 686, in setCurrentFile
    self.ui.fileNameLabel.setText("<b>%s</b>" % os.path.split(self.currentFileName)[1])
NameError: name 'os' is not defined
Aborted (core dumped)
```