### PR TITLE
`interact()` defaults to `ON_ACTION` behavior and accepts `runActionTemplate` argument

### DIFF
--- a/doc/source/parametertree/interactiveparameters.rst
+++ b/doc/source/parametertree/interactiveparameters.rst
@@ -220,6 +220,30 @@ should be directly inside the parent, use ``nest=False``:
     # directly as children of `parent`
     params = interact(a, nest=False)
 
+``runActionTemplate``
+^^^^^^^^^^^^^^^^^^^^^
+When the ``runOptions`` argument is set to (or contains) ``RunOptions.ON_ACTION``, a
+button will be added next to the parameter group which can be clicked to run the
+function with the current parameter values. The button's options can be customized
+through passing a dictionary to ``runActionTemplate``. The dictionary can contain
+any key accepted as an ``action`` parameter option. For instance, to run a function
+either by pressing the button or a shortcut, you can interact like so:
+
+.. code:: python
+
+    def a(x=5, y=6):
+        return x + y
+
+    # The button will be labeled "Run" and will run the function when clicked or when
+    # the shortcut "Ctrl+R" is pressed
+    params = interact(a, runActionTemplate={'shortcut': 'Ctrl+R'})
+
+    # Alternatively, add an icon to the button
+    params = interact(a, runActionTemplate={'icon': 'run.png'})
+
+    # Why not both?
+    params = interact(a, runActionTemplate={'icon': 'run.png', 'shortcut': 'Ctrl+R'})
+
 ``existOk``
 ^^^^^^^^^^^
 

--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -204,7 +204,7 @@ class InteractiveFunction:
 
 
 class Interactor:
-    runOptions = [RunOptions.ON_CHANGED, RunOptions.ON_ACTION]
+    runOptions = RunOptions.ON_ACTION
     parent = None
     titleFormat = None
     nest = True
@@ -283,6 +283,7 @@ class Interactor:
         parent=PARAM_UNSET,
         titleFormat=PARAM_UNSET,
         nest=PARAM_UNSET,
+        runActionTemplate=PARAM_UNSET,
         existOk=PARAM_UNSET,
         **overrides,
     ):
@@ -318,6 +319,13 @@ class Interactor:
             and arguments to that function are 'nested' inside as its children.
             If *False*, function arguments are directly added to this parameter
             instead of being placed inside a child GroupParameter
+        runActionTemplate: dict
+            Template for the action parameter which runs the function, used
+            if ``runOptions`` is set to ``GroupParameter.RUN_ACTION``. Note that
+            if keys like "name" or "type" are not included, they are inferred
+            from the previous / default ``runActionTemplate``. This allows
+            items that should only be set per-function to exist here, like
+            a ``shortcut`` or ``icon``.
         existOk: bool
             Whether it is OK for existing parameter names to bind to this function.
             See behavior during 'Parameter.insertChild'
@@ -328,15 +336,18 @@ class Interactor:
             override can be a value (e.g. 5) or a dict specification of a
             parameter (e.g. dict(type='list', limits=[0, 10, 20]))
         """
+        # Special case: runActionTemplate can be overridden to specify action
+        if runActionTemplate is not PARAM_UNSET:
+            runActionTemplate = {**self.runActionTemplate, **runActionTemplate}
         # Get every overridden default
         locs = locals()
         # Everything until action template
         opts = {
-            kk: locs[kk] for kk in self._optionNames[:-1] if locs[kk] is not PARAM_UNSET
+            kk: locs[kk] for kk in self._optionNames if locs[kk] is not PARAM_UNSET
         }
         oldOpts = self.setOpts(**opts)
         # Delete explicitly since correct values are now ``self`` attributes
-        del runOptions, titleFormat, nest, existOk, parent
+        del runOptions, titleFormat, nest, existOk, parent, runActionTemplate
 
         function = self._toInteractiveFunction(function)
         funcDict = self.functionToParameterDict(function.function, **overrides)

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -1,13 +1,18 @@
-import pytest
 from functools import wraps
-from pyqtgraph.parametertree import Parameter
-from pyqtgraph.parametertree.parameterTypes import GroupParameter as GP
+
+import numpy as np
+import pytest
+
+from pyqtgraph import functions as fn
 from pyqtgraph.parametertree import (
-    RunOptions,
     InteractiveFunction,
     Interactor,
     interact,
+    RunOptions,
 )
+from pyqtgraph.parametertree import Parameter
+from pyqtgraph.parametertree.parameterTypes import GroupParameter as GP
+from pyqtgraph.Qt import QtGui
 
 
 def test_parameter_hasdefault():
@@ -307,7 +312,7 @@ def test_remove_params():
     def inner(a=4):
         RetainVal.a = a
 
-    host = interact(inner)
+    host = interact(inner, runOptions=RunOptions.ON_CHANGED)
     host["a"] = 5
     assert RetainVal.a == 5
 
@@ -433,10 +438,31 @@ def test_class_interact():
 
 
 def test_args_interact():
-
     @interact.decorate()
     def a(*args):
         """"""
 
     assert not (a.parameters or a.extra)
     a()
+
+
+def test_interact_with_icon():
+    randomPixmap = QtGui.QPixmap(64, 64)
+    randomPixmap.fill(QtGui.QColor("red"))
+
+    parent = Parameter.create(name="parent", type="group")
+
+    @interact.decorate(
+        runActionTemplate=dict(icon=randomPixmap),
+        parent=parent,
+        runOptions=RunOptions.ON_ACTION,
+    )
+    def a():
+        """"""
+
+    groupItem = parent.child("a").itemClass(parent.child("a"), 1)
+    buttonPixmap = groupItem.button.icon().pixmap(randomPixmap.size())
+    imageBytes = [
+        fn.ndarray_from_qimage(pix.toImage()) for pix in (randomPixmap, buttonPixmap)
+    ]
+    assert np.array_equal(*imageBytes)

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -275,6 +275,11 @@ def test_interactiveFunc():
     assert not interactive.setDisconnected(True)
     assert interactive.setDisconnected(False)
 
+    host = interact(interactive, runOptions=RunOptions.ON_CHANGED)
+    interactive.disconnect()
+    host["a"] = 20
+    assert value == 10
+
 
 def test_badOptsContext():
     with pytest.raises(KeyError):


### PR DESCRIPTION
I ported a substantial number of parameter use cases to rely on `interact` and found that the majority don't favor running on change. The main motivation for that default was to avoid creating a child `Run` parameter, but this is no longer a concern with the introduction of `ActionGroupParameter`. This also aligns with the principle of least astonishment, that a (potentially expensive) function shouldn't automatically run unless a button is pressed.

Along with this, the PR also allows `interact()` to listen for button-specific keywords like `shortcut` and `icon` in its argument list.