### PR TITLE
Refactor examples using `Interactor` to run on changing function parameters

### DIFF
--- a/pyqtgraph/examples/InteractiveParameter.py
+++ b/pyqtgraph/examples/InteractiveParameter.py
@@ -33,7 +33,7 @@ def printResult(func):
 
 
 host = Parameter.create(name="Interactive Parameter Use", type="group")
-interactor = Interactor(parent=host)
+interactor = Interactor(parent=host, runOptions=RunOptions.ON_CHANGED)
 
 
 @interactor.decorate()

--- a/pyqtgraph/examples/PlotSpeedTest.py
+++ b/pyqtgraph/examples/PlotSpeedTest.py
@@ -164,4 +164,7 @@ timer.timeout.connect(update)
 timer.start(0)
 
 if __name__ == '__main__':
+    # Splitter by default gives too small of a width to the parameter tree,
+    # so fix that right before the event loop
+    pt.setMinimumSize(225,0)
     pg.exec()

--- a/pyqtgraph/examples/PlotSpeedTest.py
+++ b/pyqtgraph/examples/PlotSpeedTest.py
@@ -73,7 +73,9 @@ splitter.addWidget(pt)
 splitter.addWidget(pw)
 splitter.show()
 
-interactor = ptree.Interactor(parent=params, nest=False)
+interactor = ptree.Interactor(
+    parent=params, nest=False, runOptions=ptree.RunOptions.ON_CHANGED
+)
 
 pw.setWindowTitle('pyqtgraph example: PlotSpeedTest')
 pw.setLabel('bottom', 'Index', units='B')

--- a/pyqtgraph/examples/ScatterPlotSpeedTest.py
+++ b/pyqtgraph/examples/ScatterPlotSpeedTest.py
@@ -42,7 +42,9 @@ def fmt(name):
     return translate("ScatterPlot", name.title().strip() + ":    ")
 
 
-interactor = ptree.Interactor(titleFormat=fmt, nest=False, parent=param)
+interactor = ptree.Interactor(
+    titleFormat=fmt, nest=False, parent=param, runOptions=ptree.RunOptions.ON_CHANGED
+)
 
 
 @interactor.decorate(


### PR DESCRIPTION
Changes from #2432 meant examples which relied on default changing parameters needed to be updated. The examples still work as-is, but buttons must be pressed which is unintuitive.