### PR TITLE
Have release on publish, not on created

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,7 +5,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
Slight update to the release github action to do the release on the publishing of the action not on the creation.  Previously, the job would not trigger if you created a draft release and then published it, causing all sorts of head scratching.