### PR TITLE
make DockDrop be a non-mixin

### DIFF
--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -1,22 +1,18 @@
 import warnings
 
-from ..Qt import QT_LIB, QtCore, QtGui, QtWidgets
+from ..Qt import QtCore, QtGui, QtWidgets
 from ..widgets.VerticalLabel import VerticalLabel
 from .DockDrop import DockDrop
 
 
-class Dock(QtWidgets.QWidget, DockDrop):
+class Dock(QtWidgets.QWidget):
 
     sigStretchChanged = QtCore.Signal()
     sigClosed = QtCore.Signal(object)
 
     def __init__(self, name, area=None, size=(10, 10), widget=None, hideTitle=False, autoOrientation=True, label=None, **kargs):
-        allowedAreas = None
-        if QT_LIB.startswith('PyQt'):
-            QtWidgets.QWidget.__init__(self, allowedAreas=allowedAreas)
-        else:
-            QtWidgets.QWidget.__init__(self)
-            DockDrop.__init__(self, allowedAreas=allowedAreas)
+        QtWidgets.QWidget.__init__(self)
+        self.dockdrop = DockDrop(self)
         self._container = None
         self._name = name
         self.area = area
@@ -46,7 +42,7 @@ class Dock(QtWidgets.QWidget, DockDrop):
         self.widgets = []
         self.currentRow = 0
         #self.titlePos = 'top'
-        self.raiseOverlay()
+        self.dockdrop.raiseOverlay()
         self.hStyle = """
         Dock > QWidget {
             border: 1px solid #000;
@@ -113,8 +109,7 @@ class Dock(QtWidgets.QWidget, DockDrop):
         """
         self.label.hide()
         self.labelHidden = True
-        if 'center' in self.allowedAreas:
-            self.allowedAreas.remove('center')
+        self.dockdrop.removeAllowedArea('center')
         self.updateStyle()
 
     def showTitleBar(self):
@@ -123,7 +118,7 @@ class Dock(QtWidgets.QWidget, DockDrop):
         """
         self.label.show()
         self.labelHidden = False
-        self.allowedAreas.add('center')
+        self.dockdrop.addAllowedArea('center')
         self.updateStyle()
 
     def title(self):
@@ -180,7 +175,7 @@ class Dock(QtWidgets.QWidget, DockDrop):
 
     def resizeEvent(self, ev):
         self.setOrientation()
-        self.resizeOverlay(self.size())
+        self.dockdrop.resizeOverlay(self.size())
 
     def name(self):
         return self._name
@@ -195,7 +190,7 @@ class Dock(QtWidgets.QWidget, DockDrop):
         self.currentRow = max(row+1, self.currentRow)
         self.widgets.append(widget)
         self.layout.addWidget(widget, row, col, rowspan, colspan)
-        self.raiseOverlay()
+        self.dockdrop.raiseOverlay()
         
     def startDrag(self):
         self.drag = QtGui.QDrag(self)
@@ -249,19 +244,17 @@ class Dock(QtWidgets.QWidget, DockDrop):
     def __repr__(self):
         return "<Dock %s %s>" % (self.name(), self.stretch())
 
-    ## PySide bug: We need to explicitly redefine these methods
-    ## or else drag/drop events will not be delivered.
     def dragEnterEvent(self, *args):
-        DockDrop.dragEnterEvent(self, *args)
+        self.dockdrop.dragEnterEvent(*args)
 
     def dragMoveEvent(self, *args):
-        DockDrop.dragMoveEvent(self, *args)
+        self.dockdrop.dragMoveEvent(*args)
 
     def dragLeaveEvent(self, *args):
-        DockDrop.dragLeaveEvent(self, *args)
+        self.dockdrop.dragLeaveEvent(*args)
 
     def dropEvent(self, *args):
-        DockDrop.dropEvent(self, *args)
+        self.dockdrop.dropEvent(*args)
 
 
 class DockLabel(VerticalLabel):

--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -1,27 +1,24 @@
 import weakref
 
-from ..Qt import QT_LIB, QtWidgets
+from ..Qt import QtWidgets
 from .Container import Container, HContainer, TContainer, VContainer
 from .Dock import Dock
 from .DockDrop import DockDrop
 
 
-class DockArea(Container, QtWidgets.QWidget, DockDrop):
+class DockArea(Container, QtWidgets.QWidget):
     def __init__(self, parent=None, temporary=False, home=None):
         Container.__init__(self, self)
-        allowedAreas=['left', 'right', 'top', 'bottom']
-        if QT_LIB.startswith('PyQt'):
-            QtWidgets.QWidget.__init__(self, parent=parent, allowedAreas=allowedAreas)
-        else:
-            QtWidgets.QWidget.__init__(self, parent=parent)
-            DockDrop.__init__(self, allowedAreas=allowedAreas)
+        QtWidgets.QWidget.__init__(self, parent=parent)
+        self.dockdrop = DockDrop(self)
+        self.dockdrop.removeAllowedArea('center')
         self.layout = QtWidgets.QVBoxLayout()
         self.layout.setContentsMargins(0,0,0,0)
         self.layout.setSpacing(0)
         self.setLayout(self.layout)
         self.docks = weakref.WeakValueDictionary()
         self.topContainer = None
-        self.raiseOverlay()
+        self.dockdrop.raiseOverlay()
         self.temporary = temporary
         self.tempAreas = []
         self.home = home
@@ -146,7 +143,7 @@ class DockArea(Container, QtWidgets.QWidget, DockDrop):
         #print "Add container:", new, " -> ", container
         if obj is not None:
             new.insert(obj)
-        self.raiseOverlay()
+        self.dockdrop.raiseOverlay()
         return new
     
     def insert(self, new, pos=None, neighbor=None):
@@ -157,7 +154,7 @@ class DockArea(Container, QtWidgets.QWidget, DockDrop):
         self.layout.addWidget(new)
         new.containerChanged(self)
         self.topContainer = new
-        self.raiseOverlay()
+        self.dockdrop.raiseOverlay()
         
     def count(self):
         if self.topContainer is None:
@@ -165,7 +162,7 @@ class DockArea(Container, QtWidgets.QWidget, DockDrop):
         return 1
         
     def resizeEvent(self, ev):
-        self.resizeOverlay(self.size())
+        self.dockdrop.resizeOverlay(self.size())
         
     def addTempArea(self):
         if self.home is None:
@@ -330,19 +327,17 @@ class DockArea(Container, QtWidgets.QWidget, DockDrop):
         for dock in docks.values():
             dock.close()
             
-    ## PySide bug: We need to explicitly redefine these methods
-    ## or else drag/drop events will not be delivered.
     def dragEnterEvent(self, *args):
-        DockDrop.dragEnterEvent(self, *args)
+        self.dockdrop.dragEnterEvent(*args)
 
     def dragMoveEvent(self, *args):
-        DockDrop.dragMoveEvent(self, *args)
+        self.dockdrop.dragMoveEvent(*args)
 
     def dragLeaveEvent(self, *args):
-        DockDrop.dragLeaveEvent(self, *args)
+        self.dockdrop.dragLeaveEvent(*args)
 
     def dropEvent(self, *args):
-        DockDrop.dropEvent(self, *args)
+        self.dockdrop.dropEvent(*args)
 
     def printState(self, state=None, name='Main'):
         # for debugging

--- a/pyqtgraph/dockarea/DockDrop.py
+++ b/pyqtgraph/dockarea/DockDrop.py
@@ -3,18 +3,22 @@ __all__ = ["DockDrop"]
 from ..Qt import QtCore, QtGui, QtWidgets
 
 
-class DockDrop(object):
+class DockDrop:
     """Provides dock-dropping methods"""
-    def __init__(self, allowedAreas=None):
-        object.__init__(self)
-        if allowedAreas is None:
-            allowedAreas = ['center', 'right', 'left', 'top', 'bottom']
-        self.allowedAreas = set(allowedAreas)
-        self.setAcceptDrops(True)
+    def __init__(self, dndWidget):
+        self.dndWidget = dndWidget
+        self.allowedAreas = {'center', 'right', 'left', 'top', 'bottom'}
+        self.dndWidget.setAcceptDrops(True)
         self.dropArea = None
-        self.overlay = DropAreaOverlay(self)
+        self.overlay = DropAreaOverlay(dndWidget)
         self.overlay.raise_()
-    
+
+    def addAllowedArea(self, area):
+        self.allowedAreas.update(area)
+
+    def removeAllowedArea(self, area):
+        self.allowedAreas.discard(area)
+
     def resizeOverlay(self, size):
         self.overlay.resize(size)
         
@@ -34,18 +38,19 @@ class DockDrop(object):
         #print "drag move"
         # QDragMoveEvent inherits QDropEvent which provides posF()
         # PyQt6 provides only position()
+        width, height = self.dndWidget.width(), self.dndWidget.height()
         posF = ev.posF() if hasattr(ev, 'posF') else ev.position()
         ld = posF.x()
-        rd = self.width() - ld
+        rd = width - ld
         td = posF.y()
-        bd = self.height() - td
+        bd = height - td
         
         mn = min(ld, rd, td, bd)
         if mn > 30:
             self.dropArea = "center"
-        elif (ld == mn or td == mn) and mn > self.height()/3.:
+        elif (ld == mn or td == mn) and mn > height/3:
             self.dropArea = "center"
-        elif (rd == mn or ld == mn) and mn > self.width()/3.:
+        elif (rd == mn or ld == mn) and mn > width/3:
             self.dropArea = "center"
             
         elif rd == mn:
@@ -57,7 +62,7 @@ class DockDrop(object):
         elif bd == mn:
             self.dropArea = "bottom"
             
-        if ev.source() is self and self.dropArea == 'center':
+        if ev.source() is self.dndWidget and self.dropArea == 'center':
             #print "  no self-center"
             self.dropArea = None
             ev.ignore()
@@ -80,7 +85,7 @@ class DockDrop(object):
             return
         if area == 'center':
             area = 'above'
-        self.area.moveDock(ev.source(), area, self)
+        self.dndWidget.area.moveDock(ev.source(), area, self.dndWidget)
         self.dropArea = None
         self.overlay.setDropArea(self.dropArea)
 


### PR DESCRIPTION
This is a follow-up of #2286.
Problematic areas with the previous code:
* The DockDrop class was used as a mixin class inherited on the right-hand-side.
   - this is problematic as PyQt{5,6} (but not PySide{2,6}) supports cooperative inheritance. 
* PyQt (but not PySide) supports having virtual methods being over-ridden by a mixin class inherited on the right-hand-side
   - this can be seen in the previous code documenting this to be a "PySide bug". In fact, it is a surprising behavior of PyQt.

The above issues could perhaps be solved by inheriting DockDrop on the left-hand-side instead. But a cleaner approach seems to be to use DockDrop as a non-mixin.