### PR TITLE
Fix action parameter button that is briefly made visible before getting a parent

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes/action.py
+++ b/pyqtgraph/parametertree/parameterTypes/action.py
@@ -52,7 +52,7 @@ class ActionParameterItem(ParameterItem):
         self.layout = QtWidgets.QHBoxLayout()
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.layoutWidget.setLayout(self.layout)
-        self.button = ParameterControlledButton(param)
+        self.button = ParameterControlledButton(param, self.layoutWidget)
         #self.layout.addSpacing(100)
         self.layout.addWidget(self.button)
         self.layout.addStretch()


### PR DESCRIPTION
Before this change, spawning an `action` parameter briefly made its button visible before the button was assigned an invisible parent. This caused a brief flickering when showing a parameter tree for the first time:

https://user-images.githubusercontent.com/23620506/193437758-d245732d-8d16-431b-8467-b0ed7fa7fcbe.mp4

