### PR TITLE
Fix disconnect of signal proxy

### DIFF
--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -10,10 +10,10 @@ __all__ = ['SignalProxy']
 
 class SignalProxy(QtCore.QObject):
     """Object which collects rapid-fire signals and condenses them
-    into a single signal or a rate-limited stream of signals. 
-    Used, for example, to prevent a SpinBox from generating multiple 
+    into a single signal or a rate-limited stream of signals.
+    Used, for example, to prevent a SpinBox from generating multiple
     signals when the mouse wheel is rolled over it.
-    
+
     Emits sigDelayed after input signals have stopped for a certain period of
     time.
     """
@@ -25,7 +25,7 @@ class SignalProxy(QtCore.QObject):
         signal - a bound Signal or pyqtSignal instance
         delay - Time (in seconds) to wait for signals to stop before emitting (default 0.3s)
         slot - Optional function to connect sigDelayed to.
-        rateLimit - (signals/sec) if greater than 0, this allows signals to stream out at a 
+        rateLimit - (signals/sec) if greater than 0, this allows signals to stream out at a
                     steady rate while they are being received.
         """
 
@@ -86,9 +86,9 @@ class SignalProxy(QtCore.QObject):
         except:
             pass
         try:
-            # XXX: This is a weakref, however segfaulting on PySide and
-            # Python 2. We come back later
-            self.sigDelayed.disconnect(self.slot)
+            slot = self.slot()
+            if slot is not None:
+                self.sigDelayed.disconnect(slot)
         except:
             pass
         finally:


### PR DESCRIPTION
Back then with Python 2 support the SignalProxy disconnect was left broken behind.

**self.slot** stores a **weakref**, we disconnect properly now if needed.