### PR TITLE
unify win32 and unix mmap codepaths

### DIFF
--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -4,7 +4,6 @@ import atexit
 import enum
 import mmap
 import os
-import random
 import sys
 import tempfile
 
@@ -169,10 +168,11 @@ class RemoteGraphicsView(QtWidgets.QWidget):
         self.setMouseTracking(True)
         self.shm = None
         shmFileName = self._view.shmFileName()
-        if sys.platform.startswith('win'):
-            self.shmtag = shmFileName
+        if sys.platform == 'win32':
+            opener = lambda path, flags: os.open(path, flags | os.O_TEMPORARY)
         else:
-            self.shmFile = open(shmFileName, 'r')
+            opener = None
+        self.shmFile = open(shmFileName, 'rb', opener=opener)
         
         self._view.sceneRendered.connect(mp.proxy(self.remoteSceneChanged)) #, callSync='off'))
                                                                             ## Note: we need synchronous signals
@@ -192,16 +192,11 @@ class RemoteGraphicsView(QtWidgets.QWidget):
         return QtCore.QSize(*self._sizeHint)
         
     def remoteSceneChanged(self, data):
-        w, h, size, newfile = data
-        #self._sizeHint = (whint, hhint)
+        w, h, size = data
         if self.shm is None or self.shm.size != size:
             if self.shm is not None:
                 self.shm.close()
-            if sys.platform.startswith('win'):
-                self.shmtag = newfile   ## on windows, we create a new tag for every resize
-                self.shm = mmap.mmap(-1, size, self.shmtag) ## can't use tmpfile on windows because the file can only be opened once.
-            else:
-                self.shm = mmap.mmap(self.shmFile.fileno(), size, mmap.MAP_SHARED, mmap.PROT_READ)
+            self.shm = mmap.mmap(self.shmFile.fileno(), size, access=mmap.ACCESS_READ)
         self._img = QtGui.QImage(self.shm, w, h, QtGui.QImage.Format.Format_RGB32).copy()
         self.update()
         
@@ -257,16 +252,11 @@ class Renderer(GraphicsView):
     
     def __init__(self, *args, **kwds):
         ## Create shared memory for rendered image
-        #pg.dbg(namespace={'r': self})
-        if sys.platform.startswith('win'):
-            self.shmtag = "pyqtgraph_shmem_" + ''.join([chr((random.getrandbits(20)%25) + 97) for i in range(20)])
-            self.shm = mmap.mmap(-1, mmap.PAGESIZE, self.shmtag) # use anonymous mmap on windows
-        else:
-            self.shmFile = tempfile.NamedTemporaryFile(prefix='pyqtgraph_shmem_')
-            self.shmFile.write(b'\x00' * (mmap.PAGESIZE+1))
-            self.shmFile.flush()
-            fd = self.shmFile.fileno()
-            self.shm = mmap.mmap(fd, mmap.PAGESIZE, mmap.MAP_SHARED, mmap.PROT_WRITE)
+        self.shmFile = tempfile.NamedTemporaryFile(prefix='pyqtgraph_shmem_')
+        size = mmap.PAGESIZE
+        self.shmFile.write(b'\x00' * size)
+        self.shmFile.flush()
+        self.shm = mmap.mmap(self.shmFile.fileno(), size, access=mmap.ACCESS_WRITE)
         atexit.register(self.close)
         
         GraphicsView.__init__(self, *args, **kwds)
@@ -278,14 +268,10 @@ class Renderer(GraphicsView):
         
     def close(self):
         self.shm.close()
-        if not sys.platform.startswith('win'):
-            self.shmFile.close()
+        self.shmFile.close()
 
     def shmFileName(self):
-        if sys.platform.startswith('win'):
-            return self.shmtag
-        else:
-            return self.shmFile.name
+        return self.shmFile.name
         
     def update(self):
         self.img = None
@@ -307,19 +293,15 @@ class Renderer(GraphicsView):
             iheight = int(self.height() * dpr)
             size = iwidth * iheight * 4
             if size > self.shm.size():
-                if sys.platform.startswith('win'):
-                    ## windows says "WindowsError: [Error 87] the parameter is incorrect" if we try to resize the mmap
-                    self.shm.close()
-                    ## it also says (sometimes) 'access is denied' if we try to reuse the tag.
-                    self.shmtag = "pyqtgraph_shmem_" + ''.join([chr((random.getrandbits(20)%25) + 97) for i in range(20)])
-                    self.shm = mmap.mmap(-1, size, self.shmtag)
-                elif sys.platform == 'darwin' or sys.platform.startswith('freebsd'):
+                try:
+                    self.shm.resize(size)
+                except SystemError:
+                    # actually, the platforms on which resize() _does_ work
+                    # can also take this codepath
                     self.shm.close()
                     fd = self.shmFile.fileno()
-                    os.ftruncate(fd, size + 1)
-                    self.shm = mmap.mmap(fd, size, mmap.MAP_SHARED, mmap.PROT_WRITE)
-                else:
-                    self.shm.resize(size)
+                    os.ftruncate(fd, size)
+                    self.shm = mmap.mmap(fd, size, access=mmap.ACCESS_WRITE)
             
             ## render the scene directly to shared memory
 
@@ -338,4 +320,4 @@ class Renderer(GraphicsView):
             p = QtGui.QPainter(self.img)
             self.render(p, self.viewRect(), self.rect())
             p.end()
-            self.sceneRendered.emit((iwidth, iheight, self.shm.size(), self.shmFileName()))
+            self.sceneRendered.emit((iwidth, iheight, self.shm.size()))


### PR DESCRIPTION
#2445 added a fix for FreeBSD platforms to take the same codepath as macOS.

This PR unifies (mostly) the win32 and unix codepaths and at the same time does feature testing for mremap so that platform detection does not need to be done. (FreeBSD and macOS are not the only unix platforms to not have mremap)
