### PR TITLE
Update setup.py, import distutils after setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,10 @@ import distutils.dir_util
 import os
 import re
 import sys
-from distutils.command import build
-
 from setuptools import find_namespace_packages, setup
 from setuptools.command import install
+
+from distutils.command import build
 
 path = os.path.split(__file__)[0]
 import tools.setupHelpers as helpers


### PR DESCRIPTION
This makes the package build again with newer setuptools, fixing this build failure:

make[2]: Leaving directory '/<<PKGBUILDDIR>>/doc'
dh_auto_build
I: pybuild base:240: /usr/bin/python3 setup.py build  /<<PKGBUILDDIR>>/setup.py:38: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  import distutils.dir_util
/usr/lib/python3/dist-packages/_distutils_hack/__init__.py:18: UserWarning: Distutils was imported before Setuptools, but importing Setuptools also replaces the `distutils` module in `sys.modules`. This may lead to undesirable behaviors or errors. To avoid these issues, avoid using distutils directly, ensure that setuptools is installed in the traditional way (e.g. not an editable install), and/or make sure that setuptools is always imported before distutils.
  warnings.warn(
/usr/lib/python3/dist-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/setup.py", line 112, in <module>
    setup(
  File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 87, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 172, in setup
    ok = dist.parse_command_line()
  File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 479, in parse_command_line
    args = self._parse_command_opts(parser, args)
  File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 1107, in _parse_command_opts
    nargs = _Distribution._parse_command_opts(self, parser, args)
  File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 545, in _parse_command_opts
    raise DistutilsClassError(
distutils.errors.DistutilsClassError: command class <class '__main__.Build'> must subclass Command
E: pybuild pybuild:379: build: plugin distutils failed with: exit code=1: /usr/bin/python3 setup.py build 
dh_auto_build: error: pybuild --build -i python{version} -p 3.10 returned exit code 13
make[1]: *** [debian/rules:17: override_dh_auto_build] Error 25
make[1]: Leaving directory '/<<PKGBUILDDIR>>'
make: *** [debian/rules:6: binary-indep] Error 2

Detail the reasoning behind the code change.  If there is an associated issue that this PR will resolve add

Fixes #<IssueNumber>

### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [ ] `README.md`
- [ ] `setup.py`
- [ ] `tox.ini`
- [ ] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [ ] `pyproject.toml`
- [ ] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
