### PR TITLE
Allow plotting multiple data items at once

### DIFF
--- a/pyqtgraph/examples/MultiDataPlot.py
+++ b/pyqtgraph/examples/MultiDataPlot.py
@@ -1,0 +1,83 @@
+import traceback
+import numpy as np
+
+import pyqtgraph as pg
+from pyqtgraph.graphicsItems.ScatterPlotItem import name_list
+from pyqtgraph.Qt import QtWidgets, QtCore
+from pyqtgraph.parametertree import interact, ParameterTree, Parameter
+import random
+
+pg.mkQApp()
+
+rng = np.random.default_rng(10)
+random.seed(10)
+
+
+def sortedRandint(low, high, size):
+    return np.sort(rng.integers(low, high, size))
+
+
+def isNoneOrScalar(value):
+    return value is None or np.isscalar(value[0])
+
+
+values = {
+    # Convention 1
+    "None (replaced by integer indices)": None,
+    # Convention 2
+    "Single curve values": sortedRandint(0, 20, 15),
+    # Convention 3 list form
+    "container of (optionally) mixed-size curve values": [
+        sortedRandint(0, 20, 15),
+        *[sortedRandint(0, 20, 15) for _ in range(4)],
+    ],
+    # Convention 3 array form
+    "2D matrix": np.row_stack([sortedRandint(20, 40, 15) for _ in range(6)]),
+}
+
+
+def next_plot(xtype="random", ytype="random", symbol="o", symbolBrush="#f00"):
+    constKwargs = locals()
+    x = y = None
+    if xtype == "random":
+        xtype = random.choice(list(values))
+    if ytype == "random":
+        ytype = random.choice(list(values))
+    x = values[xtype]
+    y = values[ytype]
+    textbox.setValue(f"x={xtype}\ny={ytype}")
+    pltItem.clear()
+    try:
+        pltItem.multiDataPlot(
+            x=x, y=y, pen=cmap.getLookupTable(nPts=6), constKwargs=constKwargs
+        )
+    except Exception as e:
+        QtWidgets.QMessageBox.critical(widget, "Error", traceback.format_exc())
+
+
+cmap = pg.colormap.get("viridis")
+widget = pg.PlotWidget()
+pltItem: pg.PlotItem = widget.plotItem
+
+xytype = dict(type="list", values=list(values))
+topParam = interact(
+    next_plot,
+    symbolBrush=dict(type="color"),
+    symbol=dict(type="list", values=name_list),
+    xtype=xytype,
+    ytype=xytype,
+)
+tree = ParameterTree()
+tree.setMinimumWidth(150)
+tree.addParameters(topParam, showTop=True)
+
+textbox = Parameter.create(name="text", type="text", readonly=True)
+tree.addParameters(textbox)
+
+win = QtWidgets.QWidget()
+win.setLayout(lay := QtWidgets.QHBoxLayout())
+lay.addWidget(widget)
+lay.addWidget(tree)
+if __name__ == "__main__":
+    win.show()
+    pg.exec()

--- a/pyqtgraph/examples/utils.py
+++ b/pyqtgraph/examples/utils.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 examples_ = OrderedDict([
     ('Command-line usage', 'CLIexample.py'),
     ('Basic Plotting', Namespace(filename='Plotting.py', recommended=True)),
+    ('Plotting Datasets', 'MultiDataPlot.py'),
     ('ImageView', 'ImageView.py'),
     ('ParameterTree', 'parametertree.py'),
     ('Parameter-Function Interaction', 'InteractiveParameter.py'),

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -669,6 +669,72 @@ class PlotItem(GraphicsWidget):
         bar.setImageItem( image, insert_in=self )
         return bar
 
+    def multiDataPlot(self, *, x=None, y=None, constKwargs=None, **kwargs):
+        """
+        Allow plotting multiple curves on the same plot, changing some kwargs
+        per curve.
+
+        Parameters
+        ----------
+        x, y: array-like
+            can be in the following formats:
+              - {x or y} = [n1, n2, n3, ...]: The named argument iterates through
+                ``n`` curves, while the unspecified argument is range(len(n)) for
+                each curve.
+              - x, [y1, y2, y3, ...]
+              - [x1, x2, x3, ...], [y1, y2, y3, ...]
+              - [x1, x2, x3, ...], y
+
+              where ``x_n`` and ``y_n`` are ``ndarray`` data for each curve. Since
+              ``x`` and ``y`` values are matched using ``zip``, unequal lengths mean
+              the longer array will be truncated. Note that 2D matrices for either x
+              or y are considered lists of curve
+              data.
+        constKwargs: dict, optional
+            A dict of {str: value} passed to each curve during ``plot()``.
+        kwargs: dict, optional
+            A dict of {str: iterable} where the str is the name of a kwarg and the
+            iterable is a list of values, one for each plotted curve.
+        """
+        if (x is not None and not len(x)) or (y is not None and not len(y)):
+            # Nothing to plot -- either x or y array will bail out early from
+            # zip() below.
+            return []
+        def scalarOrNone(val):
+            return val is None or (len(val) and np.isscalar(val[0]))
+
+        if scalarOrNone(x) and scalarOrNone(y):
+            raise ValueError(
+                "If both `x` and `y` represent single curves, use `plot` instead "
+                "of `multiPlot`."
+            )
+        curves = []
+        constKwargs = constKwargs or {}
+        xy: 'dict[str, list | None]' = dict(x=x, y=y)
+        for key, oppositeVal in zip(('x', 'y'), [y, x]):
+            oppositeVal: 'Iterable | None'
+            val = xy[key]
+            if val is None:
+                # Other curve has all data, make range that supports longest chain
+                val = range(max(len(curveN) for curveN in oppositeVal))
+            if np.isscalar(val[0]):
+                # x, [y1, y2, y3, ...] or [x1, x2, x3, ...], y
+                # Repeat the single curve to match length of opposite list
+                val = [val] * len(oppositeVal)
+            xy[key] = val
+        for ii, (xi, yi) in enumerate(zip(xy['x'], xy['y'])):
+            for kk in kwargs:
+                if len(kwargs[kk]) <= ii:
+                    raise ValueError(
+                        f"Not enough values for kwarg `{kk}`. "
+                        f"Expected {ii + 1:d} (number of curves to plot), got"
+                        f" {len(kwargs[kk]):d}"
+                    )
+            kwargsi = {kk: kwargs[kk][ii] for kk in kwargs}
+            constKwargs.update(kwargsi)
+            curves.append(self.plot(xi, yi, **constKwargs))
+        return curves
+
     def scatterPlot(self, *args, **kargs):
         if 'pen' in kargs:
             kargs['symbolPen'] = kargs['pen']

--- a/tests/graphicsItems/PlotItem/test_PlotItem.py
+++ b/tests/graphicsItems/PlotItem/test_PlotItem.py
@@ -4,9 +4,29 @@ import pytest
 import pyqtgraph as pg
 
 app = pg.mkQApp()
+rng = np.random.default_rng(1001)
 
 
-@pytest.mark.parametrize('orientation', ['left', 'right', 'top', 'bottom'])
+def sorted_randint(low, high, size):
+    return np.sort(rng.integers(low, high, size))
+
+
+def is_none_or_scalar(value):
+    return value is None or np.isscalar(value[0])
+
+
+multi_data_plot_values = [
+    None,
+    sorted_randint(0, 20, 15),
+    [
+        sorted_randint(0, 20, 15),
+        *[sorted_randint(0, 20, 15) for _ in range(4)],
+    ],
+    np.row_stack([sorted_randint(20, 40, 15) for _ in range(6)]),
+]
+
+
+@pytest.mark.parametrize("orientation", ["left", "right", "top", "bottom"])
 def test_PlotItem_shared_axis_items(orientation):
     """Adding an AxisItem to multiple plots raises RuntimeError"""
     ax1 = pg.AxisItem(orientation)
@@ -51,6 +71,31 @@ def test_PlotItem_maxTraces():
     item.ctrl.forgetTracesCheck.setChecked(True)
     assert curve2 in item.curves, "curve2 should be in the item's curves"
     assert curve1 not in item.curves, "curve1 should not be in the item's curves"
+
+
+@pytest.mark.parametrize("xvalues", multi_data_plot_values)
+@pytest.mark.parametrize("yvalues", multi_data_plot_values)
+def test_PlotItem_multi_data_plot(xvalues, yvalues):
+    item = pg.PlotItem()
+    if is_none_or_scalar(xvalues) and is_none_or_scalar(yvalues):
+        with pytest.raises(ValueError):
+            item.multiDataPlot(x=xvalues, y=yvalues)
+            return
+    else:
+        curves = item.multiDataPlot(x=xvalues, y=yvalues, constKwargs={"pen": "r"})
+        check_idx = None
+        if xvalues is None:
+            check_idx = 0
+        elif yvalues is None:
+            check_idx = 1
+        if check_idx is not None:
+            for curve in curves:
+                data = curve.getData()
+                opposite_idx = 1 - check_idx
+                assert np.array_equal(
+                    data[check_idx], np.arange(len(data[opposite_idx]))
+                )
+                assert curve.opts["pen"] == "r"
 
 
 def test_PlotItem_preserve_external_visibility_control():


### PR DESCRIPTION
Allow easily plotting multiple `PlotDataItem`s at once through a `PlotItem.multiDataPlot` interface. This way, some properties can be easily cycled for each curve without all the required manual specifications. See the newly added example for some usages.