### PR TITLE
Add keyword argument in PColorMeshItem to enable consistent colormap scaling during animation

### DIFF
--- a/pyqtgraph/examples/PColorMeshItem.py
+++ b/pyqtgraph/examples/PColorMeshItem.py
@@ -45,12 +45,12 @@ z = np.exp(-(x*xn)**2/1000)[:-1,:-1]
 edgecolors   = None
 antialiasing = False
 cmap         = pg.colormap.get('viridis')
-limits       = None
+levels       = None
 # edgecolors = {'color':'w', 'width':2} # May be uncommented to see edgecolor effect
 # antialiasing = True # May be uncommented to see antialiasing effect
 # cmap         = pg.colormap.get('plasma') # May be uncommented to see a different colormap than the default 'viridis'
-# limits       = (-2,2) # may be uncommented to see changes in the absolute value of z (color_noise) which is hidden by the autoscaling colormap when using the default `limits=None`
-pcmi = pg.PColorMeshItem(edgecolors=edgecolors, antialiasing=antialiasing, colorMap=cmap, limits=limits)
+# levels       = (-2,2) # may be uncommented to see changes in the absolute value of z (color_noise) which is hidden by the autoscaling colormap when using the default `levels=None`
+pcmi = pg.PColorMeshItem(edgecolors=edgecolors, antialiasing=antialiasing, colorMap=cmap, levels=levels)
 view.addItem(pcmi)
 textitem = pg.TextItem(anchor=(1, 0))
 view.addItem(textitem)

--- a/pyqtgraph/examples/PColorMeshItem.py
+++ b/pyqtgraph/examples/PColorMeshItem.py
@@ -45,12 +45,13 @@ z = np.exp(-(x*xn)**2/1000)[:-1,:-1]
 edgecolors   = None
 antialiasing = False
 cmap         = pg.colormap.get('viridis')
-levels       = None
+levels       = (-2,2) # Will be overwritten unless enableAutoLevels is set to False
+enableAutoLevels = True 
 # edgecolors = {'color':'w', 'width':2} # May be uncommented to see edgecolor effect
 # antialiasing = True # May be uncommented to see antialiasing effect
 # cmap         = pg.colormap.get('plasma') # May be uncommented to see a different colormap than the default 'viridis'
-# levels       = (-2,2) # may be uncommented to see changes in the absolute value of z (color_noise) which is hidden by the autoscaling colormap when using the default `levels=None`
-pcmi = pg.PColorMeshItem(edgecolors=edgecolors, antialiasing=antialiasing, colorMap=cmap, levels=levels)
+# enableAutoLevels = False # may be uncommented to see changes in the absolute value of z (color_noise) which is hidden by the autoscaling colormap when using the default `levels=None`
+pcmi = pg.PColorMeshItem(edgecolors=edgecolors, antialiasing=antialiasing, colorMap=cmap, levels=levels, enableAutoLevels=enableAutoLevels)
 view.addItem(pcmi)
 textitem = pg.TextItem(anchor=(1, 0))
 view.addItem(textitem)

--- a/pyqtgraph/examples/PColorMeshItem.py
+++ b/pyqtgraph/examples/PColorMeshItem.py
@@ -44,9 +44,13 @@ z = np.exp(-(x*xn)**2/1000)[:-1,:-1]
 ## Create image item
 edgecolors   = None
 antialiasing = False
-# edgecolors = {'color':'w', 'width':2} # May be uncommened to see edgecolor effect
-# antialiasing = True # May be uncommened to see antialiasing effect
-pcmi = pg.PColorMeshItem(edgecolors=edgecolors, antialiasing=antialiasing)
+cmap         = pg.colormap.get('viridis')
+limits       = None
+# edgecolors = {'color':'w', 'width':2} # May be uncommented to see edgecolor effect
+# antialiasing = True # May be uncommented to see antialiasing effect
+# cmap         = pg.colormap.get('plasma') # May be uncommented to see a different colormap than the default 'viridis'
+# limits       = (-2,2) # may be uncommented to see changes in the absolute value of z (color_noise) which is hidden by the autoscaling colormap when using the default `limits=None`
+pcmi = pg.PColorMeshItem(edgecolors=edgecolors, antialiasing=antialiasing, colorMap=cmap, limits=limits)
 view.addItem(pcmi)
 textitem = pg.TextItem(anchor=(1, 0))
 view.addItem(textitem)
@@ -60,6 +64,7 @@ wave_amplitude  = 3
 wave_speed      = 0.3
 wave_length     = 10
 color_speed     = 0.3
+color_noise_freq = 0.05
 
 timer = QtCore.QTimer()
 timer.setSingleShot(True)
@@ -73,9 +78,10 @@ def updateData():
     
     ## Display the new data set
     t0 = time.perf_counter()
+    color_noise = np.sin(i * 2*np.pi*color_noise_freq) 
     new_x = x
     new_y = y+wave_amplitude*np.cos(x/wave_length+i)
-    new_z = np.exp(-(x-np.cos(i*color_speed)*xn)**2/1000)[:-1,:-1]
+    new_z = np.exp(-(x-np.cos(i*color_speed)*xn)**2/1000)[:-1,:-1] + color_noise
     t1 = time.perf_counter()
     pcmi.setData(new_x,
                  new_y,

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -88,6 +88,8 @@ class PColorMeshItem(GraphicsObject):
         colorMap : pyqtgraph.ColorMap
             Colormap used to map the z value to colors.
             default ``pyqtgraph.colormap.get('viridis')``
+        limits: tuple, optional, default None
+            Limits the colormap range to (low, high), None disables the limit.
         edgecolors : dict, optional
             The color of the edges of the polygons.
             Default None means no edges.
@@ -107,6 +109,7 @@ class PColorMeshItem(GraphicsObject):
 
         self.edgecolors = kwargs.get('edgecolors', None)
         self.antialiasing = kwargs.get('antialiasing', False)
+        self.cmaplim = kwargs.get('limits', None)
         
         if 'colorMap' in kwargs:
             cmap = kwargs.get('colorMap')
@@ -233,8 +236,14 @@ class PColorMeshItem(GraphicsObject):
         lut = self.lut_qbrush
         # Second we associate each z value, that we normalize, to the lut
         scale = len(lut) - 1
-        z_min = self.z.min()
-        z_max = self.z.max()
+        if self.cmaplim is None:
+            # Autoscale colormap each time setData is called
+            z_min = self.z.min()
+            z_max = self.z.max()
+        else:
+            # Use consistent colormap scaling
+            z_min = self.cmaplim[0]
+            z_max = self.cmaplim[1]
         rng = z_max - z_min
         if rng == 0:
             rng = 1

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -88,8 +88,11 @@ class PColorMeshItem(GraphicsObject):
         colorMap : pyqtgraph.ColorMap
             Colormap used to map the z value to colors.
             default ``pyqtgraph.colormap.get('viridis')``
-        limits: tuple, optional, default None
-            Limits the colormap range to (low, high), None disables the limit.
+        levels: tuple, optional, default None
+            Sets the minimum and maximum values to be represented by the colormap (min, max). 
+            Values outside this range will be clipped to the colors representing min or max.
+            ``None`` disables the limits, meaning that the colormap will autoscale 
+            each time ``setData()`` is called.
         edgecolors : dict, optional
             The color of the edges of the polygons.
             Default None means no edges.
@@ -109,7 +112,7 @@ class PColorMeshItem(GraphicsObject):
 
         self.edgecolors = kwargs.get('edgecolors', None)
         self.antialiasing = kwargs.get('antialiasing', False)
-        self.cmaplim = kwargs.get('limits', None)
+        self.levels = kwargs.get('levels', None)
         
         if 'colorMap' in kwargs:
             cmap = kwargs.get('colorMap')
@@ -236,14 +239,14 @@ class PColorMeshItem(GraphicsObject):
         lut = self.lut_qbrush
         # Second we associate each z value, that we normalize, to the lut
         scale = len(lut) - 1
-        if self.cmaplim is None:
+        if self.levels is None:
             # Autoscale colormap each time setData is called
             z_min = self.z.min()
             z_max = self.z.max()
         else:
             # Use consistent colormap scaling
-            z_min = self.cmaplim[0]
-            z_max = self.cmaplim[1]
+            z_min = self.levels[0]
+            z_max = self.levels[1]
         rng = z_max - z_min
         if rng == 0:
             rng = 1

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -214,10 +214,10 @@ class PColorMeshItem(GraphicsObject):
             "ASCII from: <https://matplotlib.org/3.2.1/api/_as_gen/
                          matplotlib.pyplot.pcolormesh.html>".
         autoLevels: bool, optional, default True
-            When set to True, PColorMeshITem will automatically select levels
+            When set to True, PColorMeshItem will automatically select levels
             based on the minimum and maximum values encountered in the data along the z axis.
             The minimum and maximum levels are mapped to the lowest and highest colors 
-            in the colormap. The autoLevels parameter is ignored if ``enableAutoLevels==False`` 
+            in the colormap. The autoLevels parameter is ignored if ``enableAutoLevels is False`` 
         """
         autoLevels = kwargs.get('autoLevels', True)
 
@@ -253,7 +253,7 @@ class PColorMeshItem(GraphicsObject):
         # Second we associate each z value, that we normalize, to the lut
         scale = len(lut) - 1
         # Decide whether to autoscale the colormap or use the same levels as before
-        if (self.levels is None) or (self.enableAutoLevels == True and autoLevels == True):
+        if (self.levels is None) or (self.enableAutoLevels and autoLevels):
             # Autoscale colormap 
             z_min = self.z.min()
             z_max = self.z.max()


### PR DESCRIPTION
I've added a new keyword argument to PColorMeshItem that allows absolute scaling of the colormap (in addition to the autoscaling that is already present, and still default). This is especially useful when plotting animations where the absolute value of the z axis (color) matters. I've also modified the PColorMeshItem example to showcase why this feature might be important in certain cases.

I see that [ColorBarItem]( https://pyqtgraph.readthedocs.io/en/latest/api_reference/graphicsItems/colorbaritem.html) uses both `limits` and `levels` about the corresponding parameter, so I wasn't exactly sure what to call it, but I ended up with `limits` as I felt that was most self explanatory.

This is my first PR in this repo, so I might have missed some mandatory updates. In that case, please let me know, and I will try to amend the mistakes.