### PR TITLE
re-enable hmac authentication for win32

### DIFF
--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -85,11 +85,6 @@ class Process(RemoteEventHandler):
         ## random authentication key
         authkey = os.urandom(20)
 
-        ## Windows seems to have a hard time with hmac 
-        if sys.platform.startswith('win'):
-            authkey = None
-
-        #print "key:", ' '.join([str(ord(x)) for x in authkey])
         ## Listen for connection from remote process (and find free port number)
         l = multiprocessing.connection.Listener(('localhost', 0), authkey=authkey)
         port = l.address[1]


### PR DESCRIPTION
The commit that disabled it was in November 2013, but didn't specify which version of Windows was having the issue.

This PR has been tested to be working on Windows 7, Python 3.8.10.
