### PR TITLE
fix: use connect='finite' if finite-ness of data is unknown

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -271,8 +271,8 @@ class PlotDataItem(GraphicsObject):
                               values exist, unpredictable behavior will occur. The data may not be
                               displayed or the plot may take a significant performance hit.
                               
-                              In the default 'auto' connect mode, `PlotDataItem` will apply this 
-                              setting automatically.
+                              In the default 'auto' connect mode, `PlotDataItem` will automatically
+                              override this setting.
             ================= =======================================================================
 
         **Meta-info keyword arguments:**
@@ -877,14 +877,17 @@ class PlotDataItem(GraphicsObject):
             ): # draw if visible...
             # auto-switch to indicate non-finite values as interruptions in the curve:
             if isinstance(curveArgs['connect'], str) and curveArgs['connect'] == 'auto': # connect can also take a boolean array
-                if dataset.containsNonfinite is None:
-                    curveArgs['connect'] = 'all' # this is faster, but silently connects the curve across any non-finite values
-                else:
-                    if dataset.containsNonfinite:
-                        curveArgs['connect'] = 'finite'
-                    else:
-                        curveArgs['connect'] = 'all' # all points can be connected, and no further check is needed.
-                        curveArgs['skipFiniteCheck'] = True
+                if dataset.containsNonfinite is False:
+                    # all points can be connected, and no further check is needed.
+                    curveArgs['connect'] = 'all'
+                    curveArgs['skipFiniteCheck'] = True
+                else:   # True or None
+                    # True: (we checked and found non-finites)
+                    #   don't connect non-finites
+                    # None: (we haven't performed a check for non-finites yet)
+                    #   use connect='finite' in case there are non-finites.
+                    curveArgs['connect'] = 'finite'
+                    curveArgs['skipFiniteCheck'] = False
             self.curve.setData(x=x, y=y, **curveArgs)
             self.curve.show()
         else: # ...hide if not.


### PR DESCRIPTION
`PlotDataItem` defaults to `connect='auto'`. In the course of its processing, `PlotDataItem` *might* perform a finite-ness check on the data for its own purpose.

Given a dataset that contains non-finites,
1) *if* this finite-ness check was performed, `PlotDataItem` switches to using `connect='finite'`.
2) *if* this finite-ness check was *not* performed, `PlotDataItem` switches to using `connect='all'`.

This ends up in a situation where such a dataset is sometimes drawn connected, sometimes drawn disconnected.

This PR changes (2) to use `connect='finite'`. This causes the underlying `PlotCurveItem` (via `arrayToQPath`) to perform its own finite checking.

Test cases can be found in #2456.

Fixes #2456
