### PR TITLE
Fix ButtonItem hover event

### DIFF
--- a/pyqtgraph/graphicsItems/ButtonItem.py
+++ b/pyqtgraph/graphicsItems/ButtonItem.py
@@ -33,12 +33,12 @@ class ButtonItem(GraphicsObject):
         if self.enabled:
             self.clicked.emit(self)
         
-    def mouseHoverEvent(self, ev):
+    def hoverEvent(self, ev):
         if not self.enabled:
             return
         if ev.isEnter():
             self.setOpacity(1.0)
-        else:
+        elif ev.isExit():
             self.setOpacity(0.7)
 
     def disable(self):


### PR DESCRIPTION
* Fix method name `mouseHoverEvent` -> `hoverEvent`. Therefore, it has never been called.
* Fix changing opacity while hovering. Change it back to "non-hover-state" only after hover event with "is-exit" occurs. (Note, that `hoverEvent` is called multiple times while mouse cursor is on the item.)

Simply have a look at the "Auto-Range-Button" in any plot to see the hovering work now.