### PR TITLE
Raise appropriate Exceptions in place of generic exceptions

### DIFF
--- a/pyqtgraph/exceptionHandling.py
+++ b/pyqtgraph/exceptionHandling.py
@@ -65,10 +65,6 @@ def setTracebackClearing(clear=True):
     clear_tracebacks = clear
 
 
-class ArrayDimensionError(Exception):
-    pass
-
-
 class ExceptionHandler(object):
     def __init__(self):
         self.orig_sys_excepthook = sys.excepthook

--- a/pyqtgraph/exceptionHandling.py
+++ b/pyqtgraph/exceptionHandling.py
@@ -65,6 +65,10 @@ def setTracebackClearing(clear=True):
     clear_tracebacks = clear
 
 
+class ArrayDimensionError(Exception):
+    pass
+
+
 class ExceptionHandler(object):
     def __init__(self):
         self.orig_sys_excepthook = sys.excepthook

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -1214,7 +1214,7 @@ def dataType(obj):
             elif obj.ndim == 2 and obj.dtype.names is None and obj.shape[1] == 2:
                 return 'Nx2array'
             else:
-                raise TypeError('array shape must be (N,) or (N,2); got %s instead' % str(obj.shape))
+                raise ValueError('array shape must be (N,) or (N,2); got %s instead' % str(obj.shape))
         elif isinstance(first, dict):
             return 'listOfDicts'
         else:

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -7,6 +7,7 @@ from .. import debug as debug
 from .. import functions as fn
 from .. import getConfigOption
 from ..Qt import QtCore
+from ..exceptionHandling import ArrayDimensionError
 from .GraphicsObject import GraphicsObject
 from .PlotCurveItem import PlotCurveItem
 from .ScatterPlotItem import ScatterPlotItem
@@ -1214,7 +1215,7 @@ def dataType(obj):
             elif obj.ndim == 2 and obj.dtype.names is None and obj.shape[1] == 2:
                 return 'Nx2array'
             else:
-                raise Exception('array shape must be (N,) or (N,2); got %s instead' % str(obj.shape))
+                raise ArrayDimensionError('array shape must be (N,) or (N,2); got %s instead' % str(obj.shape))
         elif isinstance(first, dict):
             return 'listOfDicts'
         else:

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -707,7 +707,7 @@ class PlotDataItem(GraphicsObject):
                     x = np.array(data['x'])
                 if 'y' in data:
                     y = np.array(data['y'])
-            elif dt ==  'listOfDicts':
+            elif dt == 'listOfDicts':
                 if 'x' in data[0]:
                     x = np.array([d.get('x',None) for d in data])
                 if 'y' in data[0]:
@@ -719,13 +719,13 @@ class PlotDataItem(GraphicsObject):
                 y = data.view(np.ndarray)
                 x = data.xvals(0).view(np.ndarray)
             else:
-                raise Exception('Invalid data type %s' % type(data))
+                raise TypeError('Invalid data type %s' % type(data))
 
         elif len(args) == 2:
             seq = ('listOfValues', 'MetaArray', 'empty')
             dtyp = dataType(args[0]), dataType(args[1])
             if dtyp[0] not in seq or dtyp[1] not in seq:
-                raise Exception('When passing two unnamed arguments, both must be a list or array of values. (got %s, %s)' % (str(type(args[0])), str(type(args[1]))))
+                raise TypeError('When passing two unnamed arguments, both must be a list or array of values. (got %s, %s)' % (str(type(args[0])), str(type(args[1]))))
             if not isinstance(args[0], np.ndarray):
                 #x = np.array(args[0])
                 if dtyp[0] == 'MetaArray':

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -7,7 +7,6 @@ from .. import debug as debug
 from .. import functions as fn
 from .. import getConfigOption
 from ..Qt import QtCore
-from ..exceptionHandling import ArrayDimensionError
 from .GraphicsObject import GraphicsObject
 from .PlotCurveItem import PlotCurveItem
 from .ScatterPlotItem import ScatterPlotItem
@@ -1215,7 +1214,7 @@ def dataType(obj):
             elif obj.ndim == 2 and obj.dtype.names is None and obj.shape[1] == 2:
                 return 'Nx2array'
             else:
-                raise ArrayDimensionError('array shape must be (N,) or (N,2); got %s instead' % str(obj.shape))
+                raise TypeError('array shape must be (N,) or (N,2); got %s instead' % str(obj.shape))
         elif isinstance(first, dict):
             return 'listOfDicts'
         else:


### PR DESCRIPTION
Fixes #2167 
Raise `TypeError` in place of generic `Exception` for `PlotDataItem.setData()`.
Introduced and raised a new exception named `ArrayDimensionError` when numpy arrays have an Invalid shape.

### Other Tasks 

<details>
  <summary>Raise `TypeError` in place of generic `Exception` for `PlotDataItem.setData()`</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [X] `README.md`
- [X] `setup.py`
- [X] `tox.ini`
- [X] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [X] `pyproject.toml`
- [X] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
