### PR TITLE
ROI: Add test with mouseDrag event and check snapping

### DIFF
--- a/tests/graphicsItems/test_ROI.py
+++ b/tests/graphicsItems/test_ROI.py
@@ -12,6 +12,7 @@ from tests.ui_testing import mouseClick, mouseDrag, mouseMove, resizeWindow
 app = pg.mkQApp()
 pg.setConfigOption("mouseRateLimit", 0)
 
+
 def test_getArrayRegion(transpose=False):
     pr = pg.PolyLineROI([[0, 0], [27, 0], [0, 28]], closed=True)
     pr.setPos(1, 1)
@@ -24,38 +25,40 @@ def test_getArrayRegion(transpose=False):
     for roi, name in rois:
         # For some ROIs, resize should not be used.
         testResize = not isinstance(roi, pg.PolyLineROI)
-        
+
         origMode = pg.getConfigOption('imageAxisOrder')
         try:
             if transpose:
                 pg.setConfigOptions(imageAxisOrder='row-major')
-                check_getArrayRegion(roi, 'roi/'+name, testResize, transpose=True)
+                check_getArrayRegion(roi, 'roi/' + name, testResize,
+                                     transpose=True)
             else:
                 pg.setConfigOptions(imageAxisOrder='col-major')
-                check_getArrayRegion(roi, 'roi/'+name, testResize)
+                check_getArrayRegion(roi, 'roi/' + name, testResize)
         finally:
             pg.setConfigOptions(imageAxisOrder=origMode)
-    
+
+
 def test_getArrayRegion_axisorder():
     test_getArrayRegion(transpose=True)
 
-    
+
 def check_getArrayRegion(roi, name, testResize=True, transpose=False):
-    # on windows, edges corner pixels seem to be slightly different from other platforms
-    # giving a pxCount=2 for a fudge factor
-    if isinstance(roi, (pg.ROI, pg.RectROI)) and platform.system() == "Windows":
+    # on windows, edges corner pixels seem to be slightly different from
+    # other platforms giving a pxCount=2 for a fudge factor
+    if (isinstance(roi, (pg.ROI, pg.RectROI))
+            and platform.system() == "Windows"):
         pxCount = 2
     else:
-        pxCount=-1
-
+        pxCount = -1
 
     initState = roi.getState()
-    
+
     win = pg.GraphicsView()
     win.show()
     resizeWindow(win, 200, 400)
-    # Don't use Qt's layouts for testing--these generate unpredictable results.    
-    # Instead, place the viewboxes manually 
+    # Don't use Qt's layouts for testing--these generate unpredictable results.
+    # Instead, place the viewboxes manually
     vb1 = pg.ViewBox()
     win.scene().addItem(vb1)
     vb1.setPos(6, 6)
@@ -65,44 +68,47 @@ def check_getArrayRegion(roi, name, testResize=True, transpose=False):
     win.scene().addItem(vb2)
     vb2.setPos(6, 203)
     vb2.resize(188, 191)
-    
+
     img1 = pg.ImageItem(border='w')
     img2 = pg.ImageItem(border='w')
 
     vb1.addItem(img1)
     vb2.addItem(img2)
-    
+
     np.random.seed(0)
     data = np.random.normal(size=(7, 30, 31, 5))
     data[0, :, :, :] += 10
     data[:, 1, :, :] += 10
     data[:, :, 2, :] += 10
     data[:, :, :, 3] += 10
-    
+
     if transpose:
         data = data.transpose(0, 2, 1, 3)
-    
+
     img1.setImage(data[0, ..., 0])
     vb1.setAspectLocked()
     vb1.enableAutoRange(True, True)
-    
+
     roi.setZValue(10)
     vb1.addItem(roi)
 
     if isinstance(roi, pg.RectROI):
         if transpose:
-            assert roi.getAffineSliceParams(data, img1, axes=(1, 2)) == ([28.0, 27.0], ((1.0, 0.0), (0.0, 1.0)), (1.0, 1.0))
+            assert roi.getAffineSliceParams(data, img1, axes=(1, 2)) == (
+                [28.0, 27.0], ((1.0, 0.0), (0.0, 1.0)), (1.0, 1.0))
         else:
-            assert roi.getAffineSliceParams(data, img1, axes=(1, 2)) == ([27.0, 28.0], ((1.0, 0.0), (0.0, 1.0)), (1.0, 1.0))
+            assert roi.getAffineSliceParams(data, img1, axes=(1, 2)) == (
+                [27.0, 28.0], ((1.0, 0.0), (0.0, 1.0)), (1.0, 1.0))
 
     rgn = roi.getArrayRegion(data, img1, axes=(1, 2))
-    #assert np.all((rgn == data[:, 1:-2, 1:-2, :]) | (rgn == 0))
+    # assert np.all((rgn == data[:, 1:-2, 1:-2, :]) | (rgn == 0))
     img2.setImage(rgn[0, ..., 0])
     vb2.setAspectLocked()
     vb2.enableAutoRange(True, True)
-    
+
     app.processEvents()
-    assertImageApproved(win, name+'/roi_getarrayregion', 'Simple ROI region selection.', pxCount=pxCount)
+    assertImageApproved(win, name + '/roi_getarrayregion',
+                        'Simple ROI region selection.', pxCount=pxCount)
 
     with pytest.raises(TypeError):
         roi.setPos(0, False)
@@ -111,34 +117,44 @@ def check_getArrayRegion(roi, name, testResize=True, transpose=False):
     rgn = roi.getArrayRegion(data, img1, axes=(1, 2))
     img2.setImage(rgn[0, ..., 0])
     app.processEvents()
-    assertImageApproved(win, name+'/roi_getarrayregion_halfpx', 'Simple ROI region selection, 0.5 pixel shift.', pxCount=pxCount)
+    assertImageApproved(win, name + '/roi_getarrayregion_halfpx',
+                        'Simple ROI region selection, 0.5 pixel shift.',
+                        pxCount=pxCount)
 
     roi.setAngle(45)
     roi.setPos([3, 0])
     rgn = roi.getArrayRegion(data, img1, axes=(1, 2))
     img2.setImage(rgn[0, ..., 0])
     app.processEvents()
-    assertImageApproved(win, name+'/roi_getarrayregion_rotate', 'Simple ROI region selection, rotation.', pxCount=pxCount)
+    assertImageApproved(win, name + '/roi_getarrayregion_rotate',
+                        'Simple ROI region selection, rotation.',
+                        pxCount=pxCount)
 
     if testResize:
         roi.setSize([60, 60])
         rgn = roi.getArrayRegion(data, img1, axes=(1, 2))
         img2.setImage(rgn[0, ..., 0])
         app.processEvents()
-        assertImageApproved(win, name+'/roi_getarrayregion_resize', 'Simple ROI region selection, resized.', pxCount=pxCount)
+        assertImageApproved(win, name + '/roi_getarrayregion_resize',
+                            'Simple ROI region selection, resized.',
+                            pxCount=pxCount)
 
     img1.setPos(0, img1.height())
     img1.setTransform(QtGui.QTransform().scale(1, -1).rotate(20), True)
     rgn = roi.getArrayRegion(data, img1, axes=(1, 2))
     img2.setImage(rgn[0, ..., 0])
     app.processEvents()
-    assertImageApproved(win, name+'/roi_getarrayregion_img_trans', 'Simple ROI region selection, image transformed.', pxCount=pxCount)
+    assertImageApproved(win, name + '/roi_getarrayregion_img_trans',
+                        'Simple ROI region selection, image transformed.',
+                        pxCount=pxCount)
 
     vb1.invertY()
     rgn = roi.getArrayRegion(data, img1, axes=(1, 2))
     img2.setImage(rgn[0, ..., 0])
     app.processEvents()
-    assertImageApproved(win, name+'/roi_getarrayregion_inverty', 'Simple ROI region selection, view inverted.', pxCount=pxCount)
+    assertImageApproved(win, name + '/roi_getarrayregion_inverty',
+                        'Simple ROI region selection, view inverted.',
+                        pxCount=pxCount)
 
     roi.setState(initState)
     img1.setPos(0, 0)
@@ -146,8 +162,11 @@ def check_getArrayRegion(roi, name, testResize=True, transpose=False):
     rgn = roi.getArrayRegion(data, img1, axes=(1, 2))
     img2.setImage(rgn[0, ..., 0])
     app.processEvents()
-    assertImageApproved(win, name+'/roi_getarrayregion_anisotropic', 'Simple ROI region selection, image scaled anisotropically.', pxCount=pxCount)
-    
+    assertImageApproved(
+        win, name + '/roi_getarrayregion_anisotropic',
+        'Simple ROI region selection, image scaled anisotropically.',
+        pxCount=pxCount)
+
     # allow the roi to be re-used
     roi.scene().removeItem(roi)
 
@@ -168,90 +187,156 @@ def test_mouseClickEvent():
     vb.addItem(roi)
     app.processEvents()
 
-    mouseClick(plt, roi.mapToScene(pg.Point(2, 2)), QtCore.Qt.MouseButton.LeftButton)
+    mouseClick(plt, roi.mapToScene(pg.Point(2, 2)),
+               QtCore.Qt.MouseButton.LeftButton)
 
 
-def test_PolyLineROI():
-    rois = [
-        (pg.PolyLineROI([[0, 0], [10, 0], [0, 15]], closed=True, pen=0.3), 'closed'),
-        (pg.PolyLineROI([[0, 0], [10, 0], [0, 15]], closed=False, pen=0.3), 'open')
-    ]
-    
-    #plt = pg.plot()
+def test_mouseDragEventSnap():
     plt = pg.GraphicsView()
     plt.show()
     resizeWindow(plt, 200, 200)
     vb = pg.ViewBox()
     plt.scene().addItem(vb)
     vb.resize(200, 200)
-    #plt.plotItem = pg.PlotItem()
-    #plt.scene().addItem(plt.plotItem)
-    #plt.plotItem.resize(200, 200)
-    
+    QtTest.QTest.qWaitForWindowExposed(plt)
+    QtTest.QTest.qWait(100)
+
+    # A Rectangular roi with scaleSnap enabled
+    initial_x = 20
+    initial_y = 20
+    roi = pg.RectROI((initial_x, initial_y), (20, 20), scaleSnap=True,
+                     translateSnap=True, snapSize=1.0, movable=True)
+    vb.addItem(roi)
+    app.processEvents()
+
+    # Snap size roundtrip
+    assert roi.snapSize == 1.0
+    roi.snapSize = 0.2
+    assert roi.snapSize == 0.2
+    roi.snapSize = 1.0
+    assert roi.snapSize == 1.0
+
+    # Snap position check
+    snapped = roi.getSnapPosition(pg.Point(2.5, 3.5), snap=True)
+    assert snapped == pg.Point(2.0, 4.0)
+
+    # Only drag in y direction
+    roi_position = roi.mapToView(pg.Point(initial_x, initial_y))
+    mouseDrag(plt, roi_position, roi_position + pg.Point(0, 10),
+              QtCore.Qt.MouseButton.LeftButton)
+    assert roi.pos() == pg.Point(initial_x, 19)
+
+    mouseDrag(plt, roi_position, roi_position + pg.Point(0, 10),
+              QtCore.Qt.MouseButton.LeftButton)
+    assert roi.pos() == pg.Point(initial_x, 18)
+
+    # Only drag in x direction
+    mouseDrag(plt, roi_position, roi_position + pg.Point(10, 0),
+              QtCore.Qt.MouseButton.LeftButton)
+    assert roi.pos() == pg.Point(21, 18)
+
+
+def test_PolyLineROI():
+    rois = [
+        (pg.PolyLineROI([[0, 0], [10, 0], [0, 15]], closed=True, pen=0.3),
+         'closed'),
+        (pg.PolyLineROI([[0, 0], [10, 0], [0, 15]], closed=False, pen=0.3),
+         'open')
+    ]
+
+    # plt = pg.plot()
+    plt = pg.GraphicsView()
+    plt.show()
+    resizeWindow(plt, 200, 200)
+    vb = pg.ViewBox()
+    plt.scene().addItem(vb)
+    vb.resize(200, 200)
+    # plt.plotItem = pg.PlotItem()
+    # plt.scene().addItem(plt.plotItem)
+    # plt.plotItem.resize(200, 200)
 
     plt.scene().minDragTime = 0  # let us simulate mouse drags very quickly.
 
-    # seemingly arbitrary requirements; might need longer wait time for some platforms..
+    # seemingly arbitrary requirements; might need longer wait time for some
+    # platforms..
     QtTest.QTest.qWaitForWindowExposed(plt)
     QtTest.QTest.qWait(100)
-    
+
     for r, name in rois:
         vb.clear()
         vb.addItem(r)
         vb.autoRange()
         app.processEvents()
-        
-        assertImageApproved(plt, 'roi/polylineroi/'+name+'_init', 'Init %s polyline.' % name)
+
+        assertImageApproved(plt, 'roi/polylineroi/' + name + '_init',
+                            'Init %s polyline.' % name)
         initState = r.getState()
         assert len(r.getState()['points']) == 3
-        
+
         # hover over center
         center = r.mapToScene(pg.Point(3, 3))
         mouseMove(plt, center)
-        assertImageApproved(plt, 'roi/polylineroi/'+name+'_hover_roi', 'Hover mouse over center of ROI.')
-        
+        assertImageApproved(plt, 'roi/polylineroi/' + name + '_hover_roi',
+                            'Hover mouse over center of ROI.')
+
         # drag ROI
-        mouseDrag(plt, center, center + pg.Point(10, -10), QtCore.Qt.MouseButton.LeftButton)
-        assertImageApproved(plt, 'roi/polylineroi/'+name+'_drag_roi', 'Drag mouse over center of ROI.')
-        
+        mouseDrag(plt, center, center + pg.Point(10, -10),
+                  QtCore.Qt.MouseButton.LeftButton)
+        assertImageApproved(plt, 'roi/polylineroi/' + name + '_drag_roi',
+                            'Drag mouse over center of ROI.')
+
         # hover over handle
         pt = r.mapToScene(pg.Point(r.getState()['points'][2]))
         mouseMove(plt, pt)
-        assertImageApproved(plt, 'roi/polylineroi/'+name+'_hover_handle', 'Hover mouse over handle.')
-        
+        assertImageApproved(plt, 'roi/polylineroi/' + name + '_hover_handle',
+                            'Hover mouse over handle.')
+
         # drag handle
-        mouseDrag(plt, pt, pt + pg.Point(5, 20), QtCore.Qt.MouseButton.LeftButton)
-        assertImageApproved(plt, 'roi/polylineroi/'+name+'_drag_handle', 'Drag mouse over handle.')
-        
-        # hover over segment 
-        pt = r.mapToScene((pg.Point(r.getState()['points'][2]) + pg.Point(r.getState()['points'][1])) * 0.5)
-        mouseMove(plt, pt+pg.Point(0, 2))
-        assertImageApproved(plt, 'roi/polylineroi/'+name+'_hover_segment', 'Hover mouse over diagonal segment.')
-        
+        mouseDrag(plt, pt, pt + pg.Point(5, 20),
+                  QtCore.Qt.MouseButton.LeftButton)
+        assertImageApproved(plt, 'roi/polylineroi/' + name + '_drag_handle',
+                            'Drag mouse over handle.')
+
+        # hover over segment
+        pt = r.mapToScene((pg.Point(r.getState()['points'][2]) + pg.Point(
+            r.getState()['points'][1])) * 0.5)
+        mouseMove(plt, pt + pg.Point(0, 2))
+        assertImageApproved(plt, 'roi/polylineroi/' + name + '_hover_segment',
+                            'Hover mouse over diagonal segment.')
+
         # click segment
         mouseClick(plt, pt, QtCore.Qt.MouseButton.LeftButton)
-        assertImageApproved(plt, 'roi/polylineroi/'+name+'_click_segment', 'Click mouse over segment.')
+        assertImageApproved(plt, 'roi/polylineroi/' + name + '_click_segment',
+                            'Click mouse over segment.')
 
         # drag new handle
-        mouseMove(plt, pt+pg.Point(10, -10)) # pg bug: have to move the mouse off/on again to register hover
-        mouseDrag(plt, pt, pt + pg.Point(10, -10), QtCore.Qt.MouseButton.LeftButton)
-        assertImageApproved(plt, 'roi/polylineroi/'+name+'_drag_new_handle', 'Drag mouse over created handle.')
-        
+        mouseMove(plt, pt + pg.Point(10,
+                                     -10))
+        # pg bug: have to move the mouse off/on again to register hover
+        mouseDrag(plt, pt, pt + pg.Point(10, -10),
+                  QtCore.Qt.MouseButton.LeftButton)
+        assertImageApproved(plt,
+                            'roi/polylineroi/' + name + '_drag_new_handle',
+                            'Drag mouse over created handle.')
+
         # clear all points
         r.clearPoints()
-        assertImageApproved(plt, 'roi/polylineroi/'+name+'_clear', 'All points cleared.')
+        assertImageApproved(plt, 'roi/polylineroi/' + name + '_clear',
+                            'All points cleared.')
         assert len(r.getState()['points']) == 0
-        
+
         # call setPoints
         r.setPoints(initState['points'])
-        assertImageApproved(plt, 'roi/polylineroi/'+name+'_setpoints', 'Reset points to initial state.')
+        assertImageApproved(plt, 'roi/polylineroi/' + name + '_setpoints',
+                            'Reset points to initial state.')
         assert len(r.getState()['points']) == 3
-        
+
         # call setState
         r.setState(initState)
-        assertImageApproved(plt, 'roi/polylineroi/'+name+'_setstate', 'Reset ROI to initial state.')
+        assertImageApproved(plt, 'roi/polylineroi/' + name + '_setstate',
+                            'Reset ROI to initial state.')
         assert len(r.getState()['points']) == 3
-    
+
     plt.hide()
 
 
@@ -268,7 +353,8 @@ def test_LineROI_coords(p1, p2):
     pw.addItem(lineroi)
 
     # first two handles are the scale-rotate handles positioned by pos1, pos2
-    for expected, (name, scenepos) in zip([p1, p2], lineroi.getSceneHandlePositions()):
+    for expected, (name, scenepos) in zip([p1, p2],
+                                          lineroi.getSceneHandlePositions()):
         got = lineroi.mapSceneToParent(scenepos)
         assert math.isclose(got.x(), expected[0])
         assert math.isclose(got.y(), expected[1])


### PR DESCRIPTION
By working on the **scaleSnap (x, y)** feature, i realized that the changes will become noisy.

I do a pre step here by flaking the test region and adding a simple test with a rect roi for snapping. No logical changes are involved.
