### PR TITLE
test and fix for ChecklistParameter.show bug

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes/checklist.py
+++ b/pyqtgraph/parametertree/parameterTypes/checklist.py
@@ -66,6 +66,7 @@ class ChecklistParameterItem(GroupParameterItem):
         self.btnGrp.removeButton(child.widget)
 
     def optsChanged(self, param, opts):
+        super().optsChanged(param, opts)
         if 'expanded' in opts:
             for btn in self.metaBtns.values():
                 btn.setVisible(opts['expanded'])

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -1,10 +1,11 @@
-import sys
+from unittest.mock import MagicMock
 
 import numpy as np
 
 import pyqtgraph as pg
 import pyqtgraph.parametertree as pt
 from pyqtgraph.functions import eq
+from pyqtgraph.parametertree.parameterTypes import ChecklistParameterItem
 from pyqtgraph.Qt import QtCore, QtGui
 
 app = pg.mkQApp()
@@ -162,6 +163,17 @@ def test_data_race():
     p.sigValueChanged.connect(override)
     pi.widget.setValue(2)
     assert p.value() == pi.widget.value() == 1
+
+
+def test_checklist_show_hide():
+    p = pt.Parameter.create(name='checklist', type='checklist', limits=["a", "b", "c"])
+    pi = ChecklistParameterItem(p, 0)
+    pi.setHidden = MagicMock()
+    p.hide()
+    pi.setHidden.assert_called_with(True)
+    p.show()
+    pi.setHidden.assert_called_with(False)
+
 
 def test_pen_settings():
     # Option from constructor


### PR DESCRIPTION
ChecklistParameters weren't able to show/hide, which was traced to a lack of super call in `optsChanged`. All other parameter types were checked for similar problems, but none found. The test mocks the Qt lib's `setHidden` to be able to verify behavior.