### PR TITLE
fix segmented line mode with no segments

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -73,7 +73,7 @@ class LineSegments:
     def arrayToLineSegments(self, x, y, connect, finiteCheck):
         # analogue of arrayToQPath taking the same parameters
         if len(x) < 2:
-            return []
+            return [],
 
         connect_array = None
         if isinstance(connect, np.ndarray):

--- a/tests/graphicsItems/test_PlotCurveItem.py
+++ b/tests/graphicsItems/test_PlotCurveItem.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import pyqtgraph as pg
+from pyqtgraph.graphicsItems.PlotCurveItem import LineSegments
 from tests.image_testing import assertImageApproved
 
 
@@ -35,3 +36,13 @@ def test_PlotCurveItem():
     assertImageApproved(p, 'plotcurveitem/connectarray', "Plot curve with connection array.")
 
     p.close()
+
+
+def test_LineSegments():
+    ls = LineSegments()
+
+    # test the boundary case where the dataset consists of a single point
+    xy = np.array([0.])
+    segs = ls.arrayToLineSegments(xy, xy, connect='all', finiteCheck=True)
+    assert isinstance(segs, tuple) and len(segs) in [1, 2]
+    assert len(segs[0]) == 0


### PR DESCRIPTION
The bug occurs under both PyQt and PySide. It was introduced in aac73a86bb23165e9a9a93757cc1c46f911d3ea9 when adding support for the (potential) array form of `drawLines()` under PySide6. In that commit, `arrayToLineSegments` was modified to return a one or two element tuple. The early return codepath in the function was not similarly modified to return a tuple.

This early return codepath would be triggered by a dataset of length one. A length zero dataset would exit even earlier and thus not trigger this bug.

 How to trigger the bug:
1) Run PlotSpeedTest.py
2) set nsamples=1
3) set Width=2

Fixes #2479

