### PR TITLE
Fix `ViewBox.autoRange()` for case of data with constant y-value

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -593,7 +593,9 @@ class ViewBox(GraphicsWidget):
 
             # If we requested 0 range, try to preserve previous scale.
             # Otherwise just pick an arbitrary scale.
+            preserve = False
             if mn == mx:
+                preserve = True
                 dy = self.state['viewRange'][ax][1] - self.state['viewRange'][ax][0]
                 if dy == 0:
                     dy = 1
@@ -613,13 +615,14 @@ class ViewBox(GraphicsWidget):
                 raise Exception("Cannot set range [%s, %s]" % (str(mn), str(mx)))
 
             # Apply padding
-            if padding is None:
-                xpad = self.suggestPadding(ax)
-            else:
-                xpad = padding
-            p = (mx-mn) * xpad
-            mn -= p
-            mx += p
+            if not preserve:
+                if padding is None:
+                    xpad = self.suggestPadding(ax)
+                else:
+                    xpad = padding
+                p = (mx-mn) * xpad
+                mn -= p
+                mx += p
 
             # max range cannot be larger than bounds, if they are given
             if limits[ax][0] is not None and limits[ax][1] is not None:


### PR DESCRIPTION
Calling `ViewBox.autoRange()` multiple times lead to different results if the plotted data points have all identical y-values. For example, when you plot an array like [1.0, 1.0, ... 1.0], as I do in the mwe below.

The reason for that can be found in `ViewBox.setRange(rect, padding, ...)`, where for this special case of 0 extent of the vertical axis, the current visible range shall be preserved, see also comment "If we requested 0 range, try to preserve previous scale." in line 594.
But with `padding` being not equal to 0.0, the current visible range is not preserved, but rather enlarged by the padding.

The only way I see to circumvent this is to add some other special handling here.


Here a mwe which simply plots some data as described above und further calls `ViewBox.autoRange()` when you click into the widget.

```
import pyqtgraph as pg
from PySide2 import QtCore


app = pg.mkQApp()

class ClickablePlotWidget(pg.PlotWidget):
    clicked: QtCore.Signal = QtCore.Signal()

    def mousePressEvent(self, ev):
        self.clicked.emit()
        super().mousePressEvent(ev)


p = ClickablePlotWidget()
p.show()

p.plot([1.0, 1.0, 1.0])  # bad
# p.plot([1.0, 10.0, 1.0])  # good

def _autorange():
    print("ViewBox.autoRange()")
    vb = p.plotItem.getViewBox()
    vb.autoRange()
    # vb.autoRange(padding=0.0)  # workaround

p.clicked.connect(_autorange)


if __name__ == '__main__':
    pg.exec()
```
