### PR TITLE
fix: ndarray_from_qimage does not hold a reference to qimage

### DIFF
--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -467,7 +467,9 @@ def test_interact_with_icon():
 
     groupItem = parent.child("a").itemClass(parent.child("a"), 1)
     buttonPixmap = groupItem.button.icon().pixmap(randomPixmap.size())
-    imageBytes = [
-        fn.ndarray_from_qimage(pix.toImage()) for pix in (randomPixmap, buttonPixmap)
-    ]
+
+    # hold references to the QImages
+    images = [ pix.toImage() for pix in (randomPixmap, buttonPixmap) ]
+
+    imageBytes = [ fn.ndarray_from_qimage(img) for img in images ]
     assert np.array_equal(*imageBytes)


### PR DESCRIPTION
Note: `ndarray_from_qimage` is a library internal function.

It is the user's responsibility to ensure that the life-cycle of the `QImage` exceeds that of the created `ndarray` view.
A search of the usages of `ndarray_from_qimage` within the library will show safe ways to use it.
