### PR TITLE
Added 'value' argument to ActionParameterItem that is called on click event

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes/action.py
+++ b/pyqtgraph/parametertree/parameterTypes/action.py
@@ -45,7 +45,7 @@ class ParameterControlledButton(QtWidgets.QPushButton):
 
 
 class ActionParameterItem(ParameterItem):
-    """ParameterItem displaying a clickable button."""
+    """ParameterItem displaying a clickable button. Accepts a 'value' parameter of a zero-argument function which is called on click event."""
     def __init__(self, param, depth):
         ParameterItem.__init__(self, param, depth)
         self.layoutWidget = QtWidgets.QWidget()

--- a/pyqtgraph/parametertree/parameterTypes/action.py
+++ b/pyqtgraph/parametertree/parameterTypes/action.py
@@ -57,6 +57,9 @@ class ActionParameterItem(ParameterItem):
         self.layout.addWidget(self.button)
         self.layout.addStretch()
         self.titleChanged()
+        activateFn = param.opts.get('value', None)
+        if activateFn is not None:
+            self.button.clicked.connect(activateFn)
 
     def treeWidgetChanged(self):
         ParameterItem.treeWidgetChanged(self)


### PR DESCRIPTION
Altered pyqtgraph.parametertree.parameterTypes.action.ActionParameterItem to accept a 'value' argument of a zero-argument function and assign it to self.button.clicked. The function is called on the ParameterControlledButton's click event.

This is a more streamlined style of constructing a button with a click event than the previous behavior, which called for defining a function separate from the Parameter group constructor and then manually binding it to the sigActivated event.

Fixes #1421 

### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [ ] `README.md`
- [ ] `setup.py`
- [ ] `tox.ini`
- [ ] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [ ] `pyproject.toml`
- [ ] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
