### PR TITLE
fix wrong logic for assert_alldead

### DIFF
--- a/tests/test_ref_cycles.py
+++ b/tests/test_ref_cycles.py
@@ -14,8 +14,8 @@ app = pg.mkQApp()
 def assert_alldead(refs):
     for ref in refs:
         obj = ref()
-        assert obj is None or not (
-            isinstance(obj, pg.QtCore.QObject) and pg.Qt.isQObjectAlive(obj)
+        assert obj is None or (
+            isinstance(obj, pg.QtCore.QObject) and not pg.Qt.isQObjectAlive(obj)
         )
 
 def qObjectTree(root):


### PR DESCRIPTION
#2502 introduced a bug when relaxing the test criteria for pass.
It would have passed, for example, numpy arrays that were still alive.
