### PR TITLE
Make `ActionGroup` compatible with existing Parameter conventions

### DIFF
--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -4,7 +4,7 @@ import inspect
 import pydoc
 
 from . import Parameter
-from .parameterTypes import ActionGroup
+from .parameterTypes import ActionGroupParameter
 from .. import functions as fn
 
 
@@ -494,7 +494,7 @@ class Interactor:
         return child
 
     def _resolveRunAction(self, interactiveFunction, functionGroup, functionTip):
-        if isinstance(functionGroup, ActionGroup):
+        if isinstance(functionGroup, ActionGroupParameter):
             functionGroup.setButtonOpts(visible=True)
             child = None
         else:

--- a/pyqtgraph/parametertree/parameterTypes/__init__.py
+++ b/pyqtgraph/parametertree/parameterTypes/__init__.py
@@ -1,6 +1,6 @@
 from ..Parameter import registerParameterItemType, registerParameterType
 from .action import ActionParameter, ActionParameterItem
-from .actiongroup import ActionGroupParameter, ActionGroupParameterItem
+from .actiongroup import ActionGroup, ActionGroupParameter, ActionGroupParameterItem
 from .basetypes import (
     GroupParameter,
     GroupParameterItem,

--- a/pyqtgraph/parametertree/parameterTypes/__init__.py
+++ b/pyqtgraph/parametertree/parameterTypes/__init__.py
@@ -1,6 +1,6 @@
 from ..Parameter import registerParameterItemType, registerParameterType
 from .action import ActionParameter, ActionParameterItem
-from .actiongroup import ActionGroup, ActionGroupParameterItem
+from .actiongroup import ActionGroupParameter, ActionGroupParameterItem
 from .basetypes import (
     GroupParameter,
     GroupParameterItem,
@@ -28,9 +28,9 @@ registerParameterItemType('float', NumericParameterItem, SimpleParameter, overri
 registerParameterItemType('int',   NumericParameterItem, SimpleParameter, override=True)
 registerParameterItemType('str',   StrParameterItem,     SimpleParameter, override=True)
 
-registerParameterType('group',         GroupParameter, override=True)
+registerParameterType('group',        GroupParameter,       override=True)
 # Keep actiongroup private for now, mainly useful for Interactor but not externally
-registerParameterType('_actiongroup',  ActionGroup,    override=True)
+registerParameterType('_actiongroup', ActionGroupParameter, override=True)
 
 registerParameterType('action',    ActionParameter,      override=True)
 registerParameterType('calendar',  CalendarParameter,    override=True)

--- a/pyqtgraph/parametertree/parameterTypes/actiongroup.py
+++ b/pyqtgraph/parametertree/parameterTypes/actiongroup.py
@@ -1,3 +1,5 @@
+import warnings
+
 from ...Qt import QtCore
 from .action import ParameterControlledButton
 from .basetypes import GroupParameter, GroupParameterItem
@@ -58,3 +60,20 @@ class ActionGroupParameter(GroupParameter):
         buttonOpts = self.opts.get("button", {}).copy()
         buttonOpts.update(opts)
         self.setOpts(button=buttonOpts)
+
+
+class ActionGroup(ActionGroupParameter):
+    sigActivated = QtCore.Signal()
+
+    def __init__(self, **opts):
+        warnings.warn(
+            "`ActionGroup` is deprecated and will be removed in the first release after "
+            "January 2023. Use `ActionGroupParameter` instead. See "
+            "https://github.com/pyqtgraph/pyqtgraph/pull/2505 for details.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(**opts)
+
+    def activate(self):
+        self.sigActivated.emit()

--- a/pyqtgraph/parametertree/parameterTypes/actiongroup.py
+++ b/pyqtgraph/parametertree/parameterTypes/actiongroup.py
@@ -37,17 +37,18 @@ class ActionGroupParameterItem(GroupParameterItem):
         super().optsChanged(param, opts)
 
 
-class ActionGroup(GroupParameter):
+class ActionGroupParameter(GroupParameter):
     itemClass = ActionGroupParameterItem
 
-    sigActivated = QtCore.Signal()
+    sigActivated = QtCore.Signal(object)
 
     def __init__(self, **opts):
         opts.setdefault("button", {})
         super().__init__(**opts)
 
     def activate(self):
-        self.sigActivated.emit()
+        self.sigActivated.emit(self)
+        self.emitStateChanged('activated', None)
 
     def setButtonOpts(self, **opts):
         """


### PR DESCRIPTION
- The name didn't end with `Parameter` which is unlike every other class
- `sigActivated` should emit `self` instead of nothing
- `emitStateChanged` should be fired during `activate`
