### PR TITLE
Update Copyright To PyQtGraph Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PyQtGraph
 [![Discord](https://img.shields.io/discord/946624673200893953.svg?label=PyQtGraph&logo=discord)](https://discord.gg/3Qxjz5BF)
 A pure-Python graphics library for PyQt5/PyQt6/PySide2/PySide6
 
-Copyright 2020 Luke Campagnola, University of North Carolina at Chapel Hill
+Copyright 2022 PyQtGraph developers
 
 <http://www.pyqtgraph.org>
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -80,7 +80,7 @@ project = 'pyqtgraph'
 now = datetime.utcfromtimestamp(
     int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
 )
-copyright = '2011 - {}, Luke Campagnola'.format(now.year)
+copyright = '2011 - {}, PyQtGraph developers'.format(now.year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -346,7 +346,7 @@ if os.getenv("BUILD_DASH_DOCSET"):  # used for building dash docsets
     }
 else:
     html_sidebars = {
-        "**": ["sidebar-nav-bs.html", "sidebar-ethical-ads.html"],
+        "**": ["sidebar-nav-bs.html"],
         'index': []  # don't show sidebar on main landing page
     }
 


### PR DESCRIPTION
Had @campagnola 's blessing on this, copyright is moved away from Luke Campagnola exclusively to a more generic "pyqtgraph developers".  I left the module docstrings in for the time being, but they will likely be subject to removal at a later time.

Also realized after #2475 was merged, we had two ethical ads on the sidebar, not one.  This PR removes that.