### PR TITLE
ErrorBarItem: call update() last

### DIFF
--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -48,9 +48,9 @@ class ErrorBarItem(GraphicsObject):
         self.opts.update(opts)
         self.setVisible(all(self.opts[ax] is not None for ax in ['x', 'y']))
         self.path = None
-        self.update()
         self.prepareGeometryChange()
         self.informViewBoundsChanged()
+        self.update()
         
     def setOpts(self, **opts):
         # for backward compatibility

--- a/tests/graphicsItems/test_ErrorBarItem.py
+++ b/tests/graphicsItems/test_ErrorBarItem.py
@@ -14,13 +14,11 @@ def test_ErrorBarItem_defer_data():
     curve = pg.PlotCurveItem(x=x, y=x)
     plot.addItem(curve)
     app.processEvents()
-    app.processEvents()
     r_no_ebi = plot.viewRect()
 
     # ErrorBarItem with no data shouldn't affect the view rect
     err = pg.ErrorBarItem()
     plot.addItem(err)
-    app.processEvents()
     app.processEvents()
     r_empty_ebi = plot.viewRect()
 
@@ -28,14 +26,12 @@ def test_ErrorBarItem_defer_data():
 
     err.setData(x=x, y=x, bottom=x, top=x)
     app.processEvents()
-    app.processEvents()
     r_ebi = plot.viewRect()
 
     assert r_ebi.height() > r_empty_ebi.height()
 
     # unset data, ErrorBarItem disappears and view rect goes back to original
     err.setData(x=None, y=None)
-    app.processEvents()
     app.processEvents()
     r_clear_ebi = plot.viewRect()
 


### PR DESCRIPTION
in test_ErrorBarItem.py, processEvents() was called twice to resolve some flakiness in the test. (2fd533721589cebecf26f2761ccf5eb8db4b94dd)
moving update() to the end of the method seems to make the tests stable without resorting to calling processEvents() twice.

In fact, when running the test suite under WSL2, the error appears reliably. (Running the single test alone will pass though) 
The changes in this PR make those errors go away on WSL2, so hopefully this is the correct fix.
