### PR TITLE
Revert "instantiate QMenu with a parent"

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -201,7 +201,7 @@ class PlotItem(GraphicsWidget):
         self.ctrlMenu.setTitle(translate("PlotItem", 'Plot Options'))
         self.subMenus = []
         for name, grp in menuItems:
-            sm = QtWidgets.QMenu(name, self.ctrlMenu)
+            sm = QtWidgets.QMenu(name)
             act = QtWidgets.QWidgetAction(self)
             act.setDefaultWidget(grp)
             sm.addAction(act)

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -24,7 +24,7 @@ class ViewBoxMenu(QtWidgets.QMenu):
         self.widgetGroups = []
         self.dv = QtGui.QDoubleValidator(self)
         for axis in 'XY':
-            m = QtWidgets.QMenu(self)
+            m = QtWidgets.QMenu()
             m.setTitle(f"{axis} {translate('ViewBox', 'axis')}")
             w = QtWidgets.QWidget()
             ui = ui_template.Ui_Form()
@@ -56,7 +56,7 @@ class ViewBoxMenu(QtWidgets.QMenu):
         self.ctrl[0].invertCheck.toggled.connect(self.xInvertToggled)
         self.ctrl[1].invertCheck.toggled.connect(self.yInvertToggled)
         
-        self.leftMenu = QtWidgets.QMenu(translate("ViewBox", "Mouse Mode"), self)
+        self.leftMenu = QtWidgets.QMenu(translate("ViewBox", "Mouse Mode"))
         group = QtGui.QActionGroup(self)
         
         # This does not work! QAction _must_ be initialized with a permanent 


### PR DESCRIPTION
This reverts commit 2ae77165aea17d517aee0abe920d62cdd86ad299 which was meant to fix #2497.
However, this commit seems to be responsible for causing segfaults in the CI for Ubuntu 20.04 / Python 3.10.

It has been observed to cause segfaults for both PySide6 6.3.2 and PySide6 6.4.0.1 when run under Python 3.10.
