### PR TITLE
Maintain argument propagatoin to super class

### DIFF
--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -31,14 +31,14 @@ GLOptions = {
 class GLGraphicsItem(QtCore.QObject):
     _nextId = 0
     
-    def __init__(self, parentItem=None):
+    def __init__(self, parentItem: 'GLGraphicsItem' = None):
         super().__init__()
         self._id = GLGraphicsItem._nextId
         GLGraphicsItem._nextId += 1
         
-        self.__parent = None
+        self.__parent: GLGraphicsItem | None = None
         self.__view = None
-        self.__children = set()
+        self.__children: set[GLGraphicsItem] = set()
         self.__transform = Transform3D()
         self.__visible = True
         self.__initialized = False

--- a/pyqtgraph/opengl/items/GLAxisItem.py
+++ b/pyqtgraph/opengl/items/GLAxisItem.py
@@ -12,8 +12,8 @@ class GLAxisItem(GLGraphicsItem):
     
     """
     
-    def __init__(self, size=None, antialias=True, glOptions='translucent'):
-        GLGraphicsItem.__init__(self)
+    def __init__(self, size=None, antialias=True, glOptions='translucent', parentItem=None):
+        super().__init__(parentItem=parentItem)
         if size is None:
             size = QtGui.QVector3D(1,1,1)
         self.antialias = antialias

--- a/pyqtgraph/opengl/items/GLBarGraphItem.py
+++ b/pyqtgraph/opengl/items/GLBarGraphItem.py
@@ -7,7 +7,7 @@ from .GLMeshItem import GLMeshItem
 
 
 class GLBarGraphItem(GLMeshItem):
-    def __init__(self, pos, size):
+    def __init__(self, pos, size, parentItem=None):
         """
         pos is (...,3) array of the bar positions (the corner of each bar)
         size is (...,3) array of the sizes of each bar
@@ -27,4 +27,4 @@ class GLBarGraphItem(GLMeshItem):
         faces = cubeFaces + (np.arange(nCubes) * 8).reshape(nCubes,1,1)
         md = MeshData(verts.reshape(nCubes*8,3), faces.reshape(nCubes*12,3))
 
-        GLMeshItem.__init__(self, meshdata=md, shader='shaded', smooth=False)
+        super().__init__(meshdata=md, shader='shaded', smooth=False, parentItem=parentItem)

--- a/pyqtgraph/opengl/items/GLBoxItem.py
+++ b/pyqtgraph/opengl/items/GLBoxItem.py
@@ -11,8 +11,8 @@ class GLBoxItem(GLGraphicsItem):
     
     Displays a wire-frame box.
     """
-    def __init__(self, size=None, color=None, glOptions='translucent'):
-        GLGraphicsItem.__init__(self)
+    def __init__(self, size=None, color=None, glOptions='translucent', parentItem=None):
+        super().__init__(parentItem=parentItem)
         if size is None:
             size = QtGui.QVector3D(1,1,1)
         self.setSize(size=size)

--- a/pyqtgraph/opengl/items/GLGradientLegendItem.py
+++ b/pyqtgraph/opengl/items/GLGradientLegendItem.py
@@ -10,7 +10,7 @@ class GLGradientLegendItem(GLGraphicsItem):
     Displays legend colorbar on the screen.
     """
 
-    def __init__(self, **kwds):
+    def __init__(self, parentItem=None, **kwds):
         """
         Arguments:
             pos: position of the colorbar on the screen, from the top left corner, in pixels
@@ -24,7 +24,7 @@ class GLGradientLegendItem(GLGraphicsItem):
                 size as percentage
                 legend title
         """
-        GLGraphicsItem.__init__(self)
+        super().__init__(parentItem=parentItem)
         glopts = kwds.pop("glOptions", "additive")
         self.setGLOptions(glopts)
         self.pos = (10, 10)

--- a/pyqtgraph/opengl/items/GLGraphItem.py
+++ b/pyqtgraph/opengl/items/GLGraphItem.py
@@ -14,8 +14,8 @@ class GLGraphItem(GLGraphicsItem):
     Useful for drawing networks, trees, etc.
     """
 
-    def __init__(self, **kwds):
-        GLGraphicsItem.__init__(self)
+    def __init__(self, parentItem=None, **kwds):
+        super().__init__(parentItem=parentItem)
 
         self.edges = None
         self.edgeColor = QtGui.QColor(QtCore.Qt.GlobalColor.white)

--- a/pyqtgraph/opengl/items/GLGridItem.py
+++ b/pyqtgraph/opengl/items/GLGridItem.py
@@ -14,8 +14,8 @@ class GLGridItem(GLGraphicsItem):
     Displays a wire-frame grid. 
     """
     
-    def __init__(self, size=None, color=(255, 255, 255, 76.5), antialias=True, glOptions='translucent'):
-        GLGraphicsItem.__init__(self)
+    def __init__(self, size=None, color=(255, 255, 255, 76.5), antialias=True, glOptions='translucent', parentItem=None):
+        super().__init__(parentItem=parentItem)
         self.setGLOptions(glOptions)
         self.antialias = antialias
         if size is None:

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -13,7 +13,7 @@ class GLImageItem(GLGraphicsItem):
     """
     
     
-    def __init__(self, data, smooth=False, glOptions='translucent'):
+    def __init__(self, data, smooth=False, glOptions='translucent', parentItem=None):
         """
         
         ==============  =======================================================================================
@@ -26,7 +26,7 @@ class GLImageItem(GLGraphicsItem):
         
         self.smooth = smooth
         self._needUpdate = False
-        GLGraphicsItem.__init__(self)
+        super().__init__(parentItem=parentItem)
         self.setData(data)
         self.setGLOptions(glOptions)
         self.texture = None

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -10,9 +10,9 @@ __all__ = ['GLLinePlotItem']
 class GLLinePlotItem(GLGraphicsItem):
     """Draws line plots in 3D."""
     
-    def __init__(self, **kwds):
+    def __init__(self, parentItem=None, **kwds):
         """All keyword arguments are passed to setData()"""
-        GLGraphicsItem.__init__(self)
+        super().__init__(parentItem=parentItem)
         glopts = kwds.pop('glOptions', 'additive')
         self.setGLOptions(glopts)
         self.pos = None

--- a/pyqtgraph/opengl/items/GLMeshItem.py
+++ b/pyqtgraph/opengl/items/GLMeshItem.py
@@ -14,7 +14,7 @@ class GLMeshItem(GLGraphicsItem):
     
     Displays a 3D triangle mesh. 
     """
-    def __init__(self, **kwds):
+    def __init__(self, parentItem=None, **kwds):
         """
         ============== =====================================================
         **Arguments:**
@@ -47,7 +47,7 @@ class GLMeshItem(GLGraphicsItem):
             'computeNormals': True,
         }
         
-        GLGraphicsItem.__init__(self)
+        super().__init__(parentItem=parentItem)
         glopts = kwds.pop('glOptions', 'opaque')
         self.setGLOptions(glopts)
         shader = kwds.pop('shader', None)

--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -11,8 +11,8 @@ __all__ = ['GLScatterPlotItem']
 class GLScatterPlotItem(GLGraphicsItem):
     """Draws points at a list of 3D positions."""
     
-    def __init__(self, **kwds):
-        super().__init__()
+    def __init__(self, parentItem=None, **kwds):
+        super().__init__(parentItem=parentItem)
         glopts = kwds.pop('glOptions', 'additive')
         self.setGLOptions(glopts)
         self.pos = None

--- a/pyqtgraph/opengl/items/GLSurfacePlotItem.py
+++ b/pyqtgraph/opengl/items/GLSurfacePlotItem.py
@@ -12,7 +12,7 @@ class GLSurfacePlotItem(GLMeshItem):
     
     Displays a surface plot on a regular x,y grid
     """
-    def __init__(self, x=None, y=None, z=None, colors=None, **kwds):
+    def __init__(self, x=None, y=None, z=None, colors=None, parentItem=None, **kwds):
         """
         The x, y, z, and colors arguments are passed to setData().
         All other keyword arguments are passed to GLMeshItem.__init__().
@@ -24,7 +24,7 @@ class GLSurfacePlotItem(GLMeshItem):
         self._color = None
         self._vertexes = None
         self._meshdata = MeshData()
-        GLMeshItem.__init__(self, meshdata=self._meshdata, **kwds)
+        super().__init__(parentItem=parentItem, meshdata=self._meshdata, **kwds)
         
         self.setData(x, y, z, colors)
         

--- a/pyqtgraph/opengl/items/GLTextItem.py
+++ b/pyqtgraph/opengl/items/GLTextItem.py
@@ -10,9 +10,9 @@ __all__ = ['GLTextItem']
 class GLTextItem(GLGraphicsItem):
     """Draws text in 3D."""
 
-    def __init__(self, **kwds):
+    def __init__(self, parentItem=None, **kwds):
         """All keyword arguments are passed to setData()"""
-        GLGraphicsItem.__init__(self)
+        super().__init__(parentItem=parentItem)
         glopts = kwds.pop('glOptions', 'additive')
         self.setGLOptions(glopts)
 

--- a/pyqtgraph/opengl/items/GLVolumeItem.py
+++ b/pyqtgraph/opengl/items/GLVolumeItem.py
@@ -14,7 +14,7 @@ class GLVolumeItem(GLGraphicsItem):
     """
     
     
-    def __init__(self, data, sliceDensity=1, smooth=True, glOptions='translucent'):
+    def __init__(self, data, sliceDensity=1, smooth=True, glOptions='translucent', parentItem=None):
         """
         ==============  =======================================================================================
         **Arguments:**
@@ -29,7 +29,7 @@ class GLVolumeItem(GLGraphicsItem):
         self.data = None
         self._needUpload = False
         self.texture = None
-        GLGraphicsItem.__init__(self)
+        super().__init__(parentItem=parentItem)
         self.setGLOptions(glOptions)
         self.setData(data)
         

--- a/tests/opengl/items/common.py
+++ b/tests/opengl/items/common.py
@@ -1,0 +1,6 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+
+
+def ensure_parentItem(parent: GLGraphicsItem, child: GLGraphicsItem):
+    assert child in parent.childItems()
+    assert parent is child.parentItem()

--- a/tests/opengl/items/test_GLAxisItem.py
+++ b/tests/opengl/items/test_GLAxisItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLAxisItem
 

--- a/tests/opengl/items/test_GLAxisItem.py
+++ b/tests/opengl/items/test_GLAxisItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLAxisItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLAxisItem(parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLBarGraphItem.py
+++ b/tests/opengl/items/test_GLBarGraphItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 import numpy as np
 
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem

--- a/tests/opengl/items/test_GLBarGraphItem.py
+++ b/tests/opengl/items/test_GLBarGraphItem.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLBarGraphItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLBarGraphItem(np.ndarray([0,0,0]), np.ndarray([0,0,0]), parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLBoxItem.py
+++ b/tests/opengl/items/test_GLBoxItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLBoxItem
 

--- a/tests/opengl/items/test_GLBoxItem.py
+++ b/tests/opengl/items/test_GLBoxItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLBoxItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLBoxItem(parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLGradientLegendItem.py
+++ b/tests/opengl/items/test_GLGradientLegendItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLGradientLegendItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLGradientLegendItem(parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLGradientLegendItem.py
+++ b/tests/opengl/items/test_GLGradientLegendItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLGradientLegendItem
 

--- a/tests/opengl/items/test_GLGraphItem.py
+++ b/tests/opengl/items/test_GLGraphItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLGraphItem
 

--- a/tests/opengl/items/test_GLGraphItem.py
+++ b/tests/opengl/items/test_GLGraphItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLGraphItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLGraphItem(parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLGridItem.py
+++ b/tests/opengl/items/test_GLGridItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLGridItem
 

--- a/tests/opengl/items/test_GLGridItem.py
+++ b/tests/opengl/items/test_GLGridItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLGridItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLGridItem(parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLImageItem.py
+++ b/tests/opengl/items/test_GLImageItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLAxisItem
 

--- a/tests/opengl/items/test_GLImageItem.py
+++ b/tests/opengl/items/test_GLImageItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLAxisItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLAxisItem(parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLLinePlotItem.py
+++ b/tests/opengl/items/test_GLLinePlotItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLLinePlotItem
 

--- a/tests/opengl/items/test_GLLinePlotItem.py
+++ b/tests/opengl/items/test_GLLinePlotItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLLinePlotItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLLinePlotItem(parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLMeshItem.py
+++ b/tests/opengl/items/test_GLMeshItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLMeshItem
 

--- a/tests/opengl/items/test_GLMeshItem.py
+++ b/tests/opengl/items/test_GLMeshItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLMeshItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLMeshItem(parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLScatterPlotItem.py
+++ b/tests/opengl/items/test_GLScatterPlotItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLScatterPlotItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLScatterPlotItem(parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLScatterPlotItem.py
+++ b/tests/opengl/items/test_GLScatterPlotItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLScatterPlotItem
 

--- a/tests/opengl/items/test_GLSurfacePlotItem.py
+++ b/tests/opengl/items/test_GLSurfacePlotItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLSurfacePlotItem
 

--- a/tests/opengl/items/test_GLSurfacePlotItem.py
+++ b/tests/opengl/items/test_GLSurfacePlotItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLSurfacePlotItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLSurfacePlotItem(parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLTextItem.py
+++ b/tests/opengl/items/test_GLTextItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLTextItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLTextItem(parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLTextItem.py
+++ b/tests/opengl/items/test_GLTextItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLTextItem
 

--- a/tests/opengl/items/test_GLVolumeItem.py
+++ b/tests/opengl/items/test_GLVolumeItem.py
@@ -1,0 +1,10 @@
+from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
+from pyqtgraph.opengl import GLVolumeItem
+
+from common import ensure_parentItem
+
+
+def test_parentItem():
+    parent = GLGraphicsItem()
+    child = GLVolumeItem(None, parentItem=parent)
+    ensure_parentItem(parent, child)

--- a/tests/opengl/items/test_GLVolumeItem.py
+++ b/tests/opengl/items/test_GLVolumeItem.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('OpenGL')
+
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLVolumeItem
 


### PR DESCRIPTION
All classes from `pyqtgraph.opengl.__init__` based on `GLGraphicsItem` didn't respect `parentItem` argument, which leads to `setParentItem()` call each time you want to group up graphics.

Fixes #2514