### PR TITLE
Fix vertical alignment of spans for highlighted code block

### DIFF
--- a/doc/source/_static/dash.css
+++ b/doc/source/_static/dash.css
@@ -22,3 +22,8 @@ width.  To be used with sphinx-pydata-theme
   flex-grow: 1;
   max-width: 100%;
 }
+
+/* patching issue from pydata-sphinx-theme */
+div.viewcode-block:target {
+  display: block;
+}


### PR DESCRIPTION
When viewing the source code inside dash, the highlighted code block would have vertical alignment of all the spans.  This did not occur in the regular/html version of the docs.  I believe this is a bug/issue w/ the pydata-sphinx-theme, but this was fixed by specifying `display: block` in `dash.css` 

See https://github.com/hynek/doc2dash/issues/135 for more information