### PR TITLE
partial fix for Qmenu leak

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -207,6 +207,7 @@ class PlotItem(GraphicsWidget):
             sm.addAction(act)
             self.subMenus.append(sm)
             self.ctrlMenu.addMenu(sm)
+            sm.setParent(None)  # workaround PySide bug (present at least up to 6.4.0)
         
         self.stateGroup = WidgetGroup()
         for name, w in menuItems:

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -33,6 +33,7 @@ class ViewBoxMenu(QtWidgets.QMenu):
             a.setDefaultWidget(w)
             m.addAction(a)
             self.addMenu(m)
+            m.setParent(None)  # workaround PySide bug (present at least up to 6.4.0)
             self.axes.append(m)
             self.ctrl.append(ui)
             wg = WidgetGroup(w)

--- a/tests/test_qmenu_leak_workaround.py
+++ b/tests/test_qmenu_leak_workaround.py
@@ -1,0 +1,25 @@
+import sys
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtWidgets
+
+def test_qmenu_leak_workaround():
+    # refer to https://github.com/pyqtgraph/pyqtgraph/pull/2518
+    pg.mkQApp()
+    topmenu = QtWidgets.QMenu()
+    submenu = QtWidgets.QMenu()
+
+    refcnt1 = sys.getrefcount(submenu)
+
+    # check that after the workaround,
+    # submenu has no change in refcnt
+    topmenu.addMenu(submenu)
+    submenu.setParent(None) # this is the workaround for PySide{2,6},
+                            # and should have no effect on bindings
+                            # where it is not needed.
+    refcnt2 = sys.getrefcount(submenu)
+    assert refcnt2 == refcnt1
+    
+    # check that topmenu is not a C++ parent of submenu.
+    # i.e. deleting topmenu leaves submenu alive
+    del topmenu
+    assert pg.Qt.isQObjectAlive(submenu)

--- a/tests/test_ref_cycles.py
+++ b/tests/test_ref_cycles.py
@@ -13,10 +13,7 @@ app = pg.mkQApp()
 
 def assert_alldead(refs):
     for ref in refs:
-        obj = ref()
-        assert obj is None or (
-            isinstance(obj, pg.QtCore.QObject) and not pg.Qt.isQObjectAlive(obj)
-        )
+        assert ref() is None
 
 def qObjectTree(root):
     """Return root and its entire tree of qobject children"""


### PR DESCRIPTION
Partially fixes #2497

There are 3 places that leak `QMenu`s. This PR fixes 2 of them. The last one is left unfixed as fixing it causes a CI segfault on PySide6 >= 6.3 on Linux platforms. It is believed that the last leak is masking a latent issue.

The workaround used has changed from #2502. In #2502, "topmenu" was made the `C++ parent` of "submenu".
It was found that PySide{2,6} binding makes "topmenu" a `Python-wrapper parent` of "submenu", increasing the refcnt of "submenu", even though "submenu" has no `C++ parent`.
The workaround here relies on PySide's `setParent(None)` dropping this refcnt. (Note that the `C++ parent` was already `None` to begin with)
The end-result is that the life-state of "submenu" remains the same before and after `addMenu`, as shown in the output of the following script: refcnt and shiboken.dump output remains the same.

If upstream fixes the leak, then this `setParent(None)` call should have no effect.

```python
from PySide6 import QtGui, QtWidgets
import shiboken6 as shiboken
import sys

app = QtWidgets.QApplication([])
topmenu = QtWidgets.QMenu()
topmenu.setObjectName("topmenu")
submenu = QtWidgets.QMenu()
submenu.setObjectName("submenu")

print(shiboken.dump(submenu))

print(sys.getrefcount(submenu))
topmenu.addMenu(submenu)
submenu.setParent(None) # let Python do the cleanup
print(sys.getrefcount(submenu))
del topmenu
print(sys.getrefcount(submenu))
print(shiboken.dump(submenu))
```
Output
```
C++ address....... PySide6.QtWidgets.QMenu/0000021A1C923C40
hasOwnership...... 1
containsCppWrapper 1
validCppObject.... 1
wasCreatedByPython 1

2
2
2
C++ address....... PySide6.QtWidgets.QMenu/0000021A1C923C40
hasOwnership...... 1
containsCppWrapper 1
validCppObject.... 1
wasCreatedByPython 1
```

As mentioned, this PR only fixes 2 of the leaks. When running the test scripts in #2497, the rate of memory growth is reduced and only 1 QMenu is leaked.

