### PR TITLE
fix setMaximumHeight(1e6) in  SpinBox.py

### DIFF
--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -572,7 +572,7 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
         # SpinBox has very large margins on some platforms; this is a hack to remove those
         # margins and allow more compact packing of controls.
         if not self.opts['compactHeight']:
-            self.setMaximumHeight(1e6)
+            self.setMaximumHeight(1000000)
             return
         h = QtGui.QFontMetrics(self.font()).height()
         if self._lastFontHeight != h:


### PR DESCRIPTION
After upgrading my KDE Neon and thus Qt to 5.15.6 I had found out that my software hiccups at pytqgraph SpinBox. I had tracked down problem to SpinBox.py, where method `setMaximumHeight` is fed with `1e6` which is float, and these are pixels (logically it should be integer numbers). Interestingly older Qt versions had not complained before and was consuming float without any complaining. Simple fix is to change this `1e6`  to `1000000`.

This fix is simple and straightforward.