### PR TITLE
Minor improvements to `InteractiveFunction` ecosystem

### DIFF
--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -197,7 +197,7 @@ class InteractiveFunction:
     def __repr__(self):
         return (
             str(self) + " with keys:\n"
-            f"params={list(self.parameters)}, "
+            f"parameters={list(self.parameters)}, "
             f"extra={list(self.extra)}, "
             f"closures={list(self.closures)}"
         )

--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -342,9 +342,7 @@ class Interactor:
         # Get every overridden default
         locs = locals()
         # Everything until action template
-        opts = {
-            kk: locs[kk] for kk in self._optionNames if locs[kk] is not PARAM_UNSET
-        }
+        opts = {kk: locs[kk] for kk in self._optionNames if locs[kk] is not PARAM_UNSET}
         oldOpts = self.setOpts(**opts)
         # Delete explicitly since correct values are now ``self`` attributes
         del runOptions, titleFormat, nest, existOk, parent, runActionTemplate

--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -388,7 +388,8 @@ class Interactor:
         for name in checkNames:
             childOpts = children[chNames.index(name)]
             child = self.resolveAndHookupParameterChild(funcGroup, childOpts, function)
-            useParams.append(child)
+            if child is not None:
+                useParams.append(child)
 
         function.hookupParameters(useParams)
         if RunOptions.ON_ACTION in self.runOptions:

--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -192,7 +192,7 @@ class InteractiveFunction:
         return oldDisconnect
 
     def __str__(self):
-        return f"InteractiveFunction(`<{self.function.__name__}>`) at {hex(id(self))}"
+        return f"{type(self).__name__}(`<{self.function.__name__}>`) at {hex(id(self))}"
 
     def __repr__(self):
         return (

--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -457,9 +457,9 @@ class Interactor:
         funcGroup = self.parent
         if self.nest:
             funcGroup = Parameter.create(**functionDict)
-            funcGroup.sigActivated.connect(interactiveFunction.runFromAction)
             if self.parent:
-                self.parent.addChild(funcGroup, existOk=self.existOk)
+                funcGroup = self.parent.addChild(funcGroup, existOk=self.existOk)
+            funcGroup.sigActivated.connect(interactiveFunction.runFromAction)
         return funcGroup
 
     @staticmethod

--- a/pyqtgraph/parametertree/parameterTypes/actiongroup.py
+++ b/pyqtgraph/parametertree/parameterTypes/actiongroup.py
@@ -35,7 +35,6 @@ class ActionGroupParameterItem(GroupParameterItem):
         if "button" in opts:
             buttonOpts = opts["button"] or dict(visible=False)
             self.button.updateOpts(param, buttonOpts)
-            self.treeWidgetChanged()
         super().optsChanged(param, opts)
 
 

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -491,3 +491,17 @@ def test_interact_ignore_none_child():
     interactor = InteractorSubclass()
     out = interactor(lambda a=None: a, runOptions=[])
     assert "a" not in out.names
+
+
+def test_interact_existing_parent():
+    lastValue = None
+
+    def a():
+        nonlocal lastValue
+        lastValue = 5
+
+    parent = Parameter.create(name="parent", type="group")
+    outParam = interact(a, parent=parent)
+    assert outParam in parent.names.values()
+    outParam.activate()
+    assert lastValue == 5

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -11,6 +11,7 @@ from pyqtgraph.parametertree import (
     RunOptions,
 )
 from pyqtgraph.parametertree import Parameter
+from pyqtgraph.parametertree.Parameter import PARAM_TYPES
 from pyqtgraph.parametertree.parameterTypes import GroupParameter as GP
 from pyqtgraph.Qt import QtGui
 
@@ -473,3 +474,20 @@ def test_interact_with_icon():
 
     imageBytes = [ fn.ndarray_from_qimage(img) for img in images ]
     assert np.array_equal(*imageBytes)
+
+
+def test_interact_ignore_none_child():
+    class InteractorSubclass(Interactor):
+        def resolveAndHookupParameterChild(
+            self, functionGroup, childOpts, interactiveFunction
+        ):
+            if childOpts["type"] not in PARAM_TYPES:
+                # Optionally add to `extra` instead
+                return None
+            return super().resolveAndHookupParameterChild(
+                functionGroup, childOpts, interactiveFunction
+            )
+
+    interactor = InteractorSubclass()
+    out = interactor(lambda a=None: a, runOptions=[])
+    assert "a" not in out.names


### PR DESCRIPTION
- [x] Previously, subclasses of `InteractiveFunction` would still declare themselves to be `InteractiveFuntion` objects when `str()` was called. This no longer happens
- [x] Minor formatting of repr key (`param` -> `parameters`)
- [x] (the main reason for PR) allow better customization of `resolveAndHookupParameterChild`. It may be desirable to subclass `Interactor` and optionally ignore some children depending on a criteria (i.e., not a valid parameter type). In these cases, a simple change of allowing a `None` return value accommodates this. See the additional test case for an example. I considered making this default behavior for `Interactor`, but I wasn't sure if it was more sensible to fail (the current behavior), add to `extra`, or ignore. It is easy enough for users to customize for their needed behavior through a subclass, so I left the normal `interactAndHookupParameterChild` behavior for now.
- [x] Handle interacting when ActionGroup already exists in parent. See new test case for details. Previously, the function group was created, had signals hooked up, and was added to the parent parameter. However, if an existing child was returned, this new group had no relation to the parent tree and its signals wouldn't matter. Fixed by overriding the function group with the return value of `addChild`, which preserves old behavior and works in the new test case.