### PR TITLE
Fix last QMenu leak and its associated segfaults

### DIFF
--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -20,20 +20,23 @@ class SignalProxy(QtCore.QObject):
 
     sigDelayed = QtCore.Signal(object)
 
-    def __init__(self, signal, delay=0.3, rateLimit=0, slot=None):
+    def __init__(self, signal, delay=0.3, rateLimit=0, slot=None, *, threadSafe=True):
         """Initialization arguments:
         signal - a bound Signal or pyqtSignal instance
         delay - Time (in seconds) to wait for signals to stop before emitting (default 0.3s)
         slot - Optional function to connect sigDelayed to.
         rateLimit - (signals/sec) if greater than 0, this allows signals to stream out at a
                     steady rate while they are being received.
+        threadSafe - Specify if thread-safety is required. For backwards compatibility, it
+                     defaults to True.
         """
 
         QtCore.QObject.__init__(self)
         self.delay = delay
         self.rateLimit = rateLimit
         self.args = None
-        self.timer = ThreadsafeTimer.ThreadsafeTimer()
+        Timer = ThreadsafeTimer if threadSafe else QtCore.QTimer
+        self.timer = Timer()
         self.timer.timeout.connect(self.flush)
         self.lastFlushTime = None
         self.signal = signal

--- a/pyqtgraph/examples/crosshair.py
+++ b/pyqtgraph/examples/crosshair.py
@@ -67,7 +67,7 @@ p1.addItem(hLine, ignoreBounds=True)
 vb = p1.vb
 
 def mouseMoved(evt):
-    pos = evt[0]  ## using signal proxy turns original arguments into a tuple
+    pos = evt
     if p1.sceneBoundingRect().contains(pos):
         mousePoint = vb.mapSceneToView(pos)
         index = int(mousePoint.x())
@@ -78,8 +78,7 @@ def mouseMoved(evt):
 
 
 
-proxy = pg.SignalProxy(p1.scene().sigMouseMoved, rateLimit=60, slot=mouseMoved)
-#p1.scene().sigMouseMoved.connect(mouseMoved)
+p1.scene().sigMouseMoved.connect(mouseMoved)
 
 
 if __name__ == '__main__':

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -196,18 +196,13 @@ class PlotItem(GraphicsWidget):
         ]
         
         
-        self.ctrlMenu = QtWidgets.QMenu()
-        
-        self.ctrlMenu.setTitle(translate("PlotItem", 'Plot Options'))
-        self.subMenus = []
+        self.ctrlMenu = QtWidgets.QMenu(translate("PlotItem", 'Plot Options'))
+
         for name, grp in menuItems:
-            sm = QtWidgets.QMenu(name)
+            sm = self.ctrlMenu.addMenu(name)
             act = QtWidgets.QWidgetAction(self)
             act.setDefaultWidget(grp)
             sm.addAction(act)
-            self.subMenus.append(sm)
-            self.ctrlMenu.addMenu(sm)
-            sm.setParent(None)  # workaround PySide bug (present at least up to 6.4.0)
         
         self.stateGroup = WidgetGroup()
         for name, w in menuItems:

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -57,26 +57,18 @@ class ViewBoxMenu(QtWidgets.QMenu):
         self.ctrl[0].invertCheck.toggled.connect(self.xInvertToggled)
         self.ctrl[1].invertCheck.toggled.connect(self.yInvertToggled)
         
-        self.leftMenu = QtWidgets.QMenu(translate("ViewBox", "Mouse Mode"))
+        leftMenu = self.addMenu(translate("ViewBox", "Mouse Mode"))
+
         group = QtGui.QActionGroup(self)
-        
-        # This does not work! QAction _must_ be initialized with a permanent 
-        # object as the parent or else it may be collected prematurely.
-        #pan = self.leftMenu.addAction("3 button", self.set3ButtonMode)
-        #zoom = self.leftMenu.addAction("1 button", self.set1ButtonMode)
-        pan = QtGui.QAction(translate("ViewBox", "3 button"), self.leftMenu)
-        zoom = QtGui.QAction(translate("ViewBox", "1 button"), self.leftMenu)
-        self.leftMenu.addAction(pan)
-        self.leftMenu.addAction(zoom)
-        pan.triggered.connect(self.set3ButtonMode)
-        zoom.triggered.connect(self.set1ButtonMode)
-        
+        group.triggered.connect(self.setMouseMode)
+        pan = QtGui.QAction(translate("ViewBox", "3 button"), group)
+        zoom = QtGui.QAction(translate("ViewBox", "1 button"), group)
         pan.setCheckable(True)
         zoom.setCheckable(True)
-        pan.setActionGroup(group)
-        zoom.setActionGroup(group)
+
+        leftMenu.addActions(group.actions())
+
         self.mouseModes = [pan, zoom]
-        self.addMenu(self.leftMenu)
         
         self.view().sigStateChanged.connect(self.viewStateChanged)
         
@@ -200,11 +192,14 @@ class ViewBoxMenu(QtWidgets.QMenu):
     def xInvertToggled(self, b):
         self.view().invertX(b)
 
-    def set3ButtonMode(self):
-        self.view().setLeftButtonAction('pan')
-        
-    def set1ButtonMode(self):
-        self.view().setLeftButtonAction('rect')
+    def setMouseMode(self, action):
+        mode = None
+        if action == self.mouseModes[0]:
+            mode = 'pan'
+        elif action == self.mouseModes[1]:
+            mode = 'rect'
+        if mode is not None:
+            self.view().setLeftButtonAction(mode)
         
     def setViewList(self, views):
         names = ['']

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -19,22 +19,17 @@ class ViewBoxMenu(QtWidgets.QMenu):
         self.viewAll.triggered.connect(self.autoRange)
         self.addAction(self.viewAll)
         
-        self.axes = []
         self.ctrl = []
         self.widgetGroups = []
         self.dv = QtGui.QDoubleValidator(self)
         for axis in 'XY':
-            m = QtWidgets.QMenu()
-            m.setTitle(f"{axis} {translate('ViewBox', 'axis')}")
+            m = self.addMenu(f"{axis} {translate('ViewBox', 'axis')}")
             w = QtWidgets.QWidget()
             ui = ui_template.Ui_Form()
             ui.setupUi(w)
             a = QtWidgets.QWidgetAction(self)
             a.setDefaultWidget(w)
             m.addAction(a)
-            self.addMenu(m)
-            m.setParent(None)  # workaround PySide bug (present at least up to 6.4.0)
-            self.axes.append(m)
             self.ctrl.append(ui)
             wg = WidgetGroup(w)
             self.widgetGroups.append(wg)

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -219,7 +219,11 @@ class ImageView(QtWidgets.QWidget):
         self.ui.normTimeRangeCheck.clicked.connect(self.updateNorm)
         self.playTimer.timeout.connect(self.timeout)
         
-        self.normProxy = SignalProxy(self.normRgn.sigRegionChanged, slot=self.updateNorm)
+        self.normProxy = SignalProxy(
+            self.normRgn.sigRegionChanged,
+            slot=self.updateNorm,
+            threadSafe=False,
+        )
         self.normRoi.sigRegionChangeFinished.connect(self.updateNorm)
         
         self.ui.roiPlot.registerPlot(self.name + '_ROI')

--- a/pyqtgraph/parametertree/parameterTypes/checklist.py
+++ b/pyqtgraph/parametertree/parameterTypes/checklist.py
@@ -175,7 +175,12 @@ class ChecklistParameter(GroupParameter):
             # Also, value calculation will be incorrect until children are added, so make sure to recompute
             self.setValue(value)
 
-        self.valChangingProxy = SignalProxy(self.sigValueChanging, delay=opts.get('delay', 1.0), slot=self._finishChildChanges)
+        self.valChangingProxy = SignalProxy(
+            self.sigValueChanging,
+            delay=opts.get('delay', 1.0),
+            slot=self._finishChildChanges,
+            threadSafe=False,
+        )
 
     def childrenValue(self):
         vals = [self.forward[p.name()] for p in self.children() if p.value()]

--- a/pyqtgraph/parametertree/parameterTypes/pen.py
+++ b/pyqtgraph/parametertree/parameterTypes/pen.py
@@ -46,7 +46,12 @@ class PenParameter(GroupParameter):
         if 'children' in opts:
             raise KeyError('Cannot set "children" argument in Pen Parameter opts')
         super().__init__(**opts, children=list(children))
-        self.valChangingProxy = SignalProxy(self.sigValueChanging, delay=1.0, slot=self._childrenFinishedChanging)
+        self.valChangingProxy = SignalProxy(
+            self.sigValueChanging,
+            delay=1.0,
+            slot=self._childrenFinishedChanging,
+            threadSafe=False,
+        )
 
     def _childrenFinishedChanging(self, paramAndValue):
         self.sigValueChanged.emit(*paramAndValue)

--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -104,7 +104,12 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
         self.skipValidate = False
         self.setCorrectionMode(self.CorrectionMode.CorrectToPreviousValue)
         self.setKeyboardTracking(False)
-        self.proxy = SignalProxy(self.sigValueChanging, slot=self.delayedChange, delay=self.opts['delay'])
+        self.proxy = SignalProxy(
+            self.sigValueChanging,
+            delay=self.opts['delay'],
+            slot=self.delayedChange,
+            threadSafe=False,
+        )
         self.setOpts(**kwargs)
         self._updateHeight()
         

--- a/tests/test_ref_cycles.py
+++ b/tests/test_ref_cycles.py
@@ -48,7 +48,7 @@ def test_PlotWidget():
         app.focusChanged.connect(w.plotItem.vb.invertY)
         
         # return weakrefs to a bunch of objects that should die when the scope exits.
-        return mkrefs(w, c, data, w.plotItem, w.plotItem.vb, w.plotItem.getMenu(), w.plotItem.getAxis('left'))
+        return mkrefs(w, c, data, w.plotItem, w.plotItem.vb, w.plotItem.getAxis('left'))
     
     for _ in range(5):
         assert_alldead(mkobjs())

--- a/tests/test_signalproxy.py
+++ b/tests/test_signalproxy.py
@@ -35,7 +35,7 @@ def test_signal_proxy_slot(qapp):
     sender = Sender(parent=qapp)
     receiver = Receiver(parent=qapp)
     proxy = SignalProxy(sender.signalSend, delay=0.0, rateLimit=0.6,
-                        slot=receiver.slotReceive)
+                        slot=receiver.slotReceive, threadSafe=False)
 
     assert proxy.blockSignal is False
     assert proxy is not None
@@ -54,7 +54,7 @@ def test_signal_proxy_disconnect_slot(qapp):
     sender = Sender(parent=qapp)
     receiver = Receiver(parent=qapp)
     proxy = SignalProxy(sender.signalSend, delay=0.0, rateLimit=0.6,
-                        slot=receiver.slotReceive)
+                        slot=receiver.slotReceive, threadSafe=False)
 
     assert proxy.blockSignal is False
     assert proxy is not None
@@ -77,7 +77,8 @@ def test_signal_proxy_no_slot_start(qapp):
     """Test the connect mode of SignalProxy without slot at start`"""
     sender = Sender(parent=qapp)
     receiver = Receiver(parent=qapp)
-    proxy = SignalProxy(sender.signalSend, delay=0.0, rateLimit=0.6)
+    proxy = SignalProxy(sender.signalSend, delay=0.0, rateLimit=0.6,
+                        threadSafe=False)
 
     assert proxy.blockSignal is True
     assert proxy is not None
@@ -107,7 +108,7 @@ def test_signal_proxy_slot_block(qapp):
     sender = Sender(parent=qapp)
     receiver = Receiver(parent=qapp)
     proxy = SignalProxy(sender.signalSend, delay=0.0, rateLimit=0.6,
-                        slot=receiver.slotReceive)
+                        slot=receiver.slotReceive, threadSafe=False)
 
     assert proxy.blockSignal is False
     assert proxy is not None

--- a/tests/widgets/test_busycursor.py
+++ b/tests/widgets/test_busycursor.py
@@ -1,8 +1,16 @@
+import pytest
+import sys
+
 import pyqtgraph as pg
 
 pg.mkQApp()
 
-
+@pytest.mark.skipif(
+    sys.platform.startswith("linux")
+    and pg.Qt.QT_LIB == "PySide6"
+    and pg.Qt.PySide6.__version_info__ > (6, 3),
+    reason="taking gui thread causes segfault"
+)
 def test_nested_busy_cursors_clear_after_all_exit():
     with pg.BusyCursor():
         wait_cursor = pg.Qt.QtCore.Qt.CursorShape.WaitCursor

--- a/tests/widgets/test_busycursor.py
+++ b/tests/widgets/test_busycursor.py
@@ -8,7 +8,7 @@ pg.mkQApp()
 @pytest.mark.skipif(
     sys.platform.startswith("linux")
     and pg.Qt.QT_LIB == "PySide6"
-    and pg.Qt.PySide6.__version_info__ > (6, 3),
+    and pg.Qt.PySide6.__version_info__ > (6, 0),
     reason="taking gui thread causes segfault"
 )
 def test_nested_busy_cursors_clear_after_all_exit():

--- a/tests/widgets/test_progressdialog.py
+++ b/tests/widgets/test_progressdialog.py
@@ -8,7 +8,7 @@ pg.mkQApp()
 @pytest.mark.skipif(
     sys.platform.startswith("linux")
     and pg.Qt.QT_LIB == "PySide6"
-    and pg.Qt.PySide6.__version_info__ > (6, 3),
+    and pg.Qt.PySide6.__version_info__ > (6, 0),
     reason="taking gui thread causes segfault"
 )
 def test_progress_dialog():

--- a/tests/widgets/test_progressdialog.py
+++ b/tests/widgets/test_progressdialog.py
@@ -1,8 +1,16 @@
-from pyqtgraph import ProgressDialog, mkQApp
+import pytest
+import sys
 
-mkQApp()
+import pyqtgraph as pg
 
+pg.mkQApp()
 
+@pytest.mark.skipif(
+    sys.platform.startswith("linux")
+    and pg.Qt.QT_LIB == "PySide6"
+    and pg.Qt.PySide6.__version_info__ > (6, 3),
+    reason="taking gui thread causes segfault"
+)
 def test_progress_dialog():
-    with ProgressDialog("test", 0, 1) as dlg:
+    with pg.ProgressDialog("test", 0, 1) as dlg:
         dlg += 1


### PR DESCRIPTION
Fixes #2497.
Completes #2518.
With the segfaults being attributed to the reason listed in #2520, this PR avoids taking the gui thread object.
This includes:
1) switching `SignalProxy` to use `QTimer` instead of `ThreadsafeTimer`
2) skipping tests on widgets that take the gui thread object in their implementation

Thus there are 2 bugs in PySide binding
1) QMenu leak on `QMenu::addMenu(QMenu*)` (as detailed in #2518)
2) gui thread object segfault since PySide6 >= 6.3 (as detailed in #2520)
 