### PR TITLE
bump dev version to correct value

### DIFF
--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -3,7 +3,7 @@ PyQtGraph - Scientific Graphics and GUI Library for Python
 www.pyqtgraph.org
 """
 
-__version__ = '0.13.1.dev0'
+__version__ = '0.13.2.dev0'
 
 ### import all the goodies and add some helper functions for easy CLI use
 


### PR DESCRIPTION
After the 0.13.1 release, the current github repo should be be 0.13.2.dev0, but is 0.13.1.dev0. This PR fixes the issue.