### PR TITLE
Remove parameter tree size hint overloads

### DIFF
--- a/pyqtgraph/parametertree/ParameterItem.py
+++ b/pyqtgraph/parametertree/ParameterItem.py
@@ -164,12 +164,6 @@ class ParameterItem(QtWidgets.QTreeWidgetItem):
         if not title or title == 'params':
             return
         self.setText(0, title)
-        fm = QtGui.QFontMetrics(self.font(0))
-        textFlags = QtCore.Qt.TextFlag.TextSingleLine
-        size = fm.size(textFlags, self.text(0))
-        size.setHeight(int(size.height() * 1.35))
-        size.setWidth(int(size.width() * 1.15))
-        self.setSizeHint(0, size)
 
     def limitsChanged(self, param, limits):
         """Called when the parameter's limits have changed"""

--- a/pyqtgraph/parametertree/ParameterTree.py
+++ b/pyqtgraph/parametertree/ParameterTree.py
@@ -174,32 +174,3 @@ class ParameterTree(TreeWidget):
     # def wheelEvent(self, ev):
     #     self.clearSelection()
     #     return super().wheelEvent(ev)
-
-    def sizeHint(self):
-        w, h = 0, 0
-        ind = self.indentation()
-        for x in self.listAllItems():
-            if x.isHidden():
-                continue
-            try:
-                depth = x.depth
-            except AttributeError:
-                depth = 0
-
-            s0 = x.sizeHint(0)
-            s1 = x.sizeHint(1)
-            w = max(w, depth * ind + max(0, s0.width()) + max(0, s1.width()))
-            h += max(0, s0.height(), s1.height())
-            # typ = x.param.opts['type'] if isinstance(x, ParameterItem) else x
-            # print(typ, depth * ind, (s0.width(), s0.height()), (s1.width(), s1.height()), (w, h))
-
-        # todo: find out if this alternative can be made to work (currently fails when color or colormap are present)
-        # print('custom', (w, h))
-        # w = self.sizeHintForColumn(0) + self.sizeHintForColumn(1)
-        # h = self.viewportSizeHint().height()
-        # print('alternative', (w, h))
-
-        if not self.header().isHidden():
-            h += self.header().height()
-
-        return QtCore.QSize(w, h)

--- a/pyqtgraph/parametertree/parameterTypes/action.py
+++ b/pyqtgraph/parametertree/parameterTypes/action.py
@@ -68,7 +68,7 @@ class ActionParameterItem(ParameterItem):
         tree.setItemWidget(self, 0, self.layoutWidget)
 
     def titleChanged(self):
-        self.setSizeHint(0, self.button.sizeHint())
+        pass
 
 
 class ActionParameter(Parameter):

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -68,20 +68,6 @@ class WidgetParameterItem(ParameterItem):
 
         self.optsChanged(self.param, self.param.opts)
 
-        # set size hints
-        sw = self.widget.sizeHint()
-        sb = self.defaultBtn.sizeHint()
-        # shrink row heights a bit for more compact look
-        sw.setHeight(int(sw.height() * 0.9))
-        sb.setHeight(int(sb.height() * 0.9))
-        if self.asSubItem:
-            self.setSizeHint(1, sb)
-            self.subItem.setSizeHint(0, sw)
-        else:
-            w = sw.width() + sb.width()
-            h = max(sw.height(), sb.height())
-            self.setSizeHint(1, QtCore.QSize(w, h))
-
     def makeWidget(self):
         """
         Return a single widget whose position in the tree is determined by the


### PR DESCRIPTION
I might be missing something, so it would be great for others to verify. On my machine, parameter tree & item sizing appears to work better by removing all custom size hint logic... The biggest difference is spawning a window with just a parameter tree
- Before this change, the window had to be manually resized to fit all parameters
- Now, (for me) the window is correctly sized immediately.