### PR TITLE
fix: instantiate QApplication for test_Parameter.py

### DIFF
--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -1,6 +1,7 @@
 from functools import wraps
 
 import numpy as np
+import pyqtgraph as pg
 import pytest
 
 from pyqtgraph import functions as fn
@@ -15,6 +16,7 @@ from pyqtgraph.parametertree.Parameter import PARAM_TYPES
 from pyqtgraph.parametertree.parameterTypes import GroupParameter as GP
 from pyqtgraph.Qt import QtGui
 
+pg.mkQApp()
 
 def test_parameter_hasdefault():
     opts = {"name": "param", "type": int, "value": 1}


### PR DESCRIPTION
As `test_Parameter.py` instantiates some gui elements, it needs `QApplication` to have been instantiated. When this test is run alone, it will segfault. i.e. it was relying on other tests in the test-suite having instantiated `QApplication`.

