### PR TITLE
remove resizeEvent on screen change

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -58,21 +58,6 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         self.keyTimer = QtCore.QTimer()
         self.keyTimer.timeout.connect(self.evalKeyState)
 
-    def _updateScreen(self, screen):
-        self._updatePixelRatio()
-        if screen is not None:
-            screen.physicalDotsPerInchChanged.connect(self._updatePixelRatio)
-            screen.logicalDotsPerInchChanged.connect(self._updatePixelRatio)
-    
-    def _updatePixelRatio(self):
-        event = QtGui.QResizeEvent(self.size(), self.size())
-        self.resizeEvent(event)
-    
-    def showEvent(self, event):
-        window = self.window().windowHandle()
-        window.screenChanged.connect(self._updateScreen)
-        self._updateScreen(window.screen())
-        
     def deviceWidth(self):
         dpr = self.devicePixelRatioF()
         return int(self.width() * dpr)


### PR DESCRIPTION
ISSUE: On Qt 6.4.x and Linux, the OpenGL examples making use of `GLViewWidget` will start up with a black window. Resizing the window will make it return to normal. i.e. render something.

The issue is caused by a section of code that was originally meant to handle change in device pixel ratio when dragging the window to another screen. Upon inspection, the remaining section of code (that is deleted in this PR) actually does nothing useful. The code sends a resize event upon change of screen. But in fact, even when changing device pixel ratio, the size will not change as sizes are expressed as virtual pixels.
e.g. Screen 1 has DPR 2 and Screen 2 has DPR 1. On both screens, the program will have the same virtual size of say (640, 480).

Note: `GLViewWidget` already knows to use the `deviceWidth` and `deviceHeight` when necessary. 

For simpler testing of this PR, a standalone simplified version of `GLViewWidget` is included below.
By commenting or uncommenting the `showEvent` method, the changes that this PR makes can be tested.
```python
import OpenGL.GL as GL
from pyqtgraph.Qt import QtCore, QtGui, QtWidgets
import pyqtgraph as pg

class GLWidget(QtWidgets.QOpenGLWidget):
    
    def _updateScreen(self, screen):
        self._updatePixelRatio()
        if screen is not None:
            screen.physicalDotsPerInchChanged.connect(self._updatePixelRatio)
            screen.logicalDotsPerInchChanged.connect(self._updatePixelRatio)
    
    def _updatePixelRatio(self):
        event = QtGui.QResizeEvent(self.size(), self.size())
        self.resizeEvent(event)
    
    # def showEvent(self, event):
    #     window = self.window().windowHandle()
    #     window.screenChanged.connect(self._updateScreen)
    #     self._updateScreen(window.screen())
        
    def paintGL(self):
        GL.glClearColor(0, 0, 0, 1)
        GL.glClear(GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT)
        GL.glLineWidth(2)

        GL.glColor4f(1, 0, 0, 1)
        GL.glBegin(GL.GL_LINES)
        GL.glVertex2f(-1, -1)
        GL.glVertex2f(1, 1)
        GL.glEnd()

        GL.glColor4f(0, 1, 0, 1)
        GL.glBegin(GL.GL_LINES)
        GL.glVertex2f(-1, 1)
        GL.glVertex2f(1, -1)
        GL.glEnd()

    def resizeGL(self, *args):
        print('resizeGL', args)

if __name__ == '__main__':
    pg.mkQApp()

    main = GLWidget()
    main.show()

    pg.exec()
```