### PR TITLE
use ThreadsafeTimer class instead of module

### DIFF
--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -1,9 +1,9 @@
 import weakref
 from time import perf_counter
 
-from . import ThreadsafeTimer
 from .functions import SignalBlock
 from .Qt import QtCore
+from .ThreadsafeTimer import ThreadsafeTimer
 
 __all__ = ['SignalProxy']
 


### PR DESCRIPTION
Very simple fix: after bf3820a,  `SignalProxy` imports the `ThreadsafeTimer` module instead of class. MWE below fails:

```python
import pyqtgraph as pg
pg.mkQApp()
edit = pg.QtWidgets.QTextEdit()
sp = pg.SignalProxy(edit.textChanged)

# TypeError: 'module' object is not callable
```

This PR imports the class instead.