### PR TITLE
Add STDF-Viewer to Used By list

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,5 +138,6 @@ Here is a partial listing of some of the applications that make use of PyQtGraph
 * [PySpectra](http://hasyweb.desy.de/services/computing/Spock/node138.html)
 * [rapidtide](https://rapidtide.readthedocs.io/en/latest/)
 * [Semi-Supervised Semantic Annotator](https://gitlab.com/s3a/s3a)
+* [STDF-Viewer](https://github.com/noonchen/STDF-Viewer)
 
 Do you use PyQtGraph in your own project, and want to add it to the list?  Submit a pull request to update this listing!


### PR DESCRIPTION
The latest version of STDF-Viewer uses `pyqtgraph` to visualize and analyze semiconductor datalog.