### PR TITLE
compute floating point boundingRect

### DIFF
--- a/pyqtgraph/examples/customGraphicsItem.py
+++ b/pyqtgraph/examples/customGraphicsItem.py
@@ -19,6 +19,7 @@ class CandlestickItem(pg.GraphicsObject):
     def generatePicture(self):
         ## pre-computing a QPicture object allows paint() to run much more quickly, 
         ## rather than re-drawing the shapes every time.
+        bounds = QtCore.QRectF()
         self.picture = QtGui.QPicture()
         p = QtGui.QPainter(self.picture)
         p.setPen(pg.mkPen('w'))
@@ -30,7 +31,9 @@ class CandlestickItem(pg.GraphicsObject):
             else:
                 p.setBrush(pg.mkBrush('g'))
             p.drawRect(QtCore.QRectF(t-w, open, w*2, close-open))
+            bounds |= QtCore.QRectF(t-w, min, w*2, max-min)
         p.end()
+        self._bounds = bounds
     
     def paint(self, p, *args):
         p.drawPicture(0, 0, self.picture)
@@ -38,8 +41,7 @@ class CandlestickItem(pg.GraphicsObject):
     def boundingRect(self):
         ## boundingRect _must_ indicate the entire area that will be drawn on
         ## or else we will get artifacts and possibly crashing.
-        ## (in this case, QPicture does all the work of computing the bouning rect for us)
-        return QtCore.QRectF(self.picture.boundingRect())
+        return self._bounds
 
 data = [  ## fields are (time, open, close, min, max).
     (1., 10, 13, 5, 15),

--- a/pyqtgraph/graphicsItems/BarGraphItem.py
+++ b/pyqtgraph/graphicsItems/BarGraphItem.py
@@ -159,9 +159,7 @@ class BarGraphItem(GraphicsObject):
         self.picture.play(p)
             
     def boundingRect(self):
-        if self.picture is None:
-            self.drawPicture()
-        return QtCore.QRectF(self.picture.boundingRect())
+        return self.shape().controlPointRect()
     
     def shape(self):
         if self.picture is None:

--- a/pyqtgraph/graphicsItems/NonUniformImage.py
+++ b/pyqtgraph/graphicsItems/NonUniformImage.py
@@ -76,6 +76,7 @@ class NonUniformImage(GraphicsObject):
 
         x, y, z = self.data
 
+        bounds = QtCore.QRectF()
         self.picture = QtGui.QPicture()
         p = QtGui.QPainter(self.picture)
         p.setPen(mkPen(None))
@@ -116,7 +117,11 @@ class NonUniformImage(GraphicsObject):
                 b = y[0] if j == 0 else (y[j - 1] + y[j]) / 2
                 t = (y[j] + y[j + 1]) / 2 if j < y.size - 1 else y[-1]
 
-                p.drawRect(QtCore.QRectF(l, t, r - l, b - t))
+                rect = QtCore.QRectF(l, t, r - l, b - t)
+                bounds |= rect
+                p.drawRect(rect)
+
+        self._bounds = bounds
 
         if self.border is not None:
             p.setPen(self.border)
@@ -131,4 +136,4 @@ class NonUniformImage(GraphicsObject):
         p.drawPicture(0, 0, self.picture)
 
     def boundingRect(self):
-        return QtCore.QRectF(self.picture.boundingRect())
+        return self._bounds


### PR DESCRIPTION
Fixes #2550
A few `GraphicsItem`s compute their bounding rectangle with `QPicture::boundingRect() -> QRect`, probably following the example in `customGraphicsItem.py`. This causes issues when the data limits exceed the int32 range of a `QRect`.

This PR fixes the cases where the bounding rectangle can be easily built up from the drawing primitives used.
