### PR TITLE
Use base_prefix to detect virtual env

### DIFF
--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -136,7 +136,9 @@ class Process(RemoteEventHandler):
         # the multiprocessing connection. Technically, only the launched subprocess needs to
         # send its pid back. Practically, we hijack the ppid parameter to indicate to the
         # subprocess that pid exchange is needed.
-        xchg_pids = sys.platform == 'win32' and os.getenv('VIRTUAL_ENV') is not None
+        #
+        # We detect a virtual environment using sys.base_prefix, see https://docs.python.org/3/library/sys.html#sys.base_prefix
+        xchg_pids = sys.platform == 'win32' and sys.prefix != sys.base_prefix
 
         ## Send everything the remote process needs to start correctly
         data = dict(

--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -138,6 +138,7 @@ class Process(RemoteEventHandler):
         # subprocess that pid exchange is needed.
         #
         # We detect a virtual environment using sys.base_prefix, see https://docs.python.org/3/library/sys.html#sys.base_prefix
+        # See https://github.com/pyqtgraph/pyqtgraph/pull/2566 and https://github.com/spyder-ide/spyder/issues/20273
         xchg_pids = sys.platform == 'win32' and sys.prefix != sys.base_prefix
 
         ## Send everything the remote process needs to start correctly


### PR DESCRIPTION
See the discussion in #1860.

Detect presence of a virtual enviroment using `sys.prefix != sys.base_prefix`. This is more robust than a check on the environment variable `VIRTUAL_ENV`.

Fixes #1052

@j9ac9k @pijyoi 

A minimal example (using Windows):

1. Create a virtual environment using virtualenv
2. Activate the environment
3. Run `python -c "import os; print(os.environ.get('VIRTUAL_ENV'))"`. The output shows the location of the virtualenv
4. Install Spyder (`pip install spyder`)
5. Start spyder (by typing the command `spyder`). In the Spyder console window run `import sys; print(sys.prefix)`. The output is the location of the virtual environment, which shows the console session in spyder is indeed running the virtual environment.
7. In the same console window of spyder run `import os; print(os.environ.get('VIRTUAL_ENV'))`. The output is `None`. So the original check does not work in this case
7. In the same console window run `import sys; sys.prefix != sys.base_prefix`. The output is `True`

### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [ ] `README.md`
- [ ] `setup.py`
- [ ] `tox.ini`
- [ ] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [ ] `pyproject.toml`
- [ ] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
