### PR TITLE
feat(PlotItem) define context menu action visibility

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -1083,6 +1083,23 @@ class PlotItem(GraphicsWidget):
     
     def menuEnabled(self):
         return self._menuEnabled
+
+    def setContextMenuActionVisible(self, name : str, visible : bool) -> None:
+        """
+        Changes the context menu action visibility
+
+        =============== ====================================================================
+        **Arguments:**
+        name            (str) Action name ('Transforms', 'Downsample', 'Average', 'Alpha', 'Grid', 'Points'
+
+        visible            (bool) If `True`, action is visible. If `False` action is invisible
+        =============== ====================================================================
+        """
+        translated_name = translate("PlotItem", name)
+        for action in self.ctrlMenu.actions():
+            if action.text() == translated_name:
+                action.setVisible(visible)
+                break
     
     def hoverEvent(self, ev):
         if ev.enter:

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -1088,12 +1088,15 @@ class PlotItem(GraphicsWidget):
         """
         Changes the context menu action visibility
 
-        =============== ====================================================================
-        **Arguments:**
-        name            (str) Action name ('Transforms', 'Downsample', 'Average', 'Alpha', 'Grid', 'Points'
-
-        visible            (bool) If `True`, action is visible. If `False` action is invisible
-        =============== ====================================================================
+        Parameters
+        ----------
+        name: str
+            Action name
+            must be one of 'Transforms', 'Downsample', 'Average','Alpha', 'Grid', or 'Points'
+        visible: bool
+            Determines if action will be display
+            True action is visible
+            False action is invisible.
         """
         translated_name = translate("PlotItem", name)
         for action in self.ctrlMenu.actions():


### PR DESCRIPTION
Add method `setContextMenuActionVisible` in `PlotItem`.

Based on action `name` ('Transforms', 'Downsample', 'Average', 'Alpha', 'Grid', 'Points'), action is set visible depending on the argument `visible`

To avoid issue with translation (action text is translated) action name is translated to get correction action.

Fixes #2351 
