### PR TITLE
PColorMeshItem: implement dataBounds and pixelPadding

### DIFF
--- a/pyqtgraph/examples/PColorMeshItem.py
+++ b/pyqtgraph/examples/PColorMeshItem.py
@@ -67,6 +67,12 @@ wave_length     = 10
 color_speed     = 0.3
 color_noise_freq = 0.05
 
+# display info in top-right corner
+miny = np.min(y) - wave_amplitude
+maxy = np.max(y) + wave_amplitude
+view.setYRange(miny, maxy)
+textitem.setPos(np.max(x), maxy)
+
 timer = QtCore.QTimer()
 timer.setSingleShot(True)
 # not using QTimer.singleShot() because of persistence on PyQt. see PR #1605
@@ -91,11 +97,7 @@ def updateData():
 
     i += wave_speed
 
-    # display info in top-right corner
     textitem.setText(f'{(t2 - t1)*1000:.1f} ms')
-    if textpos is None:
-        textpos = pcmi.width(), pcmi.height()
-        textitem.setPos(*textpos)
 
     # cap update rate at fps
     delay = max(1000/fps - (t2 - t0), 0)

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -12,12 +12,6 @@ from .GraphicsObject import GraphicsObject
 __all__ = ['PColorMeshItem']
 
 
-if Qt.QT_LIB.startswith('PyQt'):
-    wrapinstance = Qt.sip.wrapinstance
-else:
-    wrapinstance = Qt.shiboken.wrapInstance
-
-
 class QuadInstances:
     def __init__(self):
         self.polys = []
@@ -27,7 +21,7 @@ class QuadInstances:
 
         # 2 * (size + 1) vertices, (x, y)
         arr = np.empty((2 * (size + 1), 2), dtype=np.float64)
-        ptrs = list(map(wrapinstance,
+        ptrs = list(map(Qt.compat.wrapinstance,
             itertools.count(arr.ctypes.data, arr.strides[0]),
             itertools.repeat(QtCore.QPointF, arr.shape[0])))
 
@@ -102,6 +96,7 @@ class PColorMeshItem(GraphicsObject):
         edgecolors : dict, optional
             The color of the edges of the polygons.
             Default None means no edges.
+            Only cosmetic pens are supported.
             The dict may contains any arguments accepted by :func:`mkColor() <pyqtgraph.mkColor>`.
             Example: ``mkPen(color='w', width=2)``
         antialiasing : bool, default False
@@ -115,8 +110,14 @@ class PColorMeshItem(GraphicsObject):
         self.x = None
         self.y = None
         self.z = None
+        self._dataBounds = None
 
         self.edgecolors = kwargs.get('edgecolors', None)
+        if self.edgecolors is not None:
+            self.edgecolors = fn.mkPen(self.edgecolors)
+            # force the pen to be cosmetic. see discussion in
+            # https://github.com/pyqtgraph/pyqtgraph/pull/2586
+            self.edgecolors.setCosmetic(True)
         self.antialiasing = kwargs.get('antialiasing', False)
         self.levels = kwargs.get('levels', None)
         self.enableAutoLevels = kwargs.get('enableAutoLevels', True)
@@ -164,6 +165,8 @@ class PColorMeshItem(GraphicsObject):
             self.x = None
             self.y = None
             self.z = None
+
+            self._dataBounds = None
             
         # User only specified z
         elif len(args)==1:
@@ -172,6 +175,8 @@ class PColorMeshItem(GraphicsObject):
             y = np.arange(0, args[0].shape[1]+1, 1)
             self.x, self.y = np.meshgrid(x, y, indexing='ij')
             self.z = args[0]
+
+            self._dataBounds = ((x[0], x[-1]), (y[0], y[-1]))
 
         # User specified x, y, z
         elif len(args)==3:
@@ -186,6 +191,10 @@ class PColorMeshItem(GraphicsObject):
             self.x = args[0]
             self.y = args[1]
             self.z = args[2]
+
+            xmn, xmx = np.min(self.x), np.max(self.x)
+            ymn, ymx = np.min(self.y), np.max(self.y)
+            self._dataBounds = ((xmn, xmx), (ymn, ymx))
 
         else:
             ValueError('Data must been sent as (z) or (x, y, z)')
@@ -242,7 +251,7 @@ class PColorMeshItem(GraphicsObject):
         if self.edgecolors is None:
             painter.setPen(QtCore.Qt.PenStyle.NoPen)
         else:
-            painter.setPen(fn.mkPen(self.edgecolors))
+            painter.setPen(self.edgecolors)
             if self.antialiasing:
                 painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
                 
@@ -327,7 +336,34 @@ class PColorMeshItem(GraphicsObject):
 
 
 
+    def dataBounds(self, ax, frac=1.0, orthoRange=None):
+        if self._dataBounds is None:
+            return (None, None)
+        return self._dataBounds[ax]
+
+    def pixelPadding(self):
+        # pen is known to be cosmetic
+        pen = self.edgecolors
+        no_pen = (pen is None) or (pen.style() == QtCore.Qt.PenStyle.NoPen)
+        return 0 if no_pen else (pen.widthF() or 1) * 0.5
+
     def boundingRect(self):
-        if self.qpicture is None:
-            return QtCore.QRectF(0., 0., 0., 0.)
-        return QtCore.QRectF(self.qpicture.boundingRect())
+        xmn, xmx = self.dataBounds(ax=0)
+        if xmn is None or xmx is None:
+            return QtCore.QRectF()
+        ymn, ymx = self.dataBounds(ax=1)
+        if ymn is None or ymx is None:
+            return QtCore.QRectF()
+
+        px = py = 0
+        pxPad = self.pixelPadding()
+        if pxPad > 0:
+            # determine length of pixel in local x, y directions
+            px, py = self.pixelVectors()
+            px = 0 if px is None else px.length()
+            py = 0 if py is None else py.length()
+            # return bounds expanded by pixel size
+            px *= pxPad
+            py *= pxPad
+
+        return QtCore.QRectF(xmn-px, ymn-py, (2*px)+xmx-xmn, (2*py)+ymx-ymn)

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -322,19 +322,16 @@ class PColorMeshItem(GraphicsObject):
 
 
     def width(self):
-        if self.x is None:
-            return None
-        return np.max(self.x)
-
-
+        if self._dataBounds is None:
+            return 0
+        bounds = self._dataBounds[0]
+        return bounds[1]-bounds[0]
 
     def height(self):
-        if self.y is None:
-            return None
-        return np.max(self.y)
-
-
-
+        if self._dataBounds is None:
+            return 0
+        bounds = self._dataBounds[1]
+        return bounds[1]-bounds[0]
 
     def dataBounds(self, ax, frac=1.0, orthoRange=None):
         if self._dataBounds is None:


### PR DESCRIPTION
using `QPicture.boundingRect()` to compute `boundingRect()` has issues, which includes rounding the values to the next integral value.

Other issue fixed: `width()` and `height()` methods assume that the minimum coord is 0

Script that demonstrates the issues fixed by this PR.
- Coords are chosen to be small and the bounding box will be over-sized on `master`.
- print out of width() and height() are not correct on `master`.

```python
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore, QtGui, QtWidgets
import numpy as np

class ObjectBounds(QtWidgets.QGraphicsItem):
    def paint(self, painter, *args):
        pen = QtGui.QPen(QtCore.Qt.GlobalColor.red, 0, QtCore.Qt.PenStyle.DashLine)
        rect = self.boundingRect()
        painter.setPen(pen)
        painter.drawRect(rect)
        # print(rect)

    def boundingRect(self):
        return self.parentItem().boundingRect()

pg.mkQApp()
pw = pg.PlotWidget()
pw.show()

rng = np.random.default_rng()
shape = (100, 100)
az = np.linspace(np.pi/6, np.pi*5/6, shape[0]+1)
rg = np.linspace(0.25, 1.25, shape[1]+1)
X = rg[:, np.newaxis] * np.cos(az)
Y = rg[:, np.newaxis] * np.sin(az)
Z = rng.uniform(size=shape)

pcmi = pg.PColorMeshItem(X, Y, Z)
pw.addItem(pcmi)
rect = ObjectBounds(pcmi)

print(pcmi.width(), pcmi.height())

pg.exec()
```
