### PR TITLE
NonUniformImage: implement floating point boundingRect

### DIFF
--- a/pyqtgraph/graphicsItems/NonUniformImage.py
+++ b/pyqtgraph/graphicsItems/NonUniformImage.py
@@ -131,4 +131,5 @@ class NonUniformImage(GraphicsObject):
         p.drawPicture(0, 0, self.picture)
 
     def boundingRect(self):
-        return QtCore.QRectF(self.picture.boundingRect())
+        x, y, _ = self.data
+        return QtCore.QRectF(x[0], y[0], x[-1]-x[0], y[-1]-y[0])


### PR DESCRIPTION
using QPicture.boundingRect() to compute boundingRect() has issues, which includes rounding the values to the next integral value.

The data bounds are easily computed. The bulk of the code deals with handling the optional border rectangle. 