### PR TITLE
create internals.PrimitiveArray

### DIFF
--- a/pyqtgraph/Qt/internals.py
+++ b/pyqtgraph/Qt/internals.py
@@ -1,9 +1,13 @@
 import ctypes
+import itertools
 import numpy as np
-from . import QT_LIB
+from . import QT_LIB, QtCore, QtGui
 from . import compat
 
 __all__ = ["get_qpainterpath_element_array"]
+
+if QT_LIB.startswith('PyQt'):
+    from . import sip
 
 class QArrayDataQt5(ctypes.Structure):
     _fields_ = [
@@ -69,3 +73,81 @@ def get_qpainterpath_element_array(qpath, nelems=None):
 
     vp = compat.voidptr(eptr, itemsize*nelems, writable)
     return np.frombuffer(vp, dtype=dtype)
+
+class PrimitiveArray:
+    # QPainter has a C++ native API that takes an array of objects:
+    #   drawPrimitives(const Primitive *array, int count, ...)
+    # where "Primitive" is one of QPointF, QLineF, QRectF, PixmapFragment
+    #
+    # PySide (with the exception of drawPixmapFragments) and older PyQt
+    # require a Python list of "Primitive" instances to be provided to
+    # the respective "drawPrimitives" method.
+    #
+    # This is inefficient because:
+    # 1) constructing the Python list involves calling wrapinstance multiple times.
+    #    - this is mitigated here by reusing the instance pointers
+    # 2) The binding will anyway have to repack the instances into a contiguous array,
+    #    in order to call the underlying C++ native API.
+    #
+    # Newer PyQt provides sip.array, which is more efficient.
+    #
+    # PySide's drawPixmapFragments() takes an instance to the first item of a
+    # C array of PixmapFragment(s) _and_ the length of the array.
+    # There is no overload that takes a Python list of PixmapFragment(s).
+
+    def __init__(self, Klass, nfields, method=None):
+        self._Klass = Klass
+        self._nfields = nfields
+        self._ndarray = None
+
+        if QT_LIB.startswith('PyQt'):
+            if method is None:
+                method = (
+                    hasattr(sip, 'array') and
+                    (
+                        (0x60301 <= QtCore.PYQT_VERSION) or
+                        (0x50f07 <= QtCore.PYQT_VERSION < 0x60000)
+                    )
+                )
+            self.use_sip_array = method
+        else:
+            self.use_sip_array = False
+
+        if QT_LIB.startswith('PySide'):
+            if method is None:
+                method = (
+                    Klass is QtGui.QPainter.PixmapFragment
+                )
+            self.use_ptr_to_array = method
+        else:
+            self.use_ptr_to_array = False
+
+        self.resize(0)
+
+    def resize(self, size):
+        if self._ndarray is not None and len(self._ndarray) == size:
+            return
+
+        if self.use_sip_array:
+            self._objs = sip.array(self._Klass, size)
+            vp = sip.voidptr(self._objs, size*self._nfields*8)
+            array = np.frombuffer(vp, dtype=np.float64).reshape((-1, self._nfields))
+        elif self.use_ptr_to_array:
+            array = np.empty((size, self._nfields), dtype=np.float64)
+            self._objs = compat.wrapinstance(array.ctypes.data, self._Klass)
+        else:
+            array = np.empty((size, self._nfields), dtype=np.float64)
+            self._objs = list(map(compat.wrapinstance,
+                itertools.count(array.ctypes.data, array.strides[0]),
+                itertools.repeat(self._Klass, array.shape[0])))
+
+        self._ndarray = array
+
+    def __len__(self):
+        return len(self._ndarray)
+
+    def ndarray(self):
+        return self._ndarray
+
+    def instances(self):
+        return self._objs

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -1,7 +1,6 @@
 from ..Qt import QtCore, QtGui, QtWidgets
 
 HAVE_OPENGL = hasattr(QtWidgets, 'QOpenGLWidget')
-import itertools
 import math
 import sys
 import warnings
@@ -40,35 +39,20 @@ _have_native_drawlines_array = Qt.QT_LIB.startswith('PySide') and have_native_dr
 
 class LineSegments:
     def __init__(self):
-        self.use_sip_array = (
-            Qt.QT_LIB.startswith('PyQt') and
-            hasattr(Qt.sip, 'array') and
-            (
-                (0x60301 <= QtCore.PYQT_VERSION) or
-                (0x50f07 <= QtCore.PYQT_VERSION < 0x60000)
-            )
-        )
-        self.use_native_drawlines = Qt.QT_LIB.startswith('PySide') and _have_native_drawlines_array
-        self.alloc(0)
+        method = None
 
-    def alloc(self, size):
-        if self.use_sip_array:
-            self.objs = Qt.sip.array(QtCore.QLineF, size)
-            vp = Qt.sip.voidptr(self.objs, len(self.objs)*4*8)
-            self.arr = np.frombuffer(vp, dtype=np.float64).reshape((-1, 4))
-        elif self.use_native_drawlines:
-            self.arr = np.empty((size, 4), dtype=np.float64)
-            self.objs = Qt.compat.wrapinstance(self.arr.ctypes.data, QtCore.QLineF)
-        else:
-            self.arr = np.empty((size, 4), dtype=np.float64)
-            self.objs = list(map(Qt.compat.wrapinstance,
-                itertools.count(self.arr.ctypes.data, self.arr.strides[0]),
-                itertools.repeat(QtCore.QLineF, self.arr.shape[0])))
+        # "use_native_drawlines" is pending the following issue and code review
+        # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1924
+        # https://codereview.qt-project.org/c/pyside/pyside-setup/+/415702
+        self.use_native_drawlines = Qt.QT_LIB.startswith('PySide') and _have_native_drawlines_array
+        if self.use_native_drawlines:
+            method = True
+
+        self.array = Qt.internals.PrimitiveArray(QtCore.QLineF, 4, method=method)
 
     def get(self, size):
-        if size != self.arr.shape[0]:
-            self.alloc(size)
-        return self.objs, self.arr
+        self.array.resize(size)
+        return self.array.instances(), self.array.ndarray()
 
     def arrayToLineSegments(self, x, y, connect, finiteCheck):
         # analogue of arrayToQPath taking the same parameters


### PR DESCRIPTION
Refactor the array code in `ScatterPlotItem` and `PlotCurveItem` into PrimitiveArray.

It may look as though that there is one behavior change made in this PR. Previously in `ScatterPlotItem`, if the number of items was zero, then the call to `drawPixmapFragments` would be skipped.
I have looked through the logs, and this skipping behavior was added when adding support for PyQt's `sip.array`. Testing shows that PyQt does currently support zero-length sip arrays. I suspect it was added when testing against preliminary versions of `sip.array`.

Script to verify that zero-length `sip.array`(s) work.
```python
from PyQt6 import QtCore, QtGui, sip

app = QtGui.QGuiApplication([])
array = sip.array(QtGui.QPainter.PixmapFragment, 0)
print(array)

pix = QtGui.QPixmap(51, 51)
pix.fill(QtCore.Qt.GlobalColor.cyan)

qimg = QtGui.QImage(200, 200, QtGui.QImage.Format.Format_RGB32)
qimg.fill(QtCore.Qt.GlobalColor.white)
painter = QtGui.QPainter(qimg)
painter.drawPixmapFragments(array, pix)
painter.end()

print('done')
```

Besides cleaning up the code, this PR will hopefully make it simpler to add support for `drawRects` and `drawPoints`.

Sample script to exercise `drawRects` using this PR. This may help #2287. 
```python
import numpy as np
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore, QtGui, QtWidgets

class CheckerBoardItem(pg.GraphicsObject):
    def __init__(self, size):
        super().__init__()
        self.size = size

        x = np.arange(self.size)
        y = np.arange(self.size)[:, np.newaxis]
        bitmap = (y & 1) ^ (x & 1)
        X, Y = np.meshgrid(x, y)
        nzidx = bitmap.nonzero()

        self.array = pg.Qt.internals.PrimitiveArray(QtCore.QRectF, 4)
        self.array.resize(nzidx[0].size)
        memory = self.array.ndarray()
        memory[:, 0] = X[nzidx]
        memory[:, 1] = Y[nzidx]
        memory[:, 2:4] = 1

    def paint(self, painter, *args):
        rect = QtCore.QRectF(0, 0, self.size, self.size)
        painter.fillRect(rect, QtCore.Qt.GlobalColor.blue)

        inst = self.array.instances()
        painter.setPen(QtCore.Qt.PenStyle.NoPen)
        painter.setBrush(QtCore.Qt.GlobalColor.white)
        painter.drawRects(inst)

    def boundingRect(self):
        return QtCore.QRectF(0, 0, self.size, self.size)

pg.mkQApp()
pw = pg.PlotWidget()
pw.show()
cbi = CheckerBoardItem(32)
pw.addItem(cbi)
pg.exec()
```
