### PR TITLE
PlotCurveItem error with stepMode="center", autoRange and autoVisible

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -266,6 +266,8 @@ class PlotCurveItem(GraphicsObject):
         ## If an orthogonal range is specified, mask the data now
         if orthoRange is not None:
             mask = (d2 >= orthoRange[0]) * (d2 <= orthoRange[1])
+            if self.opts.get("stepMode", None) == "center":
+                mask = mask[:-1]  # len(y) == len(x) - 1 when stepMode is center
             d = d[mask]
             #d2 = d2[mask]
 


### PR DESCRIPTION
An IndexError is raised for PlotCurveItems with stepMode="center" when dataBounds  is called and orthoRange is not None. The mask created in dataBounds is 1 element too long (len(x) == len(y) + 1) and must be trimmed.

Fixes #2594
