### PR TITLE
Prepare support for PySide6 drawLines and friends

### DIFF
--- a/pyqtgraph/Qt/internals.py
+++ b/pyqtgraph/Qt/internals.py
@@ -105,7 +105,10 @@ class PrimitiveArray:
     def __init__(self, Klass, nfields, *, use_array=None):
         self._Klass = Klass
         self._nfields = nfields
-        self._ndarray = None
+        self._capa = -1
+
+        self.use_sip_array = False
+        self.use_ptr_to_array = False
 
         if QT_LIB.startswith('PyQt'):
             if use_array is None:
@@ -117,8 +120,6 @@ class PrimitiveArray:
                     )
                 )
             self.use_sip_array = use_array
-        else:
-            self.use_sip_array = False
 
         if QT_LIB.startswith('PySide'):
             if use_array is None:
@@ -127,25 +128,40 @@ class PrimitiveArray:
                     or pyside_version_info >= (6, 4, 3)
                 )
             self.use_ptr_to_array = use_array
-        else:
-            self.use_ptr_to_array = False
 
         self.resize(0)
 
     def resize(self, size):
-        if self._ndarray is not None and len(self._ndarray) == size:
-            return
-
         if self.use_sip_array:
-            self._objs = sip.array(self._Klass, size)
-            vp = sip.voidptr(self._objs, size*self._nfields*8)
-            self._ndarray = np.frombuffer(vp, dtype=np.float64).reshape((-1, self._nfields))
-        elif self.use_ptr_to_array:
-            self._ndarray = np.empty((size, self._nfields), dtype=np.float64)
-            self._objs = None
+            # For reference, SIP_VERSION 6.7.8 first arrived
+            # in PyQt5_sip 12.11.2 and PyQt6_sip 13.4.2
+            if sip.SIP_VERSION >= 0x60708:
+                if size <= self._capa:
+                    self._size = size
+                    return
+            else:
+                # sip.array prior to SIP_VERSION 6.7.8 had a
+                # buggy slicing implementation.
+                # so trigger a reallocate for any different size
+                if size == self._capa:
+                    return
+
+            self._siparray = sip.array(self._Klass, size)
+
         else:
+            if size <= self._capa:
+                self._size = size
+                return
             self._ndarray = np.empty((size, self._nfields), dtype=np.float64)
-            self._objs = self._wrap_instances(self._ndarray)
+
+            if self.use_ptr_to_array:
+                # defer creation
+                self._objs = None
+            else:
+                self._objs = self._wrap_instances(self._ndarray)
+
+        self._capa = size
+        self._size = size
 
     def _wrap_instances(self, array):
         return list(map(compat.wrapinstance,
@@ -153,31 +169,58 @@ class PrimitiveArray:
             itertools.repeat(self._Klass, array.shape[0])))
 
     def __len__(self):
-        return len(self._ndarray)
+        return self._size
 
     def ndarray(self):
-        return self._ndarray
+        # ndarray views are cheap to recreate each time
+        if self.use_sip_array:
+            if sip.SIP_VERSION >= 0x60708:
+                mv = self._siparray
+            else:
+                # sip.array prior to SIP_VERSION 6.7.8 had a buggy buffer protocol
+                # that set the wrong size.
+                # workaround it by going through a sip.voidptr
+                mv = sip.voidptr(self._siparray, self._capa*self._nfields*8)
+            # note that we perform the slicing by using only _size rows
+            nd = np.frombuffer(mv, dtype=np.float64, count=self._size*self._nfields)
+            return nd.reshape((-1, self._nfields))
+        else:
+            return self._ndarray[:self._size]
 
     def instances(self):
         # this returns an iterable container of Klass instances.
         # for "use_ptr_to_array" mode, such a container may not
         # be required at all, so its creation is deferred
+        if self.use_sip_array:
+            if self._size == self._capa:
+                # avoiding slicing when it's not necessary
+                # handles the case where sip.array had a buggy
+                # slicing implementation 
+                return self._siparray
+            else:
+                # this is a view
+                return self._siparray[:self._size]
+
         if self._objs is None:
             self._objs = self._wrap_instances(self._ndarray)
-        return self._objs
+
+        if self._size == self._capa:
+            return self._objs
+        else:
+            # this is a shallow copy
+            return self._objs[:self._size]
 
     def drawargs(self):
         # returns arguments to apply to the respective drawPrimitives() functions
         if self.use_ptr_to_array:
-            size = len(self._ndarray)
-            if size:
+            if self._capa > 0:
                 # wrap memory only if it is safe to do so
                 ptr = compat.wrapinstance(self._ndarray.ctypes.data, self._Klass)
             else:
                 # shiboken translates None <--> nullptr
                 # alternatively, we could instantiate a dummy _Klass()
                 ptr = None
-            return ptr, size
+            return ptr, self._size
 
         else:
-            return self._objs,
+            return self.instances(),

--- a/pyqtgraph/graphicsItems/BarGraphItem.py
+++ b/pyqtgraph/graphicsItems/BarGraphItem.py
@@ -233,8 +233,8 @@ class BarGraphItem(GraphicsObject):
         if self._singleColor:
             p.setPen(self._sharedPen)
             p.setBrush(self._sharedBrush)
-            inst = self._rectarray.instances()
-            p.drawRects(inst)
+            drawargs = self._rectarray.drawargs()
+            p.drawRects(*drawargs)
         else:
             if self.picture is None:
                 self.drawPicture()

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -19,14 +19,11 @@ class LineSegments:
     def __init__(self):
         self.array = Qt.internals.PrimitiveArray(QtCore.QLineF, 4)
 
-    def get(self, size):
-        self.array.resize(size)
-        return self.array.instances(), self.array.ndarray()
-
     def arrayToLineSegments(self, x, y, connect, finiteCheck):
         # analogue of arrayToQPath taking the same parameters
         if len(x) < 2:
-            return [],
+            self.array.resize(0)
+            return self.array.drawargs()
 
         connect_array = None
         if isinstance(connect, np.ndarray):
@@ -58,13 +55,11 @@ class LineSegments:
                 x = x[backfill_idx]
                 y = y[backfill_idx]
 
-        segs = []
-        nsegs = 0
-
         if connect == 'all':
             nsegs = len(x) - 1
+            self.array.resize(nsegs)
             if nsegs:
-                segs, memory = self.get(nsegs)
+                memory = self.array.ndarray()
                 memory[:, 0] = x[:-1]
                 memory[:, 2] = x[1:]
                 memory[:, 1] = y[:-1]
@@ -72,8 +67,9 @@ class LineSegments:
 
         elif connect == 'pairs':
             nsegs = len(x) // 2
+            self.array.resize(nsegs)
             if nsegs:
-                segs, memory = self.get(nsegs)
+                memory = self.array.ndarray()
                 memory = memory.reshape((-1, 2))
                 memory[:, 0] = x[:nsegs * 2]
                 memory[:, 1] = y[:nsegs * 2]
@@ -83,17 +79,19 @@ class LineSegments:
             # - 'array'
             # - 'finite' with non-finite elements
             nsegs = np.count_nonzero(connect_array)
+            self.array.resize(nsegs)
             if nsegs:
-                segs, memory = self.get(nsegs)
+                memory = self.array.ndarray()
                 memory[:, 0] = x[:-1][connect_array]
                 memory[:, 2] = x[1:][connect_array]
                 memory[:, 1] = y[:-1][connect_array]
                 memory[:, 3] = y[1:][connect_array]
 
-        if nsegs and self.use_native_drawlines:
-            return segs, nsegs
         else:
-            return segs,
+            nsegs = 0
+            self.array.resize(nsegs)
+
+        return self.array.drawargs()
 
 
 class PlotCurveItem(GraphicsObject):

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -15,40 +15,9 @@ from .GraphicsObject import GraphicsObject
 __all__ = ['PlotCurveItem']
 
 
-def have_native_drawlines_array():
-    size = 10
-    line = QtCore.QLineF(0, 0, size, size)
-    qimg = QtGui.QImage(size, size, QtGui.QImage.Format.Format_RGB32)
-    qimg.fill(QtCore.Qt.GlobalColor.transparent)
-    painter = QtGui.QPainter(qimg)
-    painter.setPen(QtCore.Qt.GlobalColor.white)
-
-    try:
-        painter.drawLines(line, 1)
-    except TypeError:
-        success = False
-    else:
-        success = True
-    finally:
-        painter.end()
-
-    return success
-
-_have_native_drawlines_array = Qt.QT_LIB.startswith('PySide') and have_native_drawlines_array()
-
-
 class LineSegments:
     def __init__(self):
-        use_array = None
-
-        # "use_native_drawlines" is pending the following issue and code review
-        # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1924
-        # https://codereview.qt-project.org/c/pyside/pyside-setup/+/415702
-        self.use_native_drawlines = Qt.QT_LIB.startswith('PySide') and _have_native_drawlines_array
-        if self.use_native_drawlines:
-            use_array = True
-
-        self.array = Qt.internals.PrimitiveArray(QtCore.QLineF, 4, use_array=use_array)
+        self.array = Qt.internals.PrimitiveArray(QtCore.QLineF, 4)
 
     def get(self, size):
         self.array.resize(size)

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -958,12 +958,8 @@ class ScatterPlotItem(GraphicsObject):
                 frags[:, 6:10] = [1.0, 1.0, 0.0, 1.0]   # scaleX, scaleY, rotation, opacity
 
                 profiler('prep')
-                inst = self._pixmapFragments.instances()
-                if Qt.QT_LIB.startswith('PySide'):
-                    args = inst, sr.size
-                else:
-                    args = inst,
-                p.drawPixmapFragments(*args, self.fragmentAtlas.pixmap)
+                drawargs = self._pixmapFragments.drawargs()
+                p.drawPixmapFragments(*drawargs, self.fragmentAtlas.pixmap)
                 profiler('draw')
             else:
                 # render each symbol individually

--- a/tests/graphicsItems/test_PlotCurveItem.py
+++ b/tests/graphicsItems/test_PlotCurveItem.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import pyqtgraph as pg
-from pyqtgraph.graphicsItems.PlotCurveItem import LineSegments
+from pyqtgraph.graphicsItems.PlotCurveItem import arrayToLineSegments
 from tests.image_testing import assertImageApproved
 
 
@@ -38,12 +38,11 @@ def test_PlotCurveItem():
     p.close()
 
 
-def test_LineSegments():
-    ls = LineSegments()
-
+def test_arrayToLineSegments():
     # test the boundary case where the dataset consists of a single point
     xy = np.array([0.])
-    segs = ls.arrayToLineSegments(xy, xy, connect='all', finiteCheck=True)
+    parray = arrayToLineSegments(xy, xy, connect='all', finiteCheck=True)
+    segs = parray.drawargs()
     assert isinstance(segs, tuple) and len(segs) in [1, 2]
     if len(segs) == 1:
         assert len(segs[0]) == 0

--- a/tests/graphicsItems/test_PlotCurveItem.py
+++ b/tests/graphicsItems/test_PlotCurveItem.py
@@ -13,6 +13,7 @@ def test_PlotCurveItem():
     v = p.addViewBox()
     data = np.array([1,4,2,3,np.inf,5,7,6,-np.inf,8,10,9,np.nan,-1,-2,0])
     c = pg.PlotCurveItem(data)
+    c.setSegmentedLineMode('off')   # test images assume non-segmented-line-mode
     v.addItem(c)
     v.autoRange()
     

--- a/tests/graphicsItems/test_PlotCurveItem.py
+++ b/tests/graphicsItems/test_PlotCurveItem.py
@@ -45,4 +45,7 @@ def test_LineSegments():
     xy = np.array([0.])
     segs = ls.arrayToLineSegments(xy, xy, connect='all', finiteCheck=True)
     assert isinstance(segs, tuple) and len(segs) in [1, 2]
-    assert len(segs[0]) == 0
+    if len(segs) == 1:
+        assert len(segs[0]) == 0
+    elif len(segs) == 2:
+        assert segs[1] == 0


### PR DESCRIPTION
As PYSIDE-1924 (https://bugreports.qt.io/browse/PYSIDE-1924) feature has been added, we can prepare pyqtgraph to make use of it when it gets into a released version.
For now, testing can be done with the wheels at https://download.qt.io/snapshots/ci/pyside/dev/latest/

One issue is that PySide6's array API implementation will requirement passing of different arguments than the other codepaths. For this, we add a `drawargs()` method.

A synthetic benchmark to exercise the new API.
```python
import numpy as np
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore, QtGui

from time import perf_counter

def generate_pattern(nsegs, size):
    rng = np.random.default_rng()
    x = rng.random(nsegs) * size
    y = rng.random(nsegs) * size
    arr = np.empty((nsegs, 4), dtype=np.float64)
    arr[:, 0] = x
    arr[:, 1] = y
    arr[:, 2] = x + 2
    arr[:, 3] = y + 2
    return arr

nsegs = 10_000
size = 500
nframes = 100
pattern = generate_pattern(nsegs, size)

def run(use_array):
    # generate lines once
    segments = pg.Qt.internals.PrimitiveArray(QtCore.QLineF, 4, use_array=use_array)
    segments.resize(nsegs)
    memory = segments.ndarray()
    memory[:] = pattern

    # draw multiple frames using the same lines array
    t0 = perf_counter()
    for _ in range(nframes):
        qimg = QtGui.QImage(size, size, QtGui.QImage.Format.Format_RGB32)
        qimg.fill(QtCore.Qt.GlobalColor.transparent)
        painter = QtGui.QPainter(qimg)
        painter.setPen(QtCore.Qt.GlobalColor.cyan)
        painter.drawLines(*segments.drawargs())
        painter.end()
    t1 = perf_counter()
    return t1 - t0

for use_array in [False, None, True]:
    duration = run(use_array)
    fps = int(nframes / duration)
    print(f'{use_array=} {duration=:.3f} {fps=}')
```
