### PR TITLE
BarGraphItem: calculate boundingRect without drawing

### DIFF
--- a/pyqtgraph/graphicsItems/BarGraphItem.py
+++ b/pyqtgraph/graphicsItems/BarGraphItem.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from .. import functions as fn
 from .. import getConfigOption
+from .. import Qt
 from ..Qt import QtCore, QtGui
 from .GraphicsObject import GraphicsObject
 
@@ -48,6 +49,14 @@ class BarGraphItem(GraphicsObject):
             pens=None,
             brushes=None,
         )
+
+        if 'pen' not in opts:
+            opts['pen'] = getConfigOption('foreground')
+        if 'brush' not in opts:
+            opts['brush'] = (128, 128, 128)
+        # the first call to _updateColors() will thus always be an update
+
+        self._rectarray = Qt.internals.PrimitiveArray(QtCore.QRectF, 4)
         self._shape = None
         self.picture = None
         self.setOpts(**opts)
@@ -56,31 +65,74 @@ class BarGraphItem(GraphicsObject):
         self.opts.update(opts)
         self.picture = None
         self._shape = None
+        self._prepareData()
+        self._updateColors(opts)
+        self.prepareGeometryChange()
         self.update()
         self.informViewBoundsChanged()
-        
-    def drawPicture(self):
-        self.picture = QtGui.QPicture()
-        self._shape = QtGui.QPainterPath()
-        p = QtGui.QPainter(self.picture)
-        
-        pen = self.opts['pen']
-        pens = self.opts['pens']
-        
-        if pen is None and pens is None:
-            pen = getConfigOption('foreground')
-        
-        brush = self.opts['brush']
-        brushes = self.opts['brushes']
-        if brush is None and brushes is None:
-            brush = (128, 128, 128)
-        
+
+    def _updatePenWidth(self, pen):
+        no_pen = pen is None or pen.style() == QtCore.Qt.PenStyle.NoPen
+        if no_pen:
+            return
+
+        idx = pen.isCosmetic()
+        self._penWidth[idx] = max(self._penWidth[idx], pen.widthF())
+
+    def _updateColors(self, opts):
+        # the logic here is to permit the user to update only data
+        # without updating pens/brushes
+
+        # update only if fresh pen/pens supplied
+        if 'pen' in opts or 'pens' in opts:
+            self._penWidth = [0, 0]
+
+            if self.opts['pens'] is None:
+                # pens not configured, use single pen
+                pen = self.opts['pen']
+                pen = fn.mkPen(pen)
+                self._updatePenWidth(pen)
+                self._sharedPen = pen
+                self._pens = None
+            else:
+                # pens configured, ignore single pen (if any)
+                pens = []
+                for pen in self.opts['pens']:
+                    if not isinstance(pen, QtGui.QPen):
+                        pen = fn.mkPen(pen)
+                    pens.append(pen)
+                self._updatePenWidth(pen)
+                self._sharedPen = None
+                self._pens = pens
+
+        # update only if fresh brush/brushes supplied
+        if 'brush' in opts or 'brushes' in opts:
+            if self.opts['brushes'] is None:
+                # brushes not configured, use single brush
+                brush = self.opts['brush']
+                self._sharedBrush = fn.mkBrush(brush)
+                self._brushes = None
+            else:
+                # brushes configured, ignore single brush (if any)
+                brushes = []
+                for brush in self.opts['brushes']:
+                    if not isinstance(brush, QtGui.QBrush):
+                        brush = fn.mkBrush(brush)
+                    brushes.append(brush)
+                self._sharedBrush = None
+                self._brushes = brushes
+
+        self._singleColor = (
+            self._sharedPen is not None and
+            self._sharedBrush is not None
+        )
+
+    def _getNormalizedCoords(self):
         def asarray(x):
             if x is None or np.isscalar(x) or isinstance(x, np.ndarray):
                 return x
             return np.array(x)
 
-        
         x = asarray(self.opts.get('x'))
         x0 = asarray(self.opts.get('x0'))
         x1 = asarray(self.opts.get('x1'))
@@ -118,66 +170,71 @@ class BarGraphItem(GraphicsObject):
             if y1 is None:
                 raise Exception('must specify either y1 or height')
             height = y1 - y0
-        
-        p.setPen(fn.mkPen(pen))
-        p.setBrush(fn.mkBrush(brush))
-        dataBounds = QtCore.QRectF()
-        pixelPadding = 0
-        for i in range(len(x0 if not np.isscalar(x0) else y0)):
-            if pens is not None:
-                p.setPen(fn.mkPen(pens[i]))
-            if brushes is not None:
-                p.setBrush(fn.mkBrush(brushes[i]))
-                
-            if np.isscalar(x0):
-                x = x0
-            else:
-                x = x0[i]
-            if np.isscalar(y0):
-                y = y0
-            else:
-                y = y0[i]
-            if np.isscalar(width):
-                w = width
-            else:
-                w = width[i]
-            if np.isscalar(height):
-                h = height
-            else:
-                h = height[i]
-                
-                
-            rect = QtCore.QRectF(x, y, w, h)
-            p.drawRect(rect)
-            self._shape.addRect(rect)
 
-            pen = p.pen()
-            pw = pen.widthF()
-            if pen.style() == QtCore.Qt.PenStyle.NoPen:
-                pw = 0
-            elif pw == 0:
-                pw = 1
-            pw *= 0.5
-            if pen.isCosmetic():
-                dataBounds |= rect
-                pixelPadding = max(pixelPadding, pw)
-            else:
-                dataBounds |= rect.adjusted(-pw, -pw, pw, pw)
+        # ensure x0 < x1 and y0 < y1
+        t0, t1 = x0, x0 + width
+        x0 = np.minimum(t0, t1, dtype=np.float64)
+        x1 = np.maximum(t0, t1, dtype=np.float64)
+        t0, t1 = y0, y0 + height
+        y0 = np.minimum(t0, t1, dtype=np.float64)
+        y1 = np.maximum(t0, t1, dtype=np.float64)
 
-        p.end()
-        self._dataBounds = dataBounds
-        self._pixelPadding = pixelPadding
-        self.prepareGeometryChange()
-        
-        
+        # here, all of x0, y0, x1, y1 are numpy objects,
+        # BUT could possibly be numpy scalars
+        return x0, y0, x1, y1
+
+    def _prepareData(self):
+        x0, y0, x1, y1 = self._getNormalizedCoords()
+        xmn, xmx = np.min(x0), np.max(x1)
+        ymn, ymx = np.min(y0), np.max(y1)
+        self._dataBounds = (xmn, xmx), (ymn, ymx)
+
+        self._rectarray.resize(max(x0.size, y0.size))
+        memory = self._rectarray.ndarray()
+        memory[:, 0] = x0
+        memory[:, 1] = y0
+        memory[:, 2] = x1 - x0
+        memory[:, 3] = y1 - y0
+
+    def _render(self, painter):
+        if self._sharedPen is not None:
+            painter.setPen(self._sharedPen)
+        if self._sharedBrush is not None:
+            painter.setBrush(self._sharedBrush)
+
+        rects = self._rectarray.instances()
+        for idx, rect in enumerate(rects):
+            if self._pens is not None:
+                painter.setPen(self._pens[idx])
+            if self._brushes is not None:
+                painter.setBrush(self._brushes[idx])
+
+            painter.drawRect(rect)
+
+    def drawPicture(self):
+        self.picture = QtGui.QPicture()
+        painter = QtGui.QPainter(self.picture)
+        self._render(painter)
+        painter.end()
+
     def paint(self, p, *args):
-        if self.picture is None:
-            self.drawPicture()
-        self.picture.play(p)
+        if self._singleColor:
+            p.setPen(self._sharedPen)
+            p.setBrush(self._sharedBrush)
+            inst = self._rectarray.instances()
+            p.drawRects(inst)
+        else:
+            if self.picture is None:
+                self.drawPicture()
+            self.picture.play(p)
             
     def shape(self):
-        if self.picture is None:
-            self.drawPicture()
+        if self._shape is None:
+            shape = QtGui.QPainterPath()
+            rects = self._rectarray.instances()
+            for rect in rects:
+                shape.addRect(rect)
+            self._shape = shape
         return self._shape
 
     def implements(self, interface=None):
@@ -193,17 +250,25 @@ class BarGraphItem(GraphicsObject):
         return self.opts.get('x'),  self.opts.get('height')
 
     def dataBounds(self, ax, frac=1.0, orthoRange=None):
-        if self.picture is None:
-            self.drawPicture()
-        l, t, r, b = self._dataBounds.getCoords()
-        return [l, r] if ax == 0 else [t, b]
+        # _penWidth is available after _updateColors()
+        pw = self._penWidth[0] * 0.5
+        # _dataBounds is available after _prepareData()
+        bounds = self._dataBounds[ax]
+        return (bounds[0] - pw, bounds[1] + pw)
 
     def pixelPadding(self):
-        if self.picture is None:
-            self.drawPicture()
-        return self._pixelPadding
+        # _penWidth is available after _updateColors()
+        pw = (self._penWidth[1] or 1) * 0.5
+        return pw
 
     def boundingRect(self):
+        xmn, xmx = self.dataBounds(ax=0)
+        if xmn is None or xmx is None:
+            return QtCore.QRectF()
+        ymn, ymx = self.dataBounds(ax=1)
+        if ymn is None or ymx is None:
+            return QtCore.QRectF()
+
         px = py = 0
         pxPad = self.pixelPadding()
         if pxPad > 0:
@@ -214,4 +279,5 @@ class BarGraphItem(GraphicsObject):
             # return bounds expanded by pixel size
             px *= pxPad
             py *= pxPad
-        return self._dataBounds.adjusted(-px, -py, px, py)
+
+        return QtCore.QRectF(xmn-px, ymn-py, (2*px)+xmx-xmn, (2*py)+ymx-ymn)

--- a/pyqtgraph/graphicsItems/BarGraphItem.py
+++ b/pyqtgraph/graphicsItems/BarGraphItem.py
@@ -197,19 +197,31 @@ class BarGraphItem(GraphicsObject):
         memory[:, 3] = y1 - y0
 
     def _render(self, painter):
-        if self._sharedPen is not None:
-            painter.setPen(self._sharedPen)
-        if self._sharedBrush is not None:
-            painter.setBrush(self._sharedBrush)
+        multi_pen = self._pens is not None
+        multi_brush = self._brushes is not None
+        no_pen = (
+            not multi_pen
+            and self._sharedPen.style() == QtCore.Qt.PenStyle.NoPen
+        )
 
         rects = self._rectarray.instances()
-        for idx, rect in enumerate(rects):
-            if self._pens is not None:
-                painter.setPen(self._pens[idx])
-            if self._brushes is not None:
-                painter.setBrush(self._brushes[idx])
 
-            painter.drawRect(rect)
+        if no_pen and multi_brush:
+            for idx, rect in enumerate(rects):
+                painter.fillRect(rect, self._brushes[idx])
+        else:
+            if not multi_pen:
+                painter.setPen(self._sharedPen)
+            if not multi_brush:
+                painter.setBrush(self._sharedBrush)
+
+            for idx, rect in enumerate(rects):
+                if multi_pen:
+                    painter.setPen(self._pens[idx])
+                if multi_brush:
+                    painter.setBrush(self._brushes[idx])
+
+                painter.drawRect(rect)
 
     def drawPicture(self):
         self.picture = QtGui.QPicture()


### PR DESCRIPTION
This is a rewrite/restructuring of `BarGraphItem` to address some issues with the existing implementation:
1) `boundingRect`, `dataBounds` and `pixelPadding` all trigger the rendering code.
    * in this PR, bounding rectangle is calculated directly from the data values.
    * in this PR, pen width is calculated outside of the rendering code.
2) pens and brushes are always recreated even if only the data values were modified.
    * in this PR, pens and brushes are only recreated if they are modified
3) Even if the user passes in pre-created `QPen`s and `QBrush`es, a copy will be made.
    * in this PR, `QPen`s and `QBrush`es are not copied. The user is able to use the same `QPen` or `QBrush` instance for multiple bars.
4) Computation of the `QRectF`s are done one by one in a Python loop.
    * in this PR, numpy vector operations are used to calculate all the `QRectF`s
5) `drawRects()` is not used.
    * in this PR, `drawRects()` is used if only a single color is being used. This path also skips creation of `QPicture`.

A animated script to exercise and benchmark the various combinations of using `BarGraphItem`.
It seems to demonstrate a largish speedup vs master. 
```python
import itertools
import time
import numpy as np
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore, QtGui, QtWidgets

pg.mkQApp()
glw = pg.GraphicsLayoutWidget()
glw.show()
plt1 = glw.addPlot()
plt2 = glw.addPlot()
glw.nextRow()
plt3 = glw.addPlot()
plt4 = glw.addPlot()

ttt = np.linspace(0, 1, 100)
s = np.sin(2*np.pi*1.0*ttt)
dt = ttt[1] - ttt[0]

# user pen and default brush
bgi1 = pg.BarGraphItem(x=ttt, width=dt, y1=s, y0=0, pen={'color':'w'})
# default pen and user brush
bgi2 = pg.BarGraphItem(y=ttt, height=dt, x1=s, x0=0, brush=(0,0,255,150))

# pre-made QBrush objects shared amongst all the bars
# pens are not pre-made and will be created by BarGraphItem
# (old implementation will re-create them every cycle)
pens = itertools.cycle([{'color': x} for x in 'rgby'])
pens = [next(pens) for _ in range(len(ttt))]
brushes = itertools.cycle([pg.mkBrush(255,0,0), pg.mkBrush(0,255,0), pg.mkBrush(0,0,255)])
brushes3 = [next(brushes) for _ in range(len(ttt))]
bgi3 = pg.BarGraphItem(x=ttt, width=dt, y1=s, y0=0, pens=pens, brushes=brushes3)

# pre-made QBrush objects that we will roll together with the plot
# to not have a border, we need to create a NoPen
no_pen = pg.mkPen(None)
brushes4 = [pg.mkBrush(abs(s[idx])*255,0,0) for idx in range(len(ttt))]
bgi4 = pg.BarGraphItem(y=ttt, height=dt, x1=s, x0=0, pen=no_pen, brushes=brushes4)

plt1.addItem(bgi1)
plt2.addItem(bgi2)
plt3.addItem(bgi3)
plt4.addItem(bgi4)

frame_cnt = 0
last_time = time.perf_counter()
def update():
    global frame_cnt, last_time
    global brushes4
    global s
    now = time.perf_counter()
    elapsed = now - last_time
    if elapsed > 2.0:
        fps = frame_cnt / elapsed
        print(fps)
        frame_cnt = 0
        last_time = now
    s = np.roll(s, 1)
    brushes4.insert(0, brushes4.pop())
    bgi1.setOpts(y1=s)
    bgi2.setOpts(x1=s)
    bgi3.setOpts(y1=s)
    bgi4.setOpts(x1=s, brushes=brushes4)
    QtWidgets.QApplication.instance().processEvents()
    frame_cnt += 1

timer = QtCore.QTimer()
timer.timeout.connect(update)
timer.start(0)

pg.exec()
```

Remarks:
1) This PR motivated some of the changes made in #2596.
2) `BarGraphItem` probably wasn't intended for use in animated updates.
