### PR TITLE
Fix GraphicsScene ValueError in mouseReleaseEvent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
     -   id: check-added-large-files
         args: ['--maxkb=100']
@@ -15,6 +15,6 @@ repos:
     -   id: debug-statements
     -   id: check-ast
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -1,3 +1,4 @@
+import warnings
 import weakref
 from time import perf_counter, perf_counter_ns
 
@@ -220,10 +221,18 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
                 cev = [e for e in self.clickEvents if e.button() == ev.button()]
                 if cev:
                     if self.sendClickEvent(cev[0]):
-                        #print "sent click event"
                         ev.accept()
-                    self.clickEvents.remove(cev[0])
-                
+                    try:
+                        self.clickEvents.remove(cev[0])
+                    except ValueError:
+                        warnings.warn(
+                            ("A ValueError can occur here with errant "
+                             "QApplication.processEvent() calls, see "
+                            "https://github.com/pyqtgraph/pyqtgraph/pull/2580 "
+                            "for more information."),
+                            RuntimeWarning,
+                            stacklevel=2
+                        )
         if not ev.buttons():
             self.dragItem = None
             self.dragButtons = []


### PR DESCRIPTION
This PR addresses the issue where during a mouse release event, the mouse event that was present in a list is not present after `GraphicsScene.sigMouseClicked` is fired _and_ along the way there is a call to `QApplication.processEvents()`  

While this is not a pyqtgraph bug, numerous users have run into an issue here, and the nature of this error is not severe enough to emit an exception, so instead, pyqtgraph emits a warning with a message that should notify the developer to look for extra calls to `processEvents()`

Fixes #2580 
Fixes #2117

