### PR TITLE
Slight CI Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,15 @@
-# Set update schedule for GitHub Actions
-
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
-  - package-ecosystem: pip
-    directory: /doc
+  - package-ecosystem: "pip"
+    directory: "/doc"
     schedule:
-      interval: daily
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: ".github/workflows/etc"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/etc/requirements-numpy.txt
+++ b/.github/workflows/etc/requirements-numpy.txt
@@ -1,0 +1,5 @@
+# numpy based on python version and NEP-29 requirements
+numpy; python_version == '3.10'
+numpy; python_version == '3.11'
+numpy~=1.21.0; python_version == '3.9'
+numpy~=1.20.0; python_version == '3.8'

--- a/.github/workflows/etc/requirements.txt
+++ b/.github/workflows/etc/requirements.txt
@@ -1,10 +1,7 @@
-# numpy based on python version and NEP-29 requirements
-numpy; python_version == '3.10'
-numpy~=1.21.0; python_version == '3.9'
-numpy~=1.20.0; python_version == '3.8'
+-r requirements-numpy.txt
 
 # image testing
-scipy
+scipy==1.10.0
 
 # optional high performance paths
 numba==0.56.4; python_version == '3.9'
@@ -13,8 +10,8 @@ numba==0.56.4; python_version == '3.9'
 pyopengl==3.1.6
 
 # supplimental tools
-matplotlib
-h5py
+matplotlib==3.6.3
+h5py==3.8.0
 
 # testing
 pytest==7.2.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
       shell: cmd
     - name: Install Dependencies
       run: |
-        python -m pip install -r .github/workflows/requirements.txt ${{ matrix.qt-version }} .
+        python -m pip install -r .github/workflows/etc/requirements.txt ${{ matrix.qt-version }} .
     - name: "Install Linux VirtualDisplay"
       if: runner.os == 'Linux'
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,8 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      shell: bash
     - name: pip cache
       uses: actions/cache@v3
       with:
@@ -167,7 +168,8 @@ jobs:
           miniforge-variant: Mambaforge
           environment-file: ${{ matrix.environment-file }}
           auto-update-conda: false
-          python-version: "3.9"
+          python-version: "3.11"
+          use-mamba: true
       - name: "Install Test Framework"
         run: pip install pytest pytest-xdist
       - name: "Install Windows-Mesa OpenGL DLL"
@@ -239,10 +241,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python 3.9
+      - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Build Wheel
         run: |
           python -m pip install setuptools wheel
@@ -261,7 +263,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.11'
     - name: Install Dependencies
       run: |
         python -m pip install PyQt5 numpy scipy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         qt-lib: [pyqt, pyside]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - python-version: "3.8"
             qt-lib: "pyqt"
@@ -41,6 +41,12 @@ jobs:
             qt-lib: "pyqt"
             qt-version: "PyQt6"
           - python-version: "3.10"
+            qt-lib: "pyside"
+            qt-version: "PySide6-Essentials"
+          - python-version: "3.11"
+            qt-lib: "pyqt"
+            qt-version: "PyQt6"
+          - python-version: "3.11"
             qt-lib: "pyside"
             qt-version: "PySide6-Essentials"
     steps:

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -4,19 +4,19 @@ numpy~=1.21.0; python_version == '3.9'
 numpy~=1.20.0; python_version == '3.8'
 
 # image testing
-scipy==1.8.1
+scipy
 
 # optional high performance paths
-numba==0.55.2; python_version == '3.9'
+numba==0.56.4; python_version == '3.9'
 
 # optional 3D
 pyopengl==3.1.6
 
 # supplimental tools
-matplotlib==3.6.1
-h5py==3.7.0
+matplotlib
+h5py
 
 # testing
-pytest==7.1.2
-pytest-xdist==2.5.0
+pytest==7.2.1
+pytest-xdist==3.2.0
 pytest-xvfb==2.0.0; sys_platform == 'linux'


### PR DESCRIPTION
- Move away from now deprecated `set-output`
- Add Python 3.11
- Have dependabot updated pinned dependencies in `.github/workflows/etc/requirements.txt`
  - With the exception of numpy which we pin based on python version number we support