### PR TITLE
Dependabot, leave numpy alone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,8 @@ updates:
       interval: "daily"
   - package-ecosystem: "pip"
     directory: ".github/workflows/etc"
+    ignore:
+      - dependency-name: "numpy"
+      # NEP-29 governs supported versions of NumPy
     schedule:
       interval: "daily"

--- a/.github/workflows/etc/requirements-numpy.txt
+++ b/.github/workflows/etc/requirements-numpy.txt
@@ -1,5 +1,0 @@
-# numpy based on python version and NEP-29 requirements
-numpy; python_version == '3.10'
-numpy; python_version == '3.11'
-numpy~=1.21.0; python_version == '3.9'
-numpy~=1.20.0; python_version == '3.8'

--- a/.github/workflows/etc/requirements.txt
+++ b/.github/workflows/etc/requirements.txt
@@ -1,4 +1,8 @@
--r requirements-numpy.txt
+# numpy based on python version and NEP-29 requirements
+numpy; python_version == '3.10'
+numpy; python_version == '3.11'
+numpy~=1.21.0; python_version == '3.9'
+numpy~=1.20.0; python_version == '3.8'
 
 # image testing
 scipy==1.10.0


### PR DESCRIPTION
Slight tweak to dependabot to ensure it does not attempt to update numpy