### PR TITLE
rename "method" to "use_array" and make it keyword only

### DIFF
--- a/pyqtgraph/Qt/internals.py
+++ b/pyqtgraph/Qt/internals.py
@@ -75,6 +75,9 @@ def get_qpainterpath_element_array(qpath, nelems=None):
     return np.frombuffer(vp, dtype=dtype)
 
 class PrimitiveArray:
+    # Note: This class is an internal implementation detail and is not part
+    #       of the public API.
+    #
     # QPainter has a C++ native API that takes an array of objects:
     #   drawPrimitives(const Primitive *array, int count, ...)
     # where "Primitive" is one of QPointF, QLineF, QRectF, PixmapFragment
@@ -95,30 +98,30 @@ class PrimitiveArray:
     # C array of PixmapFragment(s) _and_ the length of the array.
     # There is no overload that takes a Python list of PixmapFragment(s).
 
-    def __init__(self, Klass, nfields, method=None):
+    def __init__(self, Klass, nfields, *, use_array=None):
         self._Klass = Klass
         self._nfields = nfields
         self._ndarray = None
 
         if QT_LIB.startswith('PyQt'):
-            if method is None:
-                method = (
+            if use_array is None:
+                use_array = (
                     hasattr(sip, 'array') and
                     (
                         (0x60301 <= QtCore.PYQT_VERSION) or
                         (0x50f07 <= QtCore.PYQT_VERSION < 0x60000)
                     )
                 )
-            self.use_sip_array = method
+            self.use_sip_array = use_array
         else:
             self.use_sip_array = False
 
         if QT_LIB.startswith('PySide'):
-            if method is None:
-                method = (
+            if use_array is None:
+                use_array = (
                     Klass is QtGui.QPainter.PixmapFragment
                 )
-            self.use_ptr_to_array = method
+            self.use_ptr_to_array = use_array
         else:
             self.use_ptr_to_array = False
 

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -39,16 +39,16 @@ _have_native_drawlines_array = Qt.QT_LIB.startswith('PySide') and have_native_dr
 
 class LineSegments:
     def __init__(self):
-        method = None
+        use_array = None
 
         # "use_native_drawlines" is pending the following issue and code review
         # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-1924
         # https://codereview.qt-project.org/c/pyside/pyside-setup/+/415702
         self.use_native_drawlines = Qt.QT_LIB.startswith('PySide') and _have_native_drawlines_array
         if self.use_native_drawlines:
-            method = True
+            use_array = True
 
-        self.array = Qt.internals.PrimitiveArray(QtCore.QLineF, 4, method=method)
+        self.array = Qt.internals.PrimitiveArray(QtCore.QLineF, 4, use_array=use_array)
 
     def get(self, size):
         self.array.resize(size)


### PR DESCRIPTION
Even though PrimitiveArray is not public facing API, its `__init__` argument "`method : bool`" was not named correctly.

This rename was originally meant to be part of #2596, but as #2596 needs more testing, the rename is extracted out to get it in before the next release.


