### PR TITLE
ImageView: make .nframes() to use .axis['t'] instead of .shape[0]

### DIFF
--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -473,8 +473,9 @@ class ImageView(QtWidgets.QWidget):
         """
         if self.image is None:
             return 0
-        else:
-            return self.image.shape[0]
+        elif self.axes['t'] is not None:
+            return self.image.shape[self.axes['t']]
+        return 1
 
     def autoLevels(self):
         """Set the min/max intensity levels automatically to match the image data."""


### PR DESCRIPTION
BUG-FIX:
This is fixing the behavior of ImageView for 3 dimensional images, where stacking of images or time frames are not at commonly expected 0'th index of arrays shape. Using hard-coded image.shape[0] causes the progress of play stop at such index if image.shape[0] is smaller than the shape at index set for axis t.

Alternatively, would not it be better to remove this method and use where needed `self.tVals.shape[0]` ? From performance point of view that would be probably better, but seeing the checking `if self.image is None:` probably there is an external reason for cases where would be 0 frames (in the end this method is public and could be called externally). Thus I had added at the end the additional case  returning `1` when there is single frame and so `nframes()` should cover all possible cases also then called externally.

Minimal Code to reproduce the BUG:
```python
import numpy as np
import pyqtgraph as pg

app = pg.Qt.App([])

imv = pg.ImageView()
data = (np.random.random((16,16,32)) * 254).astype(np.uint8) # x,y,z

imv.setImage(data, axes={"t": 2, "x": 0, "y": 1})
imv.show()
print(imv.nframes())
imv.play(4)
```
`.play()` or keyboard keys will go as far as 16 slice, because `nframes()` returns `image.shape[0]` which is 16.

also

```python
import numpy as np
import pyqtgraph as pg

app = pg.Qt.App([])

imv = pg.ImageView()
data = (np.random.random((16,16)) * 254).astype(np.uint8) # x,y

imv.setImage(data, axes={"x": 0, "y": 1})
imv.show()
print(imv.nframes())
```
will print 16, and there is only 1 frame.

This bug-fix makes the first example to play to the end, and second example to correctly return `1` as number of frames