### PR TITLE
don't use pg.plot() in tests

### DIFF
--- a/tests/exporters/test_csv.py
+++ b/tests/exporters/test_csv.py
@@ -17,7 +17,8 @@ def approxeq(a, b):
 
 
 def test_CSVExporter():
-    plt = pg.plot()
+    plt = pg.PlotWidget()
+    plt.show()
     y1 = [1,3,2,3,1,6,9,8,4,2]
     plt.plot(y=y1, name='myPlot')
 
@@ -55,7 +56,8 @@ def test_CSVExporter():
             assert (i >= len(y3) and vals[5] == '') or approxeq(float(vals[5]), y3[i])
 
 def test_CSVExporter_with_ErrorBarItem():
-    plt = pg.plot()
+    plt = pg.PlotWidget()
+    plt.show()
     x=np.arange(5)
     y=np.array([1, 2, 3, 2, 1])
     top_error = np.array([2, 3, 3, 3, 2])

--- a/tests/exporters/test_hdf5.py
+++ b/tests/exporters/test_hdf5.py
@@ -21,7 +21,8 @@ def test_HDF5Exporter(tmp_h5, combine):
     y1 = np.sin(x)
     y2 = np.cos(x)
 
-    plt = pg.plot()
+    plt = pg.PlotWidget()
+    plt.show()
     plt.plot(x=x, y=y1)
     plt.plot(x=x, y=y2)
 
@@ -51,7 +52,8 @@ def test_HDF5Exporter_unequal_lengths(tmp_h5):
     x2 = np.linspace(0, 1, 100)
     y2 = np.cos(x2)
 
-    plt = pg.plot()
+    plt = pg.PlotWidget()
+    plt.show()
     plt.plot(x=x1, y=y1, name='plot0')
     plt.plot(x=x2, y=y2)
 

--- a/tests/exporters/test_image.py
+++ b/tests/exporters/test_image.py
@@ -11,13 +11,15 @@ app = pg.mkQApp()
 def test_ImageExporter_filename_dialog():
     """Tests ImageExporter code path that opens a file dialog. Regression test
     for pull request 1133."""
-    p = pg.plot()
+    p = pg.PlotWidget()
+    p.show()
     exp = ImageExporter(p.getPlotItem())
     exp.export()
 
 
 def test_ImageExporter_toBytes():
-    p = pg.plot()
+    p = pg.PlotWidget()
+    p.show()
     p.hideAxis('bottom')
     p.hideAxis('left')
     exp = ImageExporter(p.getPlotItem())

--- a/tests/exporters/test_matplotlib.py
+++ b/tests/exporters/test_matplotlib.py
@@ -33,7 +33,8 @@ if (
 
 @skip_qt6
 def test_MatplotlibExporter():
-    plt = pg.plot()
+    plt = pg.PlotWidget()
+    plt.show()
 
     # curve item
     plt.plot([0, 1, 2], [0, 1, 2])
@@ -48,7 +49,8 @@ def test_MatplotlibExporter():
 @skip_qt6
 def test_MatplotlibExporter_nonplotitem():
     # attempting to export something other than a PlotItem raises an exception
-    plt = pg.plot()
+    plt = pg.PlotWidget()
+    plt.show()
     plt.plot([0, 1, 2], [2, 3, 4])
     exp = MatplotlibExporter(plt.getPlotItem().getViewBox())
     with pytest.raises(Exception):
@@ -59,7 +61,9 @@ def test_MatplotlibExporter_nonplotitem():
 def test_MatplotlibExporter_siscale(scale):
     # coarse test to verify that plot data is scaled before export when
     # autoSIPrefix is in effect (so mpl doesn't add its own multiplier label)
-    plt = pg.plot([0, 1, 2], [(i+1)*scale for i in range(3)])
+    plt = pg.PlotWidget()
+    plt.show()
+    plt.plot([0, 1, 2], [(i+1)*scale for i in range(3)])
     # set the label so autoSIPrefix works
     plt.setLabel('left', 'magnitude')
     exp = MatplotlibExporter(plt.getPlotItem())

--- a/tests/graphicsItems/test_ImageItem.py
+++ b/tests/graphicsItems/test_ImageItem.py
@@ -230,11 +230,18 @@ def test_setRect():
 
 
 def test_dividebyzero():
-    im = pg.image(np.random.normal(size=(100,100)))
-    im.imageItem.setAutoDownsample(True)
-    im.view.setRange(xRange=[-5+25, 5e+25],yRange=[-5e+25, 5e+25])
-    app.processEvents()
-    QtTest.QTest.qWait(1000)
-    # must manually call im.imageItem.render here or the exception
+    # test that the calculation of downsample factors
+    # does not result in a division by zero
+    plt = pg.PlotWidget()
+    plt.show()
+    plt.setAspectLocked(True)
+    imgitem = pg.ImageItem(np.random.normal(size=(100,100)))
+    imgitem.setAutoDownsample(True)
+    plt.addItem(imgitem)
+
+    plt.setRange(xRange=[-5e+25, 5e+25],yRange=[-5e+25, 5e+25])
+    QtTest.QTest.qWaitForWindowExposed(plt)
+    QtTest.QTest.qWait(100)
+    # must manually call imgitem.render here or the exception
     # will only exist on the Qt event loop
-    im.imageItem.render()
+    imgitem.render()

--- a/tests/graphicsItems/test_InfiniteLine.py
+++ b/tests/graphicsItems/test_InfiniteLine.py
@@ -10,7 +10,8 @@ def test_InfiniteLine():
     pg.setConfigOption('mouseRateLimit', -1)
 
     # Test basic InfiniteLine API
-    plt = pg.plot()
+    plt = pg.PlotWidget()
+    plt.show()
     plt.setXRange(-10, 10)
     plt.setYRange(-10, 10)
     plt.resize(600, 600)
@@ -54,7 +55,8 @@ def test_mouseInteraction():
     # disable delay of mouse move events because events is called immediately in test
     pg.setConfigOption('mouseRateLimit', -1)
 
-    plt = pg.plot()
+    plt = pg.PlotWidget()
+    plt.show()
     plt.scene().minDragTime = 0  # let us simulate mouse drags very quickly.
     vline = plt.addLine(x=0, movable=True)
     hline = plt.addLine(y=0, movable=True)

--- a/tests/graphicsItems/test_ROI.py
+++ b/tests/graphicsItems/test_ROI.py
@@ -244,7 +244,6 @@ def test_PolyLineROI():
          'open')
     ]
 
-    # plt = pg.plot()
     plt = pg.GraphicsView()
     plt.show()
     resizeWindow(plt, 200, 200)
@@ -347,7 +346,8 @@ def test_PolyLineROI():
     ((-2, 1), (-4, -8)),
 ])
 def test_LineROI_coords(p1, p2):
-    pw = pg.plot()
+    pw = pg.PlotWidget()
+    pw.show()
 
     lineroi = pg.LineROI(p1, p2, width=0.5, pen="r")
     pw.addItem(lineroi)

--- a/tests/graphicsItems/test_TextItem.py
+++ b/tests/graphicsItems/test_TextItem.py
@@ -4,7 +4,8 @@ app = pg.mkQApp()
 
 
 def test_TextItem_setAngle():
-    plt = pg.plot()
+    plt = pg.PlotWidget()
+    plt.show()
     plt.setXRange(-10, 10)
     plt.setYRange(-20, 20)
     item = pg.TextItem(text="test")

--- a/tests/imageview/test_imageview.py
+++ b/tests/imageview/test_imageview.py
@@ -8,10 +8,12 @@ app = pg.mkQApp()
 def test_nan_image():
     img = np.ones((10,10))
     img[0,0] = np.nan
-    v = pg.image(img)
-    v.imageItem.getHistogram()
+    iv = pg.ImageView()
+    iv.setImage(img)
+    iv.show()
+    iv.getImageItem().getHistogram()
     app.processEvents()
-    v.window().close()
+    iv.window().close()
 
 
 def test_timeslide_snap():


### PR DESCRIPTION
There seems to be a new recurring CI segfault on macOS / Python 3.8 / PySide2 5.15.

This PR seems to help to prevent it from happening.

`pg.plot()` and `pg.image()` will keep a permanent global reference to their created `PlotWidget` and `ImageView`.
This may be a convenience for interactive use, but not suitable for CI where a great many plots are instantiated.
