### PR TITLE
Return float values from QColor in getByIndex

### DIFF
--- a/pyqtgraph/colormap.py
+++ b/pyqtgraph/colormap.py
@@ -622,7 +622,7 @@ class ColorMap(object):
 
     def getByIndex(self, idx):
         """Retrieve a QColor by the index of the stop it is assigned to."""
-        return QtGui.QColor( *self.color[idx] )
+        return QtGui.QColor.fromRgbF( *self.color[idx] )
 
     def getGradient(self, p1=None, p2=None):
         """

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -1,3 +1,4 @@
+import PySide6
 import pytest
 
 import pyqtgraph as pg
@@ -74,3 +75,8 @@ def test_ColorMap_getColors(color_list):
     colors = cm.getColors('qcolor')
     for actual, good in zip(colors, qcols):
         assert actual.getRgbF() == good.getRgbF()
+
+def test_ColorMap_getByIndex():
+    cm = pg.ColorMap([0.0, 1.0], [(0,0,0), (255,0,0)])
+    assert cm.getByIndex(0) == PySide6.QtGui.QColor.fromRgbF(0.0, 0.0, 0.0, 1.0)
+    assert cm.getByIndex(1) == PySide6.QtGui.QColor.fromRgbF(1.0, 0.0, 0.0, 1.0)

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -1,4 +1,3 @@
-import PySide6
 import pytest
 
 import pyqtgraph as pg
@@ -78,5 +77,5 @@ def test_ColorMap_getColors(color_list):
 
 def test_ColorMap_getByIndex():
     cm = pg.ColorMap([0.0, 1.0], [(0,0,0), (255,0,0)])
-    assert cm.getByIndex(0) == PySide6.QtGui.QColor.fromRgbF(0.0, 0.0, 0.0, 1.0)
-    assert cm.getByIndex(1) == PySide6.QtGui.QColor.fromRgbF(1.0, 0.0, 0.0, 1.0)
+    assert cm.getByIndex(0) == QtGui.QColor.fromRgbF(0.0, 0.0, 0.0, 1.0)
+    assert cm.getByIndex(1) == QtGui.QColor.fromRgbF(1.0, 0.0, 0.0, 1.0)


### PR DESCRIPTION
Make `ColorMap_getByIndex` return floats for RGB values to fit expectations.

Fixes #2627 
