### PR TITLE
GLViewWidget: don't assume mouse tracking is disabled

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -418,12 +418,10 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
         xDist = dist * 2. * tan(0.5 * radians(self.opts['fov']))
         return xDist / self.width()
         
-    def mousePressEvent(self, ev):
-        lpos = ev.position() if hasattr(ev, 'position') else ev.localPos()
-        self.mousePos = lpos
-        
     def mouseMoveEvent(self, ev):
         lpos = ev.position() if hasattr(ev, 'position') else ev.localPos()
+        if not hasattr(self, 'mousePos'):
+            self.mousePos = lpos
         diff = lpos - self.mousePos
         self.mousePos = lpos
         


### PR DESCRIPTION
In `mouseMoveEvent`, it is assumed that `self.mousePos` has already been set. This amounts to assuming that there is at least one `mousePressEvent` prior to `mouseMoveEvent`.

This amounts to assuming that mouse tracking is left at its default disabled state.

This PR removes this assumption and simplifies the code by removing the `mousePressEvent` handler altogether.

Relevant documentation: https://doc.qt.io/qt-6/qwidget.html#mouseMoveEvent
"If mouse tracking is switched off, mouse move events only occur if a mouse button is pressed while the mouse is being moved. If mouse tracking is switched on, mouse move events occur even if no mouse button is pressed."

This is partially related to the `GLViewWindow` implementation in #2650. In a `QOpenGLWindow`, there is no mouse tracking enable/disable.