### PR TITLE
re-enable tests taking gui thread on PySide6

### DIFF
--- a/tests/widgets/test_busycursor.py
+++ b/tests/widgets/test_busycursor.py
@@ -8,7 +8,7 @@ pg.mkQApp()
 @pytest.mark.skipif(
     sys.platform.startswith("linux")
     and pg.Qt.QT_LIB == "PySide6"
-    and pg.Qt.PySide6.__version_info__ > (6, 0),
+    and (6, 0) < pg.Qt.PySide6.__version_info__ < (6, 4, 3),
     reason="taking gui thread causes segfault"
 )
 def test_nested_busy_cursors_clear_after_all_exit():

--- a/tests/widgets/test_progressdialog.py
+++ b/tests/widgets/test_progressdialog.py
@@ -8,7 +8,7 @@ pg.mkQApp()
 @pytest.mark.skipif(
     sys.platform.startswith("linux")
     and pg.Qt.QT_LIB == "PySide6"
-    and pg.Qt.PySide6.__version_info__ > (6, 0),
+    and (6, 0) < pg.Qt.PySide6.__version_info__ < (6, 4, 3),
     reason="taking gui thread causes segfault"
 )
 def test_progress_dialog():


### PR DESCRIPTION
https://bugreports.qt.io/browse/PYSIDE-2254 was fixed, so the tests that involve taking the gui thread can be enabled.

Fixes #2520
