### PR TITLE
Tolerate an empty BarGraphItem

### DIFF
--- a/pyqtgraph/graphicsItems/BarGraphItem.py
+++ b/pyqtgraph/graphicsItems/BarGraphItem.py
@@ -185,6 +185,11 @@ class BarGraphItem(GraphicsObject):
 
     def _prepareData(self):
         x0, y0, x1, y1 = self._getNormalizedCoords()
+        if x0.size == 0 or y0.size == 0:
+            self._dataBounds = (None, None), (None, None)
+            self._rectarray.resize(0)
+            return
+
         xmn, xmx = np.min(x0), np.max(x1)
         ymn, ymx = np.min(y0), np.max(y1)
         self._dataBounds = (xmn, xmx), (ymn, ymx)
@@ -266,6 +271,9 @@ class BarGraphItem(GraphicsObject):
         pw = self._penWidth[0] * 0.5
         # _dataBounds is available after _prepareData()
         bounds = self._dataBounds[ax]
+        if bounds[0] is None or bounds[1] is None:
+            return None, None
+
         return (bounds[0] - pw, bounds[1] + pw)
 
     def pixelPadding(self):


### PR DESCRIPTION
Sometimes, it is useful to be able to create an empty BarGraphItem to be populated later using setOpts, like

bg = pg.BarGraphItem(
    x0=[], height=[], y0=[], width=[],
    pen=...,
    brush=...
)

Avoid NumPy ValueError when computing np.max/min from and empty array in this case.

Detail the reasoning behind the code change.  If there is an associated issue that this PR will resolve add

Fixes #<IssueNumber>

### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [ ] `README.md`
- [ ] `setup.py`
- [ ] `tox.ini`
- [ ] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [ ] `pyproject.toml`
- [ ] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
