### PR TITLE
refactor GLViewWidget code into GLViewMixin

### DIFF
--- a/doc/source/api_reference/3dgraphics/glviewwidget.rst
+++ b/doc/source/api_reference/3dgraphics/glviewwidget.rst
@@ -3,5 +3,19 @@ GLViewWidget
 
 .. autoclass:: pyqtgraph.opengl.GLViewWidget
     :members:
+    :show-inheritance:
+    :inherited-members: QOpenGLWidget
 
     .. automethod:: pyqtgraph.opengl.GLViewWidget.__init__
+
+
+.. autoclass:: pyqtgraph.opengl.GLViewWidget::GLViewMixin
+
+    .. warning:: The intention of this class is to provide users who want to use
+        ``QOpenGLWindow`` instead of ``QOpenGLWidget`` but retain the benefits of
+        ``GLViewWidget``. Usage of this class should be considered experimental
+        for the time being as it may change without warning in future releases.
+
+    :members:
+
+    .. automethod:: pyqtgraph.opengl.GLViewWidget::GLViewMixin.__init__

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -9,31 +9,18 @@ from .. import functions as fn
 from .. import getConfigOption
 from ..Qt import QtCore, QtGui, QtWidgets
 
-##Vector = QtGui.QVector3D
-
-
-class GLViewWidget(QtWidgets.QOpenGLWidget):
-    
-    def __init__(self, parent=None, devicePixelRatio=None, rotationMethod='euler'):
-        """    
-        Basic widget for displaying 3D data
-          - Rotation/scale controls
-          - Axis/grid display
-          - Export options
+class GLViewMixin:
+    def __init__(self, *args, rotationMethod='euler', **kwargs):
+        """
+        Mixin class providing functionality for GLViewWidget
 
         ================ ==============================================================
         **Arguments:**
-        parent           (QObject, optional): Parent QObject. Defaults to None.
-        devicePixelRatio No longer in use. High-DPI displays should automatically
-                         detect the correct resolution.
-        rotationMethod   (str): Mechanimsm to drive the rotation method, options are 
+        rotationMethod   (str): Mechanism to drive the rotation method, options are
                          'euler' and 'quaternion'. Defaults to 'euler'.
         ================ ==============================================================
         """
-
-        QtWidgets.QOpenGLWidget.__init__(self, parent)
-        
-        self.setFocusPolicy(QtCore.Qt.FocusPolicy.ClickFocus)
+        super().__init__(*args, **kwargs)
 
         if rotationMethod not in ["euler", "quaternion"]:
             raise ValueError("Rotation method should be either 'euler' or 'quaternion'")
@@ -572,3 +559,24 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
                 glDeleteRenderbuffers(1, [depth_buf])
 
         return output
+
+
+class GLViewWidget(GLViewMixin, QtWidgets.QOpenGLWidget):
+    def __init__(self, *args, devicePixelRatio=None, **kwargs):
+        """
+        Basic widget for displaying 3D data
+          - Rotation/scale controls
+          - Axis/grid display
+          - Export options
+
+        ================ ==============================================================
+        **Arguments:**
+        parent           (QObject, optional): Parent QObject. Defaults to None.
+        devicePixelRatio No longer in use. High-DPI displays should automatically
+                         detect the correct resolution.
+        rotationMethod   (str): Mechanism to drive the rotation method, options are
+                         'euler' and 'quaternion'. Defaults to 'euler'.
+        ================ ==============================================================
+        """
+        super().__init__(*args, **kwargs)
+        self.setFocusPolicy(QtCore.Qt.FocusPolicy.ClickFocus)


### PR DESCRIPTION
Some less-often used features of GLViewWidget no longer work with QOpenGLWidget but do work with QOpenGLWindow. This code factors out the "meat" of GLViewWidget into GLViewMixin so that users can more easily inherit from it to use with QOpenGLWindow.

Sample usage:
```python
import importlib
import pyqtgraph as pg
import pyqtgraph.opengl as gl
from pyqtgraph.Qt import QT_LIB, QtWidgets
from pyqtgraph.opengl.GLViewWidget import GLViewMixin
QtOpenGL = importlib.import_module(f'{QT_LIB}.QtOpenGL')    # Qt6
import numpy as np

class GLViewWindow(GLViewMixin, QtOpenGL.QOpenGLWindow):
    def mouseReleaseEvent(self, ev):
        lpos = ev.position() if hasattr(ev, 'position') else ev.localPos()
        region = [lpos.x()-5, lpos.y()-5, 10, 10]
        # itemsAt seems to take in device pixels
        dpr = self.devicePixelRatioF()
        region = tuple([x * dpr for x in region])
        items = self.itemsAt(region)
        for item in items:
            print(item.objectName())

        if items:
            self.makeCurrent()
            ctx = self.context()
            x, y, w, h = region
            region = (x, self.deviceHeight()-(y+h), w, h)
            self.paintGL(region=region)
            ctx.swapBuffers(ctx.surface())

pg.mkQApp()

glv = GLViewWindow()
glv.setCameraParams(elevation=90, azimuth=-90, distance=50)
# X points right, Y points up
glv.show()
container = QtWidgets.QWidget.createWindowContainer(glv)
container.show()

side = 8
names = ['red', 'green', 'blue']
for idx, name in enumerate(names):
    box = np.zeros((side, side, 4), dtype=np.uint8)
    box[..., [idx, 3]] = 255
    img = gl.GLImageItem(box)
    img.setObjectName(name)
    img.translate(-side/2, -side/2, 0)  # center the box
    img.translate((idx-1)*side*2, (idx-1)*side*1, 0)
    glv.addItem(img)

pg.exec()
```

### Non-satisfactory parts 

<details>

- [x] docstrings now belong to GLViewMixin.
- [x] we don't really want to support GLViewMixin. It's a use as-is if you want class.
- [X] it would break any existing code that sub-classes from the old GLViewWidget, since the `__init__` methods have to be called manually

</details>


