### PR TITLE
inherit GraphicsWidgetAnchor on the left-hand-side

### DIFF
--- a/pyqtgraph/graphicsItems/LabelItem.py
+++ b/pyqtgraph/graphicsItems/LabelItem.py
@@ -6,7 +6,7 @@ from .GraphicsWidgetAnchor import GraphicsWidgetAnchor
 
 __all__ = ['LabelItem']
 
-class LabelItem(GraphicsWidget, GraphicsWidgetAnchor):
+class LabelItem(GraphicsWidgetAnchor, GraphicsWidget):
     """
     GraphicsWidget displaying text.
     Used mainly as axis labels, titles, etc.

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -14,7 +14,7 @@ from .ScatterPlotItem import ScatterPlotItem, drawSymbol
 __all__ = ['LegendItem', 'ItemSample']
 
 
-class LegendItem(GraphicsWidget, GraphicsWidgetAnchor):
+class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
     """
     Displays a legend used for describing the contents of a plot.
 

--- a/pyqtgraph/graphicsItems/ScaleBar.py
+++ b/pyqtgraph/graphicsItems/ScaleBar.py
@@ -8,7 +8,7 @@ from .TextItem import TextItem
 
 __all__ = ['ScaleBar']
 
-class ScaleBar(GraphicsObject, GraphicsWidgetAnchor):
+class ScaleBar(GraphicsWidgetAnchor, GraphicsObject):
     """
     Displays a rectangular bar to indicate the relative scale of objects on the view.
     """


### PR DESCRIPTION
Following the merge of https://code.qt.io/cgit/pyside/pyside-setup.git/commit/?id=e8095467f7d0332cc0987e7c541de9906e19fece slated for PySide6 6.5, inheriting `GraphicsWidgetAnchor` on the right-hand-side no longer works.

In fact, since PyQt{5,6} do implement cooperative inheritance, then the previous implementation of inheriting `GraphicsWidgetAnchor` on the right-hand-side would be wrong. i.e. `GraphicsWidgetAnchor::__init__` was being called twice on PyQt{5,6}. (Indeed, adding simple print statements shows that it was being called twice on PyQt{5,6}
There is a `connect` statement in `GraphicsWidgetAnchor::__init__`, which would make calling it multiple times *not* harmless.

Note: `GraphicsWidgetAnchor` as a mixin should be inherited on the left-hand-side.