### PR TITLE
ensure BarGraphItem works with empty arrays

### DIFF
--- a/pyqtgraph/graphicsItems/BarGraphItem.py
+++ b/pyqtgraph/graphicsItems/BarGraphItem.py
@@ -185,8 +185,8 @@ class BarGraphItem(GraphicsObject):
 
     def _prepareData(self):
         x0, y0, x1, y1 = self._getNormalizedCoords()
-        xmn, xmx = np.min(x0), np.max(x1)
-        ymn, ymx = np.min(y0), np.max(y1)
+        xmn, xmx = (np.min(x0), np.max(x1)) if x0.size and x1.size else (0, 0)
+        ymn, ymx = (np.min(y0), np.max(y1)) if y0.size and y1.size else (0, 0)
         self._dataBounds = (xmn, xmx), (ymn, ymx)
 
         self._rectarray.resize(max(x0.size, y0.size))


### PR DESCRIPTION
BarGraphItem does not work with empty (zero-size) arrays anymore. This is a problem if data is generated during runtime, but the plot shall always be visible, i.e., even without data.

Cause: np.min/max in _prepareData requires non-empty arrays

Solution: check for empty arrays and if so assign (0, 0)


### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [x] `README.md`
- [x] `setup.py`
- [x] `tox.ini`
- [x] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [x] `pyproject.toml`
- [x] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
