### PR TITLE
ViewBoxMenu: remove unused empty WidgetGroup

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -20,6 +20,7 @@ class ViewBoxMenu(QtWidgets.QMenu):
         self.addAction(self.viewAll)
         
         self.ctrl = []
+        self.widgetGroups = []
         self.dv = QtGui.QDoubleValidator(self)
         for axis in 'XY':
             m = self.addMenu(f"{axis} {translate('ViewBox', 'axis')}")
@@ -30,6 +31,7 @@ class ViewBoxMenu(QtWidgets.QMenu):
             a.setDefaultWidget(w)
             m.addAction(a)
             self.ctrl.append(ui)
+            self.widgetGroups.append(w)
             
             connects = [
                 (ui.mouseCheck.toggled, 'MouseToggled'),

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -20,7 +20,6 @@ class ViewBoxMenu(QtWidgets.QMenu):
         self.addAction(self.viewAll)
         
         self.ctrl = []
-        self.widgetGroups = []
         self.dv = QtGui.QDoubleValidator(self)
         for axis in 'XY':
             m = self.addMenu(f"{axis} {translate('ViewBox', 'axis')}")
@@ -31,8 +30,6 @@ class ViewBoxMenu(QtWidgets.QMenu):
             a.setDefaultWidget(w)
             m.addAction(a)
             self.ctrl.append(ui)
-            wg = WidgetGroup(w)
-            self.widgetGroups.append(wg)
             
             connects = [
                 (ui.mouseCheck.toggled, 'MouseToggled'),


### PR DESCRIPTION
This PR removes the unused instantiated `WidgetGroup`s from ViewBoxMenu.
In fact, until less than a year ago (74fa36da37d36a3da52019f673898ff0fe165de0), the (unused) instantiated `WidgetGroup`s were not even stored.
