### PR TITLE
Add libxcb-cursor0 to CI so Qt 6.5 works.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,8 @@ jobs:
           libxcb-randr0 \
           libxcb-render-util0 \
           libxcb-xinerama0 \
-          libopengl0
+          libopengl0 \
+          libxcb-cursor0
     - name: 'Debug Info'
       run: |
         echo python location: `which python`
@@ -204,7 +205,8 @@ jobs:
             libxcb-randr0 \
             libxcb-render-util0 \
             libxcb-xinerama0 \
-            libopengl0
+            libopengl0 \
+            libxcb-cursor0
           pip install pytest-xvfb
       - name: 'Debug Info'
         run: |


### PR DESCRIPTION
Address xcb issue with pyside6 6.5/Qt 6.5

Fix in this case was kindly shared to us by @ksunden  https://github.com/matplotlib/matplotlib/pull/25619/files