### PR TITLE
Avoid changing background colors of text and rows for group parameter…

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -337,22 +337,11 @@ class GroupParameterItem(ParameterItem):
         """
         Change set the item font to bold and increase the font size on outermost groups.
         """
-        app = mkQApp()
-        palette = app.palette()
-        background = palette.base().color()
-        h, s, l, a = background.getHslF()
-        lightness = 0.5 + (l - 0.5) * .8
-        altBackground = QtGui.QColor.fromHslF(h, s, lightness, a)
-
         for c in [0, 1]:
             font = self.font(c)
             font.setBold(True)
             if depth == 0:
                 font.setPointSize(self.pointSize() + 1)
-                self.setBackground(c, background)
-            else:
-                self.setBackground(c, altBackground)
-            self.setForeground(c, palette.text().color())
             self.setFont(c, font)
         self.titleChanged()  # sets the size hint for column 0 which is based on the new font
 


### PR DESCRIPTION
Most themes (including defaults on windows and gnome) use alternating colors for each table row. Current styling doesn't play nice with this assumption

This PR simply removes row and font coloring to avoid those difficulties:
![image](https://user-images.githubusercontent.com/23620506/231036799-348ef7c7-e957-4ac7-af0b-2dba2c84766f.png)

Note that in the "before" samples (before this PR), the colors don't match on alternate rows, styling doesn't stand out very well, and (importantly) on some popular styling choices (there are more on GH), the text isn't properly changed and appears as very low contrast against the background.

I feel this is sufficient reason to restrain from changing background colors. I tested on a few more themes without screenshots, but I don't think there are any cases where the PR causes a _worse_ appearance. Notably, `qt-material` isn't happy either way, but the problem doesn't get exacerbated with these changes.