### PR TITLE
Allow macOS to have fudge factor in test_polyROI

### DIFF
--- a/tests/graphicsItems/test_ROI.py
+++ b/tests/graphicsItems/test_ROI.py
@@ -3,6 +3,7 @@ import platform
 
 import numpy as np
 import pytest
+from packaging.version import Version, parse
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui, QtTest
@@ -326,8 +327,12 @@ def test_PolyLineROI():
 
         # call setPoints
         r.setPoints(initState['points'])
-        assertImageApproved(plt, 'roi/polylineroi/' + name + '_setpoints',
-                            'Reset points to initial state.')
+        assertImageApproved(
+            plt,
+            f'roi/polylineroi/{name}_setpoints',
+            'Reset points to initial state.',
+            pxCount=1 if platform.system() == "Darwin" and parse(platform.mac_ver()[0]) >= Version("13.0") else 0
+        )
         assert len(r.getState()['points']) == 3
 
         # call setState


### PR DESCRIPTION
I noticed a test failure locally when I tested after PyQt6 6.5 was released, it turned out to be a macOS issue, not a Qt version issue.  Not sure when this test started failing, but the current macOS CI runs on macOS 12, whereas I have macOS 13.3.1 on my machine right now.