### PR TITLE
Only apply nan mask workaround for cp version below 10.0.

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1533,7 +1533,7 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False, maskNans=Tr
     if nanMask is not None:
         alpha = True
         # Workaround for https://github.com/cupy/cupy/issues/4693, fixed in cupy 10.0.0
-        if xp == cp and StrictVersion(xp.__version__) < StrictVersion("10.0.0"):
+        if xp == cp and tuple(map(int, cp.__version__.split("."))) < (10, 0):
             imgData[nanMask, :, dst_order[3]] = 0
         else:
             imgData[nanMask, dst_order[3]] = 0

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -13,6 +13,7 @@ import struct
 import sys
 import warnings
 from collections import OrderedDict
+from distutils.version import StrictVersion
 
 import numpy as np
 
@@ -1531,8 +1532,8 @@ def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False, maskNans=Tr
     # apply nan mask through alpha channel
     if nanMask is not None:
         alpha = True
-        # Workaround for https://github.com/cupy/cupy/issues/4693
-        if xp == cp:
+        # Workaround for https://github.com/cupy/cupy/issues/4693, fixed in cupy 10.0.0
+        if xp == cp and StrictVersion(xp.__version__) < StrictVersion("10.0.0"):
             imgData[nanMask, :, dst_order[3]] = 0
         else:
             imgData[nanMask, dst_order[3]] = 0

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -13,7 +13,6 @@ import struct
 import sys
 import warnings
 from collections import OrderedDict
-from distutils.version import StrictVersion
 
 import numpy as np
 


### PR DESCRIPTION
In [#1595](https://github.com/pyqtgraph/pyqtgraph/pull/1595) a workaround was introduced for masking NaNs in cupy arrays, because the indexing is different than for numpy arrays. As of cupy version 10.0.0 the indexing can be done the same for numpy and cupy arrays again (see cupy PR [#6196](https://github.com/cupy/cupy/pull/6196)) and the workaround causes issues. This is solved by only applying the workaround if the cupy version is lower then 10.0.0. In the future the workaround can be moved completely.

Fixes [#1595](https://github.com/pyqtgraph/pyqtgraph/pull/1595)