### PR TITLE
WidgetGroup: avoid lambda by using self.sender()

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
           miniforge-variant: Mambaforge
           environment-file: ${{ matrix.environment-file }}
           auto-update-conda: false
-          python-version: "3.11"
+          python-version: "3.10"
           use-mamba: true
       - name: "Install Test Framework"
         run: pip install pytest pytest-xdist

--- a/pyqtgraph/WidgetGroup.py
+++ b/pyqtgraph/WidgetGroup.py
@@ -172,7 +172,7 @@ class WidgetGroup(QtCore.QObject):
         if signal is not None:
             if inspect.isfunction(signal) or inspect.ismethod(signal):
                 signal = signal(w)
-            signal.connect(self.mkChangeCallback(w))
+            signal.connect(self.widgetChanged)
         else:
             self.uncachedWidgets[w] = None
        
@@ -217,10 +217,8 @@ class WidgetGroup(QtCore.QObject):
         self.scales[widget] = scale
         self.setWidget(widget, val)
 
-    def mkChangeCallback(self, w):
-        return lambda *args: self.widgetChanged(w, *args)
-        
-    def widgetChanged(self, w, *args):
+    def widgetChanged(self, *args):
+        w = self.sender()
         n = self.widgetList[w]
         v1 = self.cache[n]
         v2 = self.readWidget(w)


### PR DESCRIPTION
workaround #2672 by avoiding the mechanism triggering the leak in PySide6 6.5.0 

1) `WidgetGroup` was creating lambda closures with references to both `self` and `widget`.
   * This is a bad practice and should be avoided.
   * However, prior to PySide6 6.5.0, this didn't cause a leak. (although it would not have been surprising if it had!)
2) https://github.com/pyqtgraph/pyqtgraph/issues/2672#issuecomment-1507056182 demonstrates that the leak occurs even with a lambda that has no closures.
   * i.e. various techniques using weakrefs would still have leaked
   * further testing shows that using custom `def` functions (with no closures) also leaks
3) The whole reason for the closure was to pass in an argument that would allow identification of the widget emitting the signal. This identification can be done with `QObject::sender` (https://doc.qt.io/qt-6/qobject.html#sender) and avoids the closure.


