### PR TITLE
GLViewWidget: fix mouse pos jumps when mouse tracking is off

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -417,7 +417,11 @@ class GLViewWidget(QtWidgets.QOpenGLWidget):
             dist = (pos-cam).length()
         xDist = dist * 2. * tan(0.5 * radians(self.opts['fov']))
         return xDist / self.width()
-        
+
+    def mousePressEvent(self, ev):
+        lpos = ev.position() if hasattr(ev, 'position') else ev.localPos()
+        self.mousePos = lpos
+
     def mouseMoveEvent(self, ev):
         lpos = ev.position() if hasattr(ev, 'position') else ev.localPos()
         if not hasattr(self, 'mousePos'):


### PR DESCRIPTION
This PR fixes a bug caused by #2653 and reported in https://github.com/pyqtgraph/pyqtgraph/pull/2653#issuecomment-1514535680

When mouse tracking is off, mouse move events are only delivered when the mouse button is pressed down.

Thus when the user releases the mouse button at position "A" and subsequently presses the mouse button at position "B", this results in the code seeing the mouse jump from "A" to "B".
If "A" and "B" are far apart, this results in a large panning or orbiting operation.