### PR TITLE
TypeError when using multiple pens for different lines

### DIFF
--- a/pyqtgraph/graphicsItems/GraphItem.py
+++ b/pyqtgraph/graphicsItems/GraphItem.py
@@ -108,16 +108,25 @@ class GraphItem(GraphicsObject):
             pts = self.pos[self.adjacency]
             pen = self.pen
             if isinstance(pen, np.ndarray):
-                lastPen = None
+                pen = lastPen = self.pen[0]
+                if pen.dtype.fields is None:
+                    p.setPen(
+                        fn.mkPen(color=(pen[0], pen[1], pen[2], pen[3]), width=1))
+                else:
+                    p.setPen(fn.mkPen(color=(
+                        pen['red'], pen['green'], pen['blue'], pen['alpha']), width=pen['width']))
                 for i in range(pts.shape[0]):
                     pen = self.pen[i]
                     if np.any(pen != lastPen):
                         lastPen = pen
                         if pen.dtype.fields is None:
-                            p.setPen(fn.mkPen(color=(pen[0], pen[1], pen[2], pen[3]), width=1))                            
+                            p.setPen(
+                                fn.mkPen(color=(pen[0], pen[1], pen[2], pen[3]), width=1))
                         else:
-                            p.setPen(fn.mkPen(color=(pen['red'], pen['green'], pen['blue'], pen['alpha']), width=pen['width']))
-                    p.drawLine(QtCore.QPointF(*pts[i][0]), QtCore.QPointF(*pts[i][1]))
+                            p.setPen(fn.mkPen(color=(
+                                pen['red'], pen['green'], pen['blue'], pen['alpha']), width=pen['width']))
+                    p.drawLine(QtCore.QPointF(
+                        *pts[i][0]), QtCore.QPointF(*pts[i][1]))
             else:
                 if pen == 'default':
                     pen = getConfigOption('foreground')

--- a/pyqtgraph/graphicsItems/GraphItem.py
+++ b/pyqtgraph/graphicsItems/GraphItem.py
@@ -108,25 +108,16 @@ class GraphItem(GraphicsObject):
             pts = self.pos[self.adjacency]
             pen = self.pen
             if isinstance(pen, np.ndarray):
-                pen = lastPen = self.pen[0]
-                if pen.dtype.fields is None:
-                    p.setPen(
-                        fn.mkPen(color=(pen[0], pen[1], pen[2], pen[3]), width=1))
-                else:
-                    p.setPen(fn.mkPen(color=(
-                        pen['red'], pen['green'], pen['blue'], pen['alpha']), width=pen['width']))
+                lastPen = None
                 for i in range(pts.shape[0]):
                     pen = self.pen[i]
-                    if np.any(pen != lastPen):
+                    if lastPen is None or np.any(pen != lastPen):
                         lastPen = pen
                         if pen.dtype.fields is None:
-                            p.setPen(
-                                fn.mkPen(color=(pen[0], pen[1], pen[2], pen[3]), width=1))
+                            p.setPen(fn.mkPen(color=(pen[0], pen[1], pen[2], pen[3]), width=1))                            
                         else:
-                            p.setPen(fn.mkPen(color=(
-                                pen['red'], pen['green'], pen['blue'], pen['alpha']), width=pen['width']))
-                    p.drawLine(QtCore.QPointF(
-                        *pts[i][0]), QtCore.QPointF(*pts[i][1]))
+                            p.setPen(fn.mkPen(color=(pen['red'], pen['green'], pen['blue'], pen['alpha']), width=pen['width']))
+                    p.drawLine(QtCore.QPointF(*pts[i][0]), QtCore.QPointF(*pts[i][1]))
             else:
                 if pen == 'default':
                     pen = getConfigOption('foreground')


### PR DESCRIPTION
```python
lastPen = None
for i in range(pts.shape[0]):
    pen = self.pen[i]
    if np.any(pen != lastPen):
```
comparison with None will always cause 
```
if np.any(pen != lastPen):
TypeError: Cannot compare structured or void to non-void arrays.
```
This does not really follow DRY principle but was the best solution I could come up with using static types in structured array

Detail the reasoning behind the code change.  If there is an associated issue that this PR will resolve add

Fixes #<IssueNumber>

### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [ ] `README.md`
- [ ] `setup.py`
- [ ] `tox.ini`
- [ ] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [ ] `pyproject.toml`
- [ ] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
