### PR TITLE
Restore axes list in ViewBoxMenu

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -18,7 +18,8 @@ class ViewBoxMenu(QtWidgets.QMenu):
         self.viewAll = QtGui.QAction(translate("ViewBox", "View All"), self)
         self.viewAll.triggered.connect(self.autoRange)
         self.addAction(self.viewAll)
-        
+
+        self.axes = []
         self.ctrl = []
         self.widgetGroups = []
         self.dv = QtGui.QDoubleValidator(self)
@@ -30,6 +31,7 @@ class ViewBoxMenu(QtWidgets.QMenu):
             a = QtWidgets.QWidgetAction(self)
             a.setDefaultWidget(w)
             m.addAction(a)
+            self.axes.append(m)
             self.ctrl.append(ui)
             wg = WidgetGroup(w)
             self.widgetGroups.append(wg)


### PR DESCRIPTION
Hi,

This PR is to restore the `axes` list in `ViewBoxMenu`. 

On [this commit](https://github.com/pyqtgraph/pyqtgraph/commit/8a791819e74440adaa88097b658c1eba34ef6af0) the list `self.axes` is deleted from the code. With this change there seems to be no way to modify such axes. 

An example of what we used to do with it:
```python
menu = self.plotItem.getViewBox().menu.axes[0]
action = menu.addAction("Log scale")
action.setCheckable(True)
action.setChecked(self.plotItem.getAxis("bottom").logMode)
action.setParent(menu)
action.toggled.connect(self._onXLogToggled)
self.menu.axes[0].addAction(action) 
```

Looking at `QtWidgets.QMenu` and `ViewBoxMenu`, there seems to be no alternative to access the axes.

