### PR TITLE
Don't draw InfiniteLine anti-aliased if vertical or horizontal

### DIFF
--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -337,7 +337,8 @@ class InfiniteLine(GraphicsObject):
         return self._boundingRect
 
     def paint(self, p, *args):
-        p.setRenderHint(p.RenderHint.Antialiasing)
+        if self.angle % 180 not in (0, 90):
+            p.setRenderHint(p.RenderHint.Antialiasing)
         
         left, right = self._endPoints
         pen = self.currentPen


### PR DESCRIPTION
The InfiniteLine is always drawn with anti-aliasing. This leads to the effect, that a even if the line is oriented vertically or horizontally, it might appear blurry and a bit darker if its position lies actually "between" two pixels.
This effect is even more problematic, if one has multiple lines next to each other and some of them are bright and clear and some are blurry.

See the following screenshots, which are produced with the code at the end of this post.
The first screenshot shows the current state with anti-aliasing in all cases. The left vertical line ('vertical (line_2)') appears darker than the right one ('vertical').
The second screenshot is produced with the same example code below, but with the present PR applied. There, InfiniteLine is drawn with anti-aliasing only if the line is not horizontally and not vertically oriented.
Therefore, both vertical lines appear identically.

(I show the effect only for vertical lines, but the same applies to horizontal lines.)

**Before**
![20230502_inf-line-anti-aliasing_before](https://user-images.githubusercontent.com/36670201/235597721-a5da8efe-9568-49af-97b7-ed60e6de8454.PNG)

**After**
![20230502_inf-line-anti-aliasing_after](https://user-images.githubusercontent.com/36670201/235597737-fb80cc72-d3b5-46f8-a725-3ba053a5b8a7.PNG)

```
import pyqtgraph as pg

app = pg.mkQApp()
pw = pg.PlotWidget()
pw.show()

pw.setXRange(-5,5)

pw.addItem(pg.InfiniteLine(angle=90, movable=True, label="vertical", labelOpts={"position":0.1}))
line_2 = pg.InfiniteLine(angle=90, movable=True, label="vertical (line_2)", labelOpts={"position":0.3})
pw.addItem(line_2)
line_2.setPos(-50.5*line_2.pixelWidth())
pw.addItem(pg.InfiniteLine(angle=+91, movable=True, pos=(-3,0), label="91°", labelOpts={"position":0.5}))
pw.addItem(pg.InfiniteLine(angle=30, movable=True, pos=(2,0), label="30°", labelOpts={"position":0.7}))
pw.addItem(pg.InfiniteLine(angle=45, movable=True, pos=(2,0), label="45°", labelOpts={"position":0.9}))


if __name__ == '__main__':
    pg.exec()
```

