### PR TITLE
Optimize clip and downsample

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -978,7 +978,14 @@ class PlotDataItem(GraphicsObject):
         if self.opts['autoDownsample']:
             # this option presumes that x-values have uniform spacing
 
-            finite_x = x[np.isfinite(x)]  # ignore infinite and nan values
+            if containsNonfinite is False:
+                finite_x = x
+            else:   # True or None
+                # True: (we checked and found non-finites)
+                # None: (we haven't performed a check for non-finites yet)
+                # we also land here if x is finite but y has non-finites
+                finite_x = x[np.isfinite(x)]  # ignore infinite and nan values
+
             if view_range is not None and len(finite_x) > 1:
                 dx = float(finite_x[-1]-finite_x[0]) / (len(finite_x)-1)
                 if dx != 0.0:

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -1,5 +1,6 @@
 import math
 import warnings
+import bisect
 
 import numpy as np
 
@@ -1005,12 +1006,14 @@ class PlotDataItem(GraphicsObject):
                     # find first in-view value (left edge) and first out-of-view value (right edge)
                     # since we want the curve to go to the edge of the screen, we need to preserve
                     # one down-sampled point on the left and one of the right, so we extend the interval
-                    x0 = np.searchsorted(x, view_range.left()) - ds
+                    x0 = bisect.bisect_left(x, view_range.left()) - ds
                     x0 = fn.clip_scalar(x0, 0, len(x)) # workaround
+                    # x0 = np.searchsorted(x, view_range.left()) - ds
                     # x0 = np.clip(x0, 0, len(x))
 
-                    x1 = np.searchsorted(x, view_range.right()) + ds
+                    x1 = bisect.bisect_left(x, view_range.right()) + ds
                     x1 = fn.clip_scalar(x1, x0, len(x))
+                    # x1 = np.searchsorted(x, view_range.right()) + ds
                     # x1 = np.clip(x1, 0, len(x))
                     x = x[x0:x1]
                     y = y[x0:x1]


### PR DESCRIPTION
This PR implements two of the ideas pointed out in #2710 that affect viewing of large datasets.
1) Don't do finite check if it has already been performed elsewhere
2) Use `bisect_left` instead of `np.searchsorted`
   * https://github.com/numpy/numpy/issues/13579
   * https://github.com/numpy/numpy/pull/16942

The changes done in this PR are conservative and should hopefully not break any existing use-cases.
