### PR TITLE
Adapt hide icon (invisible eye) to style of other icons

### DIFF
--- a/pyqtgraph/icons/invisibleEye.svg
+++ b/pyqtgraph/icons/invisibleEye.svg
@@ -1,35 +1,68 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
+   width="110"
+   height="110"
+   viewBox="0 0 110 110"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="invisibleEye.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   width="32"
-   height="32"
-   viewBox="0 0 32 32">
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="7.4765625"
+     inkscape:cx="27.753396"
+     inkscape:cy="53.099268"
+     inkscape:window-width="1920"
+     inkscape:window-height="1137"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8" />
   <g
-     transform="matrix(1.3011758,0,0,1.3175188,0.25361903,0.12274439)">
-    <rect
-       y="0.40677965"
-       x="0.30508474"
-       height="23.288136"
-       width="23.59322"
-       id="rect4138"
-       style="fill:#ffffff;fill-opacity:1;stroke:#2c6c90;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <ellipse
-       ry="1.573068"
-       rx="3.6511929"
-       cy="11.4375"
-       cx="12.140625"
-       id="path4198"
-       style="fill:#2c6c90;fill-opacity:1;stroke:#2c6c90;stroke-width:0.91636413;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:#2c6c90;fill-opacity:1;fill-rule:evenodd;stroke:#2c6c90;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4"
-       d="m 8.6715201,17.080139 c 1.0521449,0.453004 2.1894259,0.698358 3.3632979,0.698358 3.690918,0 7.020113,-2.425624 8.47849,-6.104757 -0.649912,-1.639573 -1.671361,-3.0302023 -2.930787,-4.068156 -4.90545,5.220041 -5.550541,5.818812 -8.9110009,9.474555 z M 18.946736,6.1550929 c 1.638602,1.4150865 2.905626,3.322301 3.614424,5.5186471 -1.531105,4.744416 -5.667,8.139677 -10.526342,8.139677 -1.723817,0 -3.3565943,-0.427269 -4.8143441,-1.190462 l -1.7681422,1.879963 c -0.3737085,0.397342 -0.9796094,0.397342 -1.3533178,0 -0.3737083,-0.397341 -0.3737083,-1.041562 0,-1.438905 L 18.985511,3.2360555 c 0.373708,-0.3973428 0.979609,-0.3973428 1.353318,0 0.373708,0.3973426 0.373708,1.0415625 0,1.438905 z M 5.4511908,14.748511 4.0968206,16.188535 C 2.953543,14.923646 2.0612502,13.38662 1.5084746,11.67374 3.0395788,6.9293251 7.1754744,3.5340623 12.034818,3.5340623 c 1.191472,0 2.339452,0.2041205 3.416205,0.5822001 l -1.56112,1.6598495 C 13.287168,5.6399817 12.666286,5.5689817 12.034818,5.5689817 c -3.6909194,0 -7.0201146,2.4256237 -8.4784913,6.1047583 0.4607503,1.162362 1.1082345,2.199605 1.8948641,3.074771 z" />
-  </g>
+     transform="matrix(1.3011758,0,0,1.3175188,37.063439,44.322322)"
+     id="g5" />
   <rect
      style="fill:none;fill-opacity:1;stroke:#2c6c90;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect4148"
      width="14.338983"
      height="7.2203388"
-     x="16.576271"
-     y="-5.0169487" />
+     x="53.386093"
+     y="39.182629" />
+  <rect
+     ry="18.687822"
+     y="5"
+     x="5"
+     height="100"
+     width="100"
+     id="rect2985-8"
+     style="display:inline;fill:#000000;fill-opacity:1;stroke:#a9a9a9;stroke-width:10;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <g
+     id="g681"
+     transform="matrix(2.8148371,0,0,2.8148371,-960.35195,-1720.358)">
+    <ellipse
+       ry="2.0725467"
+       rx="4.750844"
+       cy="630.14514"
+       cx="360.85196"
+       id="path4198"
+       style="fill:#e7e7e7;fill-opacity:1;stroke:#e7e7e7;stroke-width:1.19982;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#e7e7e7;fill-opacity:1;fill-rule:evenodd;stroke:#2c6c90;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4"
+       d="m 356.33804,637.57941 c 1.36903,0.59685 2.84883,0.9201 4.37624,0.9201 4.80254,0 9.13441,-3.1958 11.03201,-8.04313 -0.84565,-2.16017 -2.17473,-3.99235 -3.81347,-5.35987 -6.38285,6.8775 -7.22223,7.66639 -11.59478,12.4829 z m 13.36986,-14.39395 c 2.13211,1.8644 3.78073,4.37719 4.70301,7.27092 -1.99224,6.25086 -7.37377,10.72418 -13.69663,10.72418 -2.24299,0 -4.36752,-0.56294 -6.2643,-1.56846 l -2.30067,2.47689 c -0.48626,0.52351 -1.27464,0.52351 -1.7609,0 -0.48626,-0.5235 -0.48626,-1.37228 0,-1.89578 l 19.36995,-20.85364 c 0.48626,-0.5235 1.27464,-0.5235 1.7609,0 0.48626,0.52351 0.48626,1.37228 0,1.89579 z m -17.56007,11.32199 -1.76228,1.89726 c -1.4876,-1.66652 -2.64863,-3.69158 -3.36789,-5.94833 1.99224,-6.25085 7.37376,-10.72418 13.69662,-10.72418 1.55032,0 3.04404,0.26894 4.44509,0.76706 l -2.03129,2.18689 c -0.78427,-0.17936 -1.59215,-0.2729 -2.4138,-0.2729 -4.80253,0 -9.1344,3.1958 -11.032,8.04313 0.59951,1.53144 1.442,2.89802 2.46555,4.05107 z" />
+  </g>
 </svg>


### PR DESCRIPTION
The icon that is displayed when hiding a curve by clicking on the corresponding legend entry is out of style compared to all other icons used.

This PR updates this icon to reflect the style of the other icons in `icons.svg`.
I used the eye of the old icon and the background of one of the icons from `icons.svg` to create the new icon.

Before:
![old_hide_icon](https://github.com/pyqtgraph/pyqtgraph/assets/88787609/52311cf5-7097-4292-b172-5e4464a59803)

After:
![new_hide_icon](https://github.com/pyqtgraph/pyqtgraph/assets/88787609/7c935534-75bf-4d52-ada7-a276286c06ff)

