### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3"
+  apt_packages:
+    - libopengl0
 
 sphinx:
   fail_on_warning: true


### PR DESCRIPTION
RTD is failling with an opengl related error that lines up with pyopengl 3.1.7 being released.  This PR attempts to resolve that error in RTD