### PR TITLE
PySide6 6.5.1 compatibility updates

### DIFF
--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -494,7 +494,7 @@ class GradientEditorItem(TickSliderItem):
         self.linkedGradients = {}
         
         self.sigTicksChanged.connect(self._updateGradientIgnoreArgs)
-        self.sigTicksChangeFinished.connect(self.sigGradientChangeFinished.emit)
+        self.sigTicksChangeFinished.connect(self.sigGradientChangeFinished)
 
     def showTicks(self, show=True):
         for tick in self.ticks.keys():


### PR DESCRIPTION
This PR modifies code patterns in pyqtgraph that are triggering failures on the CI with PySide6 6.5.1

1) using inner functions (with value capture) as slots
  * PySide6 6.5.1 is not treating the generated inner functions with different values as distinct functions
  * This is not limited to inner functions, it also applies to lambdas
2) connecting to `Signal.emit` instead of directly to the signal

To be clear, this PR only makes the CI pass.
Whether more functionality has been broken (but not captured by the CI) is unknown.
