### PR TITLE
Numpy > 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Here is a partial listing of some of the applications that make use of PyQtGraph
 * [GraPhysio](https://github.com/jaj42/GraPhysio)
 * [HussariX](https://github.com/sem-geologist/HussariX)
 * [Joulescope](https://www.joulescope.com/)
+* [MaD GUI](https://github.com/mad-lab-fau/mad-gui)
 * [neurotic](https://neurotic.readthedocs.io)
 * [Orange3](https://orangedatamining.com/)
 * [PatchView](https://github.com/ZeitgeberH/patchview)

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -546,7 +546,7 @@ def colorDistance(colors, metric='CIE76'):
         The `N-1` sequential distances between `N` colors.
     """
     metric = metric.upper()
-    if len(colors) < 1: return np.array([], dtype=np.float)
+    if len(colors) < 1: return np.array([], dtype=float)
     if metric == 'CIE76':
         dist = []
         lab1 = None

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -79,3 +79,8 @@ def test_ColorMap_getByIndex():
     cm = pg.ColorMap([0.0, 1.0], [(0,0,0), (255,0,0)])
     assert cm.getByIndex(0) == QtGui.QColor.fromRgbF(0.0, 0.0, 0.0, 1.0)
     assert cm.getByIndex(1) == QtGui.QColor.fromRgbF(1.0, 0.0, 0.0, 1.0)
+
+def test_ColorMap_linearize():
+    cm = pg.ColorMap([0.0, 1.0], [(0,0,0), (255,0,0)], linearize=True)
+    cm.colorDistance([(0,0,0), (255,0,0)])
+    assert cm is not None

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -79,8 +79,3 @@ def test_ColorMap_getByIndex():
     cm = pg.ColorMap([0.0, 1.0], [(0,0,0), (255,0,0)])
     assert cm.getByIndex(0) == QtGui.QColor.fromRgbF(0.0, 0.0, 0.0, 1.0)
     assert cm.getByIndex(1) == QtGui.QColor.fromRgbF(1.0, 0.0, 0.0, 1.0)
-
-def test_ColorMap_linearize():
-    cm = pg.ColorMap([0.0, 1.0], [(0,0,0), (255,0,0)], linearize=True)
-    cm.colorDistance([(0,0,0), (255,0,0)])
-    assert cm is not None

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -400,3 +400,7 @@ def test_ndarray_from_qimage():
         qimg.fill(0)
         arr = pg.functions.ndarray_from_qimage(qimg)
         assert arr.shape == (h, w)
+
+def test_colorDistance():
+    pg.colorDistance([pg.Qt.QtGui.QColor(0,0,0), pg.Qt.QtGui.QColor(255,0,0)])
+    pg.colorDistance([])


### PR DESCRIPTION
Calling `pg.functions.colorDistance([])` raises an error when using numpy >= 1.20, because `np.float` is deprecated, see https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations.

- Fixes #2738 
- Adds MaD GUI as package, that uses pyqtgraph (README)

### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [x] `README.md`
- [ ] ~`setup.py`~
- [ ] ~`tox.ini`~
- [ ] ~`.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files~
- [ ] ~`pyproject.toml`~
- [ ] ~`binder/requirements.txt`~

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py` 
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
