### PR TITLE
Drop python 3.8 and numpy 1.20 support

### DIFF
--- a/.github/workflows/etc/requirements.txt
+++ b/.github/workflows/etc/requirements.txt
@@ -2,7 +2,6 @@
 numpy; python_version == '3.10'
 numpy; python_version == '3.11'
 numpy~=1.21.0; python_version == '3.9'
-numpy~=1.20.0; python_version == '3.8'
 
 # image testing
 scipy==1.10.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,18 +23,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         qt-lib: [pyqt, pyside]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         include:
-          - python-version: "3.8"
+          - python-version: "3.9"
             qt-lib: "pyqt"
             qt-version: "PyQt5~=5.15.0"
-          - python-version: "3.8"
+          - python-version: "3.9"
             qt-lib: "pyside"
             qt-version: "PySide2~=5.15.0"
-          - python-version: "3.9"
+          - python-version: "3.10"
             qt-lib: "pyqt"
             qt-version: "PyQt6~=6.2.0 PyQt6-Qt6~=6.2.0"
-          - python-version: "3.9"
+          - python-version: "3.10"
             qt-lib: "pyside"
             qt-version: "PySide6~=6.2.0"
           - python-version: "3.10"

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ This project supports:
 
 Currently this means:
 
-* Python 3.8+
+* Python 3.9+
 * Qt 5.15, 6.2+
 * [PyQt5](https://www.riverbankcomputing.com/software/pyqt/),
   [PyQt6](https://www.riverbankcomputing.com/software/pyqt/),
   [PySide2](https://wiki.qt.io/Qt_for_Python), or
   [PySide6](https://wiki.qt.io/Qt_for_Python)
-* [`numpy`](https://github.com/numpy/numpy) 1.20+
+* [`numpy`](https://github.com/numpy/numpy) 1.21+
 
 ### Optional added functionalities
 
@@ -121,6 +121,5 @@ Here is a partial listing of some of the applications that make use of PyQtGraph
 * [rapidtide](https://rapidtide.readthedocs.io/en/latest/)
 * [Semi-Supervised Semantic Annotator](https://gitlab.com/s3a/s3a)
 * [STDF-Viewer](https://github.com/noonchen/STDF-Viewer)
-
 
 Do you use PyQtGraph in your own project, and want to add it to the list?  Submit a pull request to update this listing!

--- a/pyqtgraph/debug.py
+++ b/pyqtgraph/debug.py
@@ -26,15 +26,6 @@ from numpy import ndarray
 
 from .Qt import QT_LIB, QtCore
 from .util import cprint
-
-if sys.version.startswith("3.8") and QT_LIB == "PySide2":
-    from .Qt import PySide2
-    if tuple(map(int, PySide2.__version__.split("."))) < (5, 14) \
-        and PySide2.__version__.startswith(QtCore.__version__):
-        warnings.warn(
-            "Due to PYSIDE-1140, ThreadChase and ThreadColor will not work" +
-            " on pip-installed PySide2 bindings < 5.14"
-        )
 from .util.mutex import Mutex
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,10 @@ import distutils.dir_util
 import os
 import re
 import sys
+from distutils.command import build
+
 from setuptools import find_namespace_packages, setup
 from setuptools.command import install
-
-from distutils.command import build
 
 path = os.path.split(__file__)[0]
 import tools.setupHelpers as helpers
@@ -122,7 +122,7 @@ setup(
         'style': helpers.StyleCommand
     },
     packages=find_namespace_packages(include=['pyqtgraph', 'pyqtgraph.*']),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     package_dir={"pyqtgraph": "pyqtgraph"},
     package_data={
         'pyqtgraph.examples': ['optics/*.gz', 'relativity/presets/*.cfg'],
@@ -134,7 +134,7 @@ setup(
         ],
     },
     install_requires = [
-        'numpy>=1.20.0',
+        'numpy>=1.21.0',
     ],
     **setupOpts
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 envlist = 
     ; qt 5.15.x
-    py{38,39,310}-{pyqt5,pyside2}_515
+    py{39,310,311}-{pyqt5,pyside2}_515
 
     ; qt 6.2
-    py{38,39,310}-{pyqt6,pyside6}_62
+    py{39,310,311}-{pyqt6,pyside6}_62
 
     ; qt 6-newest
-    py{38,39,310}-{pyqt6,pyside6}
+    py{39,310,311}-{pyqt6,pyside6}
 
 [base]
 deps =


### PR DESCRIPTION
Conform to NEP-29, and drop Python 3.8 support.

Drops NumPy 1.20 support as well, which should have been dropped some time ago.