### PR TITLE
Fix NumPy warning in test_functions

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -287,7 +287,7 @@ def _handle_underflow(dtype, *elements):
     "xs, ys, connect, expected", [
         *(
             (
-                np.arange(6, dtype=dtype), np.arange(0, -6, step=-1, dtype=dtype), 'all',
+                np.arange(6, dtype=dtype), np.arange(0, -6, step=-1).astype(dtype), 'all',
                 _handle_underflow(dtype,
                                   (MoveToElement, 0.0, 0.0),
                                   (LineToElement, 1.0, -1.0),
@@ -300,7 +300,7 @@ def _handle_underflow(dtype, *elements):
         ),
         *(
             (
-                np.arange(6, dtype=dtype), np.arange(0, -6, step=-1, dtype=dtype), 'pairs',
+                np.arange(6, dtype=dtype), np.arange(0, -6, step=-1).astype(dtype), 'pairs',
                 _handle_underflow(dtype,
                                   (MoveToElement, 0.0, 0.0),
                                   (LineToElement, 1.0, -1.0),
@@ -313,7 +313,7 @@ def _handle_underflow(dtype, *elements):
         ),
         *(
             (
-                np.arange(5, dtype=dtype), np.arange(0, -5, step=-1, dtype=dtype), 'pairs',
+                np.arange(5, dtype=dtype), np.arange(0, -5, step=-1).astype(dtype), 'pairs',
                 _handle_underflow(dtype,
                                   (MoveToElement, 0.0, 0.0),
                                   (LineToElement, 1.0, -1.0),
@@ -344,7 +344,7 @@ def _handle_underflow(dtype, *elements):
         ),
         *(
             (
-                np.arange(5, dtype=dtype), np.arange(0, -5, step=-1, dtype=dtype), np.array([0, 1, 0, 1, 0]),
+                np.arange(5, dtype=dtype), np.arange(0, -5, step=-1).astype(dtype), np.array([0, 1, 0, 1, 0]),
                 _handle_underflow(dtype,
                                   (MoveToElement, 0.0, 0.0),
                                   (MoveToElement, 1.0, -1.0),


### PR DESCRIPTION
Fixes the below warning about integer conversion by using astype() - overflow seems OK/desired in this case.

```
tests/test_functions.py:290
  /home/runner/work/pyqtgraph/pyqtgraph/tests/test_functions.py:290: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -1 to uint32 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)`
  will give the desired result (the cast overflows).
    np.arange(6, dtype=dtype), np.arange(0, -6, step=-1, dtype=dtype), 'all',
```