### PR TITLE
Simplify fps computation

### DIFF
--- a/pyqtgraph/examples/MultiPlotSpeedTest.py
+++ b/pyqtgraph/examples/MultiPlotSpeedTest.py
@@ -3,12 +3,11 @@
 Test the speed of rapidly updating multiple plot curves
 """
 
-from time import perf_counter
-
 import numpy as np
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore
+from utils import FrameCounter
 
 # pg.setConfigOptions(useOpenGL=True)
 app = pg.mkQApp("MultiPlot Speed Test")
@@ -36,30 +35,21 @@ plot.addItem(rgn)
 
 data = np.random.normal(size=(nPlots*23,nSamples))
 ptr = 0
-lastTime = perf_counter()
-fps = None
-count = 0
 def update():
-    global curve, data, ptr, plot, lastTime, fps, nPlots, count
-    count += 1
+    global ptr
 
     for i in range(nPlots):
         curves[i].setData(data[(ptr+i)%data.shape[0]])
 
     ptr += nPlots
-    now = perf_counter()
-    dt = now - lastTime
-    lastTime = now
-    if fps is None:
-        fps = 1.0/dt
-    else:
-        s = np.clip(dt*3., 0, 1)
-        fps = fps * (1-s) + (1.0/dt) * s
-    plot.setTitle('%0.2f fps' % fps)
-    #app.processEvents()  ## force complete redraw for every plot
+    framecnt.update()
+
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(0)
+
+framecnt = FrameCounter()
+framecnt.sigFpsUpdate.connect(lambda fps: plot.setTitle(f'{fps:.1f} fps'))
 
 if __name__ == '__main__':
     pg.exec()

--- a/pyqtgraph/examples/RemoteSpeedTest.py
+++ b/pyqtgraph/examples/RemoteSpeedTest.py
@@ -10,12 +10,12 @@ between the two cases. IF you have a multi-core CPU, it should be obvious that t
 remote case is much faster.
 """
 
-from time import perf_counter
-
 import numpy as np
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtWidgets
+
+from utils import FrameCounter
 
 app = pg.mkQApp()
 
@@ -45,11 +45,7 @@ rplt = view.pg.PlotItem()
 rplt._setProxyOptions(deferGetattr=True)  ## speeds up access to rplt.plot
 view.setCentralItem(rplt)
 
-lastUpdate = perf_counter()
-avgFps = 0.0
-
 def update():
-    global check, label, plt, lastUpdate, avgFps, rpltfunc
     data = np.random.normal(size=(10000,50)).sum(axis=1)
     data += 5 * np.sin(np.linspace(0, 10, data.shape[0]))
     
@@ -61,16 +57,15 @@ def update():
                                                       ## process.
     if lcheck.isChecked():
         lplt.plot(data, clear=True)
-        
-    now = perf_counter()
-    fps = 1.0 / (now - lastUpdate)
-    lastUpdate = now
-    avgFps = avgFps * 0.8 + fps * 0.2
-    label.setText("Generating %0.2f fps" % avgFps)
+
+    framecnt.update()
         
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(0)
+
+framecnt = FrameCounter()
+framecnt.sigFpsUpdate.connect(lambda fps : label.setText(f"Generating {fps:.1f}"))
 
 if __name__ == '__main__':
     pg.exec()

--- a/pyqtgraph/examples/VideoSpeedTest.py
+++ b/pyqtgraph/examples/VideoSpeedTest.py
@@ -7,12 +7,13 @@ is used by the view widget
 
 import argparse
 import sys
-from time import perf_counter
 
 import numpy as np
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui, QtWidgets
+
+from utils import FrameCounter
 
 pg.setConfigOption('imageAxisOrder', 'row-major')
 
@@ -240,12 +241,9 @@ ui.framesSpin.valueChanged.connect(updateSize)
 ui.cudaCheck.toggled.connect(noticeCudaCheck)
 ui.numbaCheck.toggled.connect(noticeNumbaCheck)
 
-
 ptr = 0
-lastTime = perf_counter()
-fps = None
 def update():
-    global ui, ptr, lastTime, fps, LUT, img
+    global ptr
     if ui.lutCheck.isChecked():
         useLut = LUT
     else:
@@ -276,19 +274,14 @@ def update():
         #img.setImage(data[ptr%data.shape[0]], autoRange=False)
 
     ptr += 1
-    now = perf_counter()
-    dt = now - lastTime
-    lastTime = now
-    if fps is None:
-        fps = 1.0/dt
-    else:
-        s = np.clip(dt*3., 0, 1)
-        fps = fps * (1-s) + (1.0/dt) * s
-    ui.fpsLabel.setText('%0.2f fps' % fps)
-    app.processEvents()  ## force complete redraw for every plot
+    framecnt.update()
+
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(0)
+
+framecnt = FrameCounter()
+framecnt.sigFpsUpdate.connect(lambda fps: ui.fpsLabel.setText(f'{fps:.1f} fps'))
 
 if __name__ == '__main__':
     pg.exec()

--- a/pyqtgraph/examples/infiniteline_performance.py
+++ b/pyqtgraph/examples/infiniteline_performance.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python
 
-from time import perf_counter
-
 import numpy as np
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore
+from utils import FrameCounter
 
 app = pg.mkQApp("Infinite Line Performance")
 
@@ -22,29 +21,20 @@ for i in range(100):
 
 data = np.random.normal(size=(50, 5000))
 ptr = 0
-lastTime = perf_counter()
-fps = None
-
 
 def update():
-    global curve, data, ptr, p, lastTime, fps
+    global ptr
     curve.setData(data[ptr % 10])
     ptr += 1
-    now = perf_counter()
-    dt = now - lastTime
-    lastTime = now
-    if fps is None:
-        fps = 1.0/dt
-    else:
-        s = np.clip(dt*3., 0, 1)
-        fps = fps * (1-s) + (1.0/dt) * s
-    p.setTitle('%0.2f fps' % fps)
-    app.processEvents()  # force complete redraw for every plot
+    framecnt.update()
 
 
 timer = QtCore.QTimer()
 timer.timeout.connect(update)
 timer.start(0)
+
+framecnt = FrameCounter()
+framecnt.sigFpsUpdate.connect(lambda fps: p.setTitle(f'{fps:.1f} fps'))
 
 if __name__ == '__main__':
     pg.exec()

--- a/pyqtgraph/examples/utils.py
+++ b/pyqtgraph/examples/utils.py
@@ -1,5 +1,7 @@
 from argparse import Namespace
 from collections import OrderedDict
+from time import perf_counter
+from pyqtgraph.Qt import QtCore
 
 # Avoid clash with module name
 examples_ = OrderedDict([
@@ -135,3 +137,28 @@ trivial = dict([
 skiptest = dict([
     ('ProgressDialog', 'ProgressDialog.py'),    # modal dialog
 ])
+
+
+class FrameCounter(QtCore.QObject):
+    sigFpsUpdate = QtCore.Signal(object)
+
+    def __init__(self, interval=1000):
+        super().__init__()
+        self.count = 0
+        self.last_update = 0
+        self.interval = interval
+
+    def update(self):
+        self.count += 1
+
+        if self.last_update == 0:
+            self.last_update = perf_counter()
+            self.startTimer(self.interval)
+
+    def timerEvent(self, evt):
+        now = perf_counter()
+        elapsed = now - self.last_update
+        fps = self.count / elapsed
+        self.last_update = now
+        self.count = 0
+        self.sigFpsUpdate.emit(fps)


### PR DESCRIPTION
Various examples compute fps by measuring the inverse time elapsed of _each_ frame. As there is quite a bit of jitter, the fps value is then smoothed using some rolling average.

This PR simplifies the computation by counting the number of frames that have been updated over a period of 1 second. The longish duration serves to average out the jitter and removes the need for accurate time measurement of the time elapsed of each update.
