### PR TITLE
Fix tox config, bump min numpy to 1.22

### DIFF
--- a/.github/workflows/etc/requirements.txt
+++ b/.github/workflows/etc/requirements.txt
@@ -1,7 +1,7 @@
 # numpy based on python version and NEP-29 requirements
 numpy; python_version == '3.10'
 numpy; python_version == '3.11'
-numpy~=1.21.0; python_version == '3.9'
+numpy~=1.22.0; python_version == '3.9'
 
 # image testing
 scipy==1.10.1

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Currently this means:
   [PyQt6](https://www.riverbankcomputing.com/software/pyqt/),
   [PySide2](https://wiki.qt.io/Qt_for_Python), or
   [PySide6](https://wiki.qt.io/Qt_for_Python)
-* [`numpy`](https://github.com/numpy/numpy) 1.21+
+* [`numpy`](https://github.com/numpy/numpy) 1.22+
 
 ### Optional added functionalities
 

--- a/pyqtgraph/Qt/internals.py
+++ b/pyqtgraph/Qt/internals.py
@@ -1,8 +1,9 @@
 import ctypes
 import itertools
+
 import numpy as np
-from . import QT_LIB, QtCore, QtGui
-from . import compat
+
+from . import QT_LIB, QtCore, QtGui, compat
 
 __all__ = ["get_qpainterpath_element_array"]
 
@@ -174,7 +175,11 @@ class PrimitiveArray:
     def ndarray(self):
         # ndarray views are cheap to recreate each time
         if self.use_sip_array:
-            if sip.SIP_VERSION >= 0x60708:
+            if (
+                sip.SIP_VERSION >= 0x60708 and 
+                np.__version__ != "1.22.4"  # TODO: remove me after numpy 1.23+
+            ):  # workaround for numpy/sip compatability issue
+                # see https://github.com/numpy/numpy/issues/21612
                 mv = self._siparray
             else:
                 # sip.array prior to SIP_VERSION 6.7.8 had a buggy buffer protocol

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1192,12 +1192,6 @@ def clip_scalar(val, vmin, vmax):
     """ convenience function to avoid using np.clip for scalar values """
     return vmin if val < vmin else vmax if val > vmax else val
 
-# umath.clip was slower than umath.maximum(umath.minimum).
-# See https://github.com/numpy/numpy/pull/20134 for details.
-_win32_clip_workaround_needed = (
-    sys.platform == 'win32' and
-    tuple(map(int, np.__version__.split(".")[:2])) < (1, 22)
-)
 
 def clip_array(arr, vmin, vmax, out=None):
     # replacement for np.clip due to regression in
@@ -1212,12 +1206,6 @@ def clip_array(arr, vmin, vmax, out=None):
         return np.core.umath.minimum(arr, vmax, out=out)
     elif vmax is None:
         return np.core.umath.maximum(arr, vmin, out=out)
-    elif _win32_clip_workaround_needed:
-        if out is None:
-            out = np.empty(arr.shape, dtype=np.find_common_type([arr.dtype], [type(vmax)]))
-        out = np.core.umath.minimum(arr, vmax, out=out)
-        return np.core.umath.maximum(out, vmin, out=out)
-
     else:
         return np.core.umath.clip(arr, vmin, vmax, out=out)
 

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -994,7 +994,7 @@ def interpolateArray(data, x, default=0.0, order=1):
             sax = f1 * dx[...,ax] + (1-f1) * (1-dx[...,ax])
             sax = sax.reshape(sax.shape + (1,) * (s.ndim-1-sax.ndim))
             s[ax] = sax
-        s = np.product(s, axis=0)
+        s = np.prod(s, axis=0)
         result = fieldData * s
         for i in range(md):
             result = result.sum(axis=0)

--- a/pyqtgraph/opengl/items/GLMeshItem.py
+++ b/pyqtgraph/opengl/items/GLMeshItem.py
@@ -192,7 +192,7 @@ class GLMeshItem(GLGraphicsItem):
                         glNormalPointerf(norms)
                     
                     if faces is None:
-                        glDrawArrays(GL_TRIANGLES, 0, np.product(verts.shape[:-1]))
+                        glDrawArrays(GL_TRIANGLES, 0, np.prod(verts.shape[:-1]))
                     else:
                         faces = faces.astype(np.uint32).flatten()
                         glDrawElements(GL_TRIANGLES, faces.shape[0], GL_UNSIGNED_INT, faces)

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
         ],
     },
     install_requires = [
-        'numpy>=1.21.0',
+        'numpy>=1.22.0',
     ],
     **setupOpts
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = 
+envlist =
     ; qt 5.15.x
-    py{39,310,311}-{pyqt5,pyside2}_515
+    py{39,310,311}-pyqt5_515
+    py{39,310}-pyside2_515
 
     ; qt 6.2
-    py{39,310,311}-{pyqt6,pyside6}_62
+    py{39,310,311}-pyqt6_62
+    py{39,310}-pyside6_62
 
     ; qt 6-newest
     py{39,310,311}-{pyqt6,pyside6}
@@ -19,7 +21,7 @@ deps =
     h5py
 
 [testenv]
-passenv = DISPLAY XAUTHORITY, PYTHON_VERSION
+passenv = DISPLAY,XAUTHORITY,PYTHON_VERSION
 setenv = PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command
 deps=
     {[base]deps}


### PR DESCRIPTION
PR addresses 3 issues

- Fix `tox.ini` to run only on compatible configurations
- Remove usage of `numpy.product` which is deprecated as of NumPy 1.25 and will be removed in NumPy 2.0
- Bump minimum NumPy from 1.21 to 1.22 per NEP-29 timeline