### PR TITLE
export dialog - compare items by "is" rather than "==" (operator not implemented!)

### DIFF
--- a/pyqtgraph/GraphicsScene/exportDialog.py
+++ b/pyqtgraph/GraphicsScene/exportDialog.py
@@ -104,7 +104,7 @@ class ExportDialog(QtWidgets.QWidget):
         for exp in exporters.listExporters():
             item = FormatExportListWidgetItem(exp, QtCore.QCoreApplication.translate('Exporter', exp.Name))
             self.ui.formatList.addItem(item)
-            if item == current:
+            if item is current:
                 self.ui.formatList.setCurrentRow(self.ui.formatList.count() - 1)
                 gotCurrent = True
                 


### PR DESCRIPTION
This PR cherry-picks @Zorkator 's commit to #2442 for doing a comparison in the export dialog.