### PR TITLE
workaround Python 3.11.4 flag inversion issue

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -1542,7 +1542,13 @@ class MouseDragHandler(object):
         if ev.isStart():
             if ev.button() == QtCore.Qt.MouseButton.LeftButton:
                 roi.setSelected(True)
-                mods = ev.modifiers() & ~self.snapModifier
+                mods = ev.modifiers()
+                try:
+                    mods &= ~self.snapModifier
+                except ValueError:
+                    # workaround bug in Python 3.11.4 that affects PyQt
+                    if mods & self.snapModifier:
+                        mods ^= self.snapModifier
                 if roi.translatable and mods == self.translateModifier:
                     self.dragMode = 'translate'
                 elif roi.rotatable and mods == self.rotateModifier:


### PR DESCRIPTION
CI is failing for Python 3.11.4 and PyQt6 due to https://github.com/python/cpython/issues/105497 and the next Python release is only expected to be in August (https://peps.python.org/pep-0664/#bugfix-releases).
Since there's only one place in pyqtgraph that triggers this bug, we can workaround it by using `xor` to toggle away the unwanted flag (even if it's only to make the CI go all green)
