### PR TITLE
Fix invisible InfiniteLine at plot edges

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -936,26 +936,34 @@ class AxisItem(GraphicsWidget):
         else:
             tickBounds = linkedView.mapRectToItem(self, linkedView.boundingRect())
 
+        left_offset = -1.0
+        right_offset = 1.0
+        top_offset = -1.0
+        bottom_offset = 1.0
         if self.orientation == 'left':
-            span = (bounds.topRight(), bounds.bottomRight())
+            span = (bounds.topRight() + Point(left_offset, top_offset),
+                    bounds.bottomRight() + Point(left_offset, bottom_offset))
             tickStart = tickBounds.right()
             tickStop = bounds.right()
             tickDir = -1
             axis = 0
         elif self.orientation == 'right':
-            span = (bounds.topLeft(), bounds.bottomLeft())
+            span = (bounds.topLeft() + Point(right_offset, top_offset),
+                    bounds.bottomLeft() + Point(right_offset, bottom_offset))
             tickStart = tickBounds.left()
             tickStop = bounds.left()
             tickDir = 1
             axis = 0
         elif self.orientation == 'top':
-            span = (bounds.bottomLeft(), bounds.bottomRight())
+            span = (bounds.bottomLeft() + Point(left_offset, top_offset),
+                    bounds.bottomRight() + Point(right_offset, top_offset))
             tickStart = tickBounds.bottom()
             tickStop = bounds.bottom()
             tickDir = -1
             axis = 1
         elif self.orientation == 'bottom':
-            span = (bounds.topLeft(), bounds.topRight())
+            span = (bounds.topLeft() + Point(left_offset, bottom_offset),
+                    bounds.topRight() + Point(right_offset, bottom_offset))
             tickStart = tickBounds.top()
             tickStop = bounds.top()
             tickDir = 1

--- a/pyqtgraph/graphicsItems/GraphicsWidget.py
+++ b/pyqtgraph/graphicsItems/GraphicsWidget.py
@@ -1,4 +1,4 @@
-from ..Qt import QtGui, QtWidgets
+from ..Qt import QtCore, QtGui, QtWidgets
 from .GraphicsItem import GraphicsItem
 
 __all__ = ['GraphicsWidget']
@@ -64,7 +64,7 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
             self._previousGeometry = geometry
         else:
             br = self._boundingRectCache
-        return br
+        return QtCore.QRectF(br)
 
     def shape(self):
         p = self._painterPathCache

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -475,11 +475,6 @@ class ViewBox(GraphicsWidget):
             self.sigStateChanged.emit(self)
             self.sigResized.emit(self)
 
-    def boundingRect(self):
-        br = super().boundingRect()
-        br.adjust(-0.5, 0, +0.5, +0.5)
-        return br
-
     def viewRange(self):
         """Return a the view's visible range as a list: [[xmin, xmax], [ymin, ymax]]"""
         return [x[:] for x in self.state['viewRange']]  ## return copy

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -475,6 +475,11 @@ class ViewBox(GraphicsWidget):
             self.sigStateChanged.emit(self)
             self.sigResized.emit(self)
 
+    def boundingRect(self):
+        br = super().boundingRect()
+        br.adjust(-0.5, 0, +0.5, +0.5)
+        return br
+
     def viewRange(self):
         """Return a the view's visible range as a list: [[xmin, xmax], [ymin, ymax]]"""
         return [x[:] for x in self.state['viewRange']]  ## return copy

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -475,6 +475,10 @@ class ViewBox(GraphicsWidget):
             self.sigStateChanged.emit(self)
             self.sigResized.emit(self)
 
+    def boundingRect(self):
+        br = super().boundingRect()
+        return br.adjusted(0, 0, +0.5, +0.5)
+
     def viewRange(self):
         """Return a the view's visible range as a list: [[xmin, xmax], [ymin, ymax]]"""
         return [x[:] for x in self.state['viewRange']]  ## return copy


### PR DESCRIPTION
I have an InfiniteLine in a plot, which have both the same limits, i.e. the line can be dragged until the limits of the plot but not further.
Now, if you do exactly this, the line won't be visible. 
See below the *before* screenshot and the code I used to set it up.

This problem exists for all for edges of a plot and independent of axes being visible or not.
I think, if a plot displays a range of e.g. 0..10 and you place a line at 0 or 10, you should still see it. Therefore, I consider this as a bug.

**Searching for the reasons I found the following two issues and tried to solve them in the present PR:**

1. AxisItem draws its baseline right within the plot and overlays the InfiniteLine
For abothes example with visible range of 0..10, the axis' baseline is drawn e.g. at 0, and a InfiniteLine which is placed there will be hidden behind the axis baseline.
This can easily be debugged by making the axis' baseline dashed.
Therefore I changed this and let the axis baselines be drawn right outside of the plot-area (move by 1 px in the corresponding direction)
Another idea regarding the axis baselines I had, was to let the InfiniteLine be drawn in front of the axis baseline, but this didn't work. The axis' z-value is 0.5 and I can set the InfiniteLine's z-value to anything larger than this but it's still not visible. I guess this has something to do with the parent-child relationships within the scene but I didn't analyzed this further.

2. The InfiniteLine is invisible itself, because it's out of the boundingRect of the ViewBox
This can easily be seen if the baselines of the axes are not drawn anymore. In this case you can see the InfiniteLine disappearing if its moved to the edge.
To resolve this, I increased the boundingRect of the ViewBox slightly. Here I had to play around to find the values which work for me. I don't know why the left edge behaves different than the top edge!

**Before**
![20230628_lines_at_edge_not_visible](https://github.com/pyqtgraph/pyqtgraph/assets/36670201/5734adc1-6db1-4c04-8aa7-ef02d823e04a)


**After**
![20230628_lines_at_edge_visible](https://github.com/pyqtgraph/pyqtgraph/assets/36670201/3324d8c4-c580-4913-be3f-27e62676dd6d)


```
import pyqtgraph as pg


SHOW_ALL_AXES = True

app = pg.mkQApp()
plot = pg.PlotWidget()
plot.resize(400,300)
plot.show()

if SHOW_ALL_AXES:
    plot.showAxis("right")
    plot.showAxis("top")
else:
    plot.showAxis("left", False)
    plot.showAxis("bottom", False)

plot.setLimits(xMin=0,xMax=10, yMin=0, yMax=10)
plot.setXRange(0,10)
plot.setYRange(0,10)

for pos, angle in ((0,90), (10,90), (0,0), (10,0)):
    line = pg.InfiniteLine(pos=pos,bounds=(0,10), angle=angle, pen=pg.mkPen("#00ff00"))
    line.setMovable(True)
    plot.addItem(line)
```