### PR TITLE
NonUniformImage improvements

### DIFF
--- a/pyqtgraph/examples/NonUniformImage.py
+++ b/pyqtgraph/examples/NonUniformImage.py
@@ -7,9 +7,7 @@ distributed sample points.
 import numpy as np
 
 import pyqtgraph as pg
-from pyqtgraph.graphicsItems.GradientEditorItem import Gradients
 from pyqtgraph.graphicsItems.NonUniformImage import NonUniformImage
-from pyqtgraph.Qt import QtWidgets
 
 RPM2RADS = 2 * np.pi / 60
 RADS2RPM = 1 / RPM2RADS
@@ -35,37 +33,26 @@ P_loss = kfric * W + kfric3 * W ** 3 + (res * (TAU / psi) ** 2) + k_v * (V - v_r
 P_mech = TAU * W
 P_loss[P_mech > 1.5e5] = np.NaN
 
-# green - orange - red
-Gradients['gor'] = {'ticks': [(0.0, (74, 158, 71)), (0.5, (255, 230, 0)), (1, (191, 79, 76))], 'mode': 'rgb'}
-
 app = pg.mkQApp("NonUniform Image Example")
 
-win = QtWidgets.QMainWindow()
-cw = pg.GraphicsLayoutWidget()
+win = pg.PlotWidget()
 win.show()
 win.resize(600, 400)
-win.setCentralWidget(cw)
 win.setWindowTitle('pyqtgraph example: Non-uniform Image')
 
-p = cw.addPlot(title="Power Losses [W]", row=0, col=0)
-
-lut = pg.HistogramLUTItem(orientation="horizontal")
+p = win.getPlotItem()
+p.setTitle("Power Losses [W]")
 
 p.setMouseEnabled(x=False, y=False)
 
-cw.nextRow()
-cw.addItem(lut)
-
-# load the gradient
-lut.gradient.loadPreset('gor')
-
 image = NonUniformImage(w * RADS2RPM, tau, P_loss.T)
-image.setLookupTable(lut, autoLevel=True)
 image.setZValue(-1)
 p.addItem(image)
 
-h = image.getHistogram()
-lut.plot.setData(*h)
+# green - orange - red
+cmap = pg.ColorMap([0.0, 0.5, 1.0], [(74, 158, 71), (255, 230, 0), (191, 79, 76)])
+bar = pg.ColorBarItem(colorMap=cmap, orientation='h')
+bar.setImageItem(image, insert_in=p)
 
 p.showGrid(x=True, y=True)
 

--- a/pyqtgraph/graphicsItems/HistogramLUTItem.py
+++ b/pyqtgraph/graphicsItems/HistogramLUTItem.py
@@ -351,7 +351,7 @@ class HistogramLUTItem(GraphicsWidget):
                 self.region.setRegion([mn, mx])
                 profiler('set region')
             else:
-                mn, mx = self.imageItem().levels
+                mn, mx = self.imageItem().getLevels()
                 self.region.setRegion([mn, mx])
         else:
             # plot one histogram for each channel

--- a/pyqtgraph/graphicsItems/HistogramLUTItem.py
+++ b/pyqtgraph/graphicsItems/HistogramLUTItem.py
@@ -282,7 +282,8 @@ class HistogramLUTItem(GraphicsWidget):
         HistogramLUTItem.
         """
         self.imageItem = weakref.ref(img)
-        img.sigImageChanged.connect(self.imageChanged)
+        if hasattr(img, 'sigImageChanged'):
+            img.sigImageChanged.connect(self.imageChanged)
         self._setImageLookupTable()
         self.regionChanged()
         self.imageChanged(autoLevel=True)

--- a/pyqtgraph/graphicsItems/NonUniformImage.py
+++ b/pyqtgraph/graphicsItems/NonUniformImage.py
@@ -108,7 +108,7 @@ class NonUniformImage(GraphicsObject):
 
         # get colormap, lut has precedence over cmap
         if self.lut is None:
-            lut = self.cmap.getLookupTable()
+            lut = self.cmap.getLookupTable(nPts=256)
         elif callable(self.lut):
             lut = self.lut(z)
         else:

--- a/pyqtgraph/graphicsItems/NonUniformImage.py
+++ b/pyqtgraph/graphicsItems/NonUniformImage.py
@@ -1,12 +1,12 @@
-import math
-
+import warnings
 import numpy as np
 
 from .. import functions as fn
-from .. import mkBrush, mkPen
 from ..colormap import ColorMap
+from .. import Qt
 from ..Qt import QtCore, QtGui
 from .GraphicsObject import GraphicsObject
+from .HistogramLUTItem import HistogramLUTItem
 
 __all__ = ['NonUniformImage']
 
@@ -18,7 +18,6 @@ class NonUniformImage(GraphicsObject):
     commonly used to display 2-d or slices of higher dimensional data that
     have a regular but non-uniform grid e.g. measurements or simulation results.
     """
-
     def __init__(self, x, y, z, border=None):
 
         GraphicsObject.__init__(self)
@@ -38,28 +37,37 @@ class NonUniformImage(GraphicsObject):
             raise Exception("The length of x and y must match the shape of z.")
 
         # default colormap (black - white)
-        self.cmap = ColorMap(pos=[0.0, 1.0], color=[(0.0, 0.0, 0.0, 1.0), (1.0, 1.0, 1.0, 1.0)])
+        self.cmap = ColorMap(pos=[0.0, 1.0], color=[(0, 0, 0), (255, 255, 255)])
 
         self.data = (x, y, z)
+        self.levels = None
         self.lut = None
         self.border = border
-        self.generatePicture()
+        self.picture = None
 
-    def setLookupTable(self, lut, autoLevel=False):
-        lut.sigLevelsChanged.connect(self.generatePicture)
-        lut.gradient.sigGradientChanged.connect(self.generatePicture)
+        self.update()
+
+    def setLookupTable(self, lut, update=True, **kwargs):
+        # backwards compatibility hack
+        if isinstance(lut, HistogramLUTItem):
+            warnings.warn(
+                "NonUniformImage::setLookupTable(HistogramLUTItem) is deprecated "
+                "and will be removed in a future version of PyQtGraph. "
+                "use HistogramLUTItem::setImageItem(NonUniformImage) instead",
+                DeprecationWarning, stacklevel=2
+            )
+            lut.setImageItem(self)
+            return
+
         self.lut = lut
-
-        if autoLevel:
-            _, _, z = self.data
-            f = z[np.isfinite(z)]
-            lut.setLevels(f.min(), f.max())
-
-        self.generatePicture()
+        self.picture = None
+        if update:
+            self.update()
 
     def setColorMap(self, cmap):
         self.cmap = cmap
-        self.generatePicture()
+        self.picture = None
+        self.update()
 
     def getHistogram(self, **kwds):
         """Returns x and y arrays containing the histogram values for the current image.
@@ -72,62 +80,95 @@ class NonUniformImage(GraphicsObject):
 
         return hist[1][:-1], hist[0]
 
-    def generatePicture(self):
-
-        x, y, z = self.data
-
-        self.picture = QtGui.QPicture()
-        p = QtGui.QPainter(self.picture)
-        p.setPen(mkPen(None))
-
-        # normalize
-        if self.lut is not None:
-            mn, mx = self.lut.getLevels()
-        else:
-            f = z[np.isfinite(z)]
-            mn = f.min()
-            mx = f.max()
-
-        # draw the tiles
-        for i in range(x.size):
-            for j in range(y.size):
-
-                value = z[i, j]
-
-                if np.isneginf(value):
-                    value = 0.0
-                elif np.isposinf(value):
-                    value = 1.0
-                elif math.isnan(value):
-                    continue  # ignore NaN
-                else:
-                    value = (value - mn) / (mx - mn)  # normalize
-
-                if self.lut:
-                    color = self.lut.gradient.getColor(value)
-                else:
-                    color = self.cmap.mapToQColor(value)
-
-                p.setBrush(mkBrush(color))
-
-                # left, right, bottom, top
-                l = x[0] if i == 0 else (x[i - 1] + x[i]) / 2
-                r = (x[i] + x[i + 1]) / 2 if i < x.size - 1 else x[-1]
-                b = y[0] if j == 0 else (y[j - 1] + y[j]) / 2
-                t = (y[j] + y[j + 1]) / 2 if j < y.size - 1 else y[-1]
-
-                p.drawRect(QtCore.QRectF(l, t, r - l, b - t))
-
-        if self.border is not None:
-            p.setPen(self.border)
-            p.setBrush(fn.mkBrush(None))
-            p.drawRect(self.boundingRect())
-
-        p.end()
-
+    def setLevels(self, levels):
+        self.levels = levels
+        self.picture = None
         self.update()
 
+    def getLevels(self):
+        if self.levels is None:
+            z = self.data[2]
+            z = z[np.isfinite(z)]
+            self.levels = z.min(), z.max()
+        return self.levels
+
+    def generatePicture(self):
+        x, y, z = self.data
+
+        # pad x and y so that we don't need to special-case the edges
+        x = np.pad(x, 1, mode='edge')
+        y = np.pad(y, 1, mode='edge')
+
+        x = (x[:-1] + x[1:]) / 2
+        y = (y[:-1] + y[1:]) / 2
+
+        X, Y = np.meshgrid(x[:-1], y[:-1], indexing='ij')
+        W, H = np.meshgrid(np.diff(x), np.diff(y), indexing='ij')
+        Z = z
+
+        # get colormap, lut has precedence over cmap
+        if self.lut is None:
+            lut = self.cmap.getLookupTable()
+        elif callable(self.lut):
+            lut = self.lut(z)
+        else:
+            lut = self.lut
+
+        # normalize and quantize
+        mn, mx = self.getLevels()
+        rng = mx - mn
+        if rng == 0:
+            rng = 1
+        scale = len(lut) / rng
+        Z = fn.rescaleData(Z, scale, mn, dtype=int, clip=(0, len(lut)-1))
+
+        # replace nans positions with invalid lut index
+        invalid_coloridx = len(lut)
+        Z[np.isnan(z)] = invalid_coloridx
+
+        # pre-allocate to the largest array needed
+        color_indices, counts = np.unique(Z, return_counts=True)
+        rectarray = Qt.internals.PrimitiveArray(QtCore.QRectF, 4)
+        rectarray.resize(counts.max())
+
+        # sorted_indices effectively groups together the
+        # (flattened) indices of the same coloridx together.
+        sorted_indices = np.argsort(Z, axis=None)
+        for arr in X, Y, W, H:
+            arr.shape = -1      # in-place unravel
+
+        self.picture = QtGui.QPicture()
+        painter = QtGui.QPainter(self.picture)
+        painter.setPen(fn.mkPen(None))
+
+        # draw the tiles grouped by coloridx
+        offset = 0
+        for coloridx, cnt in zip(color_indices, counts):
+            if coloridx == invalid_coloridx:
+                continue
+            indices = sorted_indices[offset:offset+cnt]
+            offset += cnt
+            rectarray.resize(cnt)
+            memory = rectarray.ndarray()
+            memory[:,0] = X[indices]
+            memory[:,1] = Y[indices]
+            memory[:,2] = W[indices]
+            memory[:,3] = H[indices]
+
+            brush = fn.mkBrush(lut[coloridx])
+            painter.setBrush(brush)
+            painter.drawRects(*rectarray.drawargs())
+
+        if self.border is not None:
+            painter.setPen(self.border)
+            painter.setBrush(fn.mkBrush(None))
+            painter.drawRect(self.boundingRect())
+
+        painter.end()
+
     def paint(self, p, *args):
+        if self.picture is None:
+            self.generatePicture()
         p.drawPicture(0, 0, self.picture)
 
     def boundingRect(self):


### PR DESCRIPTION
Behavior changes:
1) `NonUniformImage::setLookupTable` was previously implemented to take in a `HistogramLUTItem`. Now it takes in a numpy array, like `ImageItem`.

Improvements:
1) `NonUniformImage` can be used with both `HistogramLUTItem` and `ColorBarItem`, in the same way that an `ImageItem` is used. 
2) Change the example to use `ColorBarItem`. This also removes the hack of inserting a custom colormap into `GradientEditorItem`.
3) Speed up the drawing with `drawRects`. The speed up can be observed with the example at 
https://github.com/pyqtgraph/pyqtgraph/pull/2599#issuecomment-1432873261

Bugs fixed:
1) default color map was specified wrongly with floats
2) non-normalized QRectF: negative height was being computed
3) `HistogramLUTItem` was not using `ImageItem::getLevels()` accessor
