### PR TITLE
speed up PColorMeshItem

### DIFF
--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -1,11 +1,8 @@
-import warnings
-
 import numpy as np
 
 from .. import Qt, colormap
 from .. import functions as fn
 from ..Qt import QtCore, QtGui
-from .GradientEditorItem import Gradients  # List of colormaps
 from .GraphicsObject import GraphicsObject
 
 __all__ = ['PColorMeshItem']
@@ -135,19 +132,6 @@ class PColorMeshItem(GraphicsObject):
             if not isinstance(cmap, colormap.ColorMap):
                 raise ValueError('colorMap argument must be a ColorMap instance')
             self.cmap = cmap
-        elif 'cmap' in kwargs:
-            # legacy unadvertised argument for backwards compatibility.
-            # this will only use colormaps from Gradients.
-            # Note that the colors will be wrong for the hsv colormaps.
-            warnings.warn(
-                "The parameter 'cmap' will be removed in a version of PyQtGraph released after Nov 2022.",
-                DeprecationWarning, stacklevel=2
-            )
-            cmap = kwargs.get('cmap')
-            if not isinstance(cmap, str) or cmap not in Gradients:
-                raise NameError('Undefined colormap, should be one of the following: '+', '.join(['"'+i+'"' for i in Gradients.keys()])+'.')
-            pos, color = zip(*Gradients[cmap]['ticks'])
-            self.cmap = colormap.ColorMap(pos, color)
         else:
             self.cmap = colormap.get('viridis')
 


### PR DESCRIPTION
By applying some of the techniques implemented in #2764, some speed up to PCMI has been obtained.

To make the speed up measurable, the example was modified to use `FrameCounter`.
This is not quite the same behavior as the original code, which was trying to cap the animation to 25 fps.