### PR TITLE
ScaleBar: allow setParentItem(None)

### DIFF
--- a/pyqtgraph/graphicsItems/ScaleBar.py
+++ b/pyqtgraph/graphicsItems/ScaleBar.py
@@ -57,12 +57,11 @@ class ScaleBar(GraphicsWidgetAnchor, GraphicsObject):
     def boundingRect(self):
         return QtCore.QRectF()
 
-    def setParentItem(self, p):
-        ret = GraphicsObject.setParentItem(self, p)
-        if self.offset is not None:
+    def setParentItem(self, parent):
+        GraphicsObject.setParentItem(self, parent)
+        if parent is not None and self.offset is not None:
             offset = Point(self.offset)
             anchorx = 1 if offset[0] <= 0 else 0
             anchory = 1 if offset[1] <= 0 else 0
             anchor = (anchorx, anchory)
             self.anchor(itemPos=anchor, parentPos=anchor, offset=offset)
-        return ret


### PR DESCRIPTION
This fixes an issue raised on the Discord channel that removing a `ScaleBar` would raise an exception.
The same bug is present in `LegendItem`. However the fix there might not be as trivial.

Note that `setParentItem()` is a void function, so there's no need to return its value.

MWE
```python
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore

pg.mkQApp()

pw = pg.PlotWidget()
pw.show()
vb = pw.getViewBox()
sb = pg.ScaleBar(5, offset = (-30,-30))
sb.setParentItem(vb)
legend = pw.addLegend()
pdi = pw.plot(range(10), name='curve')

QtCore.QTimer.singleShot(1000, lambda: vb.removeItem(sb))
# QtCore.QTimer.singleShot(2000, lambda: vb.removeItem(legend))
pg.exec()
```
