### PR TITLE
fix: wrong key set to _pixelVectorCache

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -280,7 +280,7 @@ class GraphicsItem(object):
         #pv = Point(dti.map(normView)-dti.map(Point(0,0))), Point(dti.map(normOrtho)-dti.map(Point(0,0)))
         pv = Point(dti.map(normView).p2()), Point(dti.map(normOrtho).p2())
         self._pixelVectorCache[1] = pv
-        self._pixelVectorCache[0] = dt
+        self._pixelVectorCache[0] = key
         self._pixelVectorGlobalCache[key] = pv
         return self._pixelVectorCache[1]
     


### PR DESCRIPTION
#1212 changed the lookup key used for the local cache from `dt` to a common `key` used also by the global cache.
The local cache update at the end of the function was not similarly modified to use `key`.
At worst, this causes the very _first_ local cache lookup _after_ a computation to always be a miss.

There appears to be another inconsistency present nearby. Elsewhere in the function (2 places), a copy of `pv` is returned. This copying is not done for the return at the end of the function. This was already the behavior prior to #1212.