### PR TITLE
Fix resizing ViewBox if aspect locked + apply ViewBox limits immediately

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -461,8 +461,6 @@ class ViewBox(GraphicsWidget):
             self._viewPixelSizeCache  = None
             self._matrixNeedsUpdate = True
 
-            self._resetTarget(force=True)
-
             self.linkedXChanged()
             self.linkedYChanged()
 
@@ -1617,7 +1615,9 @@ class ViewBox(GraphicsWidget):
                     if maxRng[target] is not None and diff > maxRng[target] or \
                        minRng[target] is not None and diff < minRng[target]:
                         # tweak the target range down so we can still pan properly
-                        self.state['targetRange'][ax] = canidateRange[ax]
+                        viewRange[ax] = canidateRange[ax]
+                        self.state['viewRange'][ax] = viewRange[ax]
+                        self._resetTarget(force=True)
                         ax = target  # Switch the "fixed" axes
 
             if ax == 0:


### PR DESCRIPTION
This commit fixes the following problems, whic occur if a `ViewBox` with locked aspect ratio is resized:
1. The visible range changes suddenly at some points.
2. The set limits are not taken into account.

Note, this PR fixes also Issue #2415. (Thanks @aksy2512 for #2540, I took some ideas from your PR.)

**You can reproduce this with the mwe below:**
Run the script and then slowly decrease the window width.
You'll observe, that the minimum visible y value will go beyond -5, which is set as `yMin` limit.
This is Issue 2.
If you continue to decrease the width, shortly after the y-axis labels 2 and -6 become visible, the y-range suddenly changes to around -4 ... 0, which is the above mentioned problem 1.

**To improve traceability, I try to provide some info on why I changed what in the following:**
This is, because my fix doesn't change one simple thing. Also I had some difficulties to understand the `updateViewRange()` function and still doesn't understand everything, especially the part within `if aspect is not False ...`.

* Adjusting `viewRange` to `limits` in `updateViewRange()` is necessary to fix the limits issue (2).
* That adjusting `targetRange`, when changing `viewRange` is necessary shows me the mwe from #2415:
  There, it all works fine if you increase the width of the `LinearRegionItem`, i.e. the right plot gets updated if necessary.
  But if you then decrease the width of the `LinearRegionItem` again, the right plots x-range also decreases! This is prevented by updating the `targetRange` here.
    * But, we must not reset all targetRange parts (i.e. simply call `self._resetTarget()`) since this causes the following problem:
      If you start decreasing the width of the `LinearRegionItem` again, you observe that the right plots x-range just slightly decreases before stopping!
      You might adjust the mwe and print the x-range on a change, i.e. add `p2.getViewBox().sigXRangeChanged.connect(lambda vb, range: print(range))` to see this effect.
      This doesn't happen if we only adjust the `targetRange` parts whose corresponding `viewRange` parts we changed.
* Regarding `self._resetTarget(force=True)` in `resizeEvent(..)`, this fixes above described problem 1.
* I want to keep the influence of my fix as small as possible, therefore I added the argument to `self._resetTarget()`.
  It would be nice if we could get rid of this `if self.state['aspectLocked'] is False` completely.
  Maybe someone knows a case, where this is needed?!

**Minimum-working-example:**
```
import numpy as np
import pyqtgraph as pg

app = pg.mkQApp()
plot = pg.PlotWidget()
plot.show()

N = 10
data = np.eye(N) + np.flip(np.eye(N), axis=1)
for (n,m) in [(n,m) for n in (0,N-1) for m in (0,N-1)]:
    data[n,m] += 1.0
plot.addItem(pg.ImageItem(data, rect=[-N/2, -N/2, N, N]))
plot.showGrid(x=True, y=True)

plot.setLimits(xMin=-N/2,xMax=+N/2, yMin=-N/2, yMax=+N/2)

plot.setAspectLocked(lock=True, ratio=1.0)

plot.resize(400,200)
plot.setXRange(-5,+5)
plot.setYRange(-5,0)


if __name__ == '__main__':
    pg.exec()
```