### PR TITLE
ImageItem: request for 256-entry lut

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -526,7 +526,7 @@ class ImageItem(GraphicsObject):
         if self.image.ndim == 2 or self.image.shape[2] == 1:
             self.lut = self._ensure_proper_substrate(self.lut, self._xp)
             if isinstance(self.lut, Callable):
-                lut = self._ensure_proper_substrate(self.lut(self.image), self._xp)
+                lut = self._ensure_proper_substrate(self.lut(self.image, 256), self._xp)
             else:
                 lut = self.lut
         else:


### PR DESCRIPTION
When used with `HistogramLUTItem`, floating and uint16 images will by default receive a 512-entry LUT. This causes the rendered `QImage` to use RGBA8888 format.

This PR makes `ImageItem` request for a 256-entry LUT, which:
1) allows rendering to the more efficient Indexed8 format. (1 byte per pixel)
2) avoids interpolation of the bundled colormaps which are natively 256-entry.