### PR TITLE
Add `setLogMode` to `ErrorBarItem`

### DIFF
--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -54,10 +54,8 @@ class ErrorBarItem(GraphicsObject):
         _orig_opts = opts.copy()
         if _orig_opts.get('height', None) is not None:
             _orig_opts['top'] = _orig_opts['bottom'] = _orig_opts['height'] / 2
-            _orig_opts['height'] = None
         if _orig_opts.get('width', None) is not None:
             _orig_opts['left'] = _orig_opts['right'] = _orig_opts['width'] / 2
-            _orig_opts['width'] = None
         self._orig_opts.update(_orig_opts)
 
         self.opts.update(opts)
@@ -76,7 +74,10 @@ class ErrorBarItem(GraphicsObject):
             self.opts['left'] = copy.copy(self._orig_opts.get('left', None))
             self.opts['right'] = copy.copy(self._orig_opts.get('right', None))
             self.opts['x'] = copy.copy(self._orig_opts.get('x', None))
+            self.opts['width'] = copy.copy(self._orig_opts.get('width', None))
         if x is True and self.opts['x'] is not None:
+            # to use 'left' and 'right'
+            self.opts['width'] = None
             _x = self.opts['x']
             if self.opts['left'] is not None:
                 x_err = (np.full(_x.shape, self.opts['left'])
@@ -103,7 +104,10 @@ class ErrorBarItem(GraphicsObject):
             self.opts['bottom'] = copy.copy(self._orig_opts.get('bottom', None))
             self.opts['top'] = copy.copy(self._orig_opts.get('top', None))
             self.opts['y'] = copy.copy(self._orig_opts.get('y', None))
+            self.opts['height'] = copy.copy(self._orig_opts.get('height', None))
         if y is True and self.opts['y'] is not None:
+            # to use 'top' and 'bottom'
+            self.opts['height'] = None
             _y = self.opts['y']
             if self.opts['bottom'] is not None:
                 y_err = (np.full(_y.shape, self.opts['bottom'])

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -78,7 +78,6 @@ class ErrorBarItem(GraphicsObject):
             self.opts['x'] = copy.copy(self._orig_opts['x'])
         if x is True:
             _x = self.opts['x']
-            x_err
             left = np.full(_x.shape, -np.inf, dtype=_x.dtype)
             x_err = (np.full(_x.shape, self.opts['left'])
                      if np.isscalar(self.opts['left'])
@@ -99,9 +98,9 @@ class ErrorBarItem(GraphicsObject):
             self.opts['x'] = _x
 
         if y is not None:
-            self.opts['bottom'] = copy.deepcopy(self._orig_opts['bottom'])
-            self.opts['top'] = copy.deepcopy(self._orig_opts['top'])
-            self.opts['y'] = copy.deepcopy(self._orig_opts['y'])
+            self.opts['bottom'] = copy.copy(self._orig_opts['bottom'])
+            self.opts['top'] = copy.copy(self._orig_opts['top'])
+            self.opts['y'] = copy.copy(self._orig_opts['y'])
         if y is True:
             _y = self.opts['y']
             bottom = np.full(_y.shape, -np.inf, dtype=_y.dtype)

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -79,11 +79,11 @@ class ErrorBarItem(GraphicsObject):
         if x is True and self.opts['x'] is not None:
             _x = self.opts['x']
             if self.opts['left'] is not None:
-                left = np.full(_x.shape, -np.inf, dtype=_x.dtype)
                 x_err = (np.full(_x.shape, self.opts['left'])
                          if np.isscalar(self.opts['left'])
                          else self.opts['left'].copy())
                 valid = (_x > 0) & (_x - x_err > 0)
+                left = np.full(_x.shape, -np.inf, dtype=_x.dtype)
                 left[valid] = np.log10(_x[valid]) - np.log10(_x[valid] - x_err[valid])
                 self.opts['left'] = left
             if self.opts['right'] is not None:
@@ -106,11 +106,11 @@ class ErrorBarItem(GraphicsObject):
         if y is True and self.opts['y'] is not None:
             _y = self.opts['y']
             if self.opts['bottom'] is not None:
-                bottom = np.full(_y.shape, -np.inf, dtype=_y.dtype)
                 y_err = (np.full(_y.shape, self.opts['bottom'])
                          if np.isscalar(self.opts['bottom'])
                          else self.opts['bottom'].copy())
                 valid = (_y > 0) & (_y - y_err > 0)
+                bottom = np.full(_y.shape, -np.inf, dtype=_y.dtype)
                 bottom[valid] = np.log10(_y[valid]) - np.log10(_y[valid] - y_err[valid])
                 self.opts['bottom'] = bottom
             if self.opts['top'] is not None:
@@ -127,7 +127,7 @@ class ErrorBarItem(GraphicsObject):
             self.opts['y'] = _y
 
         if x is not None or y is not None:
-            super().setData(**self.opts)
+            self.setData(**self.opts)
 
     def drawPath(self):
         p = QtGui.QPainterPath()

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -73,50 +73,54 @@ class ErrorBarItem(GraphicsObject):
         
     def setLogMode(self, x=None, y=None):
         if x is not None:
-            self.opts['left'] = copy.copy(self._orig_opts['left'])
-            self.opts['right'] = copy.copy(self._orig_opts['right'])
-            self.opts['x'] = copy.copy(self._orig_opts['x'])
-        if x is True:
+            self.opts['left'] = copy.copy(self._orig_opts.get('left', None))
+            self.opts['right'] = copy.copy(self._orig_opts.get('right', None))
+            self.opts['x'] = copy.copy(self._orig_opts.get('x', None))
+        if x is True and self.opts['x'] is not None:
             _x = self.opts['x']
-            left = np.full(_x.shape, -np.inf, dtype=_x.dtype)
-            x_err = (np.full(_x.shape, self.opts['left'])
-                     if np.isscalar(self.opts['left'])
-                     else self.opts['left'].copy())
-            valid = (_x > 0) & (_x - x_err > 0)
-            left[valid] = np.log10(_x[valid]) - np.log10(_x[valid] - x_err[valid])
-            self.opts['left'] = left
-            x_err = (np.full(_x.shape, self.opts['right'])
-                     if np.isscalar(self.opts['right'])
-                     else self.opts['right'].copy())
-            valid = (_x > 0) & (_x + x_err > 0)
-            right = np.full(_x.shape, np.inf, dtype=_x.dtype)
-            right[valid] = np.log10(_x[valid] + x_err[valid]) - np.log10(_x[valid])
-            self.opts['right'] = right
+            if self.opts['left'] is not None:
+                left = np.full(_x.shape, -np.inf, dtype=_x.dtype)
+                x_err = (np.full(_x.shape, self.opts['left'])
+                         if np.isscalar(self.opts['left'])
+                         else self.opts['left'].copy())
+                valid = (_x > 0) & (_x - x_err > 0)
+                left[valid] = np.log10(_x[valid]) - np.log10(_x[valid] - x_err[valid])
+                self.opts['left'] = left
+            if self.opts['right'] is not None:
+                x_err = (np.full(_x.shape, self.opts['right'])
+                         if np.isscalar(self.opts['right'])
+                         else self.opts['right'].copy())
+                valid = (_x > 0) & (_x + x_err > 0)
+                right = np.full(_x.shape, np.inf, dtype=_x.dtype)
+                right[valid] = np.log10(_x[valid] + x_err[valid]) - np.log10(_x[valid])
+                self.opts['right'] = right
             valid = _x > 0
             _x[valid] = np.log10(_x[valid])
             _x[~valid] = np.nan
             self.opts['x'] = _x
 
         if y is not None:
-            self.opts['bottom'] = copy.copy(self._orig_opts['bottom'])
-            self.opts['top'] = copy.copy(self._orig_opts['top'])
-            self.opts['y'] = copy.copy(self._orig_opts['y'])
-        if y is True:
+            self.opts['bottom'] = copy.copy(self._orig_opts.get('bottom', None))
+            self.opts['top'] = copy.copy(self._orig_opts.get('top', None))
+            self.opts['y'] = copy.copy(self._orig_opts.get('y', None))
+        if y is True and self.opts['y'] is not None:
             _y = self.opts['y']
-            bottom = np.full(_y.shape, -np.inf, dtype=_y.dtype)
-            y_err = (np.full(_y.shape, self.opts['bottom'])
-                     if np.isscalar(self.opts['bottom'])
-                     else self.opts['bottom'].copy())
-            valid = (_y > 0) & (_y - y_err > 0)
-            bottom[valid] = np.log10(_y[valid]) - np.log10(_y[valid] - y_err[valid])
-            self.opts['bottom'] = bottom
-            y_err = (np.full(_y.shape, self.opts['top'])
-                     if np.isscalar(self.opts['top'])
-                     else self.opts['top'].copy())
-            valid = (_y > 0) & (_y + y_err > 0)
-            top = np.full(_y.shape, np.inf, dtype=_y.dtype)
-            top[valid] = np.log10(_y[valid] + y_err[valid]) - np.log10(_y[valid])
-            self.opts['top'] = top
+            if self.opts['bottom'] is not None:
+                bottom = np.full(_y.shape, -np.inf, dtype=_y.dtype)
+                y_err = (np.full(_y.shape, self.opts['bottom'])
+                         if np.isscalar(self.opts['bottom'])
+                         else self.opts['bottom'].copy())
+                valid = (_y > 0) & (_y - y_err > 0)
+                bottom[valid] = np.log10(_y[valid]) - np.log10(_y[valid] - y_err[valid])
+                self.opts['bottom'] = bottom
+            if self.opts['top'] is not None:
+                y_err = (np.full(_y.shape, self.opts['top'])
+                         if np.isscalar(self.opts['top'])
+                         else self.opts['top'].copy())
+                valid = (_y > 0) & (_y + y_err > 0)
+                top = np.full(_y.shape, np.inf, dtype=_y.dtype)
+                top[valid] = np.log10(_y[valid] + y_err[valid]) - np.log10(_y[valid])
+                self.opts['top'] = top
             valid = _y > 0
             _y[valid] = np.log10(_y[valid])
             _y[~valid] = np.nan

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -84,7 +84,7 @@ class ErrorBarItem(GraphicsObject):
                          if np.isscalar(self.opts['left'])
                          else self.opts['left'].copy())
                 valid = (_x > 0) & (_x - x_err > 0)
-                left = np.full(_x.shape, -np.inf, dtype=_x.dtype)
+                left = np.full(_x.shape, np.inf, dtype=_x.dtype)
                 left[valid] = np.log10(_x[valid]) - np.log10(_x[valid] - x_err[valid])
                 self.opts['left'] = left
             if self.opts['right'] is not None:
@@ -114,7 +114,7 @@ class ErrorBarItem(GraphicsObject):
                          if np.isscalar(self.opts['bottom'])
                          else self.opts['bottom'].copy())
                 valid = (_y > 0) & (_y - y_err > 0)
-                bottom = np.full(_y.shape, -np.inf, dtype=_y.dtype)
+                bottom = np.full(_y.shape, np.inf, dtype=_y.dtype)
                 bottom[valid] = np.log10(_y[valid]) - np.log10(_y[valid] - y_err[valid])
                 self.opts['bottom'] = bottom
             if self.opts['top'] is not None:

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -52,10 +52,10 @@ class ErrorBarItem(GraphicsObject):
         """
         # save the original data in case of the log mode set
         _orig_opts = opts.copy()
-        if _orig_opts['height'] is not None:
+        if _orig_opts.get('height', None) is not None:
             _orig_opts['top'] = _orig_opts['bottom'] = _orig_opts['height'] / 2
             _orig_opts['height'] = None
-        if _orig_opts['width'] is not None:
+        if _orig_opts.get('width', None) is not None:
             _orig_opts['left'] = _orig_opts['right'] = _orig_opts['width'] / 2
             _orig_opts['width'] = None
         self._orig_opts.update(_orig_opts)


### PR DESCRIPTION
The PR makes an `ErrorBarItem` scale properly when the log mode is applied.

However, I need some help. Currently, when the error bar exceeds 0 in the log mode, it's drawn sideways. However, the bar should span to the corresponding infinity. It has something to do with the `ErrorBarItem.drawPath` function (likely with `_compute_backfill_indices` from `pyqtgraph/functions.py`), but I don't know what to change there to obtain sane paths when an infinite value is passed there.

The MWE is the following:
```python
import numpy as np
import pyqtgraph as pg
from numpy.typing import NDArray

w: pg.PlotItem = pg.plot()
x: NDArray[np.float64] = np.linspace(0.0, 4.0, 4)
y: NDArray[np.float64] = np.exp(-x)
x_err: float = 0.2
y_err: NDArray[np.float64] = np.full(x.shape, 0.2)
line: pg.PlotDataItem = pg.PlotDataItem(x=x, y=y)
errors: ErrorBarItem = ErrorBarItem(x=x, y=y, width=x_err, height=y_err)
w.setLogMode(x=True, y=True)
w.addItem(line)
w.addItem(errors)
pg.exec()
```

### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [x] `README.md`
- [x] `setup.py`
- [x] `tox.ini`
- [x] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [x] `pyproject.toml`
- [x] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
