### PR TITLE
Preserve tick pen

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1042,6 +1042,12 @@ class AxisItem(GraphicsWidget):
                     raise ValueError("lineAlpha should be [0..255]")
             else:
                 raise TypeError("Line Alpha should be of type None, float or int")
+            tickPen = self.tickPen()
+            # If tickPen is a simple color, create a copy with adjusted opacity:
+            if tickPen.brush().style() == QtCore.Qt.SolidPattern:
+                color = QtGui.QColor(tickPen.color())
+                color.setAlpha(int(lineAlpha))
+                tickPen = QtGui.QPen(color)
 
             for v in ticks:
                 ## determine actual position to draw this tick
@@ -1057,10 +1063,6 @@ class AxisItem(GraphicsWidget):
                 p2[axis] = tickStop
                 if self.grid is False:
                     p2[axis] += tickLength*tickDir
-                tickPen = self.tickPen()
-                color = tickPen.color()
-                color.setAlpha(int(lineAlpha))
-                tickPen.setColor(color)
                 tickSpecs.append((tickPen, Point(p1), Point(p2)))
         profiler('compute ticks')
 

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1043,11 +1043,11 @@ class AxisItem(GraphicsWidget):
             else:
                 raise TypeError("Line Alpha should be of type None, float or int")
             tickPen = self.tickPen()
-            # If tickPen is a simple color, create a copy with adjusted opacity:
-            if tickPen.brush().style() == QtCore.Qt.SolidPattern:
-                color = QtGui.QColor(tickPen.color())
-                color.setAlpha(int(lineAlpha))
-                tickPen = QtGui.QPen(color)
+            if tickPen.brush().style() == QtCore.Qt.SolidPattern: # only adjust simple color pens
+                tickPen = QtGui.QPen(tickPen) # copy to a new QPen
+                color = QtGui.QColor(tickPen.color()) # copy to a new QColor
+                color.setAlpha(int(lineAlpha)) # adjust opacity                
+                tickPen.setColor(color)
 
             for v in ticks:
                 ## determine actual position to draw this tick

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1043,7 +1043,7 @@ class AxisItem(GraphicsWidget):
             else:
                 raise TypeError("Line Alpha should be of type None, float or int")
             tickPen = self.tickPen()
-            if tickPen.brush().style() == QtCore.Qt.SolidPattern: # only adjust simple color pens
+            if tickPen.brush().style() == QtCore.Qt.BrushStyle.SolidPattern: # only adjust simple color pens
                 tickPen = QtGui.QPen(tickPen) # copy to a new QPen
                 color = QtGui.QColor(tickPen.color()) # copy to a new QColor
                 color.setAlpha(int(lineAlpha)) # adjust opacity                


### PR DESCRIPTION
The current handling of `tickPen` in `AxisItem` doesn't work for QPens that have more complex brush settings, such as gradients: When the opacity is adjusted for different tick levels (major, minor and extra ticks), resetting the color causes the applied brush settings to be lost.

As a work-around, we can skip the opacity adjustment for any QPen that has a more complex brush setting than `Qt.SolidPattern`. This lets the ticks be drawn according to the original pen's brush settings, although without the opacity adjustments. This opens up some new drawing options.

While modifying the code, we can also move reconstructing the QPen outside the inner per-tick loop, because it only needs to be done once for major ticks, minor ticks, and extra ticks (if present).

We can also make sure that we are working with copies of QPens and QColors; The current code created problems in earlier PR #1625 by modifying the opacity of the *original* color.

Here's some code to look at the change:
```
import numpy as np
import pyqtgraph.pyqtgraph as pg

app = pg.mkQApp("Axes gradient color demo")
y = np.random.normal(size=30)
win = pg.GraphicsLayoutWidget(show=True, title="axes demo")
win.resize(500,500)

p1 = win.addPlot(title="Plain axes", y=y, row=0, col=0)
p1.showAxes(True)
for axis_name in ('top', 'right', 'bottom', 'left'):
    ax = p1.getAxis(axis_name)
    pen = ax.tickPen()
    pen.setWidth(3)
    ax.setTickPen(pen)
    ax.setPen(pen)

p2 = win.addPlot(title="Brushed axes", y=y, row=1, col=0 )
p2.showAxes(True)

cm = pg.colormap.get('CET-L17')
axL = p2.getAxis('left')
penL = cm.getPen( span=(0, axL.rect().height()), width=3, orientation='vertical' )
axL.setTickPen(penL)
axL.setPen(penL)

axT = p2.getAxis('top')
penT = cm.getPen( span=(0.0, axT.rect().width()), width=3, orientation='horizontal' )
axT.setTickPen(penT)
axT.setPen(penT)

axR = p2.getAxis('right')
cm.reverse()
penR = cm.getPen( span=(0.0, axR.rect().height()), width=3, orientation='vertical' )
axR.setTickPen(penR)
axR.setPen(penR)

axB = p2.getAxis('bottom')
penB = cm.getPen( span=(0.0, axB.rect().width()), width=3, orientation='horizontal' )
axB.setTickPen(penB)
axB.setPen(penB)

if __name__ == '__main__':
    pg.exec()
```
Current code:
![gradient axes current](https://github.com/pyqtgraph/pyqtgraph/assets/19742018/661c0bd1-eab3-4f5e-96f6-7c68efa8cc32)

Revised code:
![gradient axes update](https://github.com/pyqtgraph/pyqtgraph/assets/19742018/7803c3a6-bee4-406e-8417-039aa3a51631)

I'll admit that the use case for this is severly limited. :) 