### PR TITLE
AxisItem: Add adjustable label overlap tolerances, vertical overlap by default

### DIFF
--- a/pyqtgraph/examples/AxisItem_label_overlap.py
+++ b/pyqtgraph/examples/AxisItem_label_overlap.py
@@ -1,0 +1,74 @@
+"""
+This example demonstrates many of the 2D plotting capabilities
+in pyqtgraph. All of the plots may be panned/scaled by dragging with 
+the left/right mouse buttons. Right click on any plot to show a context menu.
+"""
+
+import numpy as np
+
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
+
+app = pg.mkQApp("AxisItem - label overlap settings")
+
+win = pg.GraphicsLayoutWidget(show=True, title="AxisItem - label overlap settings")
+win.resize(800,600)
+win.setWindowTitle("AxisItem - label overlap settings")
+
+# Enable antialiasing for prettier plots
+pg.setConfigOptions(antialias=True)
+
+x_data = np.arange(101) + 1_000.
+y_data = np.random.normal(scale=40., size=101)
+
+font = QtGui.QFont()
+font.setPointSize(14) # A larger font makes the effects more visible
+
+p1 = win.addPlot(title="Default settings: Overlap allowed for y axis", x=x_data, y=y_data)
+for axis_key in ('top', 'bottom', 'left', 'right'):
+    ax = p1.getAxis(axis_key)
+    ax.setTickFont( font )
+
+p2 = win.addPlot(title="Overlap allowed for X axis", x=x_data, y=y_data)
+for axis_key, hide_overlap in (
+    ('top'   , False), 
+    ('bottom', False),
+    ('left'  , True ),
+    ('right' , True )
+):
+    ax = p2.getAxis(axis_key)
+    ax.setStyle( hideOverlappingLabels = hide_overlap )
+    ax.setTickFont( font )
+
+win.nextRow()
+
+p3 = win.addPlot(title="All overlap disabled", x=x_data, y=y_data)
+for axis_key in ('top', 'bottom', 'left', 'right'):
+    ax = p3.getAxis(axis_key)
+    ax.setStyle( hideOverlappingLabels = True )
+    ax.setTickFont( font )
+
+p4 = win.addPlot(title="All overlap enabled, custom tolerances", x=x_data, y=y_data)
+for axis_key, tolerance in (
+    ('top'   ,  15 ),
+    ('bottom', 200 ),
+    ('left'  , 100 ),
+    ('right' ,  15 )
+):
+    ax = p4.getAxis(axis_key)
+    ax.setStyle( hideOverlappingLabels = tolerance )
+    ax.setTickFont( font )
+
+# Link all axes and set viewing range with no padding:
+for p in (p1, p2, p3, p4):
+    p.showAxes(True, showValues=(True, True, True, True))
+    if p != p1:
+        p.setXLink(p1)
+        p.setYLink(p1)
+    ax.setTickFont( font )
+p1.setXRange( 1_000., 1_100., padding=0.0)
+p1.setYRange(-60.,  60., padding=0.0)
+
+
+if __name__ == '__main__':
+    pg.exec()

--- a/pyqtgraph/examples/utils.py
+++ b/pyqtgraph/examples/utils.py
@@ -61,6 +61,7 @@ examples_ = OrderedDict([
         ('Linked Views', 'linkedViews.py'),
         ('Arrow', 'Arrow.py'),
         ('ViewBox', 'ViewBoxFeatures.py'),
+        ('AxisItem - label overlap', 'AxisItem_label_overlap.py'),
         ('Custom Graphics', 'customGraphicsItem.py'),
         ('Labeled Graph', 'CustomGraphItem.py'),
         ('PColorMeshItem', 'PColorMeshItem.py'),

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -52,6 +52,9 @@ class AxisItem(GraphicsWidget):
             raise Exception("Orientation argument must be one of 'left', 'right', 'top', or 'bottom'.")
         if orientation in ['left', 'right']:
             self.label.setRotation(-90)
+            hide_overlapping_labels = False # allow labels on vertical axis to extend above and below the length of the axis
+        else:
+            hide_overlapping_labels = True # stop labels on horizontal axis from overlapping so vertical axis labels have room
 
         self.style = {
             'tickTextOffset': [5, 2],  ## (horizontal, vertical) spacing between text and axis
@@ -59,7 +62,7 @@ class AxisItem(GraphicsWidget):
             'tickTextHeight': 18,
             'autoExpandTextSpace': True,  ## automatically expand text space if needed
             'autoReduceTextSpace': True,
-            'hideOverlappingLabels': True,
+            'hideOverlappingLabels': hide_overlapping_labels,
             'tickFont': None,
             'stopAxisAtTick': (False, False),  ## whether axis is drawn to edge of box or to last tick
             'textFillLimits': [  ## how much of the axis to fill up with tick text, maximally.
@@ -137,9 +140,12 @@ class AxisItem(GraphicsWidget):
         autoExpandTextSpace   (bool) Automatically expand text space if the tick
                               strings become too long.
         autoReduceTextSpace   (bool) Automatically shrink the axis if necessary
-        hideOverlappingLabels (bool) Hide tick labels which overlap the AxisItems'
-                              geometry rectangle. If False, labels might be drawn
-                              overlapping with tick labels from neighboring plots.
+        hideOverlappingLabels (bool or int)
+
+                              * *True*  (default for horizontal axis): Hide tick labels which extend beyond the AxisItem's geometry rectangle.
+                              * *False* (default for vertical axis): Labels may be drawn extending beyond the extent of the axis.
+                              * *(int)* sets the tolerance limit for how many pixels a label is allowed to exted beyond the axis. Defaults to 15 for `hideOverlappingLabels = False`.
+
         tickFont              (QFont or None) Determines the font used for tick
                               values. Use None for the default font.
         stopAxisAtTick        (tuple: (bool min, bool max)) If True, the axis
@@ -624,7 +630,17 @@ class AxisItem(GraphicsWidget):
                 self.setRange(*newRange)
 
     def boundingRect(self):
-        m = 0 if self.style['hideOverlappingLabels'] else 15
+        m = 0
+        hide_overlapping_labels = self.style['hideOverlappingLabels']
+        if hide_overlapping_labels is True:
+            pass # skip further checks
+        elif hide_overlapping_labels is False:
+            m = 15
+        else:
+            try:
+                m = int( self.style['hideOverlappingLabels'] )
+            except ValueError: pass # ignore any non-numeric value
+
         linkedView = self.linkedView()
         if linkedView is None or self.grid is False:
             rect = self.mapRectFromParent(self.geometry())
@@ -636,7 +652,7 @@ class AxisItem(GraphicsWidget):
             elif self.orientation == 'right':
                 rect = rect.adjusted(min(0,tl), -m, 0, m)
             elif self.orientation == 'top':
-                rect = rect.adjusted(-15, 0, 15, -min(0,tl))
+                rect = rect.adjusted(-m, 0, m, -min(0,tl))
             elif self.orientation == 'bottom':
                 rect = rect.adjusted(-m, min(0,tl), m, 0)
             return rect
@@ -696,7 +712,7 @@ class AxisItem(GraphicsWidget):
             # two levels, all offsets = 0
             axis.setTickSpacing(5, 1)
             # three levels, all offsets = 0
-            axis.setTickSpacing([(3, 0), (1, 0), (0.25, 0)])
+            axis.setTickSpacing(levels=[(3, 0), (1, 0), (0.25, 0)])
             # reset to default
             axis.setTickSpacing()
         """

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -144,7 +144,7 @@ class AxisItem(GraphicsWidget):
 
                               * *True*  (default for horizontal axis): Hide tick labels which extend beyond the AxisItem's geometry rectangle.
                               * *False* (default for vertical axis): Labels may be drawn extending beyond the extent of the axis.
-                              * *(int)* sets the tolerance limit for how many pixels a label is allowed to exted beyond the axis. Defaults to 15 for `hideOverlappingLabels = False`.
+                              * *(int)* sets the tolerance limit for how many pixels a label is allowed to extend beyond the axis. Defaults to 15 for `hideOverlappingLabels = False`.
 
         tickFont              (QFont or None) Determines the font used for tick
                               values. Use None for the default font.


### PR DESCRIPTION
This extends / adjusts the functionality added in #2385 to stop axis labels sticking out of the allocated space. That certainly avoids overlap, it leaves less room for labels, and makes it so that ticks at the edges of the axis are never labeled. 

The main problem identified in #2385 was an overlap of the x-axis labels of adjacent plots in a layout. While the width of the x-axis plots grows for larger numbers, the height of the y axis labels remains constant, so overlap is much less problematic there.

This PR 
- changes the default AxisItem behavior to allow tick labels for the *vertical* axis to extend outside the boundary box.
- adds the option of passing an integer tolerance value for `hideOverlappingLabels` to allow a user specified amount of overlap: The default of 15 pixels tolerance for enabled overlap is too small at larger font sizes. This functionality was discussed for #2385, but wasn't ultimately added. The previously allowed values of True and False function the same as before.
- fixes a bug where the label tolerance accidentally remained hardcoded for the top axis.
- adds an example to show the effect of the setting and give demonstration code
- fixes an unrelated documentation error in `setTickSpacing()`

![example AxisItem - label overlap](https://github.com/pyqtgraph/pyqtgraph/assets/19742018/256b46c7-48b1-4f21-a161-e13053dba709)
