### PR TITLE
Adding override to disable autoHistogramRange

### DIFF
--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -215,7 +215,7 @@ class ImageView(QtWidgets.QWidget):
             setattr(self, fn, getattr(self.view, fn))
 
         ## wrap functions from histogram
-        for fn in ['setHistogramRange', 'autoHistogramRange', 'getLookupTable', 'getLevels']:
+        for fn in ['setHistogramRange', 'getLookupTable', 'getLevels']:
             setattr(self, fn, getattr(self.ui.histogram, fn))
 
         self.timeLine.sigPositionChanged.connect(self.timeLineChanged)
@@ -251,6 +251,7 @@ class ImageView(QtWidgets.QWidget):
         ]
         
         self.roiClicked() ## initialize roi plot to correct shape / visibility
+        self._autoHistogramRange=True 
 
     def setImage(
             self,
@@ -263,7 +264,6 @@ class ImageView(QtWidgets.QWidget):
             pos=None,
             scale=None,
             transform=None,
-            autoHistogramRange=True,
             levelMode=None,
     ):
         """
@@ -373,7 +373,7 @@ class ImageView(QtWidgets.QWidget):
         profiler()
 
         self.currentIndex = 0
-        self.updateImage(autoHistogramRange=autoHistogramRange)
+        self.updateImage()
         if levels is None and autoLevels:
             self.autoLevels()
         if levels is not None:  ## this does nothing since getProcessedImage sets these values again.
@@ -824,14 +824,14 @@ class ImageView(QtWidgets.QWidget):
 
         self.sigTimeChanged.emit(ind, time)
 
-    def updateImage(self, autoHistogramRange=True):
+    def updateImage(self):
         ## Redraw image on screen
         if self.image is None:
             return
     
         image = self.getProcessedImage()
-        if autoHistogramRange:
-            self.ui.histogram.setHistogramRange(self.levelMin, self.levelMax)
+        if self._autoHistogramRange:
+            self.ui.histogram.setHistogramRange(self.levelMin, self.levelMax)       
         
         # Transpose image into order expected by ImageItem
         if self.imageItem.axisOrder == 'col-major':
@@ -945,3 +945,15 @@ class ImageView(QtWidgets.QWidget):
         Currently available gradients are:   
         """
         self.ui.histogram.gradient.loadPreset(name)
+
+    def autoHistogramRange(self):
+        """Enable auto-scaling on the histogram plot."""
+        self._autoHistogramRange = True 
+        # propgate the enable down to the Histogram object 
+        self.ui.histogram.autoHistogramRange()
+
+    def disableAutoHistogramRange(self):
+        """Disable auto-scaling on the histogram plot."""
+        self._autoHistogramRange = False
+        # propgate the diasable down to the Histogram object 
+        self.ui.histogram.disableAutoHistogramRange()


### PR DESCRIPTION
Detail the reasoning behind the code change.  If there is an associated issue that this PR will resolve add

Fixes #163 

Added setter and diable for autohistogramRange. Was consistent with HistogramLUTItem

### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [x] `README.md`
- [x] `setup.py`
- [x] `tox.ini`
- [x] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [x] `pyproject.toml`
- [x] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
