### PR TITLE
workaround PYSIDE-2487 for pen parameter

### DIFF
--- a/pyqtgraph/examples/optics/pyoptic.py
+++ b/pyqtgraph/examples/optics/pyoptic.py
@@ -148,7 +148,7 @@ class Optic(pg.GraphicsObject, ParamObj):
         }
         defaults.update(params)
         self._ior_cache = {}
-        self.roi.sigRegionChanged.connect(self.roiChanged)
+        self._connRoiChanged = self.roi.sigRegionChanged.connect(self.roiChanged)
         self.setParams(**defaults)
         
     def updateTransform(self):
@@ -168,14 +168,22 @@ class Optic(pg.GraphicsObject, ParamObj):
         
         # Move ROI to match
         try:
-            self.roi.sigRegionChanged.disconnect(self.roiChanged)
+            # workaround PYSIDE-2487 that affects PySide 6.5.3 by
+            # disconnecting through a handle
+            if isinstance(self._connRoiChanged, QtCore.QMetaObject.Connection):
+                self.roi.sigRegionChanged.disconnect(self._connRoiChanged)
+            else:
+                # this branch is for PySide2 5.15 which returns a
+                # boolean instead of a QMetaObject.Connection
+                self.roi.sigRegionChanged.disconnect(self.roiChanged)
+
             br = self.gitem.boundingRect()
             o = self.gitem.mapToParent(br.topLeft())
             self.roi.setAngle(self['angle'])
             self.roi.setPos(o)
             self.roi.setSize([br.width(), br.height()])
         finally:
-            self.roi.sigRegionChanged.connect(self.roiChanged)
+            self._connRoiChanged = self.roi.sigRegionChanged.connect(self.roiChanged)
         
         self.sigStateChanged.emit()
 

--- a/pyqtgraph/parametertree/parameterTypes/pen.py
+++ b/pyqtgraph/parametertree/parameterTypes/pen.py
@@ -192,6 +192,7 @@ class PenParameter(GroupParameter):
                     # that affects PySide 6.5.3
                     # Since the child param was freshly created by us, there can only have been one slot
                     # connected. So we can just disconnect all the slots without specifying which one.
+                    assert p.receivers(QtCore.SIGNAL("sigValueChanged(PyObject,PyObject)")) == 1
                     p.sigValueChanged.disconnect()
                 # Some widgets (e.g. checkbox, combobox) don't emit 'changing' signals, so tie to 'changed' as well
                 p.sigValueChanged.connect(newSetter)

--- a/pyqtgraph/parametertree/parameterTypes/pen.py
+++ b/pyqtgraph/parametertree/parameterTypes/pen.py
@@ -185,7 +185,14 @@ class PenParameter(GroupParameter):
                 if p.type() != 'color':
                     p.sigValueChanging.connect(newSetter)
                 # Force children to emulate self's value instead of being part of a tree like normal
-                p.sigValueChanged.disconnect(p._emitValueChanged)
+                try:
+                    p.sigValueChanged.disconnect(p._emitValueChanged)
+                except RuntimeError:
+                    # workaround https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2487
+                    # that affects PySide 6.5.3
+                    # Since the child param was freshly created by us, there can only have been one slot
+                    # connected. So we can just disconnect all the slots without specifying which one.
+                    p.sigValueChanged.disconnect()
                 # Some widgets (e.g. checkbox, combobox) don't emit 'changing' signals, so tie to 'changed' as well
                 p.sigValueChanged.connect(newSetter)
 


### PR DESCRIPTION
This PR workarounds a regression in PySide 6.5.3 that affects code in pyqtgraph's pen parameter.
(https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2487)

Note: Qt 6.5 is LTS and PySide 6.5.3 will be the last version to have non-commercial wheels.

Script to demonstrate that the proposed fix does disconnect the slot
```python
from PySide6 import QtCore

class Parent(QtCore.QObject):
    sig = QtCore.Signal(object)

    def pslot(self, val):
        pass

class Child(Parent):
    pass

x = Child()
x.sig.connect(x.pslot)

# disconnecting slot defined in parent fails since PySide >= 6.5.3
# x.sig.disconnect(x.pslot) 

# disconnecting all slots works
x.sig.disconnect()

# show that slots are disconnected
x.dumpObjectInfo()
```