### PR TITLE
fixed recursive PlotWidget.__getattr__ calls

### DIFF
--- a/pyqtgraph/widgets/PlotWidget.py
+++ b/pyqtgraph/widgets/PlotWidget.py
@@ -44,6 +44,9 @@ class PlotWidget(GraphicsView):
     other methods, use :func:`getPlotItem <pyqtgraph.PlotWidget.getPlotItem>`.
     """
     def __init__(self, parent=None, background='default', plotItem=None, **kargs):
+        ## start by instantiating the plotItem attribute in order to avoid recursive 
+        ## calls of PlotWidget.__getattr__ - which access self.plotItem!
+        self.plotItem = None
         """When initializing PlotWidget, *parent* and *background* are passed to 
         :func:`GraphicsWidget.__init__() <pyqtgraph.GraphicsWidget.__init__>`
         and all others are passed
@@ -74,17 +77,11 @@ class PlotWidget(GraphicsView):
         self.setParent(None)
         super(PlotWidget, self).close()
 
-    ## implicitly wrap methods from plotItem
-    ## the implementation prevents recursive calls to PlotWidget.__getattr__ that lead to a 
-    ## 'maximum recursion depth exceeded' when PlotWidget is used in a multiple inheritance 
-    ## schema - i.e., class SomeClass(PlotWidget, SomeOtherClass)
-    def __getattr__(self, attr): 
-        try:
+    def __getattr__(self, attr):  ## implicitly wrap methods from plotItem
+        if hasattr(self.plotItem, attr):
             m = getattr(self.plotItem, attr)
-        except:
-            raise AttributeError(attr)
-        if hasattr(m, '__call__'):
-            return m
+            if hasattr(m, '__call__'):
+                return m
         raise AttributeError(attr)
     
     def viewRangeChanged(self, view, range):
@@ -103,6 +100,3 @@ class PlotWidget(GraphicsView):
     def getPlotItem(self):
         """Return the PlotItem contained within."""
         return self.plotItem
-        
-        
-        

--- a/pyqtgraph/widgets/PlotWidget.py
+++ b/pyqtgraph/widgets/PlotWidget.py
@@ -74,11 +74,17 @@ class PlotWidget(GraphicsView):
         self.setParent(None)
         super(PlotWidget, self).close()
 
-    def __getattr__(self, attr):  ## implicitly wrap methods from plotItem
-        if hasattr(self.plotItem, attr):
+    ## implicitly wrap methods from plotItem
+    ## the implementation prevents recursive calls to PlotWidget.__getattr__ that lead to a 
+    ## 'maximum recursion depth exceeded' when PlotWidget is used in a multiple inheritance 
+    ## schema - i.e., class SomeClass(PlotWidget, SomeOtherClass)
+    def __getattr__(self, attr): 
+        try:
             m = getattr(self.plotItem, attr)
-            if hasattr(m, '__call__'):
-                return m
+        except:
+            raise AttributeError(attr)
+        if hasattr(m, '__call__'):
+            return m
         raise AttributeError(attr)
     
     def viewRangeChanged(self, view, range):


### PR DESCRIPTION
PlotWidget.\_\_getattr\_\_ implicitly wrap methods from PlotItem. However, the current implementation leads to recursive calls
and 'maximum recursion depth exceeded' errors when PlotWidget is used in a multiple inheritance schema - i.e., class SomeClass(PlotWidget, SomeOtherClass). The proposed PlotWidget.\_\_getattr\_\_  prevents the recursive calls by get rid of the hasattr that is the source of the problem.