### PR TITLE
ButtonItem: draw pixmap to logical size

### DIFF
--- a/pyqtgraph/graphicsItems/ButtonItem.py
+++ b/pyqtgraph/graphicsItems/ButtonItem.py
@@ -14,10 +14,11 @@ class ButtonItem(GraphicsObject):
             self.setImageFile(imageFile)
         elif pixmap is not None:
             self.setPixmap(pixmap)
-            
-        if width is not None and self.pixmap.width():
-            s = float(width) / self.pixmap.width()
-            self.setScale(s)
+
+        self._width = width
+        if self._width is None:
+            self._width = self.pixmap.width() / self.pixmap.devicePixelRatio()
+
         if parentItem is not None:
             self.setParentItem(parentItem)
         self.setOpacity(0.7)
@@ -51,8 +52,10 @@ class ButtonItem(GraphicsObject):
         
     def paint(self, p, *args):
         p.setRenderHint(p.RenderHint.Antialiasing)
-        p.drawPixmap(0, 0, self.pixmap)
+        tgtRect = QtCore.QRectF(0, 0, self._width, self._width)
+        srcRect = QtCore.QRectF(self.pixmap.rect())
+        p.drawPixmap(tgtRect, self.pixmap, srcRect)
         
     def boundingRect(self):
-        return QtCore.QRectF(self.pixmap.rect())
+        return QtCore.QRectF(0, 0, self._width, self._width)
         


### PR DESCRIPTION
On hidpi displays, `PlotItem`'s "auto" icon is rendered smaller, making it harder to click.
This is due to `ButtonItem` drawing the pixmap in device pixels.

This PR changes the drawing to use logical sizes so that the icon is the same size across different DPI displays.

Remarks:
The "auto" graphic is actually 32x32 while the logical size used is 14, which means that even on a DPI 2.0 display, we will have a nice non-blurry rendering.