### PR TITLE
pcmi: refactor setData()

### DIFF
--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -91,7 +91,7 @@ class PColorMeshItem(GraphicsObject):
             Sets the minimum and maximum values to be represented by the colormap (min, max). 
             Values outside this range will be clipped to the colors representing min or max.
             ``None`` disables the limits, meaning that the colormap will autoscale 
-            each time ``setData()`` is called - unless ``enableAutoLevels=False``.
+            the next time ``setData()`` is called with new data.
         enableAutoLevels: bool, optional, default True
             Causes the colormap levels to autoscale whenever ``setData()`` is called. 
             It is possible to override this value on a per-change-basis by using the

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -219,32 +219,35 @@ class PColorMeshItem(GraphicsObject):
             The minimum and maximum levels are mapped to the lowest and highest colors 
             in the colormap. The autoLevels parameter is ignored if ``enableAutoLevels is False`` 
         """
+        old_bounds = self._dataBounds
+        self._prepareData(args)
+        boundsChanged = old_bounds != self._dataBounds
+
         autoLevels = kwargs.get('autoLevels', True)
+        self._rerender(autoLevels=autoLevels)
 
-        # Has the view bounds changed
-        shapeChanged = False
-        if self.qpicture is None:
-            shapeChanged = True
-        elif len(args)==1:
-            if args[0].shape[0] != self.x[:,1][-1] or args[0].shape[1] != self.y[0][-1]:
-                shapeChanged = True
-        elif len(args)==3:
-            if np.any(self.x != args[0]) or np.any(self.y != args[1]):
-                shapeChanged = True
+        if boundsChanged:
+            self.prepareGeometryChange()
+            self.informViewBoundsChanged()
 
-        if len(args)==0:
-            # No data was received.
-            if self.z is None:
-                # No data is currently displayed, 
-                # so other settings (like colormap) can not be updated
-                return
-        else:
-            # Got new data. Prepare it for plotting
-            self._prepareData(args)
+        self.update()
 
+    def _rerender(self, *, autoLevels):
+        self.qpicture = None
+        if self.z is not None:
+            if (self.levels is None) or (self.enableautolevels and autoLevels):
+                # Autoscale colormap
+                z_min = self.z.min()
+                z_max = self.z.max()
+                self.setLevels( (z_min, z_max), update=False)
+            self.qpicture = self._drawPicture()
 
-        self.qpicture = QtGui.QPicture()
-        painter = QtGui.QPainter(self.qpicture)
+    def _drawPicture(self) -> QtGui.QPicture:
+        # on entry, the following members are all valid: x, y, z, levels
+        # this function does not alter any state (besides using self.quads)
+
+        picture = QtGui.QPicture()
+        painter = QtGui.QPainter(picture)
         # We set the pen of all polygons once
         if self.edgecolors is None:
             painter.setPen(QtCore.Qt.PenStyle.NoPen)
@@ -252,28 +255,17 @@ class PColorMeshItem(GraphicsObject):
             painter.setPen(self.edgecolors)
             if self.antialiasing:
                 painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
-                
 
         ## Prepare colormap
         # First we get the LookupTable
         lut = self.lut_qcolor
         # Second we associate each z value, that we normalize, to the lut
         scale = len(lut) - 1
-        # Decide whether to autoscale the colormap or use the same levels as before
-        if (self.levels is None) or (self.enableautolevels and autoLevels):
-            # Autoscale colormap 
-            z_min = self.z.min()
-            z_max = self.z.max()
-            self.setLevels( (z_min, z_max), update=False)
-        else:
-            # Use consistent colormap scaling
-            z_min = self.levels[0]
-            z_max = self.levels[1]
-        rng = z_max - z_min
+        lo, hi = self.levels[0], self.levels[1]
+        rng = hi - lo
         if rng == 0:
             rng = 1
-        norm = fn.rescaleData(self.z, scale / rng, z_min,
-            dtype=int, clip=(0, len(lut)-1))
+        norm = fn.rescaleData(self.z, scale / rng, lo, dtype=int, clip=(0, len(lut)-1))
 
         if Qt.QT_LIB.startswith('PyQt'):
             drawConvexPolygon = lambda x : painter.drawConvexPolygon(*x)
@@ -299,24 +291,7 @@ class PColorMeshItem(GraphicsObject):
                 drawConvexPolygon(polys[idx])
 
         painter.end()
-        self.update()
-
-        self.prepareGeometryChange()
-        if shapeChanged:
-            self.informViewBoundsChanged()
-
-
-
-    def _updateDisplayWithCurrentState(self, *args, **kargs):
-        ## Used for re-rendering mesh from self.z.
-        ## For example when a new colormap is applied, or the levels are adjusted
-
-        defaults = {
-            'autoLevels': False,
-        }
-        defaults.update(kargs)
-        return self.setData(*args, **defaults)
-
+        return picture
 
 
     def setLevels(self, levels, update=True):
@@ -334,9 +309,8 @@ class PColorMeshItem(GraphicsObject):
         self.levels = levels
         self.sigLevelsChanged.emit(levels)
         if update:
-            self._updateDisplayWithCurrentState()
-
-
+            self._rerender(autoLevels=False)
+            self.update()
 
     def getLevels(self):
         """
@@ -351,9 +325,8 @@ class PColorMeshItem(GraphicsObject):
         self.cmap = None    # invalidate since no longer consistent with lut
         self.lut_qcolor = lut[:]
         if update:
-            self._updateDisplayWithCurrentState()
-
-
+            self._rerender(autoLevels=False)
+            self.update()
 
     def getColorMap(self):
         return self.cmap
@@ -373,10 +346,8 @@ class PColorMeshItem(GraphicsObject):
 
 
     def paint(self, p, *args):
-        if self.z is None:
-            return
-
-        p.drawPicture(0, 0, self.qpicture)
+        if self.qpicture is not None:
+            p.drawPicture(0, 0, self.qpicture)
 
 
     def setBorder(self, b):

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -349,13 +349,6 @@ class PColorMeshItem(GraphicsObject):
         if self.qpicture is not None:
             p.drawPicture(0, 0, self.qpicture)
 
-
-    def setBorder(self, b):
-        self.border = fn.mkPen(b)
-        self.update()
-
-
-
     def width(self):
         if self._dataBounds is None:
             return 0

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -125,7 +125,7 @@ class PColorMeshItem(GraphicsObject):
             self.edgecolors.setCosmetic(True)
         self.antialiasing = kwargs.get('antialiasing', False)
         self.levels = kwargs.get('levels', None)
-        self.enableautolevels = kwargs.get('enableAutoLevels', True)
+        self._defaultAutoLevels = kwargs.get('enableAutoLevels', True)
         
         if 'colorMap' in kwargs:
             cmap = kwargs.get('colorMap')
@@ -221,7 +221,7 @@ class PColorMeshItem(GraphicsObject):
         boundsChanged = old_bounds != self._dataBounds
 
         self._rerender(
-            autoLevels=kwargs.get('autoLevels', self.enableautolevels)
+            autoLevels=kwargs.get('autoLevels', self._defaultAutoLevels)
         )
 
         if boundsChanged:
@@ -334,14 +334,10 @@ class PColorMeshItem(GraphicsObject):
         self.cmap = cmap
 
     def enableAutoLevels(self):
-        self.enableautolevels = True
-
-
+        self._defaultAutoLevels = True
 
     def disableAutoLevels(self):
-        self.enableautolevels = False
-
-
+        self._defaultAutoLevels = False
 
     def paint(self, p, *args):
         if self.qpicture is not None:

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -94,8 +94,8 @@ class PColorMeshItem(GraphicsObject):
             each time ``setData()`` is called - unless ``enableAutoLevels=False``.
         enableAutoLevels: bool, optional, default True
             Causes the colormap levels to autoscale whenever ``setData()`` is called. 
-            When enableAutoLevels is set to True, it is still possible to disable autoscaling
-            on a per-change-basis by using ``autoLevels=False`` when calling ``setData()``.
+            It is possible to override this value on a per-change-basis by using the
+            ``autoLevels`` keyword argument when calling ``setData()``.
             If ``enableAutoLevels==False`` and ``levels==None``, autoscaling will be 
             performed once when the first z data is supplied. 
         edgecolors : dict, optional
@@ -213,18 +213,16 @@ class PColorMeshItem(GraphicsObject):
 
             "ASCII from: <https://matplotlib.org/3.2.1/api/_as_gen/
                          matplotlib.pyplot.pcolormesh.html>".
-        autoLevels: bool, optional, default True
-            When set to True, PColorMeshItem will automatically select levels
-            based on the minimum and maximum values encountered in the data along the z axis.
-            The minimum and maximum levels are mapped to the lowest and highest colors 
-            in the colormap. The autoLevels parameter is ignored if ``enableAutoLevels is False`` 
+        autoLevels: bool, optional
+            If set, overrides the value of ``enableAutoLevels``
         """
         old_bounds = self._dataBounds
         self._prepareData(args)
         boundsChanged = old_bounds != self._dataBounds
 
-        autoLevels = kwargs.get('autoLevels', True)
-        self._rerender(autoLevels=autoLevels)
+        self._rerender(
+            autoLevels=kwargs.get('autoLevels', self.enableautolevels)
+        )
 
         if boundsChanged:
             self.prepareGeometryChange()
@@ -235,7 +233,7 @@ class PColorMeshItem(GraphicsObject):
     def _rerender(self, *, autoLevels):
         self.qpicture = None
         if self.z is not None:
-            if (self.levels is None) or (self.enableautolevels and autoLevels):
+            if (self.levels is None) or autoLevels:
                 # Autoscale colormap
                 z_min = self.z.min()
                 z_max = self.z.max()


### PR DESCRIPTION
`PColorMeshItem::setData()` was a giant function that was also being called by `setLevels()` and `setLookupTable()`.

This PR refactors `setData()` to `_rerender()` and `_drawPicture()` while removing `_updateDisplayWithCurrentState()`

`_rerender()` is for redrawing when only levels or colors have changed.
i.e. data bounds have not changed. 
i.e. after a call to `setLevels()` or `setLookupTable()`.

may fix #2875

It is not clear to me why `prepareGeometryChange()` is being called unconditionally, but care is taken to call `informViewBoundsChanged()` only if bounds have been detected to have changed.
```python
self.prepareGeometryChange()
if boundsChanged:
      self.informViewBoundsChanged()
```
