### PR TITLE
make ColorBarItem agnostic of the image kind

### DIFF
--- a/pyqtgraph/graphicsItems/ColorBarItem.py
+++ b/pyqtgraph/graphicsItems/ColorBarItem.py
@@ -7,7 +7,6 @@ from .. import colormap
 from .. import functions as fn
 from ..Qt import QtCore, QtGui, QtWidgets
 from .LinearRegionItem import LinearRegionItem
-from .PColorMeshItem import PColorMeshItem
 from .PlotItem import PlotItem
 
 __all__ = ['ColorBarItem']
@@ -288,10 +287,7 @@ class ColorBarItem(PlotItem):
             if img is None: continue # dereference weakref
             img.setLevels( self.values ) # (min,max) tuple
             if update_cmap and self._colorMap is not None:
-                if isinstance(img, PColorMeshItem):
-                    img.setLookupTable( self._colorMap.getLookupTable(nPts=256, mode=self._colorMap.QCOLOR) )
-                else:
-                    img.setLookupTable( self._colorMap.getLookupTable(nPts=256) )
+                img.setColorMap(self._colorMap)
 
     def _levelsChangedHandler(self, levels):
         """ internal: called when child item for some reason decides to update its levels without using ColorBarItem.

--- a/pyqtgraph/graphicsItems/ColorBarItem.py
+++ b/pyqtgraph/graphicsItems/ColorBarItem.py
@@ -41,7 +41,7 @@ class ColorBarItem(PlotItem):
 
     def __init__(self, values=None, width=25, colorMap=None, label=None,
                  interactive=True, limits=None, rounding=1,
-                 orientation='vertical', pen='w', hoverPen='r', hoverBrush='#FF000080', cmap=None ):
+                 orientation='vertical', pen='w', hoverPen='r', hoverBrush='#FF000080' ):
         """
         Creates a new ColorBarItem.
 

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -348,6 +348,7 @@ class PColorMeshItem(GraphicsObject):
 
     
     def setLookupTable(self, lut, update=True):
+        self.cmap = None    # invalidate since no longer consistent with lut
         self.lut_qcolor = lut[:]
         if update:
             self._updateDisplayWithCurrentState()
@@ -357,7 +358,9 @@ class PColorMeshItem(GraphicsObject):
     def getColorMap(self):
         return self.cmap
 
-
+    def setColorMap(self, cmap):
+        self.setLookupTable(cmap.getLookupTable(nPts=256, mode=cmap.QCOLOR), update=True)
+        self.cmap = cmap
 
     def enableAutoLevels(self):
         self.enableautolevels = True

--- a/tests/graphicsItems/test_NonUniformImage.py
+++ b/tests/graphicsItems/test_NonUniformImage.py
@@ -61,15 +61,11 @@ def test_NonUniformImage_lut():
     Z = X * Y
 
     image = NonUniformImage(x, y, Z, border=fn.mkPen('g'))
+
+    cmap = ColorMap(None, [0.0, 1.0])
+    image.setLookupTable(cmap.getLookupTable(nPts=256))
+
     viewbox.addItem(image)
-
-    lut = pg.HistogramLUTItem()
-    window.addItem(lut)
-
-    image.setLookupTable(lut, autoLevel=True)
-
-    h = image.getHistogram()
-    lut.plot.setData(*h)
 
     QtTest.QTest.qWaitForWindowExposed(window)
     QtTest.QTest.qWait(100)

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -1,5 +1,6 @@
 import pytest
 
+import numpy as np
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtGui
 
@@ -79,3 +80,15 @@ def test_ColorMap_getByIndex():
     cm = pg.ColorMap([0.0, 1.0], [(0,0,0), (255,0,0)])
     assert cm.getByIndex(0) == QtGui.QColor.fromRgbF(0.0, 0.0, 0.0, 1.0)
     assert cm.getByIndex(1) == QtGui.QColor.fromRgbF(1.0, 0.0, 0.0, 1.0)
+
+def test_round_trip():
+    # test that colormap survives a round trip.
+    # note that while both input and output are in BYTE,
+    # internally the colors are stored as float; thus
+    # there is a conversion BYTE -> float -> BYTE
+    nPts = 256
+    zebra = np.zeros((nPts, 3), dtype=np.uint8)
+    zebra[1::2, :] = 255
+    cmap = pg.ColorMap(None, zebra)
+    lut = cmap.getLookupTable(nPts=nPts)
+    assert np.all(lut == zebra)


### PR DESCRIPTION
This PR seeks to make the support of `ColorBarItem` for the various image-like `GraphicsItems` more consistent.

It changes `ColorBarItem` to update the image-like items under its control using `setColorMap` instead of `setLookupTable`.

It also tries to make `NonUniformImage` and 'PColorMeshItem` internally more consistent when both `setColorMap` and `setLookupTable` have been used.


Script to test that setting colormap from `ColorBarItem` propagates to the various image-like items.
```python
import random

import numpy as np
import pyqtgraph as pg
from pyqtgraph.Qt import QtCore
from pyqtgraph.graphicsItems.NonUniformImage import NonUniformImage

pg.mkQApp()
glw = pg.GraphicsLayoutWidget()
glw.show()

rng = np.random.default_rng(12345)
Z = rng.standard_normal(size=(50, 30))
x = np.arange(Z.shape[0])
y = np.arange(Z.shape[1])

images = []
images.append(pg.ImageItem(Z))
images.append(NonUniformImage(x, y, Z))
images.append(pg.PColorMeshItem(Z))

titles = ['Image', 'NonUniform', 'PColorMesh']
views = []
for idx, title in enumerate(titles):
    view = glw.addPlot(idx, 0, 1, 1, title=title)
    view.addItem(images[idx])
    views.append(view)

cbar = pg.ColorBarItem(colorMap='cividis', interactive=False)
cbar.setImageItem(images)
glw.addItem(cbar, 0, 1, 3, 1)

colormaps = pg.colormap.listMaps()

def update():
    # setting colormap on ColorBarItem propagates to all images
    cmap = pg.colormap.get(random.choice(colormaps))
    cbar.setColorMap(cmap)

timer = QtCore.QTimer()
timer.timeout.connect(update)
timer.start(250)

pg.exec()
```
