### PR TITLE
Fix UnderflowError in _try_rescale_float when maxVal == 0.

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -640,7 +640,7 @@ class ImageItem(GraphicsObject):
 
         minVal, maxVal = levels
         if minVal == maxVal:
-            maxVal = xp.nextafter(maxVal, 2*maxVal)
+            maxVal = xp.nextafter(maxVal, 2*maxVal) if maxVal != 0 else numpy.finfo(maxVal).eps
         rng = maxVal - minVal
         rng = 1 if rng == 0 else rng
 


### PR DESCRIPTION
In ImageItem.py, an UnderflowError exception is thrown in _try_rescale_float by numpy.nextafter() if the histogram levels minVal and maxVal are both 0. This PR fixes the problem by instead setting maxVal to the machine precision if maxVal is 0.

Tested and verified to resolve the issue without introducing new ones.
