### PR TITLE
Prevent containerChanged from collapsing an entire container tree

### DIFF
--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -210,7 +210,7 @@ class Dock(QtWidgets.QWidget):
     def containerChanged(self, c):
         if self._container is not None:
             # ask old container to close itself if it is no longer needed
-            self._container.apoptose()
+            self._container.apoptose(propagate=False)
         self._container = c
         if c is None:
             self.area = None


### PR DESCRIPTION
In #2887 it was observed that this line removes the container tree mid-construction if there is only one dock in a container. Preventing propagation here fixes that problem.

I'm not sure if this causes other issues that I can't see from my limited knowledge of the code base.
Maybe someone knows more and can judge if this change is safe.

Fixes #2887

