### PR TITLE
adding support for pyqtgraph editable install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
             qt-version: "PySide2~=5.15.0"
           - python-version: "3.10"
             qt-lib: "pyqt"
-            qt-version: "PyQt6~=6.2.0 PyQt6-Qt6~=6.2.0"
+            qt-version: "PyQt6==6.2.0 PyQt6-Qt6==6.2.0"
           - python-version: "3.10"
             qt-lib: "pyside"
             qt-version: "PySide6~=6.2.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
             qt-version: "PySide6~=6.2.0"
           - python-version: "3.11"
             qt-lib: "pyqt"
-            qt-version: "PyQt6"
+            qt-version: "PyQt6==6.2.0 PyQt6-Qt6==6.2.0"
           - python-version: "3.11"
             qt-lib: "pyside"
             qt-version: "PySide6-Essentials"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 PyQt6==6.6.0
+PyQt6-Qt6==6.6.0
 sphinx==7.2.6
 pydata-sphinx-theme==0.14.3
 sphinx-design==0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+
 [tool.black]
 line-length = 88
 target-version = ['py38']

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ from setuptools import find_namespace_packages, setup
 from setuptools.command import install
 
 path = os.path.split(__file__)[0]
-sys.path.insert(0, path)
+sys.path.append(path)
 import tools.setupHelpers as helpers
 
 ## Decide what version string to use in the build

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ from setuptools import find_namespace_packages, setup
 from setuptools.command import install
 
 path = os.path.split(__file__)[0]
+sys.path.insert(0, path)
 import tools.setupHelpers as helpers
 
 ## Decide what version string to use in the build

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,8 @@ deps=
     {[base]deps}
     pyside2_515: pyside2
     pyqt5_515: pyqt5
-    pyqt6_62: pyqt6~=6.2.0
-    pyqt6_62: PyQt6-Qt6~=6.2.0
+    pyqt6_62: pyqt6==6.2.0
+    pyqt6_62: PyQt6-Qt6==6.2.0
     pyside6_62: pyside6~=6.2.0
     pyqt6: pyqt6
     pyside6: PySide6-Essentials


### PR DESCRIPTION
This change adds build-system metadata to pyproject.toml and ensures the dir for setup.py is in sys.path.

The sys.path modification is to ensure the project ./tools/ modules can be imported in setup.py during editable install.

With this tweak to the project metadata, it should be possible to install pyqtgraph with an editable install, using setuptools

```
mkdir newproject; cd newproject
python3 -m venv --prompt newproject env
source env/bin/activate
pip install -e ../pyqtgraph/ --config-settings editable_mode=compat
```

Previous to this change, while it was possible to run `pip install -e ../pyqtgraph` but that might not have resulted in the modules actually being installed and available under the user environment.

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [n/a] `README.md` 
- [x] `setup.py`
- [n/a ] `tox.ini`
- [?] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [x] `pyproject.toml`
- [n/a] `binder/requirements.txt`

I don't think this would affect the workflow builds. Hoping it would test out though lol