### PR TITLE
Allow release info change during apt-get update on ubuntu

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
     - name: "Install Linux VirtualDisplay"
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get update -y
+        sudo apt-get update -y --allow-releaseinfo-change
         sudo apt-get install --no-install-recommends -y \
           libxkbcommon-x11-0 \
           x11-utils \
@@ -200,7 +200,7 @@ jobs:
       - name: "Install Linux VirtualDisplay"
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update -y
+          sudo apt-get update -y --allow-releaseinfo-change
           sudo apt-get install -y --no-install-recommends \
             libxkbcommon-x11-0 \
             x11-utils \


### PR DESCRIPTION
The following was showing up in the build log, for some CI builds under dependabot:

> Reading package lists...
> E: Repository 'https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease' changed its 'Origin' value from 'microsoft-ubuntu-jammy-prod jammy' to 'Pulp 3'
> E: Repository 'https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease' changed its 'Label' value from 'microsoft-ubuntu-jammy-prod jammy' to ''
> Error: Process completed with exit code 100.

This might be seen,for instance, in a [recent dependabot build for Python 3.9](https://github.com/pyqtgraph/pyqtgraph/actions/runs/6931164308/job/18852331203?pr=2885)

[apt-get(8) documentation][1] describes the --allow-releaseinfo-change arg. This was also [mentioned at Ask Ubuntu][2]

This patch updates the test-pip and test-conda jobs for the gh workflow, adding the --allow-releaseinfo-change arg for the apt-get update commands. This update is run before installing the Linux VirtualDisplay dependencies.


### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [ ] `README.md`
- [ ] `setup.py`
- [ ] `tox.ini`
- [x ] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [ ] `pyproject.toml`
- [ ] `binder/requirements.txt`


[1]: https://manpages.debian.org/unstable/apt/apt-get.8.en.html
[2]: https://askubuntu.com/a/1093202
