### PR TITLE
various fixes for NumPy 2.0

### DIFF
--- a/pyqtgraph/examples/NonUniformImage.py
+++ b/pyqtgraph/examples/NonUniformImage.py
@@ -31,7 +31,7 @@ V = np.ones_like(TAU) * v
 P_loss = kfric * W + kfric3 * W ** 3 + (res * (TAU / psi) ** 2) + k_v * (V - v_ref)
 
 P_mech = TAU * W
-P_loss[P_mech > 1.5e5] = np.NaN
+P_loss[P_mech > 1.5e5] = np.nan
 
 app = pg.mkQApp("NonUniform Image Example")
 

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -98,7 +98,7 @@ class PlotDataset(object):
         """
         Applies a logarithmic mapping transformation (base 10) if requested for the respective axis.
         This replaces the internal data. Values of ``-inf`` resulting from zeros in the original dataset are
-        replaced by ``np.NaN``.
+        replaced by ``np.nan``.
         
         Parameters
         ----------

--- a/tests/graphicsItems/PlotItem/test_PlotItem.py
+++ b/tests/graphicsItems/PlotItem/test_PlotItem.py
@@ -22,7 +22,7 @@ multi_data_plot_values = [
         sorted_randint(0, 20, 15),
         *[sorted_randint(0, 20, 15) for _ in range(4)],
     ],
-    np.row_stack([sorted_randint(20, 40, 15) for _ in range(6)]),
+    np.vstack([sorted_randint(20, 40, 15) for _ in range(6)]),
 ]
 
 

--- a/tests/graphicsItems/test_NonUniformImage.py
+++ b/tests/graphicsItems/test_NonUniformImage.py
@@ -86,7 +86,7 @@ def test_NonUniformImage_colormap():
     X, Y = np.meshgrid(x, y, indexing='ij')
     Z = X * Y
 
-    Z[:, 0] = [np.NINF, np.NAN, np.PINF]
+    Z[:, 0] = [-np.inf, np.nan, np.inf]
 
     image = NonUniformImage(x, y, Z, border=fn.mkPen('g'))
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -330,7 +330,7 @@ def _handle_underflow(dtype, *elements):
         ),
         # NaN types don't coerce to integers, don't test for all types since that doesn't make sense
         (
-            np.arange(5), np.array([0, -1, np.NaN, -3, -4]), 'finite', (
+            np.arange(5), np.array([0, -1, np.nan, -3, -4]), 'finite', (
                 (MoveToElement, 0.0, 0.0),
                 (LineToElement, 1.0, -1.0),
                 (LineToElement, 1.0, -1.0),
@@ -339,7 +339,7 @@ def _handle_underflow(dtype, *elements):
             ) 
         ),
         (
-            np.array([0, 1, np.NaN, 3, 4]), np.arange(0, -5, step=-1), 'finite', (
+            np.array([0, 1, np.nan, 3, 4]), np.arange(0, -5, step=-1), 'finite', (
                 (MoveToElement, 0.0, 0.0),
                 (LineToElement, 1.0, -1.0),
                 (LineToElement, 1.0, -1.0),


### PR DESCRIPTION
This PR fixes the test suite to pass with NumPy 2.0, which may be releasing soon (https://github.com/numpy/numpy/issues/24300).
