### PR TITLE
fix: paint method widget argument can be None

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -956,9 +956,10 @@ class ScatterPlotItem(GraphicsObject):
             if self.opts['useCache'] and self._exportOpts is False:
                 # Draw symbols from pre-rendered atlas
 
-                dpr = widget.devicePixelRatioF()
-                if dpr != self.fragmentAtlas.devicePixelRatio():
+                dpr = self.fragmentAtlas.devicePixelRatio()
+                if widget is not None and (dpr_new := widget.devicePixelRatioF()) != dpr:
                     # force a re-render if dpr changed
+                    dpr = dpr_new
                     self.fragmentAtlas.setDevicePixelRatio(dpr)
                     self.fragmentAtlas.clear()
                     self.data['sourceRect'] = 0


### PR DESCRIPTION
This PR fixes a bug introduced in #2863.
In the `paint` method, the DPR is obtained by calling `widget.devicePixelRatioF()`. However, the `widget` argument can be `None`. https://doc.qt.io/qt-6/qgraphicsitem.html#paint

This bug manifests itself at least in the Jupyter Notebook examples using `ScatterPlotItem`.