### PR TITLE
class Handle Fix allowing dict to be passed for handlePen and removing hard reset for width and cosmetic attributes -  pyqtgraph-0.13.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -64,6 +64,8 @@ pyqtgraph-0.13.2
 
 ### Bug Fixes
 
+* Fix class Handle mkPen width and cosmetic attributes had reset allowing customization by @pdmkdz in https://github.com/pyqtgraph/pyqtgraph/issues/1960
+* Fix passing a dict to handlePen by @pdmkdz in https://github.com/pyqtgraph/pyqtgraph/issues/2765
 * Fix renderView to not use mremap on FreeBSD by @yurivict in https://github.com/pyqtgraph/pyqtgraph/pull/2445
 * Fix action parameter button that is briefly made visible before getting a parent by @ntjess in https://github.com/pyqtgraph/pyqtgraph/pull/2451
 * Fix InfiniteLine bounding rect calculation by @ixjlyons in https://github.com/pyqtgraph/pyqtgraph/pull/2407

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -3,7 +3,7 @@ PyQtGraph - Scientific Graphics and GUI Library for Python
 www.pyqtgraph.org
 """
 
-__version__ = '0.13.4.dev0'
+__version__ = '0.13.4.dev1'
 
 ### import all the goodies and add some helper functions for easy CLI use
 

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -3,7 +3,7 @@ PyQtGraph - Scientific Graphics and GUI Library for Python
 www.pyqtgraph.org
 """
 
-__version__ = '0.13.4.dev1'
+__version__ = '0.13.5.dev0'
 
 ### import all the goodies and add some helper functions for easy CLI use
 

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -1336,7 +1336,7 @@ class Handle(UIGraphicsItem):
     sigClicked = QtCore.Signal(object, object)   # self, event
     sigRemoveRequested = QtCore.Signal(object)   # self
     
-    def __init__(self, radius, typ=None, pen=(200, 200, 220),
+    def __init__(self, radius, typ=None, pen={'color': (200, 200, 220),'width':0, 'cosmetic':True},
                  hoverPen=(255, 255, 0), parent=None, deletable=False):
         self.rois = []
         self.radius = radius
@@ -1344,8 +1344,6 @@ class Handle(UIGraphicsItem):
         self.pen = fn.mkPen(pen)
         self.hoverPen = fn.mkPen(hoverPen)
         self.currentPen = self.pen
-        self.pen.setWidth(0)
-        self.pen.setCosmetic(True)
         self.isMoving = False
         self.sides, self.startAng = self.types[typ]
         self.buildPath()


### PR DESCRIPTION
Adding ability to modify handlePen removing hard coded defaults for pen width set to 0 and cosmetic to True, but keeping as default for dry run.

Fixes #1960, #2765

### Files that need updates
  
- [x] `README.md`  - No changes required 
- [x] `setup.py`  - No changes required
- [x] `tox.ini`  - No changes required 
- [x] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files  - No changes required
- [x] `pyproject.toml` - No changes required 
- [x] `binder/requirements.txt` - No changes required 

### Pre Release Checklist

- [x] Update version info in `__init__.py` - version updated to 0.13.5.dev0
- [x] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [x] Have git tag in the format of pyqtgraph-<version> tag: pyqtgraph-0.13.5.dev0

### Steps To Complete

- [x] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter
