### PR TITLE
Add pickling to SRTTransform

### DIFF
--- a/pyqtgraph/SRTTransform.py
+++ b/pyqtgraph/SRTTransform.py
@@ -2,9 +2,9 @@ from math import atan2, degrees
 
 import numpy as np
 
+from . import SRTTransform3D
 from .Point import Point
 from .Qt import QtGui
-from . import SRTTransform3D
 
 
 class SRTTransform(QtGui.QTransform):
@@ -33,7 +33,6 @@ class SRTTransform(QtGui.QTransform):
         else:
             raise Exception("Cannot create SRTTransform from input type: %s" % str(type(init)))
 
-        
     def getScale(self):
         return self._state['scale']
         
@@ -142,9 +141,10 @@ class SRTTransform(QtGui.QTransform):
     def saveState(self):
         p = self._state['pos']
         s = self._state['scale']
-        #if s[0] == 0:
-            #raise Exception('Invalid scale: %s' % str(s))
         return {'pos': (p[0], p[1]), 'scale': (s[0], s[1]), 'angle': self._state['angle']}
+
+    def __reduce__(self):
+        return SRTTransform, (self.saveState(),)
 
     def restoreState(self, state):
         self._state['pos'] = Point(state.get('pos', (0,0)))

--- a/pyqtgraph/SRTTransform3D.py
+++ b/pyqtgraph/SRTTransform3D.py
@@ -2,10 +2,10 @@ from math import atan2, degrees
 
 import numpy as np
 
+from . import SRTTransform
 from .Qt import QtGui
 from .Transform3D import Transform3D
 from .Vector import Vector
-from . import SRTTransform
 
 
 class SRTTransform3D(Transform3D):
@@ -225,3 +225,6 @@ class SRTTransform3D(Transform3D):
             return m[:3,:3]
         else:
             raise Exception("Argument 'nd' must be 2 or 3")
+
+    def __reduce__(self):
+        return SRTTransform3D, (self.saveState(),)

--- a/pyqtgraph/exceptionHandling.py
+++ b/pyqtgraph/exceptionHandling.py
@@ -149,6 +149,7 @@ class ExceptionHandler(object):
 
 
 ## replace built-in excepthook only if this has not already been done
+# TODO this will never return False; the hook is set to the bound sys_excepthook method, not the instance itself
 if not (hasattr(sys.excepthook, 'implements') and sys.excepthook.implements('ExceptionHandler')):
     handler = ExceptionHandler()
     original_excepthook = handler.orig_sys_excepthook

--- a/tests/test_pickles.py
+++ b/tests/test_pickles.py
@@ -1,0 +1,22 @@
+import math
+import pickle
+
+from pyqtgraph import SRTTransform
+from pyqtgraph.parametertree import Parameter
+
+
+def test_SRTTransform():
+    a = SRTTransform({'scale': 2, 'angle': math.pi / 2})
+    b = pickle.loads(pickle.dumps(a))
+    assert a == b
+
+
+def test_SRTTransform3D():
+    a = SRTTransform({'scale': 2, 'angle': math.pi / 2})
+    b = pickle.loads(pickle.dumps(a))
+    assert a == b
+
+
+if __name__ == '__main__':
+    test_SRTTransform()
+    test_SRTTransform3D()

--- a/tests/test_pickles.py
+++ b/tests/test_pickles.py
@@ -2,7 +2,6 @@ import math
 import pickle
 
 from pyqtgraph import SRTTransform
-from pyqtgraph.parametertree import Parameter
 
 
 def test_SRTTransform():

--- a/tests/test_pickles.py
+++ b/tests/test_pickles.py
@@ -14,8 +14,3 @@ def test_SRTTransform3D():
     a = SRTTransform({'scale': 2, 'angle': math.pi / 2})
     b = pickle.loads(pickle.dumps(a))
     assert a == b
-
-
-if __name__ == '__main__':
-    test_SRTTransform()
-    test_SRTTransform3D()


### PR DESCRIPTION
These two classes can be safely pickled, so we may as well. Note: lots of other classes have the `saveState` and `restoreState` methods, which suggests we could do this in more places, but these two were the only objects that worked when I tried the naive approaches of `__getstate__`/`__setstate__` or basic `__reduce__`. If there's interest, we could investigate further implementations.


### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [x] `README.md`
- [x] `setup.py`
- [x] `tox.ini`
- [x] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [x] `pyproject.toml`
- [x] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
