### PR TITLE
disconnect only slots that got connected

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -3206,12 +3206,18 @@ def disconnect(signal, slot):
     """
     while True:
         try:
-            signal.disconnect(slot)
-            return True
+            success = signal.disconnect(slot)
+            if success is None:     # PyQt
+                success = True
         except (TypeError, RuntimeError):
-            slot = reload.getPreviousVersion(slot)
-            if slot is None:
-                return False
+            success = False
+
+        if success:
+            return True
+
+        slot = reload.getPreviousVersion(slot)
+        if slot is None:
+            return False
 
 
 class SignalBlock(object):

--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -493,10 +493,9 @@ class GraphicsItem(object):
 
         ## disconnect from previous view
         if oldView is not None:
-            for signal, slot in [('sigRangeChanged', self.viewRangeChanged),
-                                 ('sigDeviceRangeChanged', self.viewRangeChanged), 
-                                 ('sigTransformChanged', self.viewTransformChanged), 
-                                 ('sigDeviceTransformChanged', self.viewTransformChanged)]:
+            Device = 'Device' if hasattr(oldView, 'sigDeviceRangeChanged') else ''
+            for signal, slot in [(f'sig{Device}RangeChanged', self.viewRangeChanged),
+                                 (f'sig{Device}TransformChanged', self.viewTransformChanged)]:
                 try:
                     getattr(oldView, signal).disconnect(slot)
                 except (TypeError, AttributeError, RuntimeError):

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -9,7 +9,7 @@ from ... import debug as debug
 from ... import functions as fn
 from ... import getConfigOption
 from ...Point import Point
-from ...Qt import QtCore, QtGui, QtWidgets, isQObjectAlive
+from ...Qt import QtCore, QtGui, QtWidgets, isQObjectAlive, QT_LIB
 from ..GraphicsWidget import GraphicsWidget
 from ..ItemGroup import ItemGroup
 
@@ -1784,6 +1784,15 @@ class ViewBox(GraphicsWidget):
         for k in ViewBox.AllViews:
             if isQObjectAlive(k) and getConfigOption('crashWarning'):
                 sys.stderr.write('Warning: ViewBox should be closed before application exit.\n')
+
+            # PySide >= 6.7 prints a warning if we attempt to disconnect
+            # a signal that isn't connected.
+            if (
+                QT_LIB == 'PySide6' and
+                isQObjectAlive(k) and
+                k.receivers(QtCore.SIGNAL("destroyed()")) == 0
+            ):
+                continue
 
             try:
                 k.destroyed.disconnect()

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -6,8 +6,8 @@ import pytest
 from numpy.testing import assert_array_almost_equal
 
 import pyqtgraph as pg
-from pyqtgraph.functions import arrayToQPath, eq
-from pyqtgraph.Qt import QtGui
+from pyqtgraph.functions import arrayToQPath, eq, SignalBlock
+from pyqtgraph.Qt import QtCore, QtGui
 
 np.random.seed(12345)
 
@@ -409,3 +409,23 @@ def test_ndarray_from_qimage():
 def test_colorDistance():
     pg.colorDistance([pg.Qt.QtGui.QColor(0,0,0), pg.Qt.QtGui.QColor(255,0,0)])
     pg.colorDistance([])
+
+
+def test_signal_block_unconnected():
+    """Test that SignalBlock does not end up connecting an unconnected slot"""
+    class Sender(QtCore.QObject):
+        signal = QtCore.Signal()
+
+    class Receiver:
+        def __init__(self):
+            self.counter = 0
+
+        def slot(self):
+            self.counter += 1
+
+    sender = Sender()
+    receiver = Receiver()
+    with SignalBlock(sender.signal, receiver.slot):
+        pass
+    sender.signal.emit()
+    assert receiver.counter == 0


### PR DESCRIPTION
PySide 6.7 will stop raising an exception when attempting to disconnect a slot that wasn't connected in the first place.
It will instead print out a warning.
See:
https://code.qt.io/cgit/pyside/pyside-setup.git/commit/?id=d7aa15abe25bd71ea19180743ce9b41e0b788520

This PR fixes:
1) the many warnings printed due to `GraphicsItem`.
2) https://github.com/pyqtgraph/pyqtgraph/blob/master/pyqtgraph/graphicsItems/ViewBox/ViewBox.py#L1780-L1795
     - this warning gets emitted on program exit

Remaining code that still cause warnings:
1) https://github.com/pyqtgraph/pyqtgraph/blob/master/pyqtgraph/parametertree/interactive.py#L115-L118
     - this warning gets emitted in the test suite
