### PR TITLE
Center exportDialog using screen geometry

### DIFF
--- a/pyqtgraph/GraphicsScene/exportDialog.py
+++ b/pyqtgraph/GraphicsScene/exportDialog.py
@@ -51,10 +51,11 @@ class ExportDialog(QtWidgets.QWidget):
         self.selectBox.setVisible(True)
         if not self.shown:
             self.shown = True
-            vcenter = self.scene.getViewWidget().geometry().center()
-            x = max(0, int(vcenter.x() - self.width() / 2))
-            y = max(0, int(vcenter.y() - self.height() / 2))
-            self.move(x, y)
+            screen = QtWidgets.QApplication.desktop().screenNumber(QtWidgets.QApplication.desktop().cursor().pos())
+            centre = QtWidgets.QDesktopWidget().availableGeometry(screen).center()
+            frame = self.frameGeometry()
+            frame.moveCenter(centre)
+            self.move(frame.topLeft())
         
     def updateItemList(self, select=None):
         self.ui.itemTree.clear()


### PR DESCRIPTION
The fix for Issue 2510 https://github.com/pyqtgraph/pyqtgraph/pull/2510 can result in the y coordinate being 0.  See attached image where application is not full screen and exportDialog appears at the top of the screen

This fixes that by using the screen geometry to find the center of  the screen and then centers the exportDialog to the center of the active screen.

Fixes #2510


![image](https://github.com/pyqtgraph/pyqtgraph/assets/59737561/b51ad78d-924d-4326-87b8-1460efe1d91b)
