### PR TITLE
Allow ROI context menu to show if non-removable

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -762,8 +762,8 @@ class ROI(GraphicsObject):
             return self.pen
 
     def contextMenuEnabled(self):
-        return self.removable
-    
+        return self.removable or self.menu and len(self.menu.children()) > 1
+
     def raiseContextMenu(self, ev):
         if not self.contextMenuEnabled():
             return
@@ -776,13 +776,11 @@ class ROI(GraphicsObject):
         if self.menu is None:
             self.menu = QtWidgets.QMenu()
             self.menu.setTitle(translate("ROI", "ROI"))
-            remAct = QtGui.QAction(translate("ROI", "Remove ROI"), self.menu)
-            remAct.triggered.connect(self.removeClicked)
-            self.menu.addAction(remAct)
-            self.menu.remAct = remAct
-        # ROI menu may be requested when showing the handle context menu, so
-        # return the menu but disable it if the ROI isn't removable
-        self.menu.setEnabled(self.contextMenuEnabled())
+            if self.removable:
+                remAct = QtGui.QAction(translate("ROI", "Remove ROI"), self.menu)
+                remAct.triggered.connect(self.removeClicked)
+                self.menu.addAction(remAct)
+                self.menu.remAct = remAct
         return self.menu
 
     def removeClicked(self):


### PR DESCRIPTION
Previously `getmenu()` would always add a "Remove ROI" entry, but would only show the menu if `self.removable` was True. This meant that if a user adds a menu item to a non-removable ROI it is never show.

Now only add a "Remove ROI" entry for a removale ROI, and show the menu if it is removable, or there has been an item added.

Fixes #2931

Does this need to handle the removable attribute being modified later? Currently the "Remove ROI" entry is added when the menu if first made, and not changed after.

Should the menu show, if not removable and no other items are added? This would change the existing behaviour of an ROI which is to suppress the menu of the parent.

Does this need to be done for other objects?

### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [ ] `README.md`
- [ ] `setup.py`
- [ ] `tox.ini`
- [ ] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [ ] `pyproject.toml`
- [ ] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
