### PR TITLE
Fix 'import pyqtgraph.canvas' crash

### DIFF
--- a/pyqtgraph/canvas/CanvasManager.py
+++ b/pyqtgraph/canvas/CanvasManager.py
@@ -13,8 +13,9 @@ class CanvasManager(QtCore.QObject):
     def __init__(self):
         if CanvasManager.SINGLETON is not None:
             raise Exception("Can only create one canvas manager.")
-        CanvasManager.SINGLETON = self
+        # It is important to save SINGLETON *after* the call to QObject.__init__, see #2838.
         QtCore.QObject.__init__(self)
+        CanvasManager.SINGLETON = self
         self.canvases = weakref.WeakValueDictionary()
 
     @classmethod

--- a/tests/test_canvas_manager_crash.py
+++ b/tests/test_canvas_manager_crash.py
@@ -1,0 +1,8 @@
+import subprocess
+import sys
+
+
+def test_canvas_manager_singleton_crash() -> None:
+    """Regression test for #2838."""
+    proc = subprocess.run([sys.executable, "-c", "import pyqtgraph.canvas"])
+    assert proc.returncode == 0


### PR DESCRIPTION
Just importing pyqtgraph.canvas causes the interpreter to crash.

Saving the `SINGLETON` after the call to `QObject.__init__` solves the issue.

Fix #2838