### PR TITLE
coerce to dtype after creation

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -283,7 +283,7 @@ def _handle_underflow(dtype, *elements):
         for ii in range(1, 3):
             coord = el[ii]
             if coord < 0:
-                coord = np.array(coord, dtype=dtype)
+                coord = np.array(coord).astype(dtype=dtype)
             newElement.append(float(coord))
         out.append(tuple(newElement))
     return out


### PR DESCRIPTION
this is a compatibility fix for Numpy 2.0.
creating an array with dtype now fails if the value does not fit within the dtype.

Numpy 1.x behavior
```python
>>> np.array([-1.0], dtype=np.uint32)
array([4294967295], dtype=uint32)
>>> np.array([-1.0]).astype(np.uint32)
array([4294967295], dtype=uint32)
```

Numpy 2.0 behavior
```python
>>> np.array([-1.0], dtype=np.uint32)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: Python integer -1 out of bounds for uint32
>>> np.array([-1.0]).astype(np.uint32)
array([4294967295], dtype=uint32)
```