### PR TITLE
Add int typehint to ClickRadius

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -84,7 +84,7 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
     
     ExportDirectory = None
 
-    def __init__(self, clickRadius=2, moveDistance=5, parent=None):
+    def __init__(self, clickRadius: int = 2, moveDistance=5, parent=None):
         QtWidgets.QGraphicsScene.__init__(self, parent)
         self.setClickRadius(clickRadius)
         self.setMoveDistance(moveDistance)
@@ -117,14 +117,14 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
         self.sigPrepareForPaint.emit()
     
 
-    def setClickRadius(self, r):
+    def setClickRadius(self, r: int):
         """
         Set the distance away from mouse clicks to search for interacting items.
         When clicking, the scene searches first for items that directly intersect the click position
         followed by any other items that are within a rectangle that extends r pixels away from the 
         click position. 
         """
-        self._clickRadius = r
+        self._clickRadius = int(r)
         
     def setMoveDistance(self, d):
         """
@@ -432,7 +432,7 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
         r = self._clickRadius
         items_within_radius = []
         rgn = None
-        if r > 0.0:
+        if r > 0:
             rect = view.mapToScene(QtCore.QRect(0, 0, 2 * r, 2 * r)).boundingRect()
             w = rect.width()
             h = rect.height()


### PR DESCRIPTION
Added _int_ typehint to ClickRadius because QtCore.QRect constructor only handles _int_ arguments. When provided ClickRadius type is _float_, it results in QtCore crash. Tested on Python 3.10+
Have a look at:
[QRect-1](https://doc.qt.io/qtforpython-6/PySide6/QtCore/QRect.html#PySide6.QtCore.PySide6.QtCore.QRect)
[QRect-2](https://doc.qt.io/qt-6/qrect.html#QRect-3)


### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [ ] `README.md`
- [ ] `setup.py`
- [ ] `tox.ini`
- [ ] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [ ] `pyproject.toml`
- [ ] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [ ] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [ ] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [ ] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
