### PR TITLE
cast float to signed int before to unsigned int

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -278,12 +278,20 @@ _dtypes.extend(['uint8', 'uint16'])
 def _handle_underflow(dtype, *elements):
     """Wrapper around path description which converts underflow into proper points"""
     out = []
+    dtype = np.dtype(dtype)
+    # get the signed integer type of the same width
+    dtype_int = np.dtype(f'i{dtype.itemsize}')
     for el in elements:
         newElement = [el[0]]
         for ii in range(1, 3):
             coord = el[ii]
-            if coord < 0:
-                coord = np.array(coord).astype(dtype=dtype)
+            if dtype.kind == 'u' and coord < 0:
+                # coord is a float with a negative integral value.
+                # for unsigned integer types, we want negative values to
+                # wrap-around. to get consistent wrap-around behavior
+                # across different numpy versions and machine platforms,
+                # we first convert coord to a signed integer.
+                coord = np.array(coord, dtype=dtype_int).astype(dtype)
             newElement.append(float(coord))
         out.append(tuple(newElement))
     return out


### PR DESCRIPTION
It was found that #2939 was failing on arm64 platform.

x86_64 numpy 1.26.4
```python
# before #2939
# Overflow error on numpy 2.0
>>> np.array(-1.0, dtype=np.uint32)
array(4294967295, dtype=uint32)

# #2939
# works on numpy 2.0
>>> np.array(-1.0).astype(np.uint32)
array(4294967295, dtype=uint32)

# this PR
# works on numpy 2.0
>>> np.array(-1.0, dtype=np.int32).astype(np.uint32)
array(4294967295, dtype=uint32)
```

arm64 numpy 1.26.4
```python
# before #2939
# Overflow error on numpy 2.0
>>> np.array(-1.0, dtype=np.uint32)
array(4294967295, dtype=uint32)

# #2939
# same warning on numpy 2.0
>>> np.array(-1.0).astype(np.uint32)
<stdin>:1: RuntimeWarning: invalid value encountered in cast
array(0, dtype=uint32)

# this PR
# works on numpy 2.0
>>> np.array(-1.0, dtype=np.int32).astype(np.uint32)
array(4294967295, dtype=uint32)
```

Remarks:
It's not clear to me why the test in question is relying on unsigned integers wrapping around.
And furthermore, a wrapped-around uint64 would have lost precision when converting to double.