### PR TITLE
close ROI handle subpath

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -1468,14 +1468,15 @@ class Handle(UIGraphicsItem):
         self.path = QtGui.QPainterPath()
         ang = self.startAng
         dt = 2 * np.pi / self.sides
-        for i in range(0, self.sides+1):
+        for i in range(0, self.sides):
             x = size * cos(ang)
             y = size * sin(ang)
             ang += dt
             if i == 0:
                 self.path.moveTo(x, y)
             else:
-                self.path.lineTo(x, y)            
+                self.path.lineTo(x, y)
+        self.path.closeSubpath()
             
     def paint(self, p, opt, widget):
         p.setRenderHints(p.RenderHint.Antialiasing, True)


### PR DESCRIPTION
this ensures that the path is a closed polygon.
this matters for PenCap and PenJoin purposes.

`test_PolylineROI` has the following series of test images:
1) init
2) hover_roi
3) drag_roi
4) hover_handle
5) drag_handle
6) hover_segment
7) click_segment
8) drag_new_handle
9) clear

Prior to this PR, aarch64 (and ppc64le) platforms fail at `init`. (See #2110)
With this PR, the failure occurs later at `click_segment` (and `drag_new_handle`)

When the path is not closed, we end up with a polyline with its ends rendered with `SquareCap`, which according to Qt docs: "a square line end that covers the end point and **_extends beyond it by half the line width_**."
It does so happen that the failing pixels in `init` correspond to the closing point of the ROI handle. 

Failure screenshot for `click_segment`. For this case, a lot more pixels are involved.
![Screenshot 2024-03-04 230107](https://github.com/pyqtgraph/pyqtgraph/assets/2657027/f7a16386-15af-42e0-a48c-2bc8ff1ccf86)
