### PR TITLE
ImageView example: use levelMode="rgba"

### DIFF
--- a/pyqtgraph/examples/ImageView.py
+++ b/pyqtgraph/examples/ImageView.py
@@ -24,7 +24,7 @@ app = pg.mkQApp("ImageView Example")
 ## Create window with ImageView widget
 win = QtWidgets.QMainWindow()
 win.resize(800,800)
-imv = pg.ImageView(discreteTimeLine=True)
+imv = pg.ImageView(discreteTimeLine=True, levelMode='rgba')
 win.setCentralWidget(imv)
 win.show()
 win.setWindowTitle('pyqtgraph example: ImageView')
@@ -46,18 +46,6 @@ data = np.concatenate(
 # Display the data and assign each frame a time value from 1.0 to 3.0
 imv.setImage(data, xvals=np.linspace(1., 3., data.shape[0]))
 imv.play(10)
-
-## Set a custom color map
-colors = [
-    (0, 0, 0),
-    (45, 5, 61),
-    (84, 42, 55),
-    (150, 87, 60),
-    (208, 171, 141),
-    (255, 255, 255)
-]
-cmap = pg.ColorMap(pos=np.linspace(0.0, 1.0, 6), color=colors)
-imv.setColorMap(cmap)
 
 # Start up with an ROI
 imv.ui.roiBtn.setChecked(True)


### PR DESCRIPTION
Since #1611, the image data used in this example has been changed to RGB.
Using `rgba` mode is more appropriate here.

Setting a colormap has no effect on RGB images, so delete those lines too.