### PR TITLE
Aaryamantriescode SyntaxWarnings #2962

### DIFF
--- a/pyqtgraph/examples/SpinBox.py
+++ b/pyqtgraph/examples/SpinBox.py
@@ -35,7 +35,7 @@ spins = [
      pg.SpinBox(value=1e9, siPrefix=True)),
     ("Float with custom formatting", 
      pg.SpinBox(value=23.07, format='${value:0.02f}',
-                regex=r'\\$?(?P<number>(-?\\d+(\\.\\d+)?)|(-?\\.\\d+))$')),
+                regex = r'\\$?(?P<number>(-?\d+(\.\d+)?)|(-?\.\d+))$')),
     ("Int with suffix",
      pg.SpinBox(value=999, step=1, int=True, suffix="V")),
     ("Int with custom formatting", 

--- a/pyqtgraph/examples/SpinBox.py
+++ b/pyqtgraph/examples/SpinBox.py
@@ -35,7 +35,7 @@ spins = [
      pg.SpinBox(value=1e9, siPrefix=True)),
     ("Float with custom formatting", 
      pg.SpinBox(value=23.07, format='${value:0.02f}',
-                regex='\\$?(?P<number>(-?\\d+(\\.\\d+)?)|(-?\\.\\d+))$')),
+                regex=r'\\$?(?P<number>(-?\\d+(\\.\\d+)?)|(-?\\.\\d+))$')),
     ("Int with suffix",
      pg.SpinBox(value=999, step=1, int=True, suffix="V")),
     ("Int with custom formatting", 

--- a/pyqtgraph/examples/SpinBox.py
+++ b/pyqtgraph/examples/SpinBox.py
@@ -35,7 +35,7 @@ spins = [
      pg.SpinBox(value=1e9, siPrefix=True)),
     ("Float with custom formatting", 
      pg.SpinBox(value=23.07, format='${value:0.02f}',
-                regex = r'\\$?(?P<number>(-?\d+(\.\d+)?)|(-?\.\d+))$')),
+                regex = r'\$?(?P<number>(-?\d+(\.\d+)?)|(-?\.\d+))$')),
     ("Int with suffix",
      pg.SpinBox(value=999, step=1, int=True, suffix="V")),
     ("Int with custom formatting", 

--- a/pyqtgraph/examples/SpinBox.py
+++ b/pyqtgraph/examples/SpinBox.py
@@ -35,7 +35,7 @@ spins = [
      pg.SpinBox(value=1e9, siPrefix=True)),
     ("Float with custom formatting", 
      pg.SpinBox(value=23.07, format='${value:0.02f}',
-                regex='\$?(?P<number>(-?\d+(\.\d+)?)|(-?\.\d+))$')),
+                regex='\\$?(?P<number>(-?\\d+(\\.\\d+)?)|(-?\\.\\d+))$')),
     ("Int with suffix",
      pg.SpinBox(value=999, step=1, int=True, suffix="V")),
     ("Int with custom formatting", 


### PR DESCRIPTION
Fixes #2962
This was the issue [The \$ should be written \\$ or r'\$' since a few Python releases (same for all backslash escape that have no meanings). I don't have the time to search for other occurrences of this fact, but running the tests with PYTHONDEVMODE=1 should help spotting them :)]
I think I  found the issue and made changes 
