### PR TITLE
set SymbolAtlas dpr to primary screen's dpr

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -361,6 +361,8 @@ class ScatterPlotItem(GraphicsObject):
 
         self.picture = None   # QPicture used for rendering when pxmode==False
         self.fragmentAtlas = SymbolAtlas()
+        if screen := QtGui.QGuiApplication.primaryScreen():
+            self.fragmentAtlas.setDevicePixelRatio(screen.devicePixelRatio())
 
         dtype = [
             ('x', float),


### PR DESCRIPTION
Set the startup DPR of `ScatterPlotItem`'s `SymbolAtlas` to the primary screen's DPR, so that users with hidpi screens are not penalized by a guaranteed `SymbolAtlas` rebuild.

https://doc.qt.io/qt-6/qguiapplication.html#primaryScreen-prop says that:
`This will be the screen where QWindows are initially shown, unless otherwise specified.`

Fixes #2960
Test script can be found in the comments of the linked issue.

Remarks:
1) `ScatterPlotItem` can (surprisingly) be instantiated without a `QGuiApplication`, in which case there will be no primary screen.
