### PR TITLE
add fastpath for float images with nans

### DIFF
--- a/pyqtgraph/functions_numba.py
+++ b/pyqtgraph/functions_numba.py
@@ -24,11 +24,10 @@ def rescaleData(data, scale, offset, dtype, clip):
 @numba.jit(nopython=True)
 def _rescale_and_lookup1d_function(data, scale, offset, lut, out):
     vmin, vmax = 0, lut.shape[0] - 1
-    for r in range(data.shape[0]):
-        for c in range(data.shape[1]):
-            val = (data[r, c] - offset) * scale
-            val = min(max(val, vmin), vmax)
-            out[r, c] = lut[int(val)]
+    for (x, y) in np.nditer((data, out)):
+        val = (x - offset) * scale
+        val = min(max(val, vmin), vmax)
+        y[...] = lut[int(val)]
 
 def rescale_and_lookup1d(data, scale, offset, lut):
     # data should be floating point and 2d

--- a/pyqtgraph/functions_numba.py
+++ b/pyqtgraph/functions_numba.py
@@ -22,19 +22,26 @@ def rescaleData(data, scale, offset, dtype, clip):
     return data_out
 
 @numba.jit(nopython=True)
-def _rescale_and_lookup1d_function(data, scale, offset, lut, out):
+def rescale_and_lookup(data, scale, offset, lut):
+    # data should be floating point and 2d
+    # lut is 1d
     vmin, vmax = 0, lut.shape[0] - 1
+    out = np.empty_like(data, dtype=lut.dtype)
     for (x, y) in np.nditer((data, out)):
         val = (x - offset) * scale
         val = min(max(val, vmin), vmax)
         y[...] = lut[int(val)]
+    return out
 
-def rescale_and_lookup1d(data, scale, offset, lut):
-    # data should be floating point and 2d
-    # lut is 1d
-    data_out = np.empty_like(data, dtype=lut.dtype)
-    _rescale_and_lookup1d_function(data, float(scale), float(offset), lut, data_out)
-    return data_out
+@numba.jit(nopython=True)
+def rescale_and_clip(data, scale, offset, vmin, vmax):
+    # vmin and vmax <= 255
+    out = np.empty_like(data, dtype=np.uint8)
+    for (x, y) in np.nditer((data, out)):
+        val = (x - offset) * scale
+        val = min(max(val, vmin), vmax)
+        y[...] = val
+    return out
 
 @numba.jit(nopython=True)
 def numba_take(lut, data):

--- a/pyqtgraph/functions_qimage.py
+++ b/pyqtgraph/functions_qimage.py
@@ -6,38 +6,63 @@ from .util.cupy_helper import getCupy
 from .util.numba_helper import getNumbaFunctions
 
 
-def _apply_lut_for_uint16_mono(xp, image, lut):
+def _apply_lut_for_uint(xp, image, lut):
     # Note: compared to makeARGB(), we have already clipped the data to range
-    augmented_alpha = False
 
     # if lut is 1d, then lut[image] is fastest
     # if lut is 2d, then lut.take(image, axis=0) is faster than lut[image]
+    lut = _convert_2dlut_to_1dlut(xp, lut)
 
-    if not image.flags.c_contiguous:
-        image = lut.take(image, axis=0)
-
-        # if lut had dimensions (N, 1), then our resultant image would
-        # have dimensions (h, w, 1)
-        if image.ndim == 3 and image.shape[-1] == 1:
-            image = image[..., 0]
-
-        return image, augmented_alpha
-
-    # if we are contiguous, we can take a faster codepath where we
-    # ensure that the lut is 1d
-
-    lut, augmented_alpha = _convert_2dlut_to_1dlut(xp, lut)
-
-    fn_numba = getNumbaFunctions()
-    if xp == numpy and fn_numba is not None:
+    if xp == numpy and (fn_numba := getNumbaFunctions()) is not None:
+        # numba "take" supports only the 1st 2 arguments of np.take,
+        # therefore we have to convert the lut to 1d.
+        # "take" will output a c contiguous array regardless of its input.
         image = fn_numba.numba_take(lut, image)
     else:
+        # advanced indexing is memory order aware.
+        # its output can be either C or F contiguous.
         image = lut[image]
 
     if image.dtype == xp.uint32:
+        # "view" requires c contiguous for numpy < 1.23
+        image = xp.ascontiguousarray(image)
         image = image[..., xp.newaxis].view(xp.uint8)
 
-    return image, augmented_alpha
+    return image
+
+
+def _convert_lut_to_rgba(xp, lut):
+    # converts:
+    #   - None to (256, 4)
+    #   - uint8 (N,) to uint8 (N, 4)
+    #   - uint8 (N, 1) to uint8 (N, 4)
+    #   - uint8 (N, 3) to uint8 (N, 4)
+
+    if not (
+        lut is None
+        or lut.ndim == 1
+        or (
+            lut.ndim == 2
+            and lut.shape[1] in (1, 3, 4)
+        )
+    ):
+        raise ValueError("unsupported lut shape")
+
+    N = lut.shape[0] if lut is not None else 256
+
+    if lut is None:
+        lut = xp.arange(N, dtype=xp.uint8)
+
+    # convert (N,) to (N, 1)
+    if lut.ndim == 1:
+        lut = lut[:, xp.newaxis]
+
+    if lut.shape[1] == 4:
+        return lut
+
+    out = xp.full((N, 4), 255, dtype=xp.uint8)
+    out[:, 0:3] = lut
+    return out
 
 
 def _convert_2dlut_to_1dlut(xp, lut):
@@ -45,24 +70,27 @@ def _convert_2dlut_to_1dlut(xp, lut):
     #   - uint8 (N, 1) to uint8 (N,)
     #   - uint8 (N, 3) or (N, 4) to uint32 (N,)
     # this allows faster lookup as 1d lookup is faster
-    augmented_alpha = False
 
     if lut.ndim == 1:
-        return lut, augmented_alpha
+        return lut
 
     if lut.shape[1] == 3:  # rgb
         # convert rgb lut to rgba so that it is 32-bits
         lut = xp.column_stack([lut, xp.full(lut.shape[0], 255, dtype=xp.uint8)])
-        augmented_alpha = True
     if lut.shape[1] == 4:  # rgba
         lut = lut.view(xp.uint32)
     lut = lut.ravel()
 
-    return lut, augmented_alpha
+    return lut
 
 
-def _rescale_float_mono(xp, image, levels, lut):
-    augmented_alpha = False
+def _rescale_and_lookup_float(xp, image, levels, lut, *, forceApplyLut):
+    # It is usually more performant to _not_ apply the lut and
+    # instead use it as an Indexed8 ColorTable. This is only
+    # applicable if the lut has <= 256 entries.
+
+    if forceApplyLut and lut is None:
+        raise ValueError("forceApplyLut True but lut not provided")
 
     # Decide on maximum scaled value
     if lut is not None:
@@ -73,40 +101,44 @@ def _rescale_float_mono(xp, image, levels, lut):
         num_colors = 256
     dtype = xp.min_scalar_type(num_colors - 1)
 
+    # note: "dtype == uint16" ==> lut provided ==> mono-channel image
+    #       i.e. multi-channel image ==> lut is None ==> dtype == uint8
+    #
+    #       the library defaults to using 256-entry luts, so
+    #       "dtype == uint8" is the common case
+
+    apply_lut = forceApplyLut or dtype == xp.uint16
+
     minVal, maxVal = levels
     rng = maxVal - minVal
     rng = 1 if rng == 0 else rng
 
-    fn_numba = getNumbaFunctions()
     if (
-        xp == numpy
-        and image.flags.c_contiguous
-        and dtype == xp.uint16
-        and fn_numba is not None
+        apply_lut
+        and xp == numpy
+        and (fn_numba := getNumbaFunctions()) is not None
     ):
-        lut, augmented_alpha = _convert_2dlut_to_1dlut(xp, lut)
+        # this path does rescale and apply lut in one step
+        lut = _convert_2dlut_to_1dlut(xp, lut)
         image = fn_numba.rescale_and_lookup1d(image, scale / rng, minVal, lut)
+        lut = None
         if image.dtype == xp.uint32:
+            # "view" requires c contiguous for numpy < 1.23
+            image = xp.ascontiguousarray(image)
             image = image[..., xp.newaxis].view(xp.uint8)
-        return image, None, None, augmented_alpha
     else:
         image = functions.rescaleData(
             image, scale / rng, offset=minVal, dtype=dtype, clip=(0, num_colors - 1)
         )
-
-        levels = None
-
-        if image.dtype == xp.uint16 and image.ndim == 2:
-            image, augmented_alpha = _apply_lut_for_uint16_mono(xp, image, lut)
+        if apply_lut:
+            image = _apply_lut_for_uint(xp, image, lut)
             lut = None
 
-        # image is now of type uint8
-        return image, levels, lut, augmented_alpha
+    # image is now of type uint8
+    return image, lut
 
 
-def _try_combine_lut(xp, image, levels, lut):
-    augmented_alpha = False
-
+def _combine_levels_and_lut(xp, image, levels, lut):
     if (
         image.dtype == xp.uint16
         and levels is None
@@ -119,7 +151,7 @@ def _try_combine_lut(xp, image, levels, lut):
 
     if levels is None and lut is None:
         # nothing to combine
-        return image, levels, lut, augmented_alpha
+        return image, lut
 
     # distinguish between lut for levels and colors
     levels_lut = None
@@ -145,14 +177,14 @@ def _try_combine_lut(xp, image, levels, lut):
             # as (grayscale) Indexed8 ColorTable to get the same effect.
             # due to the small size of the input to rescaleData(), we
             # do not bother caching the result
-            return image, None, levels_lut, augmented_alpha
+            return image, levels_lut
         else:
             # uint16 mono, uint8 rgb, uint16 rgb
             # rescale image data by computation instead of by memory lookup
             image = functions.rescaleData(
                 image, scale=255.0 / levdiff, offset=minlev, dtype=xp.ubyte
             )
-            return image, None, colors_lut, augmented_alpha
+            return image, colors_lut
     else:
         num_colors = colors_lut.shape[0]
         effscale = num_colors / levdiff
@@ -174,9 +206,9 @@ def _try_combine_lut(xp, image, levels, lut):
 
             # apply the effective lut early for the following types:
             if image.dtype == xp.uint16 and image.ndim == 2:
-                image, augmented_alpha = _apply_lut_for_uint16_mono(xp, image, efflut)
+                image = _apply_lut_for_uint(xp, image, efflut)
                 efflut = None
-            return image, None, efflut, augmented_alpha
+            return image, efflut
         else:
             # uint16 image with colors_lut <= 256 entries
             # don't combine, we will use QImage ColorTable
@@ -187,10 +219,10 @@ def _try_combine_lut(xp, image, levels, lut):
                 dtype=lutdtype,
                 clip=(0, num_colors - 1),
             )
-            return image, None, colors_lut, augmented_alpha
+            return image, colors_lut
 
 
-def try_make_qimage(image, *, levels, lut):
+def try_make_qimage(image, *, levels, lut, transparentLocations=None):
     """
     Internal function to make an QImage from an ndarray without going
     through the full generality of makeARGB().
@@ -209,28 +241,74 @@ def try_make_qimage(image, *, levels, lut):
     if image.dtype.kind == "f" and levels is None:
         return None
 
-    # can't handle multi-channel levels
     if levels is not None:
         levels = xp.asarray(levels)
+
+        # can't handle multi-channel levels
         if levels.ndim != 1:
+            return None
+
+        # if levels is provided, multi-channel images must be 3 channels only.
+        # (because it doesn't make sense to scale a 4th alpha channel.)
+        if image.ndim == 3 and image.shape[2] != 3:
             return None
 
     if lut is not None and lut.dtype != xp.uint8:
         raise ValueError("lut dtype must be uint8")
 
-    augmented_alpha = False
+    alpha_channel_required = (
+        (   # image itself has alpha channel
+            image.ndim == 3
+            and image.shape[2] == 4
+        )
+        or
+        (    # lut has alpha channel
+            lut is not None
+            and lut.ndim == 2
+            and lut.shape[1] == 4
+        )
+    )
 
     if image.dtype.kind == "f":
-        image, levels, lut, augmented_alpha = _rescale_float_mono(
-            xp, image, levels, lut
-        )
-        # on return, we will have an uint8 image with levels None.
-        # lut if not None will have <= 256 entries
+        if image.ndim == 2:
+            # mono float images
+            if transparentLocations is None:
+                image, lut = _rescale_and_lookup_float(
+                    xp, image, levels, lut, forceApplyLut=False
+                )
+                levels = None
+                # on return, we will have an uint8 image.
+                # lut if not None will have <= 256 entries
+            else:
+                # this path creates an alpha channel
+                lut = _convert_lut_to_rgba(xp, lut)
+                alpha_channel_required = True
+
+                image, lut = _rescale_and_lookup_float(
+                    xp, image, levels, lut, forceApplyLut=True
+                )
+                levels = None
+                assert lut is None
+                image[..., 3][transparentLocations] = 0
+        else:
+            # RGB float images
+            # lut can only be None for RGB images
+            image, lut = _rescale_and_lookup_float(
+                xp, image, levels, lut, forceApplyLut=False
+            )
+            levels = None
+
+            if transparentLocations is not None:
+                alpha_channel_required = True
+                mask = xp.full(image.shape[:2], 255, dtype=xp.uint8)
+                mask[transparentLocations] = 0
+                image = xp.dstack((image, mask))
 
     # if the image data is a small int, then we can combine levels + lut
     # into a single lut for better performance
     elif image.dtype in (xp.ubyte, xp.uint16):
-        image, levels, lut, augmented_alpha = _try_combine_lut(xp, image, levels, lut)
+        image, lut = _combine_levels_and_lut(xp, image, levels, lut)
+        levels = None
 
     ubyte_nolvl = image.dtype == xp.ubyte and levels is None
     is_passthru8 = ubyte_nolvl and lut is None
@@ -266,10 +344,10 @@ def try_make_qimage(image, *, levels, lut):
         elif image.shape[2] == 3:
             fmt = QtGui.QImage.Format.Format_RGB888
         elif image.shape[2] == 4:
-            if augmented_alpha:
-                fmt = QtGui.QImage.Format.Format_RGBX8888
-            else:
+            if alpha_channel_required:
                 fmt = QtGui.QImage.Format.Format_RGBA8888
+            else:
+                fmt = QtGui.QImage.Format.Format_RGBX8888
     elif is_indexed8:
         # levels and/or lut --> lut-only
         fmt = QtGui.QImage.Format.Format_Indexed8

--- a/pyqtgraph/widgets/RawImageWidget.py
+++ b/pyqtgraph/widgets/RawImageWidget.py
@@ -64,12 +64,19 @@ class RawImageWidget(QtWidgets.QWidget):
             if (
                 not self.opts[1]    # no positional arguments
                 and {"levels", "lut"}.issuperset(self.opts[2])  # no kwargs besides levels and lut
-                and not (img.dtype.kind == "f" and xp.isnan(img.min()))
             ):
+                transparentLocations = None
+                if img.dtype.kind == "f" and xp.isnan(img.min()):
+                    nanmask = xp.isnan(img)
+                    if nanmask.ndim == 3:
+                        nanmask = nanmask.any(axis=2)
+                    transparentLocations = nanmask.nonzero()
+
                 qimage = functions_qimage.try_make_qimage(
                     img,
                     levels=self.opts[2].get("levels"),
                     lut=self.opts[2].get("lut"),
+                    transparentLocations=transparentLocations
                 )
 
             if qimage is None:


### PR DESCRIPTION
This PR augments #1693 by adding support for float images containing nans. 

To test it out.
```
set PYQTGRAPHPROFILE="ImageItem.paint"
```
Then run the following script and change the levels using the `HistogramLUTItem`. The GUI should feel more responsive with this PR versus master.
```python
import pyqtgraph as pg
import numpy as np
pg.setConfigOptions(imageAxisOrder='row-major')
# pg.setConfigOptions(useNumba=True)

Y = np.sinc(np.linspace(-6, 10, 4000))[:, np.newaxis]
X = np.sinc(np.linspace(-15, 9, 6000))
data = np.abs(Y * X)
data[data > 0.95] = -1
data = 10*np.log10(data)
data = data.astype(np.float32)

pg.mkQApp()
imv = pg.ImageView()
imv.show()
imv.setImage(data, levels=(-50, 0))
hlut = imv.getHistogramWidget()
hlut.gradient.setColorMap(pg.colormap.get("CET-C1"))
hlut.gradient.showTicks(False)
pg.exec()
```

timings from `PYQTGRAPHPROFILE`
|   |row-major master | row-major this PR | col-major master | col-major this PR |
| -------- | -------- | ------- | ------- | ------- |
| numba | 224 ms | 35 ms | 558 ms | 165 ms |
| numpy | 258 ms | 128 ms | 303 ms | 252 ms |

numba codepath with col-major is no longer worse than numpy. If you were interested in performance, you wouldn't be using col-major anyway...
