### PR TITLE
Filling correction for Fillbetweenitem

### DIFF
--- a/pyqtgraph/examples/FillBetweenItem.py
+++ b/pyqtgraph/examples/FillBetweenItem.py
@@ -20,7 +20,8 @@ gauss = np.exp(-x**2 / 20.)
 mn = mx = np.zeros(len(x))
 curves = [win.plot(x=x, y=np.zeros(len(x)), pen='k') for i in range(4)]
 brushes = [0.5, (100, 100, 255), 0.5]
-fills = [pg.FillBetweenItem(curves[i], curves[i+1], brushes[i]) for i in range(3)]
+fills = [pg.FillBetweenItem(curves[0], curves[3], brushes[0]),
+         pg.FillBetweenItem(curves[1], curves[2], brushes[1])]
 for f in fills:
     win.addItem(f)
 

--- a/pyqtgraph/graphicsItems/FillBetweenItem.py
+++ b/pyqtgraph/graphicsItems/FillBetweenItem.py
@@ -80,7 +80,6 @@ class FillBetweenItem(QtWidgets.QGraphicsPathItem):
         for p1, p2 in zip(ps1, ps2):
             intersection = p1.intersected(p2)
             if not intersection.isEmpty():
-                for i in range(intersection.size()):
-                    path.lineTo(intersection.at(i))
+                path.addPolygon(intersection)
             path.addPolygon(p1 + p2)       
         self.setPath(path)

--- a/pyqtgraph/graphicsItems/FillBetweenItem.py
+++ b/pyqtgraph/graphicsItems/FillBetweenItem.py
@@ -23,7 +23,7 @@ class FillBetweenItem(QtWidgets.QGraphicsPathItem):
         self.updatePath()
         
     def setBrush(self, *args, **kwds):
-        """Change the fill brush. Acceps the same arguments as pg.mkBrush()"""
+        """Change the fill brush. Accepts the same arguments as pg.mkBrush()"""
         QtWidgets.QGraphicsPathItem.setBrush(self, fn.mkBrush(*args, **kwds))
         
     def setPen(self, *args, **kwds):
@@ -55,7 +55,6 @@ class FillBetweenItem(QtWidgets.QGraphicsPathItem):
 
     def curveChanged(self):
         self.updatePath()
-
     def updatePath(self):
         if self.curves is None:
             self.setPath(QtGui.QPainterPath())
@@ -69,14 +68,19 @@ class FillBetweenItem(QtWidgets.QGraphicsPathItem):
 
         path = QtGui.QPainterPath()
         transform = QtGui.QTransform()
+
         ps1 = paths[0].toSubpathPolygons(transform)
         ps2 = paths[1].toReversed().toSubpathPolygons(transform)
         ps2.reverse()
+
         if len(ps1) == 0 or len(ps2) == 0:
             self.setPath(QtGui.QPainterPath())
             return
         
-            
         for p1, p2 in zip(ps1, ps2):
-            path.addPolygon(p1 + p2)
+            intersection = p1.intersected(p2)
+            if not intersection.isEmpty():
+                for i in range(intersection.size()):
+                    path.lineTo(intersection.at(i))
+            path.addPolygon(p1 + p2)       
         self.setPath(path)


### PR DESCRIPTION
Detail the reasoning behind the code change.  If there is an associated issue that this PR will resolve add

Fixes #1698 When we have 2 intersecting polygons, there's no more fill at the intersection.

![Capture d’écran du 2024-03-26 10-22-43](https://github.com/pyqtgraph/pyqtgraph/assets/96873753/5b421773-9d09-40a8-8968-a99e0d4e308d)

So, we've extracted the intersection points and used them to create a new polygon to fill the empty space.

![Capture d’écran du 2024-03-26 10-27-04](https://github.com/pyqtgraph/pyqtgraph/assets/96873753/4ca0ab80-13b3-41d7-97e4-e08e4a87c9c7)

### Other Tasks 

<details>
  <summary>Bump Dependency Versions</summary>

 - ubuntu 22.04

 - python 3.10.12  
 
 - Pyqtgraph 0.13.4.dev0

### Files that need updates
    
Confirm the following files have been either updated or there has been a determination that no update is needed.

- [X] `README.md`
- [X] `setup.py`
- [X] `tox.ini`
- [X] `.github/workflows/main.yml` and associated `requirements.txt` and conda `environemt.yml` files
- [X] `pyproject.toml`
- [X] `binder/requirements.txt`

</details>

<details>
    <summary>Pre-Release Checklist</summary>

### Pre Release Checklist

- [X] Update version info in `__init__.py`
- [ ] Update `CHANGELOG` primarily using contents from automated changelog generation in GitHub release page
- [X] Have git tag in the format of pyqtgraph-<version>

</details>


<details>
  <summary>Post-Release Checklist</summary>

### Steps To Complete

- [X] Append `.dev0` to `__version__` in `__init__.py`
- [ ] Announce on mail list
- [ ] Announce on Twitter

</details>
