### PR TITLE
Add stubs for Qt modules

### DIFF
--- a/pyqtgraph/Qt/QtCore/__init__.pyi
+++ b/pyqtgraph/Qt/QtCore/__init__.pyi
@@ -1,0 +1,5 @@
+# Import packages in reverse libOrder as defined in pyqtgraph/Qt/__init__.py
+from PySide2.QtCore import *
+from PyQt5.QtCore import *
+from PySide6.QtCore import *
+from PyQt6.QtCore import *

--- a/pyqtgraph/Qt/QtGui/__init__.pyi
+++ b/pyqtgraph/Qt/QtGui/__init__.pyi
@@ -1,0 +1,5 @@
+# Import packages in reverse libOrder as defined in pyqtgraph/Qt/__init__.py
+from PySide2.QtGui import *
+from PyQt5.QtGui import *
+from PySide6.QtGui import *
+from PyQt6.QtGui import *

--- a/pyqtgraph/Qt/QtSvg.pyi
+++ b/pyqtgraph/Qt/QtSvg.pyi
@@ -1,0 +1,5 @@
+# Import packages in reverse libOrder as defined in pyqtgraph/Qt/__init__.py
+from PySide2.QtSvg import *
+from PyQt5.QtSvg import *
+from PySide6.QtSvg import *
+from PyQt6.QtSvg import *

--- a/pyqtgraph/Qt/QtTest.pyi
+++ b/pyqtgraph/Qt/QtTest.pyi
@@ -1,0 +1,5 @@
+# Import packages in reverse libOrder as defined in pyqtgraph/Qt/__init__.py
+from PySide2.QtTest import *
+from PyQt5.QtTest import *
+from PySide6.QtTest import *
+from PyQt6.QtTest import *

--- a/pyqtgraph/Qt/QtWidgets/__init__.pyi
+++ b/pyqtgraph/Qt/QtWidgets/__init__.pyi
@@ -1,0 +1,5 @@
+# Import packages in reverse libOrder as defined in pyqtgraph/Qt/__init__.py
+from PySide2.QtWidgets import *
+from PyQt5.QtWidgets import *
+from PySide6.QtWidgets import *
+from PyQt6.QtWidgets import *

--- a/pyqtgraph/Qt/__init__.pyi
+++ b/pyqtgraph/Qt/__init__.pyi
@@ -1,52 +1,18 @@
 """
-This stub file is to aid in the PyCharm auto-completion of the Qt imports.
+This stub file is to aid in the PyCharm and VSCode auto-completion of the Qt imports.
 """
 
-from typing import Union
-
-try:
-    from PyQt5 import QtCore, QtGui, QtSvg, QtTest, QtWidgets
-
-    QtCore = QtCore
-    QtGui = QtGui
-    QtWidgets = QtWidgets
-    QtTest = QtTest
-    QtSvg = QtSvg
-except ImportError:
-    try:
-        from PyQt6 import QtCore, QtGui, QtSvg, QtTest, QtWidgets
-
-        QtCore = QtCore
-        QtGui = QtGui
-        QtWidgets = QtWidgets
-        QtTest = QtTest
-        QtSvg = QtSvg
-    except ImportError:
-        try:
-            from PySide2 import QtCore, QtGui, QtSvg, QtTest, QtWidgets
-
-            QtCore = QtCore
-            QtGui = QtGui
-            QtWidgets = QtWidgets
-            QtTest = QtTest
-            QtSvg = QtSvg
-        except ImportError:
-            try:
-                from PySide6 import QtCore, QtGui, QtSvg, QtTest, QtWidgets
-
-                QtCore = QtCore
-                QtGui = QtGui
-                QtWidgets = QtWidgets
-                QtTest = QtTest
-                QtSvg = QtSvg
-            except ImportError as e:
-                raise ImportError("No suitable qt binding found") from e
-
+from . import QtCore as QtCore
+from . import QtGui as QtGui
+from . import QtSvg as QtSvg
+from . import QtTest as QtTest
+from . import QtWidgets as QtWidgets
 
 App: QtWidgets.QApplication
 VERSION_INFO: str
 QT_LIB: str
 QtVersion: str
+
 def exec_() -> QtWidgets.QApplication: ...
-def mkQApp(name: Union[str, None] = None) -> QtWidgets.QApplication: ...
+def mkQApp(name: str | None = None) -> QtWidgets.QApplication: ...
 def isQObjectAlive(obj: QtCore.QObject) -> bool: ...


### PR DESCRIPTION
Enables editor and type checker support for Qt classes.

This change provides type information to editors and type checkers.

VSCode / Pylance will still report the import statements in the new stubs as missing imports if the given package is not installed. Nevertheless, if at least one of the packages is installed, you can import and use those classes with full auto-complete support.

It would be nice if someone could test if this also works in PyCharm or other editors / type checkers. Unfortunately I'm not able to do so.

### Other Tasks 

- [x] Check interaction with VSCode / Pylance
- [ ] Check interaction with PyCharm
