### PR TITLE
numpy 2.0: workaround regression in rescaleData

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1274,6 +1274,14 @@ def rescaleData(data, scale, offset, dtype=None, clip=None):
     else:
         work_dtype = np.float64
 
+    # from: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion
+    #   np.array([3], dtype=np.float32) + np.float64(3) will now return a float64 array.
+    #   (The higher precision of the scalar is not ignored.)
+    # this affects us even though we are performing in-place operations.
+    # a solution mentioned in the link above is to convert to a Python scalar.
+    offset = float(offset)
+    scale = float(scale)
+
     cp = getCupy()
     if cp and cp.get_array_module(data) == cp:
         # Cupy does not support nditer


### PR DESCRIPTION
Testing against NumPy 2.0rc1, a performance regression was noticed in `functions.rescaleData`.

The cause was traced to:
https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion

It does seem rather counter-intuitive that the new behavior should affect in-place operations:
e.g.
```python
data -= offset
data *= scalar
```
i.e. the resultant `dtype` can't change, so the performance regression might imply that a temporary higher precision ndarray was created? This would defeat the purpose of doing in-place operations.

~The fix in this PR is only applied to the `numpy` codepath, and not to the `cupy` and `numba` codepaths.
The `numba` codepath (`functions_numba.rescaleData`) already marks the `offset` and `scale` arguments as type `f8`.~