### PR TITLE
Set Application Icon on windows

### DIFF
--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -409,6 +409,12 @@ def mkQApp(name=None):
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
 
         QAPP.setWindowIcon(applicationIcon)
+
+        # inspired from @ccordoba12 in the Spyder project
+        # Required for correct icon on GNOME/Wayland:
+        if hasattr(QAPP, 'setDesktopFileName'):
+            QAPP.setDesktopFileName('pyqtgraph')
+
     if name is not None:
         QAPP.setApplicationName(name)
     return QAPP

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -393,23 +393,11 @@ def mkQApp(name=None):
                 QtCore.QSize(128, 128)
             )
             applicationIcon.addFile(
-                os.fsdecode(icon_path / "peegee_128px@2x.png"),
-                QtCore.QSize(128, 128)
-            )
-            applicationIcon.addFile(
                 os.fsdecode(icon_path / "peegee_256px.png"),
                 QtCore.QSize(256, 256)
             )
             applicationIcon.addFile(
-                os.fsdecode(icon_path / "peegee_256px@2x.png"),
-                QtCore.QSize(256, 256)
-            )
-            applicationIcon.addFile(
                 os.fsdecode(icon_path / "peegee_512px.png"),
-                QtCore.QSize(512, 512)
-            )
-            applicationIcon.addFile(
-                os.fsdecode(icon_path / "peegee_512px@2x.png"),
                 QtCore.QSize(512, 512)
             )
             applicationIcon.addFile(

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -364,7 +364,9 @@ def mkQApp(name=None):
             pass
         elif qtVersionCompare > (5, 14):
             os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "1"
-            QtWidgets.QApplication.setHighDpiScaleFactorRoundingPolicy(QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
+            QtWidgets.QApplication.setHighDpiScaleFactorRoundingPolicy(
+                QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
+            )
         else:  # qt 5.12 and 5.13
             QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
             QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
@@ -372,43 +374,42 @@ def mkQApp(name=None):
         QAPP = QtWidgets.QApplication(sys.argv or ["pyqtgraph"])
         QAPP.setStyle("fusion")
 
+        # determine if dark mode
+        try:
+            darkMode = QAPP.styleHints().colorScheme() == QtCore.Qt.ColorScheme.Dark
+        except AttributeError:
+            palette = QAPP.palette()
+            windowTextLightness = palette.color(QtGui.QPalette.ColorRole.WindowText).lightness()
+            windowLightness = palette.color(QtGui.QPalette.ColorRole.Window).lightness()
+            darkMode = windowTextLightness > windowLightness
+        QAPP.setProperty('darkMode', darkMode)
+
+        # set the application icon
         # python 3.9 won't take "pyqtgraph.icons.peegee" directly
         traverse_path = resources.files("pyqtgraph.icons")  
-        applicationIcon = QtGui.QIcon()
-
         peegee_traverse_path = traverse_path.joinpath("peegee")
 
         # as_file requires I feed in a file from the directory...
-        with resources.as_file(peegee_traverse_path.joinpath("peegee.svg")) as path:
-
-            # not actually interested in the filepath, but want the icon directory instead
+        with resources.as_file(
+            peegee_traverse_path.joinpath("peegee.svg")
+        ) as path:
+            # need the parent directory, not the filepath
             icon_path = path.parent
-            applicationIcon.addFile(
-                os.fsdecode(icon_path / "peegee_128px.png"),
-                QtCore.QSize(128, 128)
-            )
-            applicationIcon.addFile(
-                os.fsdecode(icon_path / "peegee_256px.png"),
-                QtCore.QSize(256, 256)
-            )
-            applicationIcon.addFile(
-                os.fsdecode(icon_path / "peegee_512px.png"),
-                QtCore.QSize(512, 512)
-            )
-            applicationIcon.addFile(
-                os.fsdecode(icon_path / "peegee.svg"),
-            )
+
+        applicationIcon = QtGui.QIcon()
+        applicationIcon.addFile(
+            os.fsdecode(icon_path / "peegee.svg"),
+        )
+        for sz in [128, 256, 512]:
+            pathname = os.fsdecode(icon_path / f"peegee_{sz}px.png")
+            applicationIcon.addFile(pathname, QtCore.QSize(sz, sz))
+
+        # handles the icon showing up on the windows taskbar
         if platform.system() == 'Windows':
             import ctypes
             myappid = "pyqtgraph.Qt.mkQApp"
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
-
         QAPP.setWindowIcon(applicationIcon)
-
-        # inspired from @ccordoba12 in the Spyder project
-        # Required for correct icon on GNOME/Wayland:
-        if hasattr(QAPP, 'setDesktopFileName'):
-            QAPP.setDesktopFileName('pyqtgraph')
 
     if name is not None:
         QAPP.setApplicationName(name)

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -371,11 +371,6 @@ def mkQApp(name=None):
 
         QAPP = QtWidgets.QApplication(sys.argv or ["pyqtgraph"])
         QAPP.setStyle("fusion")
-        styleHints = QAPP.styleHints()
-        try:
-            styleHints.colorSchemeChagned.connect(lambda x: print(f"Color Scheme Changed to {x}"))
-        except AttributeError:
-            pass
 
         # python 3.9 won't take "pyqtgraph.icons.peegee" directly
         traverse_path = resources.files("pyqtgraph.icons")  

--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -362,10 +362,11 @@ class ExampleLoader(QtWidgets.QMainWindow):
             try:
                 darkMode = app.styleHints().colorScheme() == QtCore.Qt.ColorScheme.Dark
             except AttributeError:
-                palette = app.pallete()
+                palette = app.palette()
                 windowTextLightness = palette.color(QtGui.QPalette.ColorRole.WindowText).lightness()
                 windowLightness = palette.color(QtGui.QPalette.ColorRole.Window).lightness()
                 darkMode = windowTextLightness > windowLightness
+                print(f"{darkMode=}")
             app.setProperty('darkMode', darkMode)
             self.hl = PythonHighlighter(self.ui.codeView.document())
         return super().event(event)

--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -310,7 +310,6 @@ class ExampleLoader(QtWidgets.QMainWindow):
         self.ui.codeView.setLayout(self.codeLayout)
         self.hl = PythonHighlighter(self.ui.codeView.document())
         app = QtWidgets.QApplication.instance()
-        app.paletteChanged.connect(self.updateTheme)
         policy = QtWidgets.QSizePolicy.Policy.Expanding
         self.codeLayout.addItem(QtWidgets.QSpacerItem(100,100, policy, policy), 0, 0)
         self.codeLayout.addWidget(self.codeBtn, 1, 1)
@@ -356,6 +355,20 @@ class ExampleLoader(QtWidgets.QMainWindow):
         self.ui.codeView.textChanged.connect(self.onTextChange)
         self.codeBtn.clicked.connect(self.runEditedCode)
         self.updateCodeViewTabWidth(self.ui.codeView.font())
+
+    def event(self, event):
+        if event.type() == QtCore.QEvent.Type.ApplicationPaletteChange:
+            app = QtWidgets.QApplication.instance()
+            try:
+                darkMode = app.styleHints().colorScheme() == QtCore.Qt.ColorScheme.Dark
+            except AttributeError:
+                palette = app.pallete()
+                windowTextLightness = palette.color(QtGui.QPalette.ColorRole.WindowText).lightness()
+                windowLightness = palette.color(QtGui.QPalette.ColorRole.Window).lightness()
+                darkMode = windowTextLightness > windowLightness
+            app.setProperty('darkMode', darkMode)
+            self.hl = PythonHighlighter(self.ui.codeView.document())
+        return super().event(event)
 
     def updateCodeViewTabWidth(self,font):
         """
@@ -476,9 +489,6 @@ class ExampleLoader(QtWidgets.QMainWindow):
         # finally, override application automatic detection
         app = QtWidgets.QApplication.instance()
         app.setProperty('darkMode', True)
-
-    def updateTheme(self):
-        self.hl = PythonHighlighter(self.ui.codeView.document())
 
     def populateTree(self, root, examples):
         bold_font = None


### PR DESCRIPTION
This PR makes it so the peegee icon is visible on the taskbar on Windows.  Furthermore, we set the `fusion` theme to applications created using `mkQApp()`, which handled dark mode detection on windows with Qt 6.5+.  

What still isn't working is the peegee icon not showing up on gnome/kde desktops.