### PR TITLE
bdist_wheel needs to grab peegee icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A pure-Python graphics library for PyQt5/PyQt6/PySide2/PySide6
 
 Copyright 2024 PyQtGraph developers
 
-<http://www.pyqtgraph.org>
+<https://www.pyqtgraph.org>
 
 PyQtGraph is intended for use in mathematics / scientific / engineering applications.
 Despite being written entirely in python, the library is fast due to its
@@ -30,13 +30,13 @@ This project supports:
 
 Currently this means:
 
-* Python 3.10+
+* Python 3.9+
 * Qt 5.15, 6.2+
 * [PyQt5](https://www.riverbankcomputing.com/software/pyqt/),
   [PyQt6](https://www.riverbankcomputing.com/software/pyqt/),
   [PySide2](https://wiki.qt.io/Qt_for_Python), or
   [PySide6](https://wiki.qt.io/Qt_for_Python)
-* [`numpy`](https://github.com/numpy/numpy) 1.23+
+* [`numpy`](https://github.com/numpy/numpy) 1.22+
 
 ### Optional added functionalities
 
@@ -82,10 +82,7 @@ Installation Methods
   * Latest development version: `pip install git+https://github.com/pyqtgraph/pyqtgraph@master`
 * From conda
   * Last released version: `conda install -c conda-forge pyqtgraph`
-* To install system-wide from source distribution: `python setup.py install`
 * Many linux package repositories have release versions.
-* To use with a specific project, simply copy the PyQtGraph subdirectory
-  anywhere that is importable from your project.
 
 Documentation
 -------------

--- a/setup.py
+++ b/setup.py
@@ -123,11 +123,11 @@ setup(
         'style': helpers.StyleCommand
     },
     packages=find_namespace_packages(include=['pyqtgraph', 'pyqtgraph.*']),
-    python_requires=">=3.10",
+    python_requires=">=3.9",
     package_dir={"pyqtgraph": "pyqtgraph"},
     package_data={
         'pyqtgraph.examples': ['optics/*.gz', 'relativity/presets/*.cfg'],
-        "pyqtgraph.icons": ["*.svg", "*.png"],
+        "pyqtgraph.icons": ["**/*.svg", "**/*.png"],
         "pyqtgraph": [
             "colors/maps/*.csv",
             "colors/maps/*.txt",
@@ -135,7 +135,7 @@ setup(
         ],
     },
     install_requires = [
-        'numpy>=1.23.0',
+        'numpy>=1.22.0',
     ],
     **setupOpts
 )


### PR DESCRIPTION
The peegee icons were not packaged with the wheel, now they are. 

Unwind python 3.10 and numpy 1.23 minimum requirements in prep for immediate release.