### PR TITLE
Grab compatible PyQt6-Qt6 for latest PyQt6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
             qt-version: "PySide6~=6.4.0"
           - python-version: "3.12"
             qt-lib: "pyqt"
-            qt-version: "PyQt6"
+            qt-version: "PyQt6~=6.7.0 PyQt6-Qt6~=6.7.0"
           - python-version: "3.12"
             qt-lib: "pyside"
             qt-version: "PySide6-Essentials"


### PR DESCRIPTION
PyQt6 6.7.0 just got released, which seems to grab PyQt6-Qt6 6.6.1, resulting in the following traceback:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/runner/work/pyqtgraph/pyqtgraph/pyqtgraph/__init__.py", line 18, in <module>
    from .colors import palette
  File "/home/runner/work/pyqtgraph/pyqtgraph/pyqtgraph/colors/palette.py", line 1, in <module>
    from ..Qt import QtGui
  File "/home/runner/work/pyqtgraph/pyqtgraph/pyqtgraph/Qt/__init__.py", line 185, in <module>
    import PyQt6.QtGui
ImportError: /opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/PyQt6/QtGui.abi3.so: undefined symbol: _ZN5QFont11tagToStringEj, version Qt_6
```

This PR attempts to install the latest compatible PyQt6-Qt6 library to go alongside.