### PR TITLE
Catch SystemError During Signal.disconnect()

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -3117,7 +3117,11 @@ def disconnect(signal, slot):
             success = signal.disconnect(slot)
             if success is None:     # PyQt
                 success = True
-        except (TypeError, RuntimeError):
+        except (
+            TypeError,
+            RuntimeError,
+            SystemError  # PySide6 6.7.1+ will emit this
+        ):
             success = False
 
         if success:


### PR DESCRIPTION
With PySide6 6.7.1, a SystemError will be emitted when attempting to disconnect a signal that is not connected.