### PR TITLE
remove numba for rescaleData

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -18,7 +18,6 @@ from . import Qt, debug, getConfigOption, reload
 from .metaarray import MetaArray
 from .Qt import QT_LIB, QtCore, QtGui
 from .util.cupy_helper import getCupy
-from .util.numba_helper import getNumbaFunctions
 
 # in order of appearance in this file.
 # add new functions to this list only if they are to reside in pg namespace.
@@ -1267,11 +1266,6 @@ def rescaleData(data, scale, offset, dtype=None, clip=None):
 
         # don't copy if no change in dtype
         return data_out.astype(out_dtype, copy=False)
-
-    numba_fn = getNumbaFunctions()
-    if numba_fn and clip is not None:
-        # if we got here by makeARGB(), clip will not be None at this point
-        return numba_fn.rescaleData(data, scale, offset, out_dtype, clip)
 
     return _rescaleData_nditer(data, scale, offset, work_dtype, out_dtype, clip)
 

--- a/pyqtgraph/functions_numba.py
+++ b/pyqtgraph/functions_numba.py
@@ -1,26 +1,6 @@
 import numba
 import numpy as np
 
-rescale_functions = {}
-
-def rescale_clip_source(xx, scale, offset, vmin, vmax, yy):
-    for i in range(xx.size):
-        val = (xx[i] - offset) * scale
-        yy[i] = min(max(val, vmin), vmax)
-
-def rescaleData(data, scale, offset, dtype, clip):
-    data_out = np.empty_like(data, dtype=dtype)
-    key = (data.dtype.name, data_out.dtype.name)
-    func = rescale_functions.get(key)
-    if func is None:
-        func = numba.guvectorize(
-            [f'{key[0]}[:],f8,f8,f8,f8,{key[1]}[:]'],
-            '(n),(),(),(),()->(n)',
-            nopython=True)(rescale_clip_source)
-        rescale_functions[key] = func
-    func(data, scale, offset, clip[0], clip[1], out=data_out)
-    return data_out
-
 @numba.jit(nopython=True)
 def rescale_and_lookup(data, scale, offset, lut):
     # data should be floating point and 2d

--- a/tests/test_makeARGB.py
+++ b/tests/test_makeARGB.py
@@ -10,11 +10,6 @@ from .makeARGB_test_data import EXPECTED_OUTPUTS, INPUTS, LEVELS, LUTS
 
 
 try:
-    import numba
-except ImportError:
-    pass
-
-try:
     import cupy
 except ImportError:
     pass
@@ -35,7 +30,6 @@ def _makeARGB(*args, **kwds):
 @pytest.mark.parametrize('acceleration', [
         pytest.param('numpy'),
         pytest.param('cupy', marks=pytest.mark.skipif('cupy' not in sys.modules, reason="CuPy not available")),
-        pytest.param('numba', marks=pytest.mark.skipif('numba' not in sys.modules, reason="numba not available"))
     ]
 )
 @pytest.mark.parametrize('dtype', [np.uint8, np.uint16, np.float32])
@@ -45,9 +39,7 @@ def _makeARGB(*args, **kwds):
 @pytest.mark.parametrize('scale', [None, 232, 13333])
 @pytest.mark.parametrize('use_rgba', [True, False])
 def test_makeARGB_against_generated_references(acceleration, dtype, in_fmt, level_name, lut_type, scale, use_rgba):
-    if acceleration == "numba":
-        setConfigOptions(useCupy=False, useNumba=True)
-    elif acceleration == "cupy":
+    if acceleration == "cupy":
         setConfigOptions(useCupy=True, useNumba=False)
     else:
         setConfigOptions(useCupy=False, useNumba=False)


### PR DESCRIPTION
since `try_make_qimage()` now uses its own more specialized (and faster) numba functions instead of `rescaleData()`, we no longer need the latter.

furthermore, the formulation of `functions_numba.rescaleData` using `guvectorize` was giving only a slight speedup, much less than the more specialized versions using `nditer`.