### PR TITLE
RawImageGLWidget: implement using QOpenGLTextureBlitter

### DIFF
--- a/pyqtgraph/examples/VideoSpeedTest.py
+++ b/pyqtgraph/examples/VideoSpeedTest.py
@@ -74,6 +74,7 @@ if RawImageGLWidget is None:
 else:
     ui.rawGLImg = RawImageGLWidget()
     ui.stack.addWidget(ui.rawGLImg)
+    win.destroyed.connect(ui.rawGLImg.cleanup)
 
 # read in CLI args
 ui.cudaCheck.setChecked(args.cuda and _has_cupy)


### PR DESCRIPTION
This PR reimplements RawImageGLWidget without use of PyOpenGL, using instead QtOpenGL.
Some consequences:
1) RawImageGLWidget is always available for use in VideoSpeedTest
2) RawImageGLWidget now also works on GLES
3) OpenGL object leaks are more visible since Qt will warn. 
