### PR TITLE
Remove now unneeded test skip conditions, use packaging library for version comparison.

### DIFF
--- a/pyqtgraph/examples/test_examples.py
+++ b/pyqtgraph/examples/test_examples.py
@@ -57,12 +57,7 @@ installedFrontends = sorted([
     frontend for frontend, isPresent in frontends.items() if isPresent
 ])
 
-darwin_opengl_broken = (platform.system() == "Darwin" and
-            tuple(map(int, platform.mac_ver()[0].split("."))) >= (10, 16) and
-            (sys.version_info < (3, 8, 10) or sys.version_info == (3, 9, 0)))
 
-darwin_opengl_reason = ("pyopenGL cannot find openGL library on big sur: "
-                        "https://github.com/python/cpython/pull/21241")
 
 exceptionCondition = namedtuple("exceptionCondition", ["condition", "reason"])
 conditionalExamples = {
@@ -80,23 +75,8 @@ conditionalExamples = {
     ),
 }
 
-openglExamples = ['GLViewWidget.py']
-openglExamples.extend(utils.examples_['3D Graphics'].values())
-for key in openglExamples:
-    conditionalExamples[key] = exceptionCondition(
-        not darwin_opengl_broken,
-        reason=darwin_opengl_reason
-    )
 
-@pytest.mark.skipif(
-    Qt.QT_LIB == "PySide2"
-    and tuple(map(int, Qt.PySide2.__version__.split("."))) >= (5, 14) 
-    and tuple(map(int, Qt.PySide2.__version__.split("."))) < (5, 14, 2, 2), 
-    reason="new PySide2 doesn't have loadUi functionality"
-)
-@pytest.mark.parametrize(
-    "frontend, f",
-    [
+@pytest.mark.parametrize("frontend, f", [
         pytest.param(
             frontend,
             f,
@@ -107,9 +87,8 @@ for key in openglExamples:
         )
         for frontend, f, in itertools.product(installedFrontends, files)
     ],
-    ids = [
-        " {} - {} ".format(f[1], frontend)
-        for frontend, f in itertools.product(
+    ids=[
+        f" {f[1]} - {frontend} " for frontend, f in itertools.product(
             installedFrontends,
             files
         )
@@ -122,7 +101,7 @@ def testExamples(frontend, f):
     os.chdir(path)
     sys.stdout.write(f"{name}")
     sys.stdout.flush()
-    import1 = "import %s" % frontend if frontend != '' else ''
+    import1 = f"import {frontend}" if frontend != '' else ''
     import2 = os.path.splitext(os.path.split(fn)[1])[0]
     code = """
 try:

--- a/tests/exporters/test_csv.py
+++ b/tests/exporters/test_csv.py
@@ -1,7 +1,6 @@
-"""
-CSV export test
-"""
+
 import csv
+import math
 import tempfile
 
 import numpy as np
@@ -11,12 +10,8 @@ import pyqtgraph as pg
 
 app = pg.mkQApp()
 
-
-def approxeq(a, b):
-    return (a-b) <= ((a + b) * 1e-6)
-
-
-def test_CSVExporter():
+@pytest.mark.parametrize('log_mapping', [True, False])
+def test_CSVExporter(log_mapping: bool):
     plt = pg.PlotWidget()
     plt.show()
     y1 = [1,3,2,3,1,6,9,8,4,2]
@@ -30,30 +25,26 @@ def test_CSVExporter():
     x3 = np.linspace(0, 1.0, len(y3)+1)
     plt.plot(x=x3, y=y3, stepMode="center")
 
-    for log_mapping in (False, True):
-        if log_mapping:
-            print('testing original data export in log mapped mode')
-        else:
-            print('testing data export in unmapped mode')
-        plt.setLogMode(x=log_mapping, y=log_mapping)
-        ex = pg.exporters.CSVExporter(plt.plotItem)
-        with tempfile.NamedTemporaryFile(mode="w+t", suffix='.csv', encoding="utf-8", delete=False) as tf:
-            print("  using %s as a temporary file" % tf.name)
-            ex.export(fileName=tf.name)
-            lines = [line for line in csv.reader(tf)]
-        header = lines.pop(0)
-        assert header == ['myPlot_x', 'myPlot_y', 'x0001', 'y0001', 'x0002', 'y0002']
+    # log mapping is True tests original data export in log mapped mode
+    plt.setLogMode(x=log_mapping, y=log_mapping)
+    ex = pg.exporters.CSVExporter(plt.plotItem)
+    with tempfile.NamedTemporaryFile(mode="w+t", suffix='.csv', encoding="utf-8", delete=False) as tf:
+        print(f"  using {tf.name} as a temporary file")
+        ex.export(fileName=tf.name)
+        lines = list(csv.reader(tf))
+    header = lines.pop(0)
+    assert header == ['myPlot_x', 'myPlot_y', 'x0001', 'y0001', 'x0002', 'y0002']
 
-        for i, vals in enumerate(lines):
-            vals = list(map(str.strip, vals))
-            assert (i >= len(y1) and vals[0] == '') or approxeq(float(vals[0]), i)
-            assert (i >= len(y1) and vals[1] == '') or approxeq(float(vals[1]), y1[i])
+    for i, vals in enumerate(lines):
+        vals = list(map(str.strip, vals))
+        assert (i >= len(y1) and vals[0] == '') or math.isclose(float(vals[0]), i)
+        assert (i >= len(y1) and vals[1] == '') or math.isclose(float(vals[1]), y1[i])
 
-            assert (i >= len(x2) and vals[2] == '') or approxeq(float(vals[2]), x2[i])
-            assert (i >= len(y2) and vals[3] == '') or approxeq(float(vals[3]), y2[i])
+        assert (i >= len(x2) and vals[2] == '') or math.isclose(float(vals[2]), x2[i])
+        assert (i >= len(y2) and vals[3] == '') or math.isclose(float(vals[3]), y2[i])
 
-            assert (i >= len(x3) and vals[4] == '') or approxeq(float(vals[4]), x3[i])
-            assert (i >= len(y3) and vals[5] == '') or approxeq(float(vals[5]), y3[i])
+        assert (i >= len(x3) and vals[4] == '') or math.isclose(float(vals[4]), x3[i])
+        assert (i >= len(y3) and vals[5] == '') or math.isclose(float(vals[5]), y3[i])
 
 
 def test_CSVExporter_with_ErrorBarItem():
@@ -72,9 +63,14 @@ def test_CSVExporter_with_ErrorBarItem():
     )
     plt.addItem(err)
     ex = pg.exporters.CSVExporter(plt.plotItem)
-    with tempfile.NamedTemporaryFile(mode="w+t", suffix='.csv', encoding="utf-8", delete=False) as tf:
+    with tempfile.NamedTemporaryFile(
+        mode="w+t",
+        suffix='.csv',
+        encoding="utf-8",
+        delete=False
+    ) as tf:
         ex.export(fileName=tf.name)
-        lines = [line for line in csv.reader(tf)]
+        lines = list(csv.reader(tf))
 
     header = lines.pop(0)
 

--- a/tests/exporters/test_exporter_dialog.py
+++ b/tests/exporters/test_exporter_dialog.py
@@ -19,7 +19,7 @@ def test_export_dialog():
         pos=pg.Qt.QtCore.QPointF(plt.mapFromGlobal(plt.geometry().center())),
         button=pg.Qt.QtCore.Qt.MouseButton.RightButton
     )
-    plt.scene().contextMenu[0].trigger() # show show dialog
+    plt.scene().contextMenu[0].trigger()  # show dialog
     plt.scene().showExportDialog()
     assert plt.scene().exportDialog.isVisible()
     plt.scene().exportDialog.close()

--- a/tests/exporters/test_image.py
+++ b/tests/exporters/test_image.py
@@ -9,8 +9,10 @@ app = pg.mkQApp()
 
 
 def test_ImageExporter_filename_dialog():
-    """Tests ImageExporter code path that opens a file dialog. Regression test
-    for pull request 1133."""
+    """
+    Tests ImageExporter code path that opens a file dialog.
+    Regression test for pull request 1133.
+    """
     p = pg.PlotWidget()
     p.show()
     exp = ImageExporter(p.getPlotItem())

--- a/tests/exporters/test_svg.py
+++ b/tests/exporters/test_svg.py
@@ -16,7 +16,7 @@ def test_plotscene(tmpdir):
     
     ex = pg.exporters.SVGExporter(w.scene())
 
-    tf = tmpdir.join("expot.svg")
+    tf = tmpdir.join("export.svg")
     ex.export(fileName=tf)
     # clean up after the test is done
     w.close()
@@ -66,5 +66,5 @@ def test_simple(tmpdir):
     grp2.addItem(rect3)
 
     ex = pg.exporters.SVGExporter(scene)
-    tf = tmpdir.join("expot.svg")
+    tf = tmpdir.join("export.svg")
     ex.export(fileName=tf)

--- a/tests/graphicsItems/test_AxisItem.py
+++ b/tests/graphicsItems/test_AxisItem.py
@@ -121,32 +121,24 @@ def test_AxisItem_tickFont(monkeypatch):
     app.processEvents()
     plot.close()
 
-
-def test_AxisItem_label_visibility():
+@pytest.mark.parametrize('orientation,label_kwargs,labelText,labelUnits', [
+    ('left', {}, '', '',),
+    ('left', dict(text='Position', units='mm'), 'Position', 'mm'),
+    ('left', dict(text=None, units=None), '', ''),
+    ('left', dict(text='Current', units=None), 'Current', ''),
+    ('left', dict(text='', units='V'), '', 'V')
+])
+def test_AxisItem_label_visibility(orientation, label_kwargs, labelText: str, labelUnits: str):
     """Test the visibility of the axis item using `setLabel`"""
-    axis = pg.AxisItem('left')
-    assert axis.labelText == ''
-    assert axis.labelUnits == ''
-    assert not axis.label.isVisible()
-    axis.setLabel(text='Position', units='mm')
-    assert axis.labelText == 'Position'
-    assert axis.labelUnits == 'mm'
-    assert axis.label.isVisible()
-    # XXX: `None` is converted to empty strings.
-    axis.setLabel(text=None, units=None)
-    assert axis.labelText == ''
-    assert axis.labelUnits == ''
-    assert not axis.label.isVisible()
-    axis.setLabel(text='Current', units=None)
-    assert axis.labelText == 'Current'
-    assert axis.labelUnits == ''
-    assert axis.label.isVisible()
-    axis.setLabel(text=None, units=None)
-    assert not axis.label.isVisible()
-    axis.setLabel(text='', units='V')
-    assert axis.labelText == ''
-    assert axis.labelUnits == 'V'
-    assert axis.label.isVisible()
+    axis = pg.AxisItem(orientation)
+    axis.setLabel(**label_kwargs)
+    assert axis.labelText == labelText
+    assert axis.labelUnits == labelUnits
+    assert (
+        axis.label.isVisible() 
+        if any(label_kwargs.values())
+        else not axis.label.isVisible()
+    )
 
 @pytest.mark.parametrize(
     "orientation,x,y,expected",

--- a/tests/graphicsItems/test_GraphicsItem.py
+++ b/tests/graphicsItems/test_GraphicsItem.py
@@ -1,9 +1,6 @@
-import faulthandler
 import weakref
 
 import pyqtgraph as pg
-
-faulthandler.enable()
 
 pg.mkQApp()
 

--- a/tests/graphicsItems/test_ImageItem.py
+++ b/tests/graphicsItems/test_ImageItem.py
@@ -86,12 +86,12 @@ def test_ImageItem(transpose=False):
     app.processEvents()
     assertImageApproved(w, 'imageitem/init', 'Init image item. View is auto-scaled, image axis 0 marked by 1 line, axis 1 is marked by 2 lines. Origin in bottom-left.')
     
-    # ..with colormap
+    # ... with colormap
     cmap = pg.ColorMap([0, 0.25, 0.75, 1], [[0, 0, 0, 255], [255, 0, 0, 255], [255, 255, 0, 255], [255, 255, 255, 255]])
     img.setLookupTable(cmap.getLookupTable())
     assertImageApproved(w, 'imageitem/lut', 'Set image LUT.')
     
-    # ..and different levels
+    # ... and different levels
     img.setLevels([dmax+9, dmax+13])
     assertImageApproved(w, 'imageitem/levels1', 'Levels show only axis lines.')
 
@@ -167,7 +167,7 @@ def test_ImageItem(transpose=False):
     assertImageApproved(w, 'imageitem/resolution_without_downsampling', 'Resolution test without downsampling.')
     
     img.setAutoDownsample(True)
-    assertImageApproved(w, 'imageitem/resolution_with_downsampling_x', 'Resolution test with downsampling axross x axis.')
+    assertImageApproved(w, 'imageitem/resolution_with_downsampling_x', 'Resolution test with downsampling across x axis.')
     assert img._lastDownsample == (4, 1)
     
     img.setImage(data.T, levels=[-1, 1])

--- a/tests/graphicsItems/test_InfiniteLine.py
+++ b/tests/graphicsItems/test_InfiniteLine.py
@@ -16,7 +16,7 @@ def test_InfiniteLine():
     plt.setYRange(-10, 10)
     plt.resize(600, 600)
 
-    # seemingly arbitrary requirements; might need longer wait time for some platforms..
+    # seemingly arbitrary requirements; might need longer wait time for some platforms
     QtTest.QTest.qWaitForWindowExposed(plt)
     QtTest.QTest.qWait(100)
 

--- a/tests/graphicsItems/test_LegendItem.py
+++ b/tests/graphicsItems/test_LegendItem.py
@@ -1,8 +1,8 @@
 import pyqtgraph as pg
 
+pg.mkQApp()
 
 def test_legend_item_basics():
-    pg.mkQApp()
 
     legend = pg.LegendItem()
 

--- a/tests/graphicsItems/test_LinearRegionItem.py
+++ b/tests/graphicsItems/test_LinearRegionItem.py
@@ -25,7 +25,7 @@ def test_clip_to_plot_data_item(orientation):
     # initial bounds for the LRI
     init_vals = (-1.5, 1.5)
 
-    # data for a PlotDataItem to clip to, both inside the inial bounds
+    # data for a PlotDataItem to clip to, both inside the initial bounds
     x = np.linspace(-1, 1, 10)
     y = np.linspace(1, 1.2, 10)
 

--- a/tests/graphicsItems/test_PlotCurveItem.py
+++ b/tests/graphicsItems/test_PlotCurveItem.py
@@ -17,7 +17,7 @@ def test_PlotCurveItem():
     v.addItem(c)
     v.autoRange()
     
-    # Check auto-range works. Some platform differences may be expected..
+    # Check auto-range works. Some platform differences may be expected.
     checkRange = np.array([[-1.1457564053237301, 16.145756405323731], [-3.076811473165955, 11.076811473165955]])
     assert np.allclose(v.viewRange(), checkRange)
     

--- a/tests/graphicsItems/test_PlotDataItem.py
+++ b/tests/graphicsItems/test_PlotDataItem.py
@@ -185,7 +185,7 @@ def test_clipping():
     # test center and expected number of remaining data points
     for center, num in ((-100.,1), (100.,1), (0.,len(y)) ):
         # when all elements are off-screen, only one will be kept
-        # when all elelemts are on-screen, all should be kept
+        # when all elements are on-screen, all should be kept
         # and the code should not crash for zero separation
         w.setXRange( center-50, center+50, padding=0 )
         xDisp, yDisp = c.getData()

--- a/tests/graphicsItems/test_ROI.py
+++ b/tests/graphicsItems/test_ROI.py
@@ -61,7 +61,7 @@ def check_getArrayRegion(roi, name, testResize=True, transpose=False):
     win = pg.GraphicsView()
     win.show()
     resizeWindow(win, 200, 400)
-    # Don't use Qt's layouts for testing--these generate unpredictable results.
+    # Don't use Qts' layouts for testing--these generate unpredictable results.
     # Instead, manually place the ViewBoxes
     vb1 = pg.ViewBox()
     win.scene().addItem(vb1)
@@ -315,8 +315,7 @@ def test_PolyLineROI(roi, name):
 
     plt.scene().minDragTime = 0  # let us simulate mouse drags very quickly.
 
-    # seemingly arbitrary requirements; might need longer wait time for some
-    # platforms..
+    # seemingly arbitrary requirements; might need longer wait time for some platforms.
     QtTest.QTest.qWaitForWindowExposed(plt)
     QtTest.QTest.qWait(100)
 

--- a/tests/image_testing.py
+++ b/tests/image_testing.py
@@ -153,7 +153,7 @@ def assertImageApproved(image, standardFile, message=None, **kwargs):
             print(graphstate)
 
         if os.getenv('PYQTGRAPH_AUDIT_ALL') == '1':
-            raise Exception("Image test passed, but auditing due to PYQTGRAPH_AUDIT_ALL evnironment variable.")
+            raise Exception("Image test passed, but auditing due to PYQTGRAPH_AUDIT_ALL environment variable.")
     except Exception:
         if os.getenv('PYQTGRAPH_AUDIT') == '1' or os.getenv('PYQTGRAPH_AUDIT_ALL') == '1':
             sys.excepthook(*sys.exc_info())

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -102,7 +102,7 @@ def check_param_types(param, types, map_func, init, objs, keys):
             param.setValue().
         keys : list
             The list of keys indicating the valid objects in *objs*. When
-            param.setValue() is teasted with each value from *objs*, we expect
+            param.setValue() is tested with each value from *objs*, we expect
             an exception to be raised if the associated key is not in *keys*.
     """
     val = param.value()

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -201,10 +201,6 @@ def test_pen_settings():
     p["width"] = 10
     assert p.pen.width() == 10
 
-@pytest.mark.skipif(
-    pg.Qt.QT_LIB == "PySide2" and pg.Qt.QtVersion.startswith("5.15"),
-    reason="Seems to segfault on conda + pyside2 on CI"
-)
 def test_recreate_from_savestate():
     from pyqtgraph.examples import _buildParamTypes
     created = _buildParamTypes.makeAllParamTypes()

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -109,7 +109,7 @@ def check_param_types(param, types, map_func, init, objs, keys):
     if not isinstance(types, tuple):
         types = (types,)
     assert val == init and type(val) in types
-    
+
     # test valid input types
     good_inputs = [objs[k] for k in keys if k in objs]
     good_outputs = map(map_func, good_inputs)
@@ -119,7 +119,7 @@ def check_param_types(param, types, map_func, init, objs, keys):
         if not (eq(val, y) and type(val) in types):
             raise Exception("Setting parameter %s with value %r should have resulted in %r (types: %r), "
                 "but resulted in %r (type: %r) instead." % (param, x, y, types, val, type(val)))
-        
+
     # test invalid input types
     for k,v in objs.items():
         if k in keys:
@@ -129,8 +129,10 @@ def check_param_types(param, types, map_func, init, objs, keys):
         except (TypeError, ValueError, OverflowError):
             continue
         except Exception as exc:
-            raise Exception("Setting %s parameter value to %r raised %r." % (param, v, exc))
-        
+            raise Exception(
+                "Setting %s parameter value to %r raised %r." % (param, v, exc)
+            ) from exc
+
         raise Exception("Setting %s parameter value to %r should have raised an exception." % (param, v))
         
         

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -135,8 +135,16 @@ def check_param_types(param, types, map_func, init, objs, keys):
 
         raise Exception("Setting %s parameter value to %r should have raised an exception." % (param, v))
         
-        
-def test_limits_enforcement():
+
+@pytest.mark.parametrize("k,v_in,v_out",[
+    ('float', -1, 0),
+    ('float',  2, 1),
+    ('int',   -1, 0),
+    ('int',    2, 1),
+    ('list', 'w', 'x'),
+    ('dict', 'w', 1)
+])
+def test_limits_enforcement(k, v_in, v_out):
     p = pt.Parameter.create(name='params', type='group', children=[
         dict(name='float', type='float', limits=[0, 1]),
         dict(name='int', type='int', bounds=[0, 1]),
@@ -145,14 +153,8 @@ def test_limits_enforcement():
     ])
     t = pt.ParameterTree()
     t.setParameters(p)
-    for k, vin, vout in [('float', -1, 0),
-                         ('float',  2, 1),
-                         ('int',   -1, 0),
-                         ('int',    2, 1),
-                         ('list',   'w', 'x'),
-                         ('dict',   'w', 1)]:
-        p[k] = vin
-        assert p[k] == vout
+    p[k] = v_in
+    assert p[k] == v_out
 
 
 def test_data_race():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -159,7 +159,7 @@ def test_eq():
             return False
         
     noteq = NotEq()
-    assert eq(noteq, noteq) # passes because they are the same object
+    assert eq(noteq, noteq)  # passes because they are the same object
     assert not eq(noteq, NotEq())
 
 

--- a/tests/test_makeARGB.py
+++ b/tests/test_makeARGB.py
@@ -45,7 +45,7 @@ def test_makeARGB_against_generated_references(acceleration, dtype, in_fmt, leve
         setConfigOptions(useCupy=False, useNumba=False)
 
     if dtype == np.float32 and level_name is None:
-        pytest.skip(f"{dtype=} is not compatable with {level_name=}")
+        pytest.skip(f"{dtype=} is not compatible with {level_name=}")
 
     data = INPUTS[(dtype, in_fmt)]
     levels = LEVELS.get(level_name, None)

--- a/tests/test_qpainterpathprivate.py
+++ b/tests/test_qpainterpathprivate.py
@@ -21,11 +21,6 @@ def test_qpainterpathprivate_read():
     assert memory['c'][0] == 0
     assert np.all(memory['c'][1:] == 1)
 
-
-@pytest.mark.skipif(
-    not hasattr(QtGui.QPainterPath, 'reserve'),
-    reason="needs Qt version >= 5.13"
-)
 def test_qpainterpathprivate_write():
     x0, y0 = 100, 200
     size = 100

--- a/tests/test_qt.py
+++ b/tests/test_qt.py
@@ -13,12 +13,6 @@ def test_isQObjectAlive():
     del o1
     assert not pg.Qt.isQObjectAlive(o2)
 
-@pytest.mark.skipif(
-    pg.Qt.QT_LIB == "PySide2"
-    and tuple(map(int, pg.Qt.PySide2.__version__.split("."))) >= (5, 14) 
-    and tuple(map(int, pg.Qt.PySide2.__version__.split("."))) < (5, 14, 2, 2), 
-    reason="new PySide2 doesn't have loadUi functionality"
-)
 def test_loadUiType():
     path = os.path.dirname(__file__)
     formClass, baseClass = pg.Qt.loadUiType(os.path.join(path, 'uictest.ui'))

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -1,9 +1,10 @@
 import os
+import platform
 import shutil
-import sys
 import time
 
 import pytest
+from packaging.version import Version, parse
 
 import pyqtgraph as pg
 
@@ -32,9 +33,10 @@ def remove_cache(mod):
 
 @pytest.mark.skipif(
     (
-        (pg.Qt.QT_LIB == "PySide2" and pg.Qt.QtVersion.startswith("5.15"))
-        or (pg.Qt.QT_LIB == "PySide6")
-    ) and (sys.version_info >= (3, 9)),
+        pg.Qt.QT_LIB.startswith("PySide") and
+        parse(pg.Qt.QtVersion) < Version('6.6.0') and # not sure when exactly fixed
+        platform != 'Darwin' # seems to work on macOS
+    ),
     reason="Unknown Issue"
 )
 @pytest.mark.usefixtures("tmp_module")

--- a/tests/test_signalproxy.py
+++ b/tests/test_signalproxy.py
@@ -90,7 +90,6 @@ def test_signal_proxy_no_slot_start(qapp):
     qapp.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 10)
     assert receiver.counter == 0
 
-    # Start a connect
     proxy.connectSlot(receiver.slotReceive)
     assert proxy.blockSignal is False
     sender.signalSend.emit()

--- a/tests/widgets/test_histogramlutwidget.py
+++ b/tests/widgets/test_histogramlutwidget.py
@@ -4,6 +4,8 @@ HistogramLUTWidget test:
 Tests the creation of a HistogramLUTWidget.
 """
 
+
+import itertools
 import numpy as np
 
 import pyqtgraph as pg
@@ -12,7 +14,7 @@ from pyqtgraph.Qt import QtWidgets
 
 def testHistogramLUTWidget():
     pg.mkQApp()
-    
+
     win = QtWidgets.QMainWindow()
     win.show()
 
@@ -33,14 +35,13 @@ def testHistogramLUTWidget():
     l.addWidget(w, 0, 1)
 
     data = pg.gaussianFilter(np.random.normal(size=(256, 256, 3)), (20, 20, 0))
-    for i in range(32):
-        for j in range(32):
-            data[i*8, j*8] += .1
+    for i, j in itertools.product(range(32), range(32)):
+        data[i*8, j*8] += .1
     img = pg.ImageItem(data)
     vb.addItem(img)
     vb.autoRange()
 
     w.setImageItem(img)
-    
+
     QtWidgets.QApplication.processEvents()
     win.close()

--- a/tests/widgets/test_matplotlibwidget.py
+++ b/tests/widgets/test_matplotlibwidget.py
@@ -8,6 +8,7 @@ from importlib.metadata import version
 
 import numpy as np
 import pytest
+from packaging.version import parse, Version
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtWidgets
@@ -17,8 +18,8 @@ pytest.importorskip("matplotlib")
 # see https://github.com/matplotlib/matplotlib/pull/24172
 if (
     pg.Qt.QT_LIB == "PySide6"
-    and tuple(map(int, pg.Qt.PySide6.__version__.split("."))) > (6, 4)
-    and tuple(map(int, version("matplotlib").split("."))) < (3, 6, 2)
+    and parse(pg.Qt.PySide6.__version__) > Version('6.4')
+    and parse(version("matplotlib")) < Version('3.6.2')
 ):
     pytest.skip(
         "matplotlib + PySide6 6.4 bug",

--- a/tests/widgets/test_matplotlibwidget.py
+++ b/tests/widgets/test_matplotlibwidget.py
@@ -44,7 +44,7 @@ def assert_widget_fields(mplw, parent, figsize, dpi):
 def test_init_with_qwidget_arguments():
     """
     Ensures providing only the parent argument to the constructor properly
-    intializes the widget to match the QWidget constructor prototype.
+    initializes the widget to match the QWidget constructor prototype.
     """
     win = QtWidgets.QMainWindow()
 
@@ -55,7 +55,7 @@ def test_init_with_qwidget_arguments():
 
 def test_init_with_matplotlib_arguments():
     """
-    Tests the contructor that sets variables associated with Matplotlib and
+    Tests the constructor that sets variables associated with Matplotlib and
     abstracts away any details about the underlying QWidget parent class.
     """
     figsize = (1.0, 3.0)


### PR DESCRIPTION
Some of the pytest skip conditions are now outdated as they skip versions of python or dependencies that pyqtgraph no longer supports.