### PR TITLE
RawImageGLWidget: update uploaded state on cleanup

### DIFF
--- a/pyqtgraph/widgets/RawImageWidget.py
+++ b/pyqtgraph/widgets/RawImageWidget.py
@@ -163,6 +163,7 @@ if HAVE_OPENGL:
             # explicit call of cleanup() is needed during application termination
             self.makeCurrent()
             self.m_texture.destroy()
+            self.uploaded = False
             if self.m_blitter is not None:
                 self.m_blitter.destroy()
                 self.m_blitter = None


### PR DESCRIPTION
cleanup (followed by initializeGL) will be called if QOpenGLWidget gets reparented (and not just during application shutdown)

in such a case, state variables need to be maintained.

A script that demonstrates the scenario:
1) `RawImageGLWidget` is first created parent-less and `show()`n.
   * this causes `RawImageGLWidget` to be a top-level window and triggers creation of an OpenGL context
2) next it is made a child of `QMainWindow`.
   * this causes `RawImageGLWidget` to no longer be a top-level window and triggers the creation of a new OpenGL context

Without this PR, a black window will be displayed.
```python
import sys

import pyqtgraph as pg
from pyqtgraph.Qt import QtCore, QtGui, QtWidgets

pg.setConfigOption('imageAxisOrder', 'row-major')

qimage = QtGui.QImage(sys.argv[1])
qimage.convertTo(QtGui.QImage.Format.Format_RGBA8888)
image = pg.functions.ndarray_from_qimage(qimage)

pg.mkQApp()
win = QtWidgets.QMainWindow()
img = pg.RawImageGLWidget()
img.setImage(image)
img.show()  # force a re-parent
win.setCentralWidget(img)
win.destroyed.connect(img.cleanup)
win.resize(640, 480)
win.show()
pg.exec()
```