### PR TITLE
Fix types of signals of `SpinBox`

### DIFF
--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -41,9 +41,9 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
     ## I have no idea how to get around this..
     
     
-    valueChanged = QtCore.Signal(object)     # (value)  for compatibility with QSpinBox
+    valueChanged = QtCore.Signal(float)     # (value)  for compatibility with QSpinBox
     sigValueChanged = QtCore.Signal(object)  # (self)
-    sigValueChanging = QtCore.Signal(object, object)  # (self, value)  sent immediately; no delay.
+    sigValueChanging = QtCore.Signal(object, float)  # (self, value)  sent immediately; no delay.
 
     def __init__(self, parent=None, value=0.0, **kwargs):
         """


### PR DESCRIPTION
In the constructors of the signals, use the actual types of the values passed to the corresponding `emit` calls. Namely, there should be `float`s in two places.

I haven't checked other classes for the same issue. Please take a look if you have time.