### PR TITLE
Support downsampling of image data with NaNs

### DIFF
--- a/doc/source/api_reference/graphicsItems/imageitem.rst
+++ b/doc/source/api_reference/graphicsItems/imageitem.rst
@@ -74,6 +74,7 @@ The following guidance should be observed if performance is an important factor
 
 * For floating point `image` arrays, prefer `float32` dtype to `float64` and avoid
   ``NaN`` values.
+
 * Enable Numba with :python:`pyqtgraph.setConfigOption('useNumba', True)`
 
   * JIT compilation will only accelerate repeated image display.

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1765,7 +1765,7 @@ def gaussianFilter(data, sigma):
     return filtered + baseline
     
     
-def downsample(data, n, axis=0, xvals='subsample', has_nans=False):
+def downsample(data, n, axis=0, xvals='subsample', *, has_nans=False):
     """Downsample by averaging points together across axis.
     If multiple axes are specified, runs once per axis.
     """
@@ -1773,7 +1773,7 @@ def downsample(data, n, axis=0, xvals='subsample', has_nans=False):
         if not hasattr(n, '__len__'):
             n = [n]*len(axis)
         for i in range(len(axis)):
-            data = downsample(data, n[i], axis[i])
+            data = downsample(data, n[i], axis[i], has_nans=has_nans)
         return data
     
     if n <= 1:

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1765,7 +1765,7 @@ def gaussianFilter(data, sigma):
     return filtered + baseline
     
     
-def downsample(data, n, axis=0, xvals='subsample'):
+def downsample(data, n, axis=0, xvals='subsample', has_nans=False):
     """Downsample by averaging points together across axis.
     If multiple axes are specified, runs once per axis.
     """
@@ -1786,7 +1786,10 @@ def downsample(data, n, axis=0, xvals='subsample'):
     sl[axis] = slice(0, nPts*n)
     d1 = data[tuple(sl)]
     d1.shape = tuple(s)
-    d2 = d1.mean(axis+1)
+    if has_nans:
+        d2 = np.nanmean(d1, axis+1)
+    else:
+        d2 = d1.mean(axis+1)
     return d2
 
 def _compute_backfill_indices(isfinite):

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1765,7 +1765,7 @@ def gaussianFilter(data, sigma):
     return filtered + baseline
     
     
-def downsample(data, n, axis=0, xvals='subsample', *, has_nans=False):
+def downsample(data, n, axis=0, xvals='subsample', *, nanPolicy='ignore'):
     """Downsample by averaging points together across axis.
     If multiple axes are specified, runs once per axis.
     """
@@ -1773,7 +1773,7 @@ def downsample(data, n, axis=0, xvals='subsample', *, has_nans=False):
         if not hasattr(n, '__len__'):
             n = [n]*len(axis)
         for i in range(len(axis)):
-            data = downsample(data, n[i], axis[i], has_nans=has_nans)
+            data = downsample(data, n[i], axis[i], nanPolicy=nanPolicy)
         return data
     
     if n <= 1:
@@ -1786,10 +1786,12 @@ def downsample(data, n, axis=0, xvals='subsample', *, has_nans=False):
     sl[axis] = slice(0, nPts*n)
     d1 = data[tuple(sl)]
     d1.shape = tuple(s)
-    if has_nans:
+    if nanPolicy == 'ignore':
         d2 = np.nanmean(d1, axis+1)
-    else:
+    elif nanPolicy == 'propagate':
         d2 = d1.mean(axis+1)
+    else:
+        raise ValueError(f"Keyword argument {nanPolicy=} must be one of ['propagate', 'ignore'].")
     return d2
 
 def _compute_backfill_indices(isfinite):

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1765,7 +1765,7 @@ def gaussianFilter(data, sigma):
     return filtered + baseline
     
     
-def downsample(data, n, axis=0, xvals='subsample', *, nanPolicy='ignore'):
+def downsample(data, n, axis=0, xvals='subsample', *, nanPolicy='propagate'):
     """Downsample by averaging points together across axis.
     If multiple axes are specified, runs once per axis.
     """
@@ -1788,10 +1788,10 @@ def downsample(data, n, axis=0, xvals='subsample', *, nanPolicy='ignore'):
     d1.shape = tuple(s)
     if nanPolicy == 'propagate':
         d2 = d1.mean(axis+1)
-    elif nanPolicy == 'ignore':
+    elif nanPolicy == 'omit':
         d2 = np.nanmean(d1, axis+1)
     else:
-        raise ValueError(f"Keyword argument {nanPolicy=} must be one of ['propagate', 'ignore'].")
+        raise ValueError(f"Keyword argument {nanPolicy=} must be one of {'propagate', 'omit'}.")
     return d2
 
 def _compute_backfill_indices(isfinite):

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -1786,10 +1786,10 @@ def downsample(data, n, axis=0, xvals='subsample', *, nanPolicy='ignore'):
     sl[axis] = slice(0, nPts*n)
     d1 = data[tuple(sl)]
     d1.shape = tuple(s)
-    if nanPolicy == 'ignore':
-        d2 = np.nanmean(d1, axis+1)
-    elif nanPolicy == 'propagate':
+    if nanPolicy == 'propagate':
         d2 = d1.mean(axis+1)
+    elif nanPolicy == 'ignore':
+        d2 = np.nanmean(d1, axis+1)
     else:
         raise ValueError(f"Keyword argument {nanPolicy=} must be one of ['propagate', 'ignore'].")
     return d2

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -73,7 +73,7 @@ class ImageItem(GraphicsObject):
         self.levels = None  ## [min, max] or [[redMin, redMax], ...]
         self.lut = None
         self.autoDownsample = False
-        self.nanPolicy = 'propagate'
+        self._nanPolicy = 'propagate'
         self._colorMap = None # This is only set if a color map is assigned directly
         self._lastDownsample = (1, 1)
         self._processingBuffer = None
@@ -324,6 +324,19 @@ class ImageItem(GraphicsObject):
         self._renderRequired = True
         self.update()
 
+    def getNanPolicy(self) -> str:
+        """
+        Retrieve the string representing the current NaN policy.
+
+        See :meth:setNanPolicy.
+
+        Returns
+        -------
+        { 'propagate', 'omit' }
+            The NaN policy that this ImageItem uses during downsampling.
+        """
+        return self._nanPolicy
+
     def setNanPolicy(self, nanPolicy: str):
         """
         Control how NaN values are handled during downsampling for this ImageItem.
@@ -338,7 +351,7 @@ class ImageItem(GraphicsObject):
         """
         if nanPolicy not in ['propagate', 'omit']:
             raise ValueError(f"{nanPolicy=} must be one of {'propagate', 'omit'}")
-        self.nanPolicy = nanPolicy
+        self._nanPolicy = nanPolicy
         self._renderRequired = True
         self.update()
 
@@ -422,7 +435,7 @@ class ImageItem(GraphicsObject):
         if 'autoDownsample' in kwargs:
             self.setAutoDownsample(kwargs['autoDownsample'])
         if 'nanPolicy' in kwargs:
-            self.nanPolicy = kwargs['nanPolicy']
+            self.setNanPolicy(kwargs['nanPolicy'])
         if 'rect' in kwargs:
             self.setRect(kwargs['rect'])
         if update:
@@ -742,7 +755,7 @@ class ImageItem(GraphicsObject):
                 return
 
             axes = [1, 0] if self.axisOrder == 'row-major' else [0, 1]
-            nan_policy = self.nanPolicy if self._imageHasNans else 'propagate'
+            nan_policy = self._nanPolicy if self._imageHasNans else 'propagate'
             image = fn.downsample(self.image, xds, axis=axes[0], nanPolicy=nan_policy)
             image = fn.downsample(image, yds, axis=axes[1], nanPolicy=nan_policy)
             self._lastDownsample = (xds, yds)

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -73,7 +73,7 @@ class ImageItem(GraphicsObject):
         self.levels = None  ## [min, max] or [[redMin, redMax], ...]
         self.lut = None
         self.autoDownsample = False
-        self.nanPolicy = 'ignore'
+        self.nanPolicy = 'propagate'
         self._colorMap = None # This is only set if a color map is assigned directly
         self._lastDownsample = (1, 1)
         self._processingBuffer = None
@@ -334,7 +334,8 @@ class ImageItem(GraphicsObject):
             Must be one of ['ignore`, 'propagate']. If 'nanPolicy' is 'ignore', NaNs
             are automatically ignored during downsampling, at the expense of
             performance. If 'nanPolicy' is 'propagate', NaNs are kept during
-            downsampling. ImageItem is instantiated with nanPolicy set to 'ignore'.
+            downsampling. Unless a different policy was specified, a new ImageItem is
+            created with ``nanPolicy='propagate'``.
         """
         assert nanPolicy in ['propagate', 'ignore'], (f"{nanPolicy=} must be one "
                                                       f"of ['propagate', 'ignore']")

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -330,15 +330,14 @@ class ImageItem(GraphicsObject):
 
         Parameters
         ----------
-        nanPolicy : str
-            Must be one of ['ignore`, 'propagate']. If 'nanPolicy' is 'ignore', NaNs
-            are automatically ignored during downsampling, at the expense of
-            performance. If 'nanPolicy' is 'propagate', NaNs are kept during
-            downsampling. Unless a different policy was specified, a new ImageItem is
-            created with ``nanPolicy='propagate'``.
+        nanPolicy : { 'propagate', 'omit' }
+            If 'nanPolicy' is 'ignore', NaNs are automatically ignored during
+            downsampling, at the expense of performance. If 'nanPolicy' is 'propagate',
+            NaNs are kept during downsampling. Unless a different policy was specified,
+            a new ImageItem is created with ``nanPolicy='propagate'``.
         """
-        assert nanPolicy in ['propagate', 'ignore'], (f"{nanPolicy=} must be one "
-                                                      f"of ['propagate', 'ignore']")
+        if nanPolicy not in ['propagate', 'omit']:
+            raise ValueError(f"{nanPolicy=} must be one of {'propagate', 'omit'}")
         self.nanPolicy = nanPolicy
         self._renderRequired = True
         self.update()

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -324,7 +324,7 @@ class ImageItem(GraphicsObject):
         self._renderRequired = True
         self.update()
 
-    def getNanPolicy(self) -> str:
+    def nanPolicy(self) -> str:
         """
         Retrieve the string representing the current NaN policy.
 


### PR DESCRIPTION
This PR adds tolerance for NaNs in ImageItem autodownsampling. 

In the original code, NaNs in the image data would dominate after autodownsampling. With these changes, NaNs are ignored during downsampling.