### PR TITLE
Fixes: Error when using FFT on data with one point

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -1771,6 +1771,8 @@ class PlotDataItem(GraphicsObject):
     def _fourierTransform(x, y):
         # Perform Fourier transform. If x values are not sampled uniformly,
         # then use np.interp to resample before taking fft.
+        if len(x) == 1: 
+            return np.array([0]), abs(y)
         dx = np.diff(x)
         uniform = not np.any(np.abs(dx - dx[0]) > (abs(dx[0]) / 1000.))
         if not uniform:


### PR DESCRIPTION
see #3018

### Handle single data point case in Fourier Transform
- Adds a condition to handle cases where there is only one data point
- Ensures the function returns zero frequency and the magnitude of the single data point as fallback

### Credits
The solution was proposed by [Python-simulation](https://github.com/Python-simulation) in issue #3018.

EDIT (added for automatic issue closing by @j9ac9k):

Fixes #3018