### PR TITLE
Change background color in context menu

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -2,7 +2,6 @@ import warnings
 import weakref
 from time import perf_counter, perf_counter_ns
 
-from PyQt6.QtWidgets import QColorDialog
 
 from .. import debug as debug
 from .. import getConfigOption
@@ -116,7 +115,7 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
 
     def setBackgroundFromContextMenu(self):
         # Open the color picker dialog
-        color = QColorDialog.getColor()
+        color = QtWidgets.QColorDialog.getColor()
 
         # Check if a valid color was selected
         if color.isValid():

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -114,6 +114,23 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
         self._lastMoveEventTime = 0
 
     def setBackgroundFromContextMenu(self):
+        """
+        Opens a color picker dialog to allow the user to select a background color from the context menu.
+    
+        This method performs the following steps:
+        1. Opens a QColorDialog to present a color picker to the user.
+        2. Checks if the user has selected a valid color.
+        3. If a valid color is selected:
+           a. Retrieves the selected color as a hex string.
+           b. Emits a signal (`sigBackgroundChanged`) with the selected color in hex format.
+    
+        Note:
+        - The QColorDialog is a standard dialog provided by the Qt framework that allows users to select a color.
+        - The hex format of the color is a string in the form '#RRGGBB' (e.g., '#ff5733').
+    
+        Emits:
+        sigBackgroundChanged (str): A signal that carries the hex representation of the selected color.
+        """
         # Open the color picker dialog
         color = QtWidgets.QColorDialog.getColor()
 

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -120,9 +120,7 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
         This method performs the following steps:
         1. Opens a QColorDialog to present a color picker to the user.
         2. Checks if the user has selected a valid color.
-        3. If a valid color is selected:
-           a. Retrieves the selected color as a hex string.
-           b. Emits a signal (`sigBackgroundChanged`) with the selected color in hex format.
+        3. If a valid color is selected, it retrives color as a hex string and emits a signal with the color.
     
         Note:
         - The QColorDialog is a standard dialog provided by the Qt framework that allows users to select a color.

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -137,10 +137,10 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
         # Check if a valid color was selected
         if color.isValid():
             # Store the selected color as a hex string
-            selected_color_hex = color.name()  # Color in hex format
+            selectedColorHex = color.name()  # Color in hex format
 
             # Emit the signal with the selected color
-            self.sigBackgroundChanged.emit(selected_color_hex)
+            self.sigBackgroundChanged.emit(selectedColorHex)
 
         
     def render(self, *args):

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -80,6 +80,7 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
     sigItemAdded = QtCore.Signal(object)  ## emits the item object just added
     sigItemRemoved = QtCore.Signal(object)  ## emits the item object just removed
 
+    sigBackgroundChanged = QtCore.Signal(str)   ## emitted when the Background Color was changed via the context menu
     _addressCache = weakref.WeakValueDictionary()
     
     ExportDirectory = None
@@ -101,9 +102,21 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
         
         self.contextMenu = [QtGui.QAction(QtCore.QCoreApplication.translate("GraphicsScene", "Export..."), self)]
         self.contextMenu[0].triggered.connect(self.showExportDialog)
+
+        self.setBackgroundAction = QtGui.QAction(
+            QtCore.QCoreApplication.translate("GraphicsScene", "Set Background color"), self
+        )
+        self.setBackgroundAction.triggered.connect(self.setBackgroundFromContextMenu)
+        self.contextMenu.append(self.setBackgroundAction)
         
         self.exportDialog = None
         self._lastMoveEventTime = 0
+
+    def setBackgroundFromContextMenu(self):
+        # TODO: Remove Debug Statements
+        print(self.parent)
+        print("BG Changed")
+        self.sigBackgroundChanged.emit("#ff000f")
         
     def render(self, *args):
         self.prepareForPaint()

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -2,6 +2,8 @@ import warnings
 import weakref
 from time import perf_counter, perf_counter_ns
 
+from PyQt6.QtWidgets import QColorDialog
+
 from .. import debug as debug
 from .. import getConfigOption
 from ..Point import Point
@@ -113,10 +115,17 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
         self._lastMoveEventTime = 0
 
     def setBackgroundFromContextMenu(self):
-        # TODO: Remove Debug Statements
-        print(self.parent)
-        print("BG Changed")
-        self.sigBackgroundChanged.emit("#ff000f")
+        # Open the color picker dialog
+        color = QColorDialog.getColor()
+
+        # Check if a valid color was selected
+        if color.isValid():
+            # Store the selected color as a hex string
+            selected_color_hex = color.name()  # Color in hex format
+
+            # Emit the signal with the selected color
+            self.sigBackgroundChanged.emit(selected_color_hex)
+
         
     def render(self, *args):
         self.prepareForPaint()

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -100,6 +100,7 @@ class GraphicsView(QtWidgets.QGraphicsView):
         # GraphicsScene must have parent or expect crashes!
         self.sceneObj = GraphicsScene(parent=self)
         self.setScene(self.sceneObj)
+        self.sceneObj.sigBackgroundChanged.connect(self.setBackground)
         
         ## by default we set up a central widget with a grid layout.
         ## this can be replaced if needed.


### PR DESCRIPTION
### Summary

Introduces a new feature that enables users to change the background color of plots directly through the context menu.

### Issue
Reference to issue #3073 in which the feature was introduced

### Changes Made

Added functionality to the context menu of plots to allow users to select and apply a new background color with the QColorDialog.
Implemented immediate application of the selected color, persisting until plot reset or application closure.

### How to Test

- Right-click on any plot to open the context menu.
- Select "Set Background Color" from the menu.
- Choose a color from the QColorDialog.
- Observe that the plot background color changes immediately and remains as selected until the plot is reset or the application is closed.

This feature enhancement aims to provide users with a more interactive and customizable plotting experience, enhancing visual clarity and usability in presentations and data analysis without changing the code.