### PR TITLE
don't draw non-finite pairs

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -2068,8 +2068,12 @@ def arrayToQPath(x, y, connect='all', finiteCheck=True):
 
     # decide which points are connected by lines
     if connect == 'pairs':
+        mask = 1                # by default connect every 2nd point to every 1st one
+        if finiteCheck and not all_isfinite:
+            mask = isfinite[:len(x)//2 * 2]             # ensure even number of points
+            mask = mask[0::2] & mask[1::2]              # don't connect non-finite pairs
         arr['c'][0::2] = 0
-        arr['c'][1::2] = 1  # connect every 2nd point to every 1st one
+        arr['c'][1::2] = mask
     elif connect == 'array':
         # Let's call a point with either x or y being nan is an invalid point.
         # A point will anyway not connect to an invalid point regardless of the

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -160,7 +160,17 @@ def arrayToLineSegments(x, y, connect, finiteCheck, out=None):
             # each non-finite point affects the segment before and after
             connect_array = mask[:-1] & mask[1:]
 
-    elif connect in ['pairs', 'array']:
+    elif connect == 'pairs':
+        if not all_finite:
+            # ensure that we have an even number of elements
+            npairs = len(x) // 2
+            mask = mask[:npairs*2]
+            # remove pair if at least one point within pair is non-finite
+            mask.reshape((-1, 2))[:] = (mask[0::2] & mask[1::2])[:, np.newaxis]
+            x = x[:npairs*2][mask]
+            y = y[:npairs*2][mask]
+
+    elif connect == 'array':
         if not all_finite:
             # replicate the behavior of arrayToQPath
             backfill_idx = fn._compute_backfill_indices(mask)


### PR DESCRIPTION
Comments
https://github.com/pyqtgraph/pyqtgraph/pull/2011#issuecomment-942358983
through
https://github.com/pyqtgraph/pyqtgraph/pull/2011#issuecomment-942910785
had a discussion (and a demonstrating example) on the behavior to employ when `connect="pairs"` had non-finites in the data.

This PR finally implements the saner behavior of not drawing pairs containing any non-finite coordinate.

![image](https://github.com/pyqtgraph/pyqtgraph/assets/2657027/8cbe72b6-9033-4b01-9861-9025e92f6ef9)


The image comparison of the following should have failed, but it doesn't because there are too few white pixels to trigger the image-comparison tolerance threshold.
https://github.com/pyqtgraph/pyqtgraph/blob/master/tests/images/plotcurveitem/connectpairs.png
Which raises the question of whether any of the 4 plotcurveitem reference images were useful at all.