### PR TITLE
Format DateAxisItem ticks in different timezones correctly

### DIFF
--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -152,8 +152,8 @@ class ZoomLevel:
         self.utcOffset = None
         self.exampleText = exampleText
 
-    def extendTimeRangeForSpec(self, spec, minVal, maxVal):
-        if spec.spacing < HOUR_SPACING:
+    def extendTimeRangeForSpacing(self, spacing, minVal, maxVal):
+        if spacing < HOUR_SPACING:
             return minVal, maxVal
 
         extendedMax = maxVal + abs(getPreferredOffsetFromUtc(maxVal, self.utcOffset))
@@ -184,8 +184,8 @@ class ZoomLevel:
         for spec in self.tickSpecs:
             # extend time range, so that if distance to certain local hour
             # stretches due to DST change, this hour is still included in ticks
-            extendedMin, extendedMax = self.extendTimeRangeForSpec(spec, minVal, maxVal)
-            ticks, skipFactor = spec.makeTicks(extendedMin, extendedMax, minSpc)
+            extendedRange = self.extendTimeRangeForSpacing(spec.spacing, minVal, maxVal)
+            ticks, skipFactor = spec.makeTicks(*extendedRange, minSpc)
             ticks = self.moveTicksToLocalTimeCoords(ticks, spec.spacing, skipFactor)
             # remove any ticks that were present in higher levels
             # we assume here that if the difference between a tick value and a previously seen tick value

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -172,8 +172,7 @@ class ZoomLevel:
             ticks += [applyOffsetToUtc(tick, self.utcOffset) for tick in ticks]
         elif spacing == HOUR_SPACING:
             ticks += [offsetToLocalHour(tick) for tick in ticks]
-            minutesIsZero = [offsetToLocalHour(tick) == 0 for tick in ticks]
-            ticks = ticks[minutesIsZero]
+            ticks = np.array([tick for tick in ticks if offsetToLocalHour(tick) == 0])
         return ticks
 
     def tickValues(self, minVal, maxVal, minSpc):

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -152,7 +152,9 @@ class ZoomLevel:
         self.utcOffset = None
         self.exampleText = exampleText
 
-    def extendTimeRangeForSpacing(self, spacing, minVal, maxVal):
+    def extendTimeRangeForSpacing(
+            self, spacing: int, minVal: int | float, maxVal: int | float,
+    ) -> tuple[int | float, int | float]:
         if spacing < HOUR_SPACING:
             return minVal, maxVal
 
@@ -160,7 +162,9 @@ class ZoomLevel:
         extendedMin = minVal - abs(getPreferredOffsetFromUtc(minVal, self.utcOffset))
         return extendedMin, extendedMax
 
-    def moveTicksToLocalTimeCoords(self, ticks, spacing, skipFactor):
+    def moveTicksToLocalTimeCoords(
+            self, ticks: np.ndarray, spacing: int, skipFactor: int,
+    ) -> np.ndarray:
         if len(ticks) == 0:
             return ticks
 
@@ -232,36 +236,42 @@ MS_ZOOM_LEVEL = ZoomLevel([
 ], "99:99:99")
 
 
-def fromSecsSinceEpoch(timestamp):
+def fromSecsSinceEpoch(timestamp: float | int) -> QDateTime:
     try:
         return QDateTime.fromSecsSinceEpoch(round(timestamp))
     except OverflowError:
         return QDateTime()
 
 
-def calculateUtcOffset(timestamp):
+def calculateUtcOffset(timestamp: float | int) -> int:
     return -fromSecsSinceEpoch(timestamp).offsetFromUtc()
 
 
-def getPreferredOffsetFromUtc(timestamp, preferred_offset=None):
+def getPreferredOffsetFromUtc(
+        timestamp: float | int,
+        preferred_offset: int | None = None,
+) -> int:
     """Retrieve the utc offset respecting the daylight saving time"""
     if preferred_offset is not None:
         return preferred_offset
     return calculateUtcOffset(timestamp)
 
 
-def adjustTimestampToPreferredUtcOffset(timestamp, offest=None):
+def adjustTimestampToPreferredUtcOffset(
+        timestamp: float | int,
+        offest: int | None = None,
+) -> int | float:
     return timestamp - getPreferredOffsetFromUtc(timestamp, offest)
 
 
-def offsetToLocalHour(timestamp):
+def offsetToLocalHour(timestamp: float | int) -> int:
     local = fromSecsSinceEpoch(timestamp)
     roundedToHour = local.time()
     roundedToHour.setHMS(roundedToHour.hour(), 0, 0)
     return -roundedToHour.secsTo(local.time())
 
 
-def applyOffsetFromUtc(timestamp):
+def applyOffsetFromUtc(timestamp: float | int) -> int:
     """
     UTC+4
     1970-01-02 02:00 (local) == 1970-01-01 22:00 (UTC) -> 1970-01-01 22:00 (local)
@@ -276,7 +286,10 @@ def applyOffsetFromUtc(timestamp):
     return repositioned.toSecsSinceEpoch()
 
 
-def applyOffsetToUtc(timestamp, preferred_offset=None):
+def applyOffsetToUtc(
+        timestamp: float | int,
+        preferred_offset: int | None = None,
+) -> int:
     delocalized = applyOffsetFromUtc(timestamp)
     return getPreferredOffsetFromUtc(delocalized, preferred_offset)
 

--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -165,7 +165,7 @@ class ZoomLevel:
             return ticks
 
         if (spacing == HOUR_SPACING and skipFactor > 1) or spacing > HOUR_SPACING:
-            ticks += [shiftedOffsetFromUtc(tick, self.utcOffset) for tick in ticks]
+            ticks += [applyOffsetToUtc(tick, self.utcOffset) for tick in ticks]
         elif spacing == HOUR_SPACING:
             ticks += [offsetToLocalHour(tick) for tick in ticks]
             minutesIsZero = [offsetToLocalHour(tick) == 0 for tick in ticks]
@@ -261,7 +261,7 @@ def offsetToLocalHour(timestamp):
     return -roundedToHour.secsTo(local.time())
 
 
-def shiftLocalTimeToUtcTime(timestamp):
+def applyOffsetFromUtc(timestamp):
     """
     UTC+4
     1970-01-02 02:00 (local) == 1970-01-01 22:00 (UTC) -> 1970-01-01 22:00 (local)
@@ -276,9 +276,9 @@ def shiftLocalTimeToUtcTime(timestamp):
     return repositioned.toSecsSinceEpoch()
 
 
-def shiftedOffsetFromUtc(timestamp, preferred_offset=None):
-    shifted = shiftLocalTimeToUtcTime(timestamp)
-    return getPreferredOffsetFromUtc(shifted, preferred_offset)
+def applyOffsetToUtc(timestamp, preferred_offset=None):
+    delocalized = applyOffsetFromUtc(timestamp)
+    return getPreferredOffsetFromUtc(delocalized, preferred_offset)
 
 
 class DateAxisItem(AxisItem):

--- a/tests/graphicsItems/test_DateAxisItem.py
+++ b/tests/graphicsItems/test_DateAxisItem.py
@@ -1,0 +1,252 @@
+from itertools import product
+from unittest import mock
+
+import pytest
+
+import pyqtgraph as pg
+from pyqtgraph.graphicsItems.DateAxisItem import (
+    DAY_SPACING,
+    HMS_ZOOM_LEVEL,
+    HOUR_MINUTE_ZOOM_LEVEL,
+    HOUR_SPACING,
+    MS_ZOOM_LEVEL,
+    SEC_PER_YEAR,
+    calculateUtcOffset,
+    getPreferredOffsetFromUtc,
+    shiftLocalTimeToUtcTime,
+)
+from pyqtgraph.Qt.QtCore import QDate, QDateTime, QTime, QTimeZone
+from pyqtgraph.Qt.QtGui import QFont, QFontMetrics
+
+app = pg.mkQApp()
+
+
+@pytest.fixture
+def date_axis():
+    axis = pg.DateAxisItem()
+    axis.fontMetrics = QFontMetrics(QFont())
+    yield axis
+
+
+def assert_subarray(subarray, array):
+    start = array.index(subarray[0])
+    assert array[start:start+len(subarray)] == subarray
+
+
+def test_preferred_utc_offset_respects_chosen_offset():
+    assert getPreferredOffsetFromUtc(0, 7200) == 7200
+    assert getPreferredOffsetFromUtc(0, -7200) == -7200
+
+
+def test_preferred_utc_offset_doesnt_break_with_big_timestamps():
+    timestamp = SEC_PER_YEAR ** 13
+
+    assert -16 * 3600 <= getPreferredOffsetFromUtc(timestamp) <= 16 * 3600
+    assert getPreferredOffsetFromUtc(timestamp, 3600) == 3600
+
+    assert -16 * 3600 <= getPreferredOffsetFromUtc(-timestamp) <= 16 * 3600
+    assert getPreferredOffsetFromUtc(-timestamp, -1800) == -1800
+
+
+def test_utc_offset_works_with_float_timestamp():
+    assert -16 * 3600 <= calculateUtcOffset(123456.0734) <= 16 * 3600
+
+
+def test_shift_local_time_to_utc_time_does_what_it_promises_to_do():
+    timeZone = QTimeZone(b"UTC+4")
+
+    def fromSecsSinceEpochLocal(timestamp):
+        return QDateTime.fromMSecsSinceEpoch(timestamp * 1000).toTimeZone(timeZone)
+
+    startDate = QDateTime(QDate(1970, 1, 2), QTime(2, 0), timeZone)
+    goalDate = QDateTime(QDate(1970, 1, 1), QTime(22, 0), timeZone)
+    assert (
+        startDate.toUTC().time() == goalDate.time()
+        and startDate.toUTC().date() == goalDate.date()
+    )
+
+    fromEpochSecs = "pyqtgraph.graphicsItems.DateAxisItem.QDateTime.fromSecsSinceEpoch"
+    with mock.patch(fromEpochSecs, fromSecsSinceEpochLocal):
+        shifted = shiftLocalTimeToUtcTime(startDate.toSecsSinceEpoch())
+        assert shifted == goalDate.toSecsSinceEpoch()
+
+
+@pytest.mark.parametrize(
+    ("timeZone", "transitionDate", "expectedDayTickStrings", "expectedHourTickStrings"),
+    (
+        (
+            QTimeZone(b"Europe/Berlin"),
+            QDate(2022, 10, 30),
+            ["Sun 30"],
+            ["01:00", "02:00", "02:00", "03:00", "04:00"],
+        ),
+        (
+            QTimeZone(b"Europe/Berlin"),
+            QDate(2023, 3, 26),
+            ["Sun 26"],
+            ["01:00", "03:00", "04:00", "05:00", "06:00"],
+        ),
+        (
+            QTimeZone(b"Pacific/Chatham"),
+            QDate(2024, 4, 7),
+            ["Sun 07"],
+            ["01:00", "02:00", "03:00", "03:00", "04:00"],
+        ),
+        (
+            QTimeZone(b"Pacific/Chatham"),
+            QDate(2022, 9, 25),
+            ["Sun 25"],
+            ["01:00", "02:00", "04:00", "05:00", "06:00"],
+        ),
+        # Qt wants to go backwards at 00:01 to 23:01,
+        # but according to
+        # https://www.timeanddate.com/time/change/canada/st-johns?year=1986
+        # it should be from 02:00 to 01:00. Maybe Qt bug, maybe website is wrong
+        # maybe those are different time zones and everything is fine
+        (
+            QTimeZone(b"America/St_Johns"),
+            QDate(1986, 10, 26),
+            ["Sun 26"],
+            ["00:00", "01:00", "02:00", "03:00", "04:00"],
+        ),
+        (
+            QTimeZone(b"America/St_Johns"),
+            QDate(1995, 4, 2),
+            ["Sun 02"],
+            ["02:00", "03:00", "04:00", "05:00", "06:00"],
+        ),
+        (
+            QTimeZone(b"Australia/Lord_Howe"),
+            QDate(2007, 3, 25),
+            ["Sun 25"],
+            ["01:00", "02:00", "03:00", "04:00", "05:00"],
+        ),
+        (
+            QTimeZone(b"Australia/Lord_Howe"),
+            QDate(2010, 10, 3),
+            ["Sun 03"],
+            ["01:00", "03:00", "04:00", "05:00", "06:00"],
+        ),
+    ),
+    ids=(
+        f"{zone}-{direction}"
+        for zone, direction
+        in product(
+            ("Berlin", "Chatham", "St_Johns", "Lord_Howe"),
+            ("backward", "forward"),
+        )
+    ),
+)
+def test_maps_tick_values_to_local_times(
+    timeZone,
+    transitionDate,
+    expectedDayTickStrings,
+    expectedHourTickStrings,
+    date_axis,
+):
+
+    def fromSecsSinceEpochLocal(timestamp):
+        return QDateTime.fromMSecsSinceEpoch(timestamp * 1000).toTimeZone(timeZone)
+
+    minTime = QDateTime(transitionDate, QTime(0, 0, 0, 0), timeZone).toSecsSinceEpoch()
+    maxTime = QDateTime(transitionDate, QTime(4, 0, 0, 0), timeZone).toSecsSinceEpoch()
+
+    fromEpochSecs = "pyqtgraph.graphicsItems.DateAxisItem.QDateTime.fromSecsSinceEpoch"
+    with mock.patch(fromEpochSecs, fromSecsSinceEpochLocal):
+        xvals = [x for x in range(minTime, maxTime + 3600, 3600)]
+        lengthInPixels = 600
+        tickValues = date_axis.tickValues(xvals[0] - 1, xvals[-1] + 1, lengthInPixels)
+        for spacing, ticks in tickValues:
+            if spacing == DAY_SPACING:
+                tickStrings = date_axis.tickStrings(ticks, 1, DAY_SPACING)
+                assert_subarray(expectedDayTickStrings, tickStrings)
+            elif spacing == HOUR_SPACING:
+                tickStrings = date_axis.tickStrings(ticks, 1, spacing)
+                assert_subarray(expectedHourTickStrings, tickStrings)
+
+
+@pytest.mark.parametrize(
+    ("timeZone"),
+    (
+        QTimeZone(b"Europe/Berlin"),
+        QTimeZone(b"Pacific/Chatham"),
+        QTimeZone(b"America/St_Johns"),
+        QTimeZone(b"Australia/Lord_Howe"),
+    ),
+    ids=("Berlin", "Chatham", "St_Johns", "Lord_Howe"),
+)
+def test_maps_hour_ticks_to_local_times_when_skip_greater_than_one(timeZone, date_axis):
+
+    def fromSecsSinceEpochLocal(timestamp):
+        return QDateTime.fromMSecsSinceEpoch(timestamp * 1000).toTimeZone(timeZone)
+
+    date = QDate(2023, 5, 10)
+    minTime = QDateTime(date, QTime(0, 0, 0, 0), timeZone).toSecsSinceEpoch()
+    maxTime = QDateTime(date, QTime(18, 0, 0, 0), timeZone).toSecsSinceEpoch()
+
+    fromEpochSecs = "pyqtgraph.graphicsItems.DateAxisItem.QDateTime.fromSecsSinceEpoch"
+    with mock.patch(fromEpochSecs, fromSecsSinceEpochLocal):
+        xvals = [x for x in range(minTime, maxTime + 3600, 3600)]
+
+        lengthInPixels = 200
+        tickValues = date_axis.tickValues(xvals[0] - 1, xvals[-1] + 1, lengthInPixels)
+        for spacing, ticks in tickValues:
+            if spacing == HOUR_SPACING:
+                tickStrings = date_axis.tickStrings(ticks, 1, spacing)
+                assert_subarray(["06:00", "12:00", "18:00"], tickStrings)
+
+
+@pytest.mark.parametrize(
+    ("autoSkip", "expectedHourTickStrings"),
+    (
+        (1, ["01:00", "02:00", "03:00", "04:00", "05:00"]),
+        (6, ["06:00", "12:00", "18:00"]),
+    ),
+)
+def test_custom_utc_offset_works(autoSkip, expectedHourTickStrings, date_axis):
+    size_px = 600 if autoSkip == 1 else 200
+    maxHour = 4 if autoSkip == 1 else 18
+
+    utcZone = QTimeZone(b"UTC")
+    date = QDate(2001, 1, 1)
+    minTime = QDateTime(date, QTime(0, 0, 0, 0), utcZone).toSecsSinceEpoch()
+    maxTime = QDateTime(date, QTime(maxHour, 0, 0, 0), utcZone).toSecsSinceEpoch()
+
+    xvals = [x for x in range(minTime, maxTime + 3600, 3600)]
+
+    date_axis.utcOffset = -3600
+    for spacing, ticks in date_axis.tickValues(xvals[0] - 1, xvals[-1] + 1, size_px):
+        if spacing == DAY_SPACING:
+            tickStrings = date_axis.tickStrings(ticks, 1, DAY_SPACING)
+            assert_subarray(["Mon 01"], tickStrings)
+        elif spacing == HOUR_SPACING:
+            tickStrings = date_axis.tickStrings(ticks, 1, spacing)
+            assert_subarray(expectedHourTickStrings, tickStrings)
+
+
+def test_time_range_is_not_extended_for_minutes_and_ms():
+    utcZone = QTimeZone(b"UTC")
+    date = QDate(2001, 1, 1)
+    minTime = QDateTime(date, QTime(0, 0, 0, 0), utcZone).toSecsSinceEpoch()
+    maxTime = QDateTime(date, QTime(18, 0, 0, 0), utcZone).toSecsSinceEpoch()
+
+    for zoom in (MS_ZOOM_LEVEL, HOUR_MINUTE_ZOOM_LEVEL, HMS_ZOOM_LEVEL):
+        for spec in zoom.tickSpecs:
+            if spec.spacing >= HOUR_SPACING:
+                continue
+            newRange = zoom.extendTimeRangeForSpec(spec, minTime, maxTime)
+            assert newRange == (minTime, maxTime)
+
+
+def test_time_range_is_extended_for_hour():
+    utcZone = QTimeZone(b"UTC")
+    date = QDate(2001, 1, 1)
+    minTime = QDateTime(date, QTime(0, 0, 0, 0), utcZone).toSecsSinceEpoch()
+    maxTime = QDateTime(date, QTime(18, 0, 0, 0), utcZone).toSecsSinceEpoch()
+
+    for spec in HOUR_MINUTE_ZOOM_LEVEL.tickSpecs:
+        if spec.spacing < HOUR_SPACING:
+            continue
+        newRange = HOUR_MINUTE_ZOOM_LEVEL.extendTimeRangeForSpec(spec, minTime, maxTime)
+        extMin, extMax = newRange
+        assert extMin < minTime and extMax > maxTime

--- a/tests/graphicsItems/test_DateAxisItem.py
+++ b/tests/graphicsItems/test_DateAxisItem.py
@@ -23,9 +23,9 @@ from pyqtgraph.graphicsItems.DateAxisItem import (
     YEAR_SPACING,
     TickSpec,
     ZoomLevel,
+    applyOffsetFromUtc,
     calculateUtcOffset,
     getPreferredOffsetFromUtc,
-    shiftLocalTimeToUtcTime,
 )
 from pyqtgraph.Qt.QtCore import QDate, QDateTime, QTime, QTimeZone
 from pyqtgraph.Qt.QtGui import QFont, QFontMetrics
@@ -120,7 +120,7 @@ def test_shift_local_time_to_utc_time_does_what_it_promises_to_do():
     )
 
     with inTimezone(timeZone):
-        shifted = shiftLocalTimeToUtcTime(startDate.toSecsSinceEpoch())
+        shifted = applyOffsetFromUtc(startDate.toSecsSinceEpoch())
 
     assert shifted == goalDate.toSecsSinceEpoch()
 

--- a/tests/graphicsItems/test_DateAxisItem.py
+++ b/tests/graphicsItems/test_DateAxisItem.py
@@ -20,6 +20,7 @@ from pyqtgraph.graphicsItems.DateAxisItem import (
     SEC_PER_YEAR,
     SECOND_SPACING,
     WEEK_SPACING,
+    YEAR_MONTH_ZOOM_LEVEL,
     YEAR_SPACING,
     ZoomLevel,
     applyOffsetFromUtc,
@@ -35,7 +36,7 @@ app = pg.mkQApp()
 def makeDateAxis():
     axis = pg.DateAxisItem()
     axis.fontMetrics = QFontMetrics(QFont())
-    axis.zoomLevel = None
+    axis.zoomLevel = YEAR_MONTH_ZOOM_LEVEL
     return axis
 
 
@@ -85,8 +86,8 @@ def dateAxis():
 
 
 @pytest.fixture(autouse=True)
-def use_en_us_locale():
-    locale.setlocale(locale.LC_TIME, "en_US")
+def use_c_locale():
+    locale.setlocale(locale.LC_TIME, "C")
 
 
 def test_preferred_utc_offset_respects_chosen_offset():
@@ -108,7 +109,7 @@ def test_utc_offset_works_with_float_timestamp():
     assert -16 * 3600 <= calculateUtcOffset(123456.0734) <= 16 * 3600
 
 
-def test_shift_local_time_to_utc_time_does_what_it_promises_to_do():
+def test_applyOffsetFromUtc_does_what_it_promises_to_do():
     timeZone = QTimeZone(b"UTC+4")
 
     startDate = QDateTime(QDate(1970, 1, 2), QTime(2, 0), timeZone)

--- a/tests/graphicsItems/test_DateAxisItem.py
+++ b/tests/graphicsItems/test_DateAxisItem.py
@@ -21,7 +21,6 @@ from pyqtgraph.graphicsItems.DateAxisItem import (
     SECOND_SPACING,
     WEEK_SPACING,
     YEAR_SPACING,
-    TickSpec,
     ZoomLevel,
     applyOffsetFromUtc,
     calculateUtcOffset,
@@ -288,7 +287,7 @@ def test_custom_utc_offset_works(zoomLevel, expectedHourTickStrings, dateAxis):
         (QTimeZone(b"UTC"), YEAR_SPACING, 0),
     ),
 )
-def test_extendTimeRangeForSpec_repsects_utc_offset_and_spacings(
+def test_extendTimeRangeForSpacing_repsects_utc_offset(
     localZone, spacing, expectedExtentionInHours,
 ):
     utcZone = QTimeZone(b"UTC")
@@ -296,10 +295,9 @@ def test_extendTimeRangeForSpec_repsects_utc_offset_and_spacings(
     minTime = QDateTime(date, QTime(0, 0, 0, 0), utcZone).toSecsSinceEpoch()
     maxTime = QDateTime(date, QTime(18, 0, 0, 0), utcZone).toSecsSinceEpoch()
 
-    spec = TickSpec(spacing, lambda: None, lambda: None)
-    zoom = ZoomLevel([spec], "")
+    zoom = ZoomLevel([], "")
 
     with inTimezone(localZone):
-        extMin, extMax = zoom.extendTimeRangeForSpec(spec, minTime, maxTime)
+        extMin, extMax = zoom.extendTimeRangeForSpacing(spacing, minTime, maxTime)
     assert extMax - maxTime == expectedExtentionInHours * 3600
     assert minTime - extMin == expectedExtentionInHours * 3600


### PR DESCRIPTION
An attempt to resolve https://github.com/pyqtgraph/pyqtgraph/issues/1389
I tried to follow the recommendations from [this](https://github.com/pyqtgraph/pyqtgraph/issues/1389#issuecomment-724247097) comment, which suggested touching less code, but somewhat failed, because my IDE trims whitespaces on save automatically (i hope, this is not a big deal)