### PR TITLE
bugfix: PlotCurveItem OpenGL didn't invalidate render_cache on cleanup

### DIFF
--- a/pyqtgraph/examples/MouseSelection.py
+++ b/pyqtgraph/examples/MouseSelection.py
@@ -8,7 +8,7 @@ import pyqtgraph as pg
 from pyqtgraph.Qt import QtWidgets
 pg.setConfigOptions(useOpenGL=True, enableExperimental=True)
 
-pg.mkQApp()
+app = pg.mkQApp()
 plt = pg.PlotWidget()
 plt.setWindowTitle('pyqtgraph example: Plot data selection')
 # shift plot area by adding title to test that the OpenGL code handles it
@@ -36,7 +36,9 @@ for c in curves:
     plt.addItem(c)
     c.sigClicked.connect(plotClicked)
 
-# reparent the PlotWidget to test that the OpenGL code is able to handle it
+# force a render followed by a reparent of the PlotWidget
+# to test that the OpenGL code is able to handle it
+app.processEvents()
 win = QtWidgets.QMainWindow()
 win.setCentralWidget(plt)
 win.show()

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -111,6 +111,8 @@ class OpenGLState:
             self.m_program.setUniformValue(key, value)
 
     def cleanup(self):
+        # this method should restore the state back to __init__
+
         if self.m_program is not None:
             self.m_program.setParent(None)
             self.m_program = None
@@ -124,6 +126,8 @@ class OpenGLState:
         self.widget = None
         self.context = None
         self.functions = None
+        self.vbo_nbytes = 0
+        self.render_cache = None
 
     def verticesChanged(self, curve):
         self.render_cache = None


### PR DESCRIPTION
`cleanup()` is intended to be called for the following reasons:
1) on program termination (but this may not always happen due to reasons out of our control)
2) if a context change is detected
For both cases, OpenGL objects are destroyed.

For case (2), the state of the class is expected to be restored to a freshly initialized state, in preparation for a re-initialization.

The bug here is that `render_cache` was not invalidated even though the VBO that it was relying on had just been nuked.

Included is a change to `MouseSelection.py` to trigger this bug.