### PR TITLE
PColorMeshItem: implement opengl rendering

### DIFF
--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -384,7 +384,6 @@ class PColorMeshItem(GraphicsObject):
             getConfigOption('enableExperimental')
             and isinstance(widget, QtWidgets.QOpenGLWidget)
             and self.cmap is not None   # don't support setting colormap by setLookupTable
-            and self.edgecolors is None # don't support drawing of edges
         ):
             if self.glstate is None:
                 self.glstate = OpenGLState()
@@ -393,6 +392,19 @@ class PColorMeshItem(GraphicsObject):
                 self.paintGL(widget)
             finally:
                 painter.endNativePainting()
+
+            if (
+                self.edgecolors is not None
+                and self.edgecolors.style() != QtCore.Qt.PenStyle.NoPen
+            ):
+                painter.setPen(self.edgecolors)
+                if self.antialiasing:
+                    painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
+                for idx in range(self.x.shape[0]):
+                    painter.drawPolyline(fn.arrayToQPolygonF(self.x[idx, :], self.y[idx, :]))
+                for idx in range(self.x.shape[1]):
+                    painter.drawPolyline(fn.arrayToQPolygonF(self.x[:, idx], self.y[:, idx]))
+
             return
 
         if self.qpicture is None:


### PR DESCRIPTION
`PColorMeshItem` is unusable when a non-small mesh is used.
Even panning a static `PColorMeshItem` is very slow. (i.e. just redrawing the rendered `QPicture` is slow)

Following the example of the recent OpenGL code updates to `PlotCurveItem`, we can make `PColorMeshItem` usable by rendering using OpenGL.

An example to demonstrate the speed.
We can use the peegee icons of various sizes to test out the performance.
On my laptop, `peegee_256px.png` without OpenGL gets a dismal 5 fps; whereas with OpenGL, `peegee_512@2x.png` hits 30 fps. i.e. an improvement of (1024/256)**2 * 30/5 == 96x
```python
import sys

import numpy as np

import pyqtgraph as pg
from pyqtgraph.Qt import QtCore, QtGui
from pyqtgraph.examples.utils import FrameCounter

qimage = QtGui.QImage(sys.argv[1])
qimage.convertTo(QtGui.QImage.Format.Format_Grayscale8)
z = pg.functions.ndarray_from_qimage(qimage)


Z = z
nx, ny = z.shape
x = np.linspace(0, nx, nx+1, endpoint=True)
y = np.linspace(0, ny, ny+1, endpoint=True)
X, Y = np.meshgrid(x, y)
X += (nx * 0.025) * np.sin(2*np.pi*2*np.linspace(0, 1, nx+1))[:, np.newaxis]
Y += (ny * 0.025) * np.sin(2*np.pi*2*np.linspace(0, 1, ny+1))

pg.setConfigOptions(useOpenGL=True, enableExperimental=True)

pg.mkQApp()
win = pg.PlotWidget()
win.invertY(True)
cmap = pg.colormap.ColorMap(None, [0.0, 1.0])
pcmi = pg.PColorMeshItem(X, Y, Z, colorMap=cmap)
win.addItem(pcmi)
win.setTitle('')
win.show()

cnt = 0
def update():
    global cnt
    cnt = (cnt + 1) % z.shape[1]
    Z = np.roll(z, cnt, axis=1)
    pcmi.setData(None, None, Z)
    framecnt.update()

timer = QtCore.QTimer()
timer.timeout.connect(update)
timer.start()

framecnt = FrameCounter()
framecnt.sigFpsUpdate.connect(lambda fps: win.setTitle(f'{fps:.1f} fps'))

pg.exec()
```

An addition to the `PColorMeshItem` API. A use-case that I have is that the mesh (XY) is fixed and only the Z values are varying. I have overloaded the `setData(None, None, Z)` to mean that the existing X, Y should be re-used. This allows to not waste time uploading vertices that have not changed.
(The converse also works: `setData(X, Y, None)` means that Z should be re-used; although I don't have such a use-case)

One wart is that on termination, the following error message is shown:
```
QOpenGLTexturePrivate::destroy() called without a current context.
Texture has not been destroyed
```
This message doesn't show up on a pure `QOpenGLWidget` implementation. (as opposed to this PR's doing OpenGL painting within a `QGraphicsView`)