### PR TITLE
pcmi: add support for OpenGL ES 3.0

### DIFF
--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -765,8 +765,10 @@ class OpenGLState:
             # however, when there are multiple GraphicsItems, the following bug occurs:
             # all except one of the C++ objects of the returned versionFunctions() get
             # deleted.
-            import PyQt5._QOpenGLFunctions_2_0 as QtOpenGLFunctions
-            glf = QtOpenGLFunctions.QOpenGLFunctions_2_0()
+            suffix = "ES2" if context.isOpenGLES() else "2_0"
+            modname = f"QOpenGLFunctions_{suffix}"
+            QtOpenGLFunctions = importlib.import_module(f"PyQt5._{modname}")
+            glf = getattr(QtOpenGLFunctions, modname)()
             glf.initializeOpenGLFunctions()
         elif QT_LIB == 'PySide2':
             import PySide2.QtOpenGLFunctions as QtOpenGLFunctions

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -88,8 +88,10 @@ class OpenGLState:
             # however, when there are multiple PlotCurveItems, the following bug occurs:
             # all except one of the C++ objects of the returned versionFunctions() get
             # deleted.
-            import PyQt5._QOpenGLFunctions_2_0 as QtOpenGLFunctions
-            glf = QtOpenGLFunctions.QOpenGLFunctions_2_0()
+            suffix = "ES2" if context.isOpenGLES() else "2_0"
+            modname = f"QOpenGLFunctions_{suffix}"
+            QtOpenGLFunctions = importlib.import_module(f"PyQt5._{modname}")
+            glf = getattr(QtOpenGLFunctions, modname)()
             glf.initializeOpenGLFunctions()
         elif QT_LIB == 'PySide2':
             import PySide2.QtOpenGLFunctions as QtOpenGLFunctions


### PR DESCRIPTION
On master, the OpenGL implementation of `PColorMeshItem` uses GLSL 1.40 if the OpenGL version is detected to be >= 3.1, otherwise it falls back to shaders that are compatible with both OpenGL 2.0 and OpenGL ES 2.0.

This would fail on a system with OpenGL ES >= 3.1, as the GLSL 1.40 shaders are not compatible. 

This PR makes the flat shaders compatible with OpenGL ES >= 3.0.

However, I don't have a system with OpenGL ES 3.0 *and* a Qt compiled against OpenGL ES to actually test it out.
(A Raspberry Pi 4 running 32-bit Raspberry Pi OS would be such a candidate system)

A less ideal fix would be to unconditionally use the non-flat shaders if any version of OpenGL ES is being used.