### PR TITLE
Fix scaling with locked aspect

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -510,12 +510,11 @@ class ViewBox(GraphicsWidget):
             print("make qrectf failed:", self.state['targetRange'])
             raise
 
-    def _resetTarget(self, force: bool = False):
+    def _resetTarget(self):
         # Reset target range to exactly match current view range.
         # This is used during mouse interaction to prevent unpredictable
         # behavior (because the user is unaware of targetRange).
-        if self.state['aspectLocked'] is False or force: # (interferes with aspect locking)
-            self.state['targetRange'] = [self.state['viewRange'][0][:], self.state['viewRange'][1][:]]
+        self.state['targetRange'] = [self.state['viewRange'][0][:], self.state['viewRange'][1][:]]
             
     def _effectiveLimits(self):
         # Determines restricted effective scaling range when in log mapping mode
@@ -804,7 +803,10 @@ class ViewBox(GraphicsWidget):
         scale = Point([1.0 if x is None else x, 1.0 if y is None else y])
 
         if self.state['aspectLocked'] is not False:
-            scale[0] = scale[1]
+            if x is None:
+                scale[0] = scale[1]
+            if y is None:
+                scale[1] = scale[0]
 
         vr = self.targetRect()
         if center is None:
@@ -1623,7 +1625,7 @@ class ViewBox(GraphicsWidget):
                         # tweak the target range down so we can still pan properly
                         viewRange[ax] = canidateRange[ax]
                         self.state['viewRange'][ax] = viewRange[ax]
-                        self._resetTarget(force=True)
+                        self._resetTarget()
                         ax = target  # Switch the "fixed" axes
 
             if ax == 0:


### PR DESCRIPTION
### Summary
Fixes an undocumented (?) issue with scaling ViewBoxes with locked aspect ratio when the mouse is over the axes. 

### How to reproduce the issue
1. Run the code:
```
import numpy as np
import pyqtgraph as pg

plot = pg.plot(np.random.normal(scale=10, size=100))
plot.disableAutoRange()
plot.setAspectLocked()

pg.exec()
```
2. Position the mouse pointer on the vertical axis. Scroll the mouse wheel down a few clicks. The graph will zoom out.
3. Move the mouse cursor to the horizontal axis and try scrolling the mouse wheel. The graph will **_jump back to its original state and stop responding_**.
4. Move the mouse pointer to the graph and scroll the mouse wheel upwards a few clicks. The graph will **_jump back to the zoomed out state_** and start to zoom in.
5. Move the mouse pointer to the horizontal axis and try scrolling the mouse wheel. The image will **_jump up and stop responding_**.

### Bugs Found And Changes Made
1. The ViewBox._resetTarget function had a wrong logic inside, which caused ViewBox to jump between different zoom states.
Fixed by removing unnecessary if-condition.
1.1 The function argument 'force' has become useless, so it has been removed from the signature and from calls using it.
2. The ViewBox.scaleBy function treated x  and y axes differently.
A check has been added to determine which axis is the primary axis, and the secondary axis is scaled accordingly.

### Results
When trying to reproduce the issue, there are no zoom jumps and mouse wheel works as expected.