### PR TITLE
De-ancient-ify OpenGL shaders

### DIFF
--- a/pyqtgraph/examples/GLIsosurface.py
+++ b/pyqtgraph/examples/GLIsosurface.py
@@ -40,7 +40,7 @@ verts, faces = pg.isosurface(data, data.max()/4.)
 
 md = gl.MeshData(vertexes=verts, faces=faces)
 
-colors = np.ones((md.faceCount(), 4), dtype=float)
+colors = np.ones((md.faceCount(), 4), dtype=np.float32)
 colors[:,3] = 0.2
 colors[:,2] = np.linspace(0, 1, colors.shape[0])
 md.setFaceColors(colors)

--- a/pyqtgraph/examples/GLMeshItem.py
+++ b/pyqtgraph/examples/GLMeshItem.py
@@ -72,7 +72,7 @@ md = gl.MeshData.sphere(rows=10, cols=20)
 #colors = np.random.random(size=(md.faceCount(), 4))
 #colors[:,3] = 0.3
 #colors[100:] = 0.0
-colors = np.ones((md.faceCount(), 4), dtype=float)
+colors = np.ones((md.faceCount(), 4), dtype=np.float32)
 colors[::2,0] = 0
 colors[:,1] = np.linspace(0, 1, colors.shape[0])
 md.setFaceColors(colors)
@@ -94,15 +94,15 @@ w.addItem(m4)
 # cylinder
 md = gl.MeshData.cylinder(rows=10, cols=20, radius=[1., 2.0], length=5.)
 md2 = gl.MeshData.cylinder(rows=10, cols=20, radius=[2., 0.5], length=10.)
-colors = np.ones((md.faceCount(), 4), dtype=float)
+colors = np.ones((len(md.vertexes()), 4), dtype=np.float32)
 colors[::2,0] = 0
 colors[:,1] = np.linspace(0, 1, colors.shape[0])
-md.setFaceColors(colors)
+md.setVertexColors(colors)
 m5 = gl.GLMeshItem(meshdata=md, smooth=True, drawEdges=True, edgeColor=(1,0,0,1), shader='balloon')
-colors = np.ones((md.faceCount(), 4), dtype=float)
+colors = np.ones((len(md2.vertexes()), 4), dtype=np.float32)
 colors[::2,0] = 0
 colors[:,1] = np.linspace(0, 1, colors.shape[0])
-md2.setFaceColors(colors)
+md2.setVertexColors(colors)
 m6 = gl.GLMeshItem(meshdata=md2, smooth=True, drawEdges=False, shader='balloon')
 m6.translate(0,0,7.5)
 

--- a/pyqtgraph/examples/GLPainterItem.py
+++ b/pyqtgraph/examples/GLPainterItem.py
@@ -2,8 +2,6 @@
 Demonstrate using QPainter on a subclass of GLGraphicsItem.
 """
 
-import OpenGL.GL as GL
-
 import pyqtgraph as pg
 from pyqtgraph.opengl import GLAxisItem, GLGraphicsItem, GLGridItem, GLViewWidget
 from pyqtgraph.Qt import QtCore, QtGui
@@ -17,17 +15,11 @@ class GLPainterItem(GLGraphicsItem.GLGraphicsItem):
         self.setGLOptions(glopts)
 
     def compute_projection(self):
-        modelview = GL.glGetDoublev(GL.GL_MODELVIEW_MATRIX)
-        projection = GL.glGetDoublev(GL.GL_PROJECTION_MATRIX)
-        mvp = projection.T @ modelview.T
-        mvp = QtGui.QMatrix4x4(mvp.ravel().tolist())
-
         # note that QRectF.bottom() != QRect.bottom()
         rect = QtCore.QRectF(self.view().rect())
         ndc_to_viewport = QtGui.QMatrix4x4()
         ndc_to_viewport.viewport(rect.left(), rect.bottom(), rect.width(), -rect.height())
-
-        return ndc_to_viewport * mvp
+        return ndc_to_viewport * self.mvpMatrix()
 
     def paint(self):
         self.setupGLState()

--- a/pyqtgraph/examples/GLSurfacePlot.py
+++ b/pyqtgraph/examples/GLSurfacePlot.py
@@ -44,7 +44,7 @@ w.addItem(p2)
 z = pg.gaussianFilter(np.random.normal(size=(50,50)), (1,1))
 x = np.linspace(-12, 12, 50)
 y = np.linspace(-12, 12, 50)
-colors = np.ones((50,50,4), dtype=float)
+colors = np.ones((50,50,4), dtype=np.float32)
 colors[...,0] = np.clip(np.cos(((x.reshape(50,1) ** 2) + (y.reshape(1,50) ** 2)) ** 0.5), 0, 1)
 colors[...,1] = colors[...,0]
 

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -2,7 +2,7 @@ from OpenGL.GL import *  # noqa
 from OpenGL import GL
 
 from .. import Transform3D
-from ..Qt import QtCore
+from ..Qt import QtCore, QtGui
 
 GLOptions = {
     'opaque': {
@@ -304,6 +304,27 @@ class GLGraphicsItem(QtCore.QObject):
         if tr is None:
             return point
         return tr.inverted()[0].map(point)
-        
-        
-        
+
+    def modelViewMatrix(self) -> QtGui.QMatrix4x4:
+        topobj = self
+        while (view := topobj.view()) is None:
+            topobj = topobj.parentItem()
+            if topobj is None:
+                return QtGui.QMatrix4x4()
+        return view.currentModelView()
+
+    def projectionMatrix(self) -> QtGui.QMatrix4x4:
+        topobj = self
+        while (view := topobj.view()) is None:
+            topobj = topobj.parentItem()
+            if topobj is None:
+                return QtGui.QMatrix4x4()
+        return view.currentProjection()
+
+    def mvpMatrix(self) -> QtGui.QMatrix4x4:
+        topobj = self
+        while (view := topobj.view()) is None:
+            topobj = topobj.parentItem()
+            if topobj is None:
+                return QtGui.QMatrix4x4()
+        return view.currentProjection() * view.currentModelView()

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -8,20 +8,17 @@ GLOptions = {
     'opaque': {
         GL_DEPTH_TEST: True,
         GL_BLEND: False,
-        GL_ALPHA_TEST: False,
         GL_CULL_FACE: False,
     },
     'translucent': {
         GL_DEPTH_TEST: True,
         GL_BLEND: True,
-        GL_ALPHA_TEST: False,
         GL_CULL_FACE: False,
         'glBlendFunc': (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA),
     },
     'additive': {
         GL_DEPTH_TEST: False,
         GL_BLEND: True,
-        GL_ALPHA_TEST: False,
         GL_CULL_FACE: False,
         'glBlendFunc': (GL_SRC_ALPHA, GL_ONE),
     },

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -1,6 +1,7 @@
 from OpenGL.GL import *  # noqa
 import OpenGL.GL.framebufferobjects as glfbo  # noqa
 from math import cos, radians, sin, tan
+import warnings
 
 import numpy as np
 
@@ -101,10 +102,17 @@ class GLViewMixin:
         """
         ctx = self.context()
         fmt = ctx.format()
-        if ctx.isOpenGLES() or fmt.version() < (2, 0):
+        if ctx.isOpenGLES():
+            warnings.warn(
+                f"pyqtgraph.opengl is primarily tested against OpenGL Desktop"
+                f" but OpenGL {fmt.version()} ES detected",
+                RuntimeWarning,
+                stacklevel=2
+            )
+        if fmt.version() < (2, 0):
             verString = glGetString(GL_VERSION)
             raise RuntimeError(
-                "pyqtgraph.opengl: Requires >= OpenGL 2.0 (not ES); Found %s" % verString
+                "pyqtgraph.opengl: Requires >= OpenGL 2.0; Found %s" % verString
             )
 
         for item in self.items:

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -230,7 +230,6 @@ class GLViewMixin:
                 continue
             if i is item:
                 try:
-                    glPushAttrib(GL_ALL_ATTRIB_BITS)
                     if useItemNames:
                         glLoadName(i._id)
                         self._itemNames[i._id] = i
@@ -239,9 +238,6 @@ class GLViewMixin:
                     from .. import debug
                     debug.printExc()
                     print("Error while drawing item %s." % str(item))
-                    
-                finally:
-                    glPopAttrib()
             else:
                 self._modelViewStack.append(self.currentModelView() * i.transform())
                 try:

--- a/pyqtgraph/opengl/MeshData.py
+++ b/pyqtgraph/opengl/MeshData.py
@@ -440,7 +440,7 @@ class MeshData(object):
         Return a MeshData instance with vertexes and faces computed
         for a spherical surface.
         """
-        verts = np.empty((rows+1, cols, 3), dtype=float)
+        verts = np.empty((rows+1, cols, 3), dtype=np.float32)
         
         ## compute vertexes
         phi = (np.arange(rows+1) * np.pi / rows).reshape(rows+1, 1)
@@ -479,7 +479,7 @@ class MeshData(object):
         for a cylindrical surface.
         The cylinder may be tapered with different radii at each end (truncated cone)
         """
-        verts = np.empty((rows+1, cols, 3), dtype=float)
+        verts = np.empty((rows+1, cols, 3), dtype=np.float32)
         if isinstance(radius, int):
             radius = [radius, radius] # convert to list
         ## compute vertexes

--- a/pyqtgraph/opengl/MeshData.py
+++ b/pyqtgraph/opengl/MeshData.py
@@ -312,7 +312,7 @@ class MeshData(object):
         ## I think generally this should be discouraged..
         faces = self._vertexesIndexedByFaces
         verts = {}  ## used to remember the index of each vertex position
-        self._faces = np.empty(faces.shape[:2], dtype=np.uint)
+        self._faces = np.empty(faces.shape[:2], dtype=np.uint32)
         self._vertexes = []
         self._vertexFaces = []
         self._faceNormals = None
@@ -335,7 +335,7 @@ class MeshData(object):
     
     #def _setUnindexedFaces(self, faces, vertexes, vertexColors=None, faceColors=None):
         #self._vertexes = vertexes #[QtGui.QVector3D(*v) for v in vertexes]
-        #self._faces = faces.astype(np.uint)
+        #self._faces = faces.astype(np.uint32)
         #self._edges = None
         #self._vertexFaces = None
         #self._faceNormals = None
@@ -372,7 +372,7 @@ class MeshData(object):
         if not self.hasFaceIndexedData():
             ## generate self._edges from self._faces
             nf = len(self._faces)
-            edges = np.empty(nf*3, dtype=[('i', np.uint, 2)])
+            edges = np.empty(nf*3, dtype=[('i', np.uint32, 2)])
             edges['i'][0:nf] = self._faces[:,:2]
             edges['i'][nf:2*nf] = self._faces[:,1:3]
             edges['i'][-nf:,0] = self._faces[:,2]
@@ -387,7 +387,7 @@ class MeshData(object):
             #print self._edges
         elif self._vertexesIndexedByFaces is not None:
             verts = self._vertexesIndexedByFaces
-            edges = np.empty((verts.shape[0], 3, 2), dtype=np.uint)
+            edges = np.empty((verts.shape[0], 3, 2), dtype=np.uint32)
             nf = verts.shape[0]
             edges[:,0,0] = np.arange(nf) * 3
             edges[:,0,1] = edges[:,0,0] + 1
@@ -454,7 +454,7 @@ class MeshData(object):
         verts = verts.reshape((rows+1)*cols, 3)[cols-1:-(cols-1)]  ## remove redundant vertexes from top and bottom
         
         ## compute faces
-        faces = np.empty((rows*cols*2, 3), dtype=np.uint)
+        faces = np.empty((rows*cols*2, 3), dtype=np.uint32)
         rowtemplate1 = ((np.arange(cols).reshape(cols, 1) + np.array([[0, 1, 0]])) % cols) + np.array([[0, 0, cols]])
         rowtemplate2 = ((np.arange(cols).reshape(cols, 1) + np.array([[0, 1, 1]])) % cols) + np.array([[cols, 0, cols]])
         for row in range(rows):
@@ -492,7 +492,7 @@ class MeshData(object):
         verts[...,1] = r * np.sin(th) # y = r sin(th)
         verts = verts.reshape((rows+1)*cols, 3) # just reshape: no redundant vertices...
         ## compute faces
-        faces = np.empty((rows*cols*2, 3), dtype=np.uint)
+        faces = np.empty((rows*cols*2, 3), dtype=np.uint32)
         rowtemplate1 = ((np.arange(cols).reshape(cols, 1) + np.array([[0, 1, 0]])) % cols) + np.array([[0, 0, cols]])
         rowtemplate2 = ((np.arange(cols).reshape(cols, 1) + np.array([[0, 1, 1]])) % cols) + np.array([[cols, 0, cols]])
         for row in range(rows):

--- a/pyqtgraph/opengl/items/GLBoxItem.py
+++ b/pyqtgraph/opengl/items/GLBoxItem.py
@@ -1,7 +1,9 @@
-from OpenGL.GL import *  # noqa
+import numpy as np
+
 from ... import functions as fn
 from ...Qt import QtGui
 from ..GLGraphicsItem import GLGraphicsItem
+from .GLLinePlotItem import GLLinePlotItem
 
 __all__ = ['GLBoxItem']
 
@@ -12,14 +14,22 @@ class GLBoxItem(GLGraphicsItem):
     Displays a wire-frame box.
     """
     def __init__(self, size=None, color=None, glOptions='translucent', parentItem=None):
-        super().__init__(parentItem=parentItem)
+        super().__init__()
+
+        self.lineplot = None    # mark that we are still initializing
+
         if size is None:
             size = QtGui.QVector3D(1,1,1)
         self.setSize(size=size)
         if color is None:
             color = (255,255,255,80)
         self.setColor(color)
-        self.setGLOptions(glOptions)
+
+        self.lineplot = GLLinePlotItem(
+            parentItem=self, glOptions=glOptions, mode='lines'
+        )
+        self.setParentItem(parentItem)
+        self.updateLines()
     
     def setSize(self, x=None, y=None, z=None, size=None):
         """
@@ -31,7 +41,7 @@ class GLBoxItem(GLGraphicsItem):
             y = size.y()
             z = size.z()
         self.__size = [x,y,z]
-        self.update()
+        self.updateLines()
         
     def size(self):
         return self.__size[:]
@@ -39,48 +49,46 @@ class GLBoxItem(GLGraphicsItem):
     def setColor(self, *args):
         """Set the color of the box. Arguments are the same as those accepted by functions.mkColor()"""
         self.__color = fn.mkColor(*args)
+        self.updateLines()
         
     def color(self):
         return self.__color
-    
-    def paint(self):
-        #glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-        #glEnable( GL_BLEND )
-        #glEnable( GL_ALPHA_TEST )
-        ##glAlphaFunc( GL_ALWAYS,0.5 )
-        #glEnable( GL_POINT_SMOOTH )
-        #glDisable( GL_DEPTH_TEST )
-        self.setupGLState()
-        
-        glBegin( GL_LINES )
-        
-        glColor4f(*self.color().getRgbF())
-        x,y,z = self.size()
-        glVertex3f(0, 0, 0)
-        glVertex3f(0, 0, z)
-        glVertex3f(x, 0, 0)
-        glVertex3f(x, 0, z)
-        glVertex3f(0, y, 0)
-        glVertex3f(0, y, z)
-        glVertex3f(x, y, 0)
-        glVertex3f(x, y, z)
 
-        glVertex3f(0, 0, 0)
-        glVertex3f(0, y, 0)
-        glVertex3f(x, 0, 0)
-        glVertex3f(x, y, 0)
-        glVertex3f(0, 0, z)
-        glVertex3f(0, y, z)
-        glVertex3f(x, 0, z)
-        glVertex3f(x, y, z)
+    def updateLines(self):
+        if self.lineplot is None:
+            # still initializing
+            return
+
+        x,y,z = self.size()
+        pos = np.array([
+            [0, 0, 0],
+            [0, 0, z],
+            [x, 0, 0],
+            [x, 0, z],
+            [0, y, 0],
+            [0, y, z],
+            [x, y, 0],
+            [x, y, z],
+
+            [0, 0, 0],
+            [0, y, 0],
+            [x, 0, 0],
+            [x, y, 0],
+            [0, 0, z],
+            [0, y, z],
+            [x, 0, z],
+            [x, y, z],
         
-        glVertex3f(0, 0, 0)
-        glVertex3f(x, 0, 0)
-        glVertex3f(0, y, 0)
-        glVertex3f(x, y, 0)
-        glVertex3f(0, 0, z)
-        glVertex3f(x, 0, z)
-        glVertex3f(0, y, z)
-        glVertex3f(x, y, z)
+            [0, 0, 0],
+            [x, 0, 0],
+            [0, y, 0],
+            [x, y, 0],
+            [0, 0, z],
+            [x, 0, z],
+            [0, y, z],
+            [x, y, z],
+        ], dtype=np.float32)
         
-        glEnd()
+        color = self.color().getRgbF()
+        self.lineplot.setData(pos=pos, color=color)
+        self.update()

--- a/pyqtgraph/opengl/items/GLGridItem.py
+++ b/pyqtgraph/opengl/items/GLGridItem.py
@@ -1,9 +1,9 @@
-from OpenGL.GL import *  # noqa
 import numpy as np
 
-from ... import QtGui
+from ...Qt import QtGui
 from ... import functions as fn
 from ..GLGraphicsItem import GLGraphicsItem
+from .GLLinePlotItem import GLLinePlotItem
 
 __all__ = ['GLGridItem']
 
@@ -15,15 +15,22 @@ class GLGridItem(GLGraphicsItem):
     """
     
     def __init__(self, size=None, color=(255, 255, 255, 76.5), antialias=True, glOptions='translucent', parentItem=None):
-        super().__init__(parentItem=parentItem)
-        self.setGLOptions(glOptions)
-        self.antialias = antialias
+        super().__init__()
+
+        self.lineplot = None    # mark that we are still initializing
+
         if size is None:
             size = QtGui.QVector3D(20,20,1)
         self.setSize(size=size)
         self.setSpacing(1, 1, 1)
         self.setColor(color)
-    
+
+        self.lineplot = GLLinePlotItem(
+            parentItem=self, glOptions=glOptions, mode='lines', antialias=antialias
+        )
+        self.setParentItem(parentItem)
+        self.updateLines()
+
     def setSize(self, x=None, y=None, z=None, size=None):
         """
         Set the size of the axes (in its local coordinate system; this does not affect the transform)
@@ -34,7 +41,7 @@ class GLGridItem(GLGraphicsItem):
             y = size.y()
             z = size.z()
         self.__size = [x,y,z]
-        self.update()
+        self.updateLines()
         
     def size(self):
         return self.__size[:]
@@ -49,7 +56,7 @@ class GLGridItem(GLGraphicsItem):
             y = spacing.y()
             z = spacing.z()
         self.__spacing = [x,y,z]
-        self.update() 
+        self.updateLines()
         
     def spacing(self):
         return self.__spacing[:]
@@ -57,32 +64,34 @@ class GLGridItem(GLGraphicsItem):
     def setColor(self, color):
         """Set the color of the grid. Arguments are the same as those accepted by functions.mkColor()"""
         self.__color = fn.mkColor(color)
-        self.update()
+        self.updateLines()
 
     def color(self):
         return self.__color
 
-    def paint(self):
-        self.setupGLState()
-        
-        if self.antialias:
-            glEnable(GL_LINE_SMOOTH)
-            glEnable(GL_BLEND)
-            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-            glHint(GL_LINE_SMOOTH_HINT, GL_NICEST)
-            
-        glBegin( GL_LINES )
-        
+    def updateLines(self):
+        if self.lineplot is None:
+            # still initializing
+            return
+
         x,y,z = self.size()
         xs,ys,zs = self.spacing()
         xvals = np.arange(-x/2., x/2. + xs*0.001, xs) 
         yvals = np.arange(-y/2., y/2. + ys*0.001, ys)
-        glColor4f(*self.color().getRgbF())
-        for x in xvals:
-            glVertex3f(x, yvals[0], 0)
-            glVertex3f(x,  yvals[-1], 0)
-        for y in yvals:
-            glVertex3f(xvals[0], y, 0)
-            glVertex3f(xvals[-1], y, 0)
-        
-        glEnd()
+
+        set1 = np.zeros((len(xvals), 6), dtype=np.float32)
+        set1[:, 0] = xvals
+        set1[:, 1] = yvals[0]
+        set1[:, 3] = xvals
+        set1[:, 4] = yvals[-1]
+
+        set2 = np.zeros((len(yvals), 6), dtype=np.float32)
+        set2[:, 0] = xvals[0]
+        set2[:, 1] = yvals
+        set2[:, 3] = xvals[-1]
+        set2[:, 4] = yvals
+
+        pos = np.vstack((set1, set2)).reshape((-1, 3))
+
+        self.lineplot.setData(pos=pos, color=self.color())
+        self.update()

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -93,9 +93,8 @@ class GLImageItem(GLGraphicsItem):
         
         self.setupGLState()
 
-        mat_modelview = glGetFloatv(GL_MODELVIEW_MATRIX)
-        mat_projection = glGetFloatv(GL_PROJECTION_MATRIX)
-        mat_mvp = mat_modelview @ mat_projection
+        mat_mvp = self.mvpMatrix()
+        mat_mvp = np.array(mat_mvp.data(), dtype=np.float32)
 
         shader = shaders.getShaderProgram('texture2d')
         loc_pos = glGetAttribLocation(shader.program(), "a_position")

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -93,9 +93,8 @@ class GLLinePlotItem(GLGraphicsItem):
             return
         self.setupGLState()
 
-        mat_modelview = glGetFloatv(GL_MODELVIEW_MATRIX)
-        mat_projection = glGetFloatv(GL_PROJECTION_MATRIX)
-        mat_mvp = mat_modelview @ mat_projection
+        mat_mvp = self.mvpMatrix()
+        mat_mvp = np.array(mat_mvp.data(), dtype=np.float32)
 
         context = QtGui.QOpenGLContext.currentContext()
 

--- a/pyqtgraph/opengl/items/GLMeshItem.py
+++ b/pyqtgraph/opengl/items/GLMeshItem.py
@@ -203,11 +203,11 @@ class GLMeshItem(GLGraphicsItem):
         self.setupGLState()
         
         self.parseMeshData()        
-        
-        mat_modelview = glGetFloatv(GL_MODELVIEW_MATRIX)
-        mat_projection = glGetFloatv(GL_PROJECTION_MATRIX)
-        mat_mvp = mat_modelview @ mat_projection
-        mat_normal = np.linalg.inv(mat_modelview[:3, :3]).T.copy()
+
+        mat_mvp = self.mvpMatrix()
+        mat_mvp = np.array(mat_mvp.data(), dtype=np.float32)
+        mat_normal = self.modelViewMatrix().normalMatrix()
+        mat_normal = np.array(mat_normal.data(), dtype=np.float32)
 
         if self.opts['drawFaces'] and self.vertexes is not None:
             shader = self.shader()

--- a/pyqtgraph/opengl/items/GLMeshItem.py
+++ b/pyqtgraph/opengl/items/GLMeshItem.py
@@ -1,10 +1,17 @@
+import importlib
+
 from OpenGL.GL import *  # noqa
 import numpy as np
 
-from ...Qt import QtGui
+from ...Qt import QtGui, QT_LIB
 from .. import shaders
 from ..GLGraphicsItem import GLGraphicsItem
 from ..MeshData import MeshData
+
+if QT_LIB in ["PyQt5", "PySide2"]:
+    QtOpenGL = QtGui
+else:
+    QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
 
 __all__ = ['GLMeshItem']
 
@@ -60,7 +67,14 @@ class GLMeshItem(GLGraphicsItem):
         self.normals = None
         self.colors = None
         self.faces = None
-        
+
+        self.m_vbo_position = QtOpenGL.QOpenGLBuffer(QtOpenGL.QOpenGLBuffer.Type.VertexBuffer)
+        self.m_vbo_normal = QtOpenGL.QOpenGLBuffer(QtOpenGL.QOpenGLBuffer.Type.VertexBuffer)
+        self.m_vbo_color = QtOpenGL.QOpenGLBuffer(QtOpenGL.QOpenGLBuffer.Type.VertexBuffer)
+        self.m_ibo_faces = QtOpenGL.QOpenGLBuffer(QtOpenGL.QOpenGLBuffer.Type.IndexBuffer)
+        self.m_vbo_edgeVerts = QtOpenGL.QOpenGLBuffer(QtOpenGL.QOpenGLBuffer.Type.VertexBuffer)
+        self.m_ibo_edges = QtOpenGL.QOpenGLBuffer(QtOpenGL.QOpenGLBuffer.Type.IndexBuffer)
+
     def setShader(self, shader):
         """Set the shader used when rendering faces in the mesh. (see the GL shaders example)"""
         self.opts['shader'] = shader
@@ -112,9 +126,30 @@ class GLMeshItem(GLGraphicsItem):
         self.normals = None
         self.colors = None
         self.edges = None
+        self.edgeVerts = None
         self.edgeColors = None
         self.update()
-    
+
+    def upload_vertex_buffers(self):
+
+        def upload_vbo(vbo, arr):
+            if arr is None:
+                vbo.destroy()
+                return
+            if not vbo.isCreated():
+                vbo.create()
+            vbo.bind()
+            vbo.allocate(arr, arr.nbytes)
+            vbo.release()
+
+        upload_vbo(self.m_vbo_position, self.vertexes)
+        upload_vbo(self.m_vbo_normal, self.normals)
+        upload_vbo(self.m_vbo_color, self.colors)
+        upload_vbo(self.m_ibo_faces, self.faces)
+
+        upload_vbo(self.m_vbo_edgeVerts, self.edgeVerts)
+        upload_vbo(self.m_ibo_edges, self.edges)
+
     def parseMeshData(self):
         ## interpret vertex / normal data before drawing
         ## This can:
@@ -132,7 +167,7 @@ class GLMeshItem(GLGraphicsItem):
                 self.vertexes = md.vertexes()
                 if self.opts['computeNormals']:
                     self.normals = md.vertexNormals()
-                self.faces = md.faces()
+                self.faces = md.faces().astype(np.uint32)
                 if md.hasVertexColor():
                     self.colors = md.vertexColors()
                 if md.hasFaceColor():
@@ -149,77 +184,111 @@ class GLMeshItem(GLGraphicsItem):
                     self.colors = md.vertexColors(indexed='faces')
                 elif md.hasFaceColor():
                     self.colors = md.faceColors(indexed='faces')
-                    
+
             if self.opts['drawEdges']:
                 if not md.hasFaceIndexedData():
-                    self.edges = md.edges()
+                    self.edges = md.edges().astype(np.uint32)
                     self.edgeVerts = md.vertexes()
                 else:
-                    self.edges = md.edges()
+                    self.edges = md.edges().astype(np.uint32)
                     self.edgeVerts = md.vertexes(indexed='faces')
-            return
+
+            # NOTE: it is possible for self.vertexes to be None at this point.
+            #       this situation is encountered with the bundled animated
+            #       GLSurfacePlot example. This occurs because it only sets the
+            #       z component within update().
+            self.upload_vertex_buffers()
     
     def paint(self):
         self.setupGLState()
         
         self.parseMeshData()        
         
-        if self.opts['drawFaces']:
-            with self.shader():
-                verts = self.vertexes
-                norms = self.normals
-                color = self.colors
-                faces = self.faces
-                if verts is None:
-                    return
-                glEnableClientState(GL_VERTEX_ARRAY)
-                try:
-                    glVertexPointerf(verts)
-                    
-                    if self.colors is None:
-                        color = self.opts['color']
-                        if isinstance(color, QtGui.QColor):
-                            glColor4f(*color.getRgbF())
-                        else:
-                            glColor4f(*color)
-                    else:
-                        glEnableClientState(GL_COLOR_ARRAY)
-                        glColorPointerf(color)
-                    
-                    
-                    if norms is not None:
-                        glEnableClientState(GL_NORMAL_ARRAY)
-                        glNormalPointerf(norms)
-                    
-                    if faces is None:
-                        glDrawArrays(GL_TRIANGLES, 0, np.prod(verts.shape[:-1]))
-                    else:
-                        faces = faces.astype(np.uint32).flatten()
-                        glDrawElements(GL_TRIANGLES, faces.shape[0], GL_UNSIGNED_INT, faces)
-                finally:
-                    glDisableClientState(GL_NORMAL_ARRAY)
-                    glDisableClientState(GL_VERTEX_ARRAY)
-                    glDisableClientState(GL_COLOR_ARRAY)
-            
-        if self.opts['drawEdges']:
-            verts = self.edgeVerts
-            edges = self.edges
-            glEnableClientState(GL_VERTEX_ARRAY)
-            try:
-                glVertexPointerf(verts)
-                
-                if self.edgeColors is None:
-                    color = self.opts['edgeColor']
-                    if isinstance(color, QtGui.QColor):
-                        glColor4f(*color.getRgbF())
-                    else:
-                        glColor4f(*color)
+        mat_modelview = glGetFloatv(GL_MODELVIEW_MATRIX)
+        mat_projection = glGetFloatv(GL_PROJECTION_MATRIX)
+        mat_mvp = mat_modelview @ mat_projection
+        mat_normal = np.linalg.inv(mat_modelview[:3, :3]).T.copy()
+
+        if self.opts['drawFaces'] and self.vertexes is not None:
+            shader = self.shader()
+
+            enabled_locs = []
+
+            if (loc := glGetAttribLocation(shader.program(), "a_position")) != -1:
+                self.m_vbo_position.bind()
+                glVertexAttribPointer(loc, 3, GL_FLOAT, False, 0, None)
+                self.m_vbo_position.release()
+                enabled_locs.append(loc)
+
+            if (loc := glGetAttribLocation(shader.program(), "a_normal")) != -1:
+                if self.normals is None:
+                    # the shader needs a normal but the user set computeNormals=False...
+                    glVertexAttrib3f(loc, 0, 0, 1)
                 else:
-                    glEnableClientState(GL_COLOR_ARRAY)
-                    glColorPointerf(color)
-                edges = edges.flatten()
-                glDrawElements(GL_LINES, edges.shape[0], GL_UNSIGNED_INT, edges)
-            finally:
-                glDisableClientState(GL_VERTEX_ARRAY)
-                glDisableClientState(GL_COLOR_ARRAY)
-            
+                    self.m_vbo_normal.bind()
+                    glVertexAttribPointer(loc, 3, GL_FLOAT, False, 0, None)
+                    self.m_vbo_normal.release()
+                    enabled_locs.append(loc)
+
+            if (loc := glGetAttribLocation(shader.program(), "a_color")) != -1:
+                if self.colors is None:
+                    color = self.opts['color']
+                    if isinstance(color, QtGui.QColor):
+                        color = color.getRgbF()
+                    glVertexAttrib4f(loc, *color)
+                else:
+                    self.m_vbo_color.bind()
+                    glVertexAttribPointer(loc, 4, GL_FLOAT, False, 0, None)
+                    self.m_vbo_color.release()
+                    enabled_locs.append(loc)
+
+            for loc in enabled_locs:
+                glEnableVertexAttribArray(loc)
+
+            with shader:
+                glUniformMatrix4fv(shader.uniform("u_mvp"), 1, False, mat_mvp)
+                if (uloc_normal := shader.uniform("u_normal")) != -1:
+                    glUniformMatrix3fv(uloc_normal, 1, False, mat_normal)
+
+                if (faces := self.faces) is None:
+                    glDrawArrays(GL_TRIANGLES, 0, np.prod(self.vertexes.shape[:-1]))
+                else:
+                    self.m_ibo_faces.bind()
+                    glDrawElements(GL_TRIANGLES, faces.size, GL_UNSIGNED_INT, None)
+                    self.m_ibo_faces.release()
+
+            for loc in enabled_locs:
+                glDisableVertexAttribArray(loc)
+
+        if self.opts['drawEdges']:
+            shader = shaders.getShaderProgram(None)
+
+            enabled_locs = []
+
+            if (loc := glGetAttribLocation(shader.program(), "a_position")) != -1:
+                self.m_vbo_edgeVerts.bind()
+                glVertexAttribPointer(loc, 3, GL_FLOAT, False, 0, None)
+                self.m_vbo_edgeVerts.release()
+                enabled_locs.append(loc)
+
+            # edge colors are always just one single color
+            if (loc := glGetAttribLocation(shader.program(), "a_color")) != -1:
+                color = self.opts['edgeColor']
+                if isinstance(color, QtGui.QColor):
+                    color = color.getRgbF()
+                glVertexAttrib4f(loc, *color)
+
+            for loc in enabled_locs:
+                glEnableVertexAttribArray(loc)
+
+            with shader:
+                glUniformMatrix4fv(shader.uniform("u_mvp"), 1, False, mat_mvp)
+
+                self.m_ibo_edges.bind()
+                glDrawElements(GL_LINES, self.edges.size, GL_UNSIGNED_INT, None)
+                self.m_ibo_edges.release()
+
+            for loc in enabled_locs:
+                glDisableVertexAttribArray(loc)
+
+

--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -92,9 +92,8 @@ class GLScatterPlotItem(GLGraphicsItem):
 
         self.setupGLState()
 
-        mat_modelview = glGetFloatv(GL_MODELVIEW_MATRIX)
-        mat_projection = glGetFloatv(GL_PROJECTION_MATRIX)
-        mat_mvp = mat_modelview @ mat_projection
+        mat_mvp = self.mvpMatrix()
+        mat_mvp = np.array(mat_mvp.data(), dtype=np.float32)
 
         context = QtGui.QOpenGLContext.currentContext()
         sformat = context.format()

--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -1,10 +1,17 @@
+import importlib
+
 from OpenGL.GL import *  # noqa
 import numpy as np
 
 from ... import functions as fn
-from ...Qt import QtGui
+from ...Qt import QtGui, QT_LIB
 from .. import shaders
 from ..GLGraphicsItem import GLGraphicsItem
+
+if QT_LIB in ["PyQt5", "PySide2"]:
+    QtOpenGL = QtGui
+else:
+    QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
 
 __all__ = ['GLScatterPlotItem']
 
@@ -12,16 +19,22 @@ class GLScatterPlotItem(GLGraphicsItem):
     """Draws points at a list of 3D positions."""
     
     def __init__(self, parentItem=None, **kwds):
-        super().__init__(parentItem=parentItem)
+        super().__init__()
         glopts = kwds.pop('glOptions', 'additive')
         self.setGLOptions(glopts)
         self.pos = None
         self.size = 10
         self.color = [1.0,1.0,1.0,0.5]
         self.pxMode = True
+
+        self.m_vbo_position = QtOpenGL.QOpenGLBuffer(QtOpenGL.QOpenGLBuffer.Type.VertexBuffer)
+        self.m_vbo_color = QtOpenGL.QOpenGLBuffer(QtOpenGL.QOpenGLBuffer.Type.VertexBuffer)
+        self.m_vbo_size = QtOpenGL.QOpenGLBuffer(QtOpenGL.QOpenGLBuffer.Type.VertexBuffer)
+        self.vbos_uploaded = False
+
+        self.setParentItem(parentItem)
         self.setData(**kwds)
-        self.shader = None
-    
+
     def setData(self, **kwds):
         """
         Update the data displayed by this item. All arguments are optional; 
@@ -60,137 +73,110 @@ class GLScatterPlotItem(GLGraphicsItem):
             self.size = size
                 
         self.pxMode = kwds.get('pxMode', self.pxMode)
+        self.vbos_uploaded = False
         self.update()
 
-    def initializeGL(self):
-        if self.shader is not None:
+    def upload_vbo(self, vbo, arr):
+        if arr is None:
+            vbo.destroy()
             return
-        
-        ## Generate texture for rendering points
-        w = 64
-        def genTexture(x,y):
-            r = np.hypot((x-(w-1)/2.), (y-(w-1)/2.))
-            return 255 * (w / 2 - fn.clip_array(r, w / 2 - 1, w / 2))
-        pData = np.empty((w, w, 4))
-        pData[:] = 255
-        pData[:,:,3] = np.fromfunction(genTexture, pData.shape[:2])
-        pData = pData.astype(np.ubyte)
-        
-        if getattr(self, "pointTexture", None) is None:
-            self.pointTexture = glGenTextures(1)
-        glActiveTexture(GL_TEXTURE0)
-        glEnable(GL_TEXTURE_2D)
-        glBindTexture(GL_TEXTURE_2D, self.pointTexture)
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pData.shape[0], pData.shape[1], 0, GL_RGBA, GL_UNSIGNED_BYTE, pData)
-        
-        self.shader = shaders.getShaderProgram('pointSprite')
-        
-    #def setupGLState(self):
-        #"""Prepare OpenGL state for drawing. This function is called immediately before painting."""
-        ##glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)  ## requires z-sorting to render properly.
-        #glBlendFunc(GL_SRC_ALPHA, GL_ONE)
-        #glEnable( GL_BLEND )
-        #glEnable( GL_ALPHA_TEST )
-        #glDisable( GL_DEPTH_TEST )
-        
-        ##glEnable( GL_POINT_SMOOTH )
+        if not vbo.isCreated():
+            vbo.create()
+        vbo.bind()
+        vbo.allocate(arr, arr.nbytes)
+        vbo.release()
 
-        ##glHint(GL_POINT_SMOOTH_HINT, GL_NICEST)
-        ##glPointParameterfv(GL_POINT_DISTANCE_ATTENUATION, (0, 0, -1e-3))
-        ##glPointParameterfv(GL_POINT_SIZE_MAX, (65500,))
-        ##glPointParameterfv(GL_POINT_SIZE_MIN, (0,))
-        
     def paint(self):
         if self.pos is None:
             return
 
         self.setupGLState()
-        
-        glEnable(GL_POINT_SPRITE)
-        
-        glActiveTexture(GL_TEXTURE0)
-        glEnable( GL_TEXTURE_2D )
-        glBindTexture(GL_TEXTURE_2D, self.pointTexture)
-    
-        glTexEnvi(GL_POINT_SPRITE, GL_COORD_REPLACE, GL_TRUE)
-        #glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)    ## use texture color exactly
-        #glTexEnvf( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE )  ## texture modulates current color
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
-        glEnable(GL_PROGRAM_POINT_SIZE)
-        
-            
-        with self.shader:
-            #glUniform1i(self.shader.uniform('texture'), 0)  ## inform the shader which texture to use
-            glEnableClientState(GL_VERTEX_ARRAY)
-            try:
-                pos = self.pos
-                #if pos.ndim > 2:
-                    #pos = pos.reshape((-1, pos.shape[-1]))
-                glVertexPointerf(pos)
-            
-                if isinstance(self.color, np.ndarray):
-                    glEnableClientState(GL_COLOR_ARRAY)
-                    glColorPointerf(self.color)
-                else:
-                    color = self.color
-                    if isinstance(color, QtGui.QColor):
-                        color = color.getRgbF()
-                    glColor4f(*color)
-                
-                if not self.pxMode or isinstance(self.size, np.ndarray):
-                    glEnableClientState(GL_NORMAL_ARRAY)
-                    norm = np.zeros(pos.shape, dtype=np.float32)
-                    if self.pxMode:
-                        norm[...,0] = self.size
-                    else:
-                        gpos = self.mapToView(pos.transpose()).transpose()
-                        if self.view():
-                            pxSize = self.view().pixelSize(gpos)
-                        else:
-                            pxSize = self.parentItem().view().pixelSize(gpos)
-                        norm[...,0] = self.size / pxSize
-        
-                    glNormalPointerf(norm)
-                else:
-                    glNormal3f(self.size, 0, 0)  ## vertex shader uses norm.x to determine point size
-                    #glPointSize(self.size)
-                glDrawArrays(GL_POINTS, 0, pos.shape[0])
-            finally:
-                glDisableClientState(GL_NORMAL_ARRAY)
-                glDisableClientState(GL_VERTEX_ARRAY)
-                glDisableClientState(GL_COLOR_ARRAY)
-                #posVBO.unbind()
-                ##fixes #145
-                glDisable( GL_TEXTURE_2D )
-                                
-        #for i in range(len(self.pos)):
-            #pos = self.pos[i]
-            
-            #if isinstance(self.color, np.ndarray):
-                #color = self.color[i]
-            #else:
-                #color = self.color
-            #if isinstance(self.color, QtGui.QColor):
-                #color = fn.glColor(self.color)
-                
-            #if isinstance(self.size, np.ndarray):
-                #size = self.size[i]
-            #else:
-                #size = self.size
-                
-            #pxSize = self.view().pixelSize(QtGui.QVector3D(*pos))
-            
-            #glPointSize(size / pxSize)
-            #glBegin( GL_POINTS )
-            #glColor4f(*color)  # x is blue
-            ##glNormal3f(size, 0, 0)
-            #glVertex3f(*pos)
-            #glEnd()
 
-        
-        
-        
-        
+        mat_modelview = glGetFloatv(GL_MODELVIEW_MATRIX)
+        mat_projection = glGetFloatv(GL_PROJECTION_MATRIX)
+        mat_mvp = mat_modelview @ mat_projection
+
+        context = QtGui.QOpenGLContext.currentContext()
+        sformat = context.format()
+
+        if not self.vbos_uploaded:
+            self.upload_vbo(self.m_vbo_position, self.pos)
+            if isinstance(self.color, np.ndarray):
+                self.upload_vbo(self.m_vbo_color, self.color)
+            if self.pxMode:
+                if isinstance(self.size, np.ndarray):
+                    # for this case, size only needs to be uploaded once
+                    self.upload_vbo(self.m_vbo_size, self.size)
+            else:
+                # for non-pxMode, upload a dummy array to allocate the buffer
+                point_size = np.zeros(len(self.pos), dtype=np.float32)
+                self.upload_vbo(self.m_vbo_size, point_size)
+            self.vbos_uploaded = True
+
+        if self.pxMode:
+            # if size was an (static) array, it has already been uploaded
+            point_size = self.size
+        else:
+            # whether size is a scalar or an array, non-pxMode ends up with
+            # an array that needs to be re-uploaded on each paint.
+            if not (view := self.view()):
+                view = self.parentItem().view()
+            gpos = self.mapToView(self.pos.T).T
+            pxSize = view.pixelSize(gpos)
+            point_size = np.array(self.size / pxSize, dtype=np.float32)
+
+            self.m_vbo_size.bind()
+            self.m_vbo_size.write(0, point_size, point_size.nbytes)
+            self.m_vbo_size.release()
+
+        if sformat.profile() == QtGui.QSurfaceFormat.OpenGLContextProfile.CompatibilityProfile:
+            # setting GL_POINT_SPRITE is only needed for OpenGL 2.1
+            # In Core profiles, it is an error to set it even.
+            glEnable(GL_POINT_SPRITE)
+
+        if context.isOpenGLES():
+            shader_name = 'pointSprite-es2'
+        else:
+            glEnable(GL_PROGRAM_POINT_SIZE)
+            shader_name = 'pointSprite'
+        shader = shaders.getShaderProgram(shader_name)
+
+        enabled_locs = []
+
+        if (loc := glGetAttribLocation(shader.program(), "a_position")) != -1:
+            self.m_vbo_position.bind()
+            glVertexAttribPointer(loc, 3, GL_FLOAT, False, 0, None)
+            self.m_vbo_position.release()
+            enabled_locs.append(loc)
+
+        if (loc := glGetAttribLocation(shader.program(), "a_color")) != -1:
+            if isinstance(self.color, np.ndarray):
+                self.m_vbo_color.bind()
+                glVertexAttribPointer(loc, 4, GL_FLOAT, False, 0, None)
+                self.m_vbo_color.release()
+                enabled_locs.append(loc)
+            else:
+                color = self.color
+                if isinstance(color, QtGui.QColor):
+                    color = color.getRgbF()
+                glVertexAttrib4f(loc, *color)
+
+        if (loc := glGetAttribLocation(shader.program(), "a_size")) != -1:
+            if isinstance(point_size, np.ndarray):
+                self.m_vbo_size.bind()
+                glVertexAttribPointer(loc, 1, GL_FLOAT, False, 0, None)
+                self.m_vbo_size.release()
+                enabled_locs.append(loc)
+            else:
+                glVertexAttrib1f(loc, point_size)
+
+        for loc in enabled_locs:
+            glEnableVertexAttribArray(loc)
+
+        with shader:
+            glUniformMatrix4fv(shader.uniform("u_mvp"), 1, False, mat_mvp)
+
+            glDrawArrays(GL_POINTS, 0, len(self.pos))
+
+        for loc in enabled_locs:
+            glDisableVertexAttribArray(loc)

--- a/pyqtgraph/opengl/items/GLSurfacePlotItem.py
+++ b/pyqtgraph/opengl/items/GLSurfacePlotItem.py
@@ -88,7 +88,7 @@ class GLSurfacePlotItem(GLMeshItem):
         ## Generate vertex and face array
         if self._vertexes is None:
             newVertexes = True
-            self._vertexes = np.empty((self._z.shape[0], self._z.shape[1], 3), dtype=float)
+            self._vertexes = np.empty((self._z.shape[0], self._z.shape[1], 3), dtype=np.float32)
             self.generateFaces()
             self._meshdata.setFaces(self._faces)
             updateMesh = True

--- a/pyqtgraph/opengl/items/GLSurfacePlotItem.py
+++ b/pyqtgraph/opengl/items/GLSurfacePlotItem.py
@@ -1,4 +1,3 @@
-from OpenGL.GL import *  # noqa
 import numpy as np
 
 from ..MeshData import MeshData
@@ -126,7 +125,7 @@ class GLSurfacePlotItem(GLMeshItem):
     def generateFaces(self):
         cols = self._z.shape[1]-1
         rows = self._z.shape[0]-1
-        faces = np.empty((cols*rows*2, 3), dtype=np.uint)
+        faces = np.empty((cols*rows*2, 3), dtype=np.uint32)
         rowtemplate1 = np.arange(cols).reshape(cols, 1) + np.array([[0, 1, cols+1]])
         rowtemplate2 = np.arange(cols).reshape(cols, 1) + np.array([[cols+1, 1, cols+2]])
         for row in range(rows):

--- a/pyqtgraph/opengl/items/GLVolumeItem.py
+++ b/pyqtgraph/opengl/items/GLVolumeItem.py
@@ -102,9 +102,8 @@ class GLVolumeItem(GLGraphicsItem):
         
         self.setupGLState()
 
-        mat_modelview = glGetFloatv(GL_MODELVIEW_MATRIX)
-        mat_projection = glGetFloatv(GL_PROJECTION_MATRIX)
-        mat_mvp = mat_modelview @ mat_projection
+        mat_mvp = self.mvpMatrix()
+        mat_mvp = np.array(mat_mvp.data(), dtype=np.float32)
 
         view = self.view()
         center = QtGui.QVector3D(*[x/2. for x in self.data.shape[:3]])

--- a/pyqtgraph/opengl/items/GLVolumeItem.py
+++ b/pyqtgraph/opengl/items/GLVolumeItem.py
@@ -114,7 +114,13 @@ class GLVolumeItem(GLGraphicsItem):
         d = 1 if cam[ax] > 0 else -1
         offset, num_vertices = self.lists[(ax,d)]
 
-        shader = shaders.getShaderProgram('texture3d')
+        context = QtGui.QOpenGLContext.currentContext()
+        if context.isOpenGLES():
+            shader_name = 'texture3d-es3'
+        else:
+            shader_name = 'texture3d'
+        shader = shaders.getShaderProgram(shader_name)
+
         loc_pos = glGetAttribLocation(shader.program(), "a_position")
         loc_tex = glGetAttribLocation(shader.program(), "a_texcoord")
         self.m_vbo_position.bind()

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -58,6 +58,27 @@ def initShaders():
             """)
         ]),
 
+        ShaderProgram('texture3d', [
+            VertexShader("""
+                uniform mat4 u_mvp;
+                attribute vec4 a_position;
+                attribute vec3 a_texcoord;
+                varying vec3 v_texcoord;
+                void main() {
+                    gl_Position = u_mvp * a_position;
+                    v_texcoord = a_texcoord;
+                }
+            """),
+            FragmentShader("""
+                uniform sampler3D u_texture;
+                varying vec3 v_texcoord;
+                void main()
+                {
+                    gl_FragColor = texture3D(u_texture, v_texcoord);
+                }
+            """)
+        ]),
+
         ## increases fragment alpha as the normal turns orthogonal to the view
         ## this is useful for viewing shells that enclose a volume (such as isosurfaces)
         ShaderProgram('balloon', [

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -33,7 +33,31 @@ def initShaders():
                 }
             """)
         ]),
-        
+
+        ShaderProgram('texture2d', [
+            VertexShader("""
+                uniform mat4 u_mvp;
+                attribute vec4 a_position;
+                attribute vec2 a_texcoord;
+                varying vec2 v_texcoord;
+                void main() {
+                    gl_Position = u_mvp * a_position;
+                    v_texcoord = a_texcoord;
+                }
+            """),
+            FragmentShader("""
+                #ifdef GL_ES
+                precision mediump float;
+                #endif
+                uniform sampler2D u_texture;
+                varying vec2 v_texcoord;
+                void main()
+                {
+                    gl_FragColor = texture2D(u_texture, v_texcoord);
+                }
+            """)
+        ]),
+
         ## increases fragment alpha as the normal turns orthogonal to the view
         ## this is useful for viewing shells that enclose a volume (such as isosurfaces)
         ShaderProgram('balloon', [

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -12,25 +12,54 @@ import re
 def initShaders():
     global Shaders
     Shaders = [
-        ShaderProgram(None, []),
+        ShaderProgram(None, [
+            VertexShader("""
+                uniform mat4 u_mvp;
+                attribute vec4 a_position;
+                attribute vec4 a_color;
+                varying vec4 v_color;
+                void main() {
+                    v_color = a_color;
+                    gl_Position = u_mvp * a_position;
+                }
+            """),
+            FragmentShader("""
+                #ifdef GL_ES
+                precision mediump float;
+                #endif
+                varying vec4 v_color;
+                void main() {
+                    gl_FragColor = v_color;
+                }
+            """)
+        ]),
         
         ## increases fragment alpha as the normal turns orthogonal to the view
         ## this is useful for viewing shells that enclose a volume (such as isosurfaces)
         ShaderProgram('balloon', [
             VertexShader("""
+                uniform mat4 u_mvp;
+                uniform mat3 u_normal;
+                attribute vec4 a_position;
+                attribute vec3 a_normal;
+                attribute vec4 a_color;
+                varying vec4 v_color;
                 varying vec3 normal;
                 void main() {
                     // compute here for use in fragment shader
-                    normal = normalize(gl_NormalMatrix * gl_Normal);
-                    gl_FrontColor = gl_Color;
-                    gl_BackColor = gl_Color;
-                    gl_Position = ftransform();
+                    normal = normalize(u_normal * a_normal);
+                    v_color = a_color;
+                    gl_Position = u_mvp * a_position;
                 }
             """),
             FragmentShader("""
+                #ifdef GL_ES
+                precision mediump float;
+                #endif
+                varying vec4 v_color;
                 varying vec3 normal;
                 void main() {
-                    vec4 color = gl_Color;
+                    vec4 color = v_color;
                     color.w = min(color.w + 2.0 * color.w * pow(normal.x*normal.x + normal.y*normal.y, 5.0), 1.0);
                     gl_FragColor = color;
                 }
@@ -41,19 +70,28 @@ def initShaders():
         ## This means that the colors will change depending on how the view is rotated
         ShaderProgram('viewNormalColor', [   
             VertexShader("""
+                uniform mat4 u_mvp;
+                uniform mat3 u_normal;
+                attribute vec4 a_position;
+                attribute vec3 a_normal;
+                attribute vec4 a_color;
+                varying vec4 v_color;
                 varying vec3 normal;
                 void main() {
                     // compute here for use in fragment shader
-                    normal = normalize(gl_NormalMatrix * gl_Normal);
-                    gl_FrontColor = gl_Color;
-                    gl_BackColor = gl_Color;
-                    gl_Position = ftransform();
+                    normal = normalize(u_normal * a_normal);
+                    v_color = a_color;
+                    gl_Position = u_mvp * a_position;
                 }
             """),
             FragmentShader("""
+                #ifdef GL_ES
+                precision mediump float;
+                #endif
+                varying vec4 v_color;
                 varying vec3 normal;
                 void main() {
-                    vec4 color = gl_Color;
+                    vec4 color = v_color;
                     color.x = (normal.x + 1.0) * 0.5;
                     color.y = (normal.y + 1.0) * 0.5;
                     color.z = (normal.z + 1.0) * 0.5;
@@ -65,19 +103,27 @@ def initShaders():
         ## colors fragments based on absolute face normals.
         ShaderProgram('normalColor', [   
             VertexShader("""
+                uniform mat4 u_mvp;
+                attribute vec4 a_position;
+                attribute vec3 a_normal;
+                attribute vec4 a_color;
+                varying vec4 v_color;
                 varying vec3 normal;
                 void main() {
                     // compute here for use in fragment shader
-                    normal = normalize(gl_Normal);
-                    gl_FrontColor = gl_Color;
-                    gl_BackColor = gl_Color;
-                    gl_Position = ftransform();
+                    normal = normalize(a_normal);
+                    v_color = a_color;
+                    gl_Position = u_mvp * a_position;
                 }
             """),
             FragmentShader("""
+                #ifdef GL_ES
+                precision mediump float;
+                #endif
+                varying vec4 v_color;
                 varying vec3 normal;
                 void main() {
-                    vec4 color = gl_Color;
+                    vec4 color = v_color;
                     color.x = (normal.x + 1.0) * 0.5;
                     color.y = (normal.y + 1.0) * 0.5;
                     color.z = (normal.z + 1.0) * 0.5;
@@ -90,21 +136,30 @@ def initShaders():
         ## The light source position is always relative to the camera.
         ShaderProgram('shaded', [   
             VertexShader("""
+                uniform mat4 u_mvp;
+                uniform mat3 u_normal;
+                attribute vec4 a_position;
+                attribute vec3 a_normal;
+                attribute vec4 a_color;
+                varying vec4 v_color;
                 varying vec3 normal;
                 void main() {
                     // compute here for use in fragment shader
-                    normal = normalize(gl_NormalMatrix * gl_Normal);
-                    gl_FrontColor = gl_Color;
-                    gl_BackColor = gl_Color;
-                    gl_Position = ftransform();
+                    normal = normalize(u_normal * a_normal);
+                    v_color = a_color;
+                    gl_Position = u_mvp * a_position;
                 }
             """),
             FragmentShader("""
+                #ifdef GL_ES
+                precision mediump float;
+                #endif
+                varying vec4 v_color;
                 varying vec3 normal;
                 void main() {
                     float p = dot(normal, normalize(vec3(1.0, -1.0, -1.0)));
                     p = p < 0. ? 0. : p * 0.8;
-                    vec4 color = gl_Color;
+                    vec4 color = v_color;
                     color.x = color.x * (0.2 + p);
                     color.y = color.y * (0.2 + p);
                     color.z = color.z * (0.2 + p);
@@ -116,19 +171,28 @@ def initShaders():
         ## colors get brighter near edges of object
         ShaderProgram('edgeHilight', [   
             VertexShader("""
+                uniform mat4 u_mvp;
+                uniform mat3 u_normal;
+                attribute vec4 a_position;
+                attribute vec3 a_normal;
+                attribute vec4 a_color;
+                varying vec4 v_color;
                 varying vec3 normal;
                 void main() {
                     // compute here for use in fragment shader
-                    normal = normalize(gl_NormalMatrix * gl_Normal);
-                    gl_FrontColor = gl_Color;
-                    gl_BackColor = gl_Color;
-                    gl_Position = ftransform();
+                    normal = normalize(u_normal * a_normal);
+                    v_color = a_color;
+                    gl_Position = u_mvp * a_position;
                 }
             """),
             FragmentShader("""
+                #ifdef GL_ES
+                precision mediump float;
+                #endif
+                varying vec4 v_color;
                 varying vec3 normal;
                 void main() {
-                    vec4 color = gl_Color;
+                    vec4 color = v_color;
                     float s = pow(normal.x*normal.x + normal.y*normal.y, 2.0);
                     color.x = color.x + s * (1.0-color.x);
                     color.y = color.y + s * (1.0-color.y);
@@ -147,38 +211,39 @@ def initShaders():
         ## (set the values like this: shader['uniformMap'] = array([...])
         ShaderProgram('heightColor', [
             VertexShader("""
-                varying vec4 pos;
+                uniform mat4 u_mvp;
+                attribute vec4 a_position;
+                varying float zpos;
                 void main() {
-                    gl_FrontColor = gl_Color;
-                    gl_BackColor = gl_Color;
-                    pos = gl_Vertex;
-                    gl_Position = ftransform();
+                    zpos = a_position.z;
+                    gl_Position = u_mvp * a_position;
                 }
             """),
             FragmentShader("""
+                #ifdef GL_ES
+                precision mediump float;
+                #endif
                 uniform float colorMap[9];
-                varying vec4 pos;
-                //out vec4 gl_FragColor;   // only needed for later glsl versions
-                //in vec4 gl_Color;
+                varying float zpos;
                 void main() {
-                    vec4 color = gl_Color;
-                    color.x = colorMap[0] * (pos.z + colorMap[1]);
+                    vec3 color;
+
+                    color.x = colorMap[0] * (zpos + colorMap[1]);
                     if (colorMap[2] != 1.0)
                         color.x = pow(color.x, colorMap[2]);
-                    color.x = color.x < 0. ? 0. : (color.x > 1. ? 1. : color.x);
+                    color.x = clamp(color.x, 0.0, 1.0);
                     
-                    color.y = colorMap[3] * (pos.z + colorMap[4]);
+                    color.y = colorMap[3] * (zpos + colorMap[4]);
                     if (colorMap[5] != 1.0)
                         color.y = pow(color.y, colorMap[5]);
-                    color.y = color.y < 0. ? 0. : (color.y > 1. ? 1. : color.y);
+                    color.y = clamp(color.y, 0.0, 1.0);
                     
-                    color.z = colorMap[6] * (pos.z + colorMap[7]);
+                    color.z = colorMap[6] * (zpos + colorMap[7]);
                     if (colorMap[8] != 1.0)
                         color.z = pow(color.z, colorMap[8]);
-                    color.z = color.z < 0. ? 0. : (color.z > 1. ? 1. : color.z);
+                    color.z = clamp(color.z, 0.0, 1.0);
                     
-                    color.w = 1.0;
-                    gl_FragColor = color;
+                    gl_FragColor = vec4(color, 1.0);
                 }
             """),
         ], uniforms={'colorMap': [1, 1, 1, 1, 0.5, 1, 1, 0, 1]}),
@@ -304,6 +369,13 @@ class ShaderProgram(object):
         self.setUniformData(item, None)
 
     def program(self):
+        # for reasons that may vary across drivers, having vertex attribute
+        # array generic location 0 enabled (glEnableVertexAttribArray(0)) is
+        # required for rendering to take place.
+        # this only becomes an issue if we are using glVertexAttrib{1,4}f
+        # because that's when we *don't* call glEnableVertexAttribArray.
+        # since we always need vertex coordinates to come from arrays, it is
+        # sufficient for us to bind "a_position" explicitly to 0.
         if self.prog is None:
             try:
                 compiled = [s.shader() for s in self.shaders]  ## compile all shaders
@@ -311,6 +383,9 @@ class ShaderProgram(object):
             except:
                 self.prog = -1
                 raise
+            # bind generic vertex attrib 0 to "a_position" and relink
+            glBindAttribLocation(self.prog, 0, "a_position")
+            glLinkProgram(self.prog)
         return self.prog
         
     def __enter__(self):
@@ -372,32 +447,5 @@ class ShaderProgram(object):
         #indices = []
         #for i in range(count):
             #indices.append(glGetActiveUniformBlockiv(self.program(), blockIndex, GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES))
-        
-class HeightColorShader(ShaderProgram):
-    def __enter__(self):
-        ## Program should have a uniform block declared:
-        ## 
-        ## layout (std140) uniform blockName {
-        ##     vec4 diffuse;
-        ##     vec4 ambient;
-        ## };
-        
-        ## pick any-old binding point. (there are a limited number of these per-program
-        bindPoint = 1
-        
-        ## get the block index for a uniform variable in the shader
-        blockIndex = glGetUniformBlockIndex(self.program(), "blockName")
-        
-        ## give the shader block a binding point
-        glUniformBlockBinding(self.program(), blockIndex, bindPoint)
-        
-        ## create a buffer
-        buf = glGenBuffers(1)
-        glBindBuffer(GL_UNIFORM_BUFFER, buf)
-        glBufferData(GL_UNIFORM_BUFFER, size, data, GL_DYNAMIC_DRAW)
-        ## also possible to use glBufferSubData to fill parts of the buffer
-        
-        ## bind buffer to the same binding point
-        glBindBufferBase(GL_UNIFORM_BUFFER, bindPoint, buf)
-        
+
 initShaders()

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -79,6 +79,31 @@ def initShaders():
             """)
         ]),
 
+        ShaderProgram('texture3d-es3', [
+            VertexShader("""
+                #version 300 es
+                uniform mat4 u_mvp;
+                in vec4 a_position;
+                in vec3 a_texcoord;
+                out vec3 v_texcoord;
+                void main() {
+                    gl_Position = u_mvp * a_position;
+                    v_texcoord = a_texcoord;
+                }
+            """),
+            FragmentShader("""
+                #version 300 es
+                precision mediump float;
+                uniform lowp sampler3D u_texture;
+                in vec3 v_texcoord;
+                out vec4 fragColor;
+                void main()
+                {
+                    fragColor = texture(u_texture, v_texcoord);
+                }
+            """)
+        ]),
+
         ## increases fragment alpha as the normal turns orthogonal to the view
         ## this is useful for viewing shells that enclose a volume (such as isosurfaces)
         ShaderProgram('balloon', [


### PR DESCRIPTION
This PR updates all the shaders used by `GLMeshItem` and `GLScatterPlotItem` to OpenGL ES 2.0 syntax, i.e.
1) No fixed pipeline, both vertex and fragment shaders have to be defined
2) Use generic attributes instead of built-ins `gl_Vertex`, `gl_Color`, `gl_Normal`
3) Compute own transformation matrices instead of relying on `ftransform()` and `gl_NormalMatrix`
4) Use VBOs instead of client arrays

Some fixes:
1) `GLMeshItem` example creates the wrong number of colors for the cylinders.
2) On the RPI5, the animated surface plot has a different coloration compared to regular Desktops. This was tracked down to use of undefined behavior.
![rpi5_surface_plot_discolored](https://github.com/user-attachments/assets/85ea8408-9c96-4237-a23d-4a34d71e2e43)
