### PR TITLE
Add legend double-click and legend sample click signals.

### DIFF
--- a/pyqtgraph/examples/Legend.py
+++ b/pyqtgraph/examples/Legend.py
@@ -2,6 +2,8 @@
 Demonstrates basic use of LegendItem
 """
 
+from pyqtgraph.Qt.QtWidgets import QInputDialog
+
 import numpy as np
 
 import pyqtgraph as pg
@@ -35,6 +37,41 @@ legend.addItem(bg1, 'bar')
 legend.addItem(c1, 'curve1')
 legend.addItem(c2, 'curve2')
 legend.addItem(s1, 'scatter')
+
+
+def legendDoubleClicked(legend, event):
+    # update legend font size and redraw
+    current_font_size = int(legend.labelTextSize().replace('pt', ''))
+
+    dialog = QInputDialog()
+    dialog.setWindowTitle("Input Dialog")
+    dialog.setInputMode(QInputDialog.IntInput)
+    dialog.setLabelText('Enter Label Font Size:')
+    dialog.setIntValue(current_font_size)
+
+    if dialog.exec() == QInputDialog.Accepted:
+        font_size = dialog.intValue()
+        legend.setLabelTextSize('%dpt' % font_size)
+        legend_items = legend.items.copy()
+        legend.clear()
+        # re-add items to update labels and redraw
+        for sample, label in legend_items:
+            legend.addItem(sample.item, label.text)
+
+    event.accept()
+
+
+def legendSampleClicked(plot_data_item):
+    # indicate plot data item visibility
+    if plot_data_item.isVisible():
+        print('"%s" is visible' % plot_data_item.name())
+    else:
+        print('"%s" is not visible' % plot_data_item.name())
+
+
+legend.sigDoubleClicked.connect(legendDoubleClicked)
+legend.sigSampleClicked.connect(legendSampleClicked)
+
 
 if __name__ == '__main__':
     pg.exec()

--- a/pyqtgraph/examples/Legend.py
+++ b/pyqtgraph/examples/Legend.py
@@ -45,11 +45,11 @@ def legendDoubleClicked(legend, event):
 
     dialog = QInputDialog()
     dialog.setWindowTitle("Input Dialog")
-    dialog.setInputMode(QInputDialog.IntInput)
+    dialog.setInputMode(QInputDialog.InputMode.IntInput)
     dialog.setLabelText('Enter Label Font Size:')
     dialog.setIntValue(current_font_size)
 
-    if dialog.exec() == QInputDialog.Accepted:
+    if dialog.exec() == QInputDialog.DialogCode.Accepted:
         font_size = dialog.intValue()
         legend.setLabelTextSize('%dpt' % font_size)
         legend_items = legend.items.copy()

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -29,6 +29,9 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
 
     """
 
+    sigDoubleClicked = QtCore.Signal(object, object)
+    sigSampleClicked = QtCore.Signal(object)
+
     def __init__(self, size=None, offset=None, horSpacing=25, verSpacing=0,
                  pen=None, brush=None, labelTextColor=None, frame=True,
                  labelTextSize='9pt', colCount=1, sampleType=None, **kwargs):
@@ -218,6 +221,10 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
             sample = item
         else:
             sample = self.sampleType(item)
+
+        if hasattr(sample, 'sigClicked'):
+            sample.sigClicked.connect(self.sampleClickEvent)
+
         self.items.append((sample, label))
         self._addItemToLayout(sample, label)
         self.updateSize()
@@ -339,10 +346,19 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
             dpos = ev.pos() - ev.lastPos()
             self.autoAnchor(self.pos() + dpos)
 
+    def mouseDoubleClickEvent(self, ev):
+        self.sigDoubleClicked.emit(self, ev)
+        ev.accept()
+
+    def sampleClickEvent(self, sampleItem):
+        self.sigSampleClicked.emit(sampleItem)
+
 
 class ItemSample(GraphicsWidget):
     """Class responsible for drawing a single item in a LegendItem (sans label)
     """
+
+    sigClicked = QtCore.Signal(object)
 
     def __init__(self, item):
         GraphicsWidget.__init__(self)
@@ -395,3 +411,5 @@ class ItemSample(GraphicsWidget):
 
         event.accept()
         self.update()
+        self.sigClicked.emit(self.item)
+

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -222,8 +222,7 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         else:
             sample = self.sampleType(item)
 
-        if hasattr(sample, 'sigClicked'):
-            sample.sigClicked.connect(self.sampleClickEvent)
+        sample.sigClicked.connect(self.sigSampleClicked)
 
         self.items.append((sample, label))
         self._addItemToLayout(sample, label)
@@ -349,9 +348,6 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
     def mouseDoubleClickEvent(self, ev):
         self.sigDoubleClicked.emit(self, ev)
         ev.accept()
-
-    def sampleClickEvent(self, sampleItem):
-        self.sigSampleClicked.emit(sampleItem)
 
 
 class ItemSample(GraphicsWidget):


### PR DESCRIPTION
An application may need/want to know which plot data items are visible, the sigSampleClicked signal can be used for this purpose.

An application may want to resize the legend text after a legend has been created. The sigDoubleClicked signal can be used for this.

The example Legend.py has been updated to illustrate example use cases.

Tested against PyQt6 and PySide6.

Thank you for you consideration, 
Kevin