### PR TITLE
fix ComboBox.items()

### DIFF
--- a/pyqtgraph/widgets/ComboBox.py
+++ b/pyqtgraph/widgets/ComboBox.py
@@ -110,7 +110,7 @@ class ComboBox(QtWidgets.QComboBox):
         self.addItems(items)
 
     def items(self):
-        return self.items.copy()
+        return self._items.copy()
         
     def updateList(self, items):
         # for backward compatibility


### PR DESCRIPTION
The `ComboBox.items()` method returns itself (i.e. a function).
This PR makes return a copy of the `_items` dictionary, as I believe was intended.