### PR TITLE
Raise ParseError on duplicate keys in configfile

### DIFF
--- a/pyqtgraph/configfile.py
+++ b/pyqtgraph/configfile.py
@@ -177,6 +177,8 @@ def parseString(lines, start=0, **scope):
                 else:
                     #print "Going deeper..", ln+1
                     (ln, val) = parseString(lines, start=ln+1, **scope)
+            if k in data:
+                raise ParseError(f'Duplicate key: {k}', ln+1, l)
             data[k] = val
         #print k, repr(val)
     except ParseError:

--- a/tests/test_configparser.py
+++ b/tests/test_configparser.py
@@ -14,6 +14,7 @@ def test_longArrays(tmpdir):
     config = configfile.readConfigFile(tf)
     assert all(config['arr'] == arr)
 
+
 def test_multipleParameters(tmpdir):
     """
     Test config saving and loading of multiple parameters.
@@ -30,3 +31,21 @@ def test_multipleParameters(tmpdir):
     assert config['par1'] == par1
     assert config['par2'] == par2
     assert config['par3'] == par3
+
+
+def test_duplicate_keys_error(tmpdir):
+    """
+    Test that an error is raised when duplicate keys are present in the config file.
+    """
+
+    tf = tmpdir.join("config.cfg")
+    with open(tf, 'w') as f:
+        f.write('a: 1\n')
+        f.write('a: 2\n')
+
+    try:
+        configfile.readConfigFile(tf)
+    except configfile.ParseError as e:
+        assert 'Duplicate key' in str(e)
+    else:
+        assert False, "Expected ParseError"


### PR DESCRIPTION
Maybe we shouldn't really be maintaining our own config file format, but since we're doing so anyway, here's a behavior we should have.

This includes some minor style updates, as well, which my editor demanded I make before it would let me edit the code (I kid).