### PR TITLE
Use packaging library for version comparison

### DIFF
--- a/tests/exporters/test_matplotlib.py
+++ b/tests/exporters/test_matplotlib.py
@@ -7,6 +7,8 @@ from pyqtgraph.exporters import MatplotlibExporter
 
 pytest.importorskip("matplotlib")
 import matplotlib
+from packaging.version import Version, parse
+
 
 app = pg.mkQApp()
 
@@ -22,8 +24,8 @@ skip_qt6 = pytest.mark.skipif(
 # see https://github.com/matplotlib/matplotlib/pull/24172
 if (
     pg.Qt.QT_LIB == "PySide6"
-    and tuple(map(int, pg.Qt.PySide6.__version__.split("."))) > (6, 4)
-    and tuple(map(int, version("matplotlib").split("."))) < (3, 6, 2)
+    and parse(pg.Qt.PySide6.__version__) > Version('6.4')
+    and parse(version('matplotlib')) < Version('3.6.2')
 ):
     pytest.skip(
         "matplotlib + PySide6 6.4 bug",


### PR DESCRIPTION
The release of matplotlib 3.9.1.post1 broke some of the version comparison code that is used, as it does tuple(map(int, ...)), and in this case `.post1` did not map to an int.  Since pytest uses the packaging library as a dependency, we can rely on that library in our own test suite, so we use that instead.