### PR TITLE
Bump pytest to 8.3.2

### DIFF
--- a/.github/workflows/etc/requirements.txt
+++ b/.github/workflows/etc/requirements.txt
@@ -17,6 +17,6 @@ matplotlib==3.9.2
 h5py==3.11.0
 
 # testing
-pytest==8.2.2
+pytest==8.3.2
 pytest-xdist==3.6.1
 pytest-xvfb==3.0.0; sys_platform == 'linux'


### PR DESCRIPTION
I know there is a dependabot PR for this change, but the test failure is weird... 