### PR TITLE
Option to execute repl commands in a non-GUI thread

### DIFF
--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -1,12 +1,12 @@
 import os
-import sys
 import pickle
 import subprocess
+import sys
 
 from .. import getConfigOption
 from ..Qt import QtCore, QtWidgets
-from .repl_widget import ReplWidget
 from .exception_widget import ExceptionHandlerWidget
+from .repl_widget import ReplWidget
 
 
 class ConsoleWidget(QtWidgets.QWidget):
@@ -26,8 +26,9 @@ class ConsoleWidget(QtWidgets.QWidget):
       - some terminals (eg windows cmd.exe) have notoriously unfriendly interfaces
       - ability to add extra features like exception stack introspection
       - ability to have multiple interactive prompts, including for spawned sub-processes
+      - ability to execute in either the GUI thread or a separate thread
     """
-    def __init__(self, parent=None, namespace=None, historyFile=None, text=None, editor=None):
+    def __init__(self, parent=None, namespace=None, historyFile=None, text=None, editor=None, allowNonGuiExecution=False):
         """
         ==============  =============================================================================
         **Arguments:**
@@ -41,6 +42,7 @@ class ConsoleWidget(QtWidgets.QWidget):
         ==============  =============================================================================
         """
         QtWidgets.QWidget.__init__(self, parent)
+        self._allowNonGuiExecution = allowNonGuiExecution
 
         self._setupUi()
 
@@ -80,7 +82,7 @@ class ConsoleWidget(QtWidgets.QWidget):
         self.splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical, self)
         self.layout.addWidget(self.splitter, 0, 0)
 
-        self.repl = ReplWidget(self.globals, self.locals, self)
+        self.repl = ReplWidget(self.globals, self.locals, self, allowNonGuiExecution=self._allowNonGuiExecution)
         self.splitter.addWidget(self.repl)
 
         self.historyList = QtWidgets.QListWidget(self)

--- a/pyqtgraph/console/repl_widget.py
+++ b/pyqtgraph/console/repl_widget.py
@@ -74,6 +74,10 @@ class ReplWidget(QtWidgets.QWidget):
         if self._allowNonGuiExecution:
             self.guiCheckbox = QtWidgets.QCheckBox("Exec in GUI", self)
             self.guiCheckbox.setChecked(True)
+            self.guiCheckbox.setToolTip(
+                "If your command is long-running and does not require GUI interaction,"
+                " uncheck this box to run it in a separate thread."
+            )
             self.inputLayout.addWidget(self.guiCheckbox)
 
         self.input.sigExecuteCmd.connect(self.handleCommand)

--- a/pyqtgraph/console/repl_widget.py
+++ b/pyqtgraph/console/repl_widget.py
@@ -92,9 +92,11 @@ class ReplWidget(QtWidgets.QWidget):
 
     def handleCommandExecuted(self):
         self.input.setEnabled(True)
+        self.input.setFocus()
 
     def handleException(self, exc):
         self.input.setEnabled(True)
+        self.input.setFocus()
         self.sigCommandRaisedException.emit(self, exc)
 
     def write(self, strn, style='output', scrollToBottom='auto'):

--- a/pyqtgraph/console/repl_widget.py
+++ b/pyqtgraph/console/repl_widget.py
@@ -1,7 +1,6 @@
 import code
 import queue
 import sys
-import time
 import traceback
 
 from ..functions import mkBrush

--- a/pyqtgraph/examples/ConsoleWidget.py
+++ b/pyqtgraph/examples/ConsoleWidget.py
@@ -23,7 +23,7 @@ as 'np' and 'pg'.
 
 Go, play.
 """
-c = pyqtgraph.console.ConsoleWidget(namespace=namespace, text=text)
+c = pyqtgraph.console.ConsoleWidget(namespace=namespace, text=text, allowNonGuiExecution=True)
 c.resize(800, 400)
 c.show()
 c.setWindowTitle('pyqtgraph example: ConsoleWidget')


### PR DESCRIPTION
This allows application designers to offer their users command execution in either the GUI thread (the current default) or a non-GUI thread. Users may want this if their command is expected to run a long time, does not interact directly with any GUI elements, and they don't want the entire application to freeze for the duration. GUI execution is still the default, and the checkbox to control this isn't even shown without being explicitly configured, so all existing applications will be unchanged. I regret that this wasn't built very testably, The example henceforth uses it, so it will at least get instatiated during a test run.