### PR TITLE
ParseError line numbers should account for empty lines

### DIFF
--- a/pyqtgraph/configfile.py
+++ b/pyqtgraph/configfile.py
@@ -166,10 +166,10 @@ def parseString(lines, start=0, **scope):
             if re.search(r'\S', v) and v[0] != '#':  ## eval the value
                 try:
                     val = eval(v, scope)
-                except Exception:
-                    ex = sys.exc_info()[1]
-                    raise ParseError(f"Error evaluating expression '{v}': [{ex.__class__.__name__}: {str(ex)}]",
-                                     (ln + 1), l)
+                except Exception as ex:
+                    raise ParseError(
+                        f"Error evaluating expression '{v}': [{ex.__class__.__name__}: {ex}]", ln + 1, l
+                    ) from ex
             elif ln + 1 >= len(lines) or measureIndent(lines[ln + 1]) <= indent:
                 val = {}
             else:
@@ -179,9 +179,8 @@ def parseString(lines, start=0, **scope):
             data[k] = val
     except ParseError:
         raise
-    except:
-        ex = sys.exc_info()[1]
-        raise ParseError(f"{ex.__class__.__name__}: {ex}", ln + 1, l)
+    except Exception as ex:
+        raise ParseError(f"{ex.__class__.__name__}: {ex}", ln + 1, l) from ex
     return ln, data
 
 

--- a/pyqtgraph/configfile.py
+++ b/pyqtgraph/configfile.py
@@ -123,7 +123,6 @@ def parseString(lines, start=0, **scope):
     if isinstance(lines, str):
         lines = lines.replace("\\\n", "")
         lines = lines.split('\n')
-        lines = [l for l in lines if re.search(r'\S', l) and not re.match(r'\s*#', l)]  ## remove empty lines
 
     indent = measureIndent(lines[start])
     ln = start - 1

--- a/pyqtgraph/configfile.py
+++ b/pyqtgraph/configfile.py
@@ -124,7 +124,7 @@ def parseString(lines, start=0, **scope):
         lines = lines.replace("\\\n", "")
         lines = lines.split('\n')
 
-    indent = measureIndent(lines[start])
+    indent = None
     ln = start - 1
     l = ''
 
@@ -142,6 +142,8 @@ def parseString(lines, start=0, **scope):
 
             ## Measure line indentation, make sure it is correct for this level
             lineInd = measureIndent(l)
+            if indent is None:
+                indent = lineInd
             if lineInd < indent:
                 ln -= 1
                 break

--- a/pyqtgraph/configfile.py
+++ b/pyqtgraph/configfile.py
@@ -153,7 +153,7 @@ def parseString(lines, start=0, **scope):
             if ':' not in l:
                 raise ParseError('Missing colon', ln + 1, l)
 
-            (k, p, v) = l.partition(':')
+            k, _, v = l.partition(':')
             k = k.strip()
             v = v.strip()
 

--- a/tests/test_configparser.py
+++ b/tests/test_configparser.py
@@ -49,3 +49,23 @@ def test_duplicate_keys_error(tmpdir):
         assert 'Duplicate key' in str(e)
     else:
         assert False, "Expected ParseError"
+
+
+def test_line_numbers_acconut_for_comments_and_blanks(tmpdir):
+    """
+    Test that line numbers in ParseError account for comments and blank lines.
+    """
+
+    tf = tmpdir.join("config.cfg")
+    with open(tf, 'w') as f:
+        f.write('a: 1\n')
+        f.write('\n')
+        f.write('# comment\n')
+        f.write('a: 2\n')
+
+    try:
+        configfile.readConfigFile(tf)
+    except configfile.ParseError as e:
+        assert 'at line 4' in str(e)
+    else:
+        assert False, "Expected ParseError"

--- a/tests/test_configparser.py
+++ b/tests/test_configparser.py
@@ -69,3 +69,18 @@ def test_line_numbers_acconut_for_comments_and_blanks(tmpdir):
         assert 'at line 4' in str(e)
     else:
         assert False, "Expected ParseError"
+
+
+def test_comment_indentation_is_ignored(tmpdir):
+    """
+    Test that comment indentation is ignored.
+    """
+
+    tf = tmpdir.join("config.cfg")
+    with open(tf, 'w') as f:
+        f.write('a:\n')
+        f.write('        # comment\n')
+        f.write('    b: 2\n')
+
+    retval = configfile.readConfigFile(tf)
+    assert retval['a']['b'] == 2

--- a/tests/test_configparser.py
+++ b/tests/test_configparser.py
@@ -80,7 +80,9 @@ def test_comment_indentation_is_ignored(tmpdir):
     with open(tf, 'w') as f:
         f.write('a:\n')
         f.write('        # comment\n')
-        f.write('    b: 2\n')
+        f.write('    b:\n')
+        f.write('# more comments\n')
+        f.write('        c: 2\n')
 
     retval = configfile.readConfigFile(tf)
-    assert retval['a']['b'] == 2
+    assert retval['a']['b']['c'] == 2


### PR DESCRIPTION
Comments and blank lines were already being skipped during line processing, so we don't need to pre-exclude them. Doing so impacted the accuracy of the ParseErrors. Test included. General style improvements and python-3-isms also added.