### PR TITLE
Apoptose dock area when temporary window is closed

### DIFF
--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -210,7 +210,7 @@ class Dock(QtWidgets.QWidget):
     def containerChanged(self, c):
         if self._container is not None:
             # ask old container to close itself if it is no longer needed
-            self._container.apoptose(propagate=False)
+            self._container.apoptose()
         self._container = c
         if c is None:
             self.area = None

--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -286,7 +286,11 @@ class DockArea(Container, QtWidgets.QWidget):
                 self.buildFromState(o, docks, obj, depth+1, missing=missing)
             # remove this container if possible. (there are valid situations when a restore will
             # generate empty containers, such as when using missing='ignore')
-            obj.apoptose(propagate=False)
+            # There are 2 cases where this container should be removed:
+            #   1. There are no child items which might happen in missing is set to 'ignore'
+            #   2. To remove a superfluous container (Another container as the sole children of this container)
+            if obj.count() == 0 or (obj.count() == 1 and isinstance(obj.widget(0), Container)):
+                obj.apoptose(propagate=False)
             obj.restoreState(state)  ## this has to be done later?     
 
     def findAll(self, obj=None, c=None, d=None):

--- a/tests/dockarea/test_dockarea.py
+++ b/tests/dockarea/test_dockarea.py
@@ -197,7 +197,7 @@ def test_restoring_fails_silently_if_only_one_dock_in_container():
                  ['vertical', [
                      ['horizontal', [
                         ['vertical', [
-                            ['vertical', [
+                            ['vertical', [  # A single dock in a container should not lead to the collapse of this side of the tree.
                                 ['dock', 'Plot 1', {}]],
                              {'sizes': [314]}
                             ],
@@ -222,8 +222,8 @@ def test_restoring_fails_silently_if_only_one_dock_in_container():
 
 
 def test_floating_and_closed_before_save_and_restore_state():
-    # Test that undocking and redocking a dock doesn't break save- and restoreState functionality.
-    # Regression test for GH issue #3125
+    # Test that undocking and redocking a dock by closing the temporary window doesn't break
+    # save- and restoreState functionality. Regression test for GH issue #3125
     a = da.DockArea()
     d1 = da.Dock("dock 1")
     a.addDock(d1, 'left')
@@ -234,6 +234,19 @@ def test_floating_and_closed_before_save_and_restore_state():
     a2.restoreState(state, missing='create')
     assert a2.saveState() == state
 
+
+def test_floating_and_redock_by_dragging_back_before_save_and_restore_state():
+    # Test that undocking and dragging the dock back to the main window closes the temporary window and therefore
+    # doesn't break save- and restoreState functionality. Regression test for GH issue #3125
+    a = da.DockArea()
+    d1 = da.Dock("dock 1")
+    a.addDock(d1, 'left')
+    a.floatDock(d1)
+    a.moveDock(d1, 'left', None)
+    state = a.saveState()
+    a2 = da.DockArea()
+    a2.restoreState(state, missing='create')
+    assert a2.saveState() == state
 
 def test_floating_dock_closed_by_restore_state_doesnt_error():
     # Test that closing a floating dock by calling restoreState doesn't raise an exception.

--- a/tests/dockarea/test_dockarea.py
+++ b/tests/dockarea/test_dockarea.py
@@ -181,6 +181,73 @@ def test_dockarea():
         assert clean_state(state4['main']) == clean_state(state2['main'])
 
 
+def test_restoring_fails_silently_if_only_one_dock_in_container():
+    # Test that restoring state with a single dock in a container does not silently collapse and delete an entire
+    # container tree.
+    # Regression test for GH issue #2887
+    dockArea = da.DockArea()
+    dockArea.addDock(da.Dock(name="Plot 1", closable=False), 'left')
+    dockArea.addDock(da.Dock(name="Plot 2", closable=False), 'left')
+    dockArea.addDock(da.Dock(name="Plot 4", closable=False), 'left')
+    dockArea.addDock(da.Dock(name="Table 1", closable=False), 'left')
+    dockArea.addDock(da.Dock(name="Table 2", closable=False), 'left')
+    dockArea.addDock(da.Dock(name="Table 3", closable=False), 'left')
+
+    state = {'main':
+                 ['vertical', [
+                     ['horizontal', [
+                        ['vertical', [
+                            ['vertical', [
+                                ['dock', 'Plot 1', {}]],
+                             {'sizes': [314]}
+                            ],
+                            ['dock', 'Plot 2', {}]],
+                        {'sizes': [314, 313]}],
+                        ['vertical', [
+                            ['dock', 'Table 3', {}],
+                            ['dock', 'Table 2', {}],
+                            ['dock', 'Table 1', {}]],
+                            {'sizes': [208, 207, 208]}]
+                     ],
+                      {'sizes': [784, 783]}
+                     ],
+                     ['dock', 'Plot 4', {}]
+                 ],
+                  {'sizes': [631, 210]}
+                 ],
+            'float': []}
+    dockArea.restoreState(state)
+    c, d = dockArea.findAll()
+    assert len(d) == 6
+
+
+def test_floating_and_closed_before_save_and_restore_state():
+    # Test that undocking and redocking a dock doesn't break save- and restoreState functionality.
+    # Regression test for GH issue #3125
+    a = da.DockArea()
+    d1 = da.Dock("dock 1")
+    a.addDock(d1, 'left')
+    a.floatDock(d1)
+    a.tempAreas[0].win.close()
+    state = a.saveState()
+    a2 = da.DockArea()
+    a2.restoreState(state, missing='create')
+    assert a2.saveState() == state
+
+
+def test_floating_dock_closed_by_restore_state_doesnt_error():
+    # Test that closing a floating dock by calling restoreState doesn't raise an exception.
+    a = da.DockArea()
+    d1 = da.Dock("dock 1")
+    a.addDock(d1, 'left')
+    d2 = da.Dock("dock 2")
+    a.addDock(d2, 'left')
+    state = a.saveState()
+    a.floatDock(d1)
+    a.restoreState(state) # Should not raise an exception
+    assert a.saveState() == state
+
+
 def clean_state(state):
     # return state dict with sizes removed
     ch = [clean_state(x) for x in state[1]] if isinstance(state[1], list) else state[1]


### PR DESCRIPTION
 After the fix for #2887 was introduced floating temp areas were not removed anymore when it was closed.
 This lead to a TypeError when calling saveState and then restoreState, because it tried to restore half-present floating windows.
Now the apoptose method of the temporary area of the floating window is called explicitly in its closeEvent method.
This leads to a duplicate call to dock_area.apoptose only in the case when a floating window is closed by calling restoreState on the original dock area. In that case an exception would be raised be removeArea, because the temporary dock_area was alread removed,
This is handled by setting the reference to the original dock area to None in the dock_areas apoptose method, which breaks the cycle.
Introduced regression tests for #2887 and #3125 as well as another potential failure case discovered while trying to fix the issue.
 Fixes #3125