### PR TITLE
Use Monospace font in Console Widget CmdInput

### DIFF
--- a/pyqtgraph/console/CmdInput.py
+++ b/pyqtgraph/console/CmdInput.py
@@ -11,8 +11,8 @@ class CmdInput(QtWidgets.QLineEdit):
         self.ps2 = "... "
         self.history = [""]
         self.ptr = 0
-        font = QtGui.QFont("Courier New", )
-        font.setStyleStrategy(QtGui.QFont.StyleStrategy.PreferAntialias)
+        font = QtGui.QFont("monospace")
+        font.setStyleHint(QtGui.QFont.StyleHint.TypeWriter, QtGui.QFont.StyleStrategy.PreferAntialias)
         self.setFont(font)
         self.setMultiline(False)
     

--- a/pyqtgraph/console/CmdInput.py
+++ b/pyqtgraph/console/CmdInput.py
@@ -1,4 +1,4 @@
-from ..Qt import QtCore, QtWidgets
+from ..Qt import QtCore, QtGui, QtWidgets
 
 
 class CmdInput(QtWidgets.QLineEdit):
@@ -11,6 +11,9 @@ class CmdInput(QtWidgets.QLineEdit):
         self.ps2 = "... "
         self.history = [""]
         self.ptr = 0
+        font = QtGui.QFont("Courier New", )
+        font.setStyleStrategy(QtGui.QFont.StyleStrategy.PreferAntialias)
+        self.setFont(font)
         self.setMultiline(False)
     
     def setMultiline(self, ml):

--- a/pyqtgraph/console/repl_widget.py
+++ b/pyqtgraph/console/repl_widget.py
@@ -48,9 +48,8 @@ class ReplWidget(QtWidgets.QWidget):
         self.setLayout(self.layout)
 
         self.output = QtWidgets.QTextEdit(self)
-        font = QtGui.QFont()
-        font.setFamily("Courier New")
-        font.setStyleStrategy(QtGui.QFont.StyleStrategy.PreferAntialias)
+        font = QtGui.QFont("monospace")
+        font.setStyleHint(QtGui.QFont.StyleHint.TypeWriter, QtGui.QFont.StyleStrategy.PreferAntialias)
         self.output.setFont(font)
         self.output.setReadOnly(True)
         self.layout.addWidget(self.output)
@@ -216,4 +215,3 @@ class StdoutInterceptor:
         sys.stderr = self._orig_stderr
         self._orig_stdout = None
         self._orig_stderr = None
-


### PR DESCRIPTION
The repl uses a monospace font (Courier New by default) to display the command output, but the text input widget was using the system default. This commit applies the same font styling to the LineEdit widget used in the Console widget.

before:
![before](https://github.com/user-attachments/assets/2eb82c2b-c24f-4987-ba4f-acf1c93a8b3f)

after:
![after](https://github.com/user-attachments/assets/0297725a-9c9a-4c5c-bedd-9ed04f59aa27)

This looks a lot more consistent in my opinion.