### PR TITLE
Fix ConsoleWidget ReplWidget.write() always scrolling to bottom (`scrollToBottom` not working)

### DIFF
--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -1,12 +1,12 @@
 import os
-import sys
 import pickle
 import subprocess
+import sys
 
 from .. import getConfigOption
 from ..Qt import QtCore, QtWidgets
-from .repl_widget import ReplWidget
 from .exception_widget import ExceptionHandlerWidget
+from .repl_widget import ReplWidget
 
 
 class ConsoleWidget(QtWidgets.QWidget):
@@ -56,7 +56,7 @@ class ConsoleWidget(QtWidgets.QWidget):
         self.input.setFocus()
         
         if text is not None:
-            self.output.setPlainText(text)
+            self.output.insertPlainText(text)
 
         self.historyFile = historyFile
         

--- a/pyqtgraph/console/repl_widget.py
+++ b/pyqtgraph/console/repl_widget.py
@@ -1,6 +1,9 @@
-import code, sys, traceback
-from ..Qt import QtWidgets, QtGui, QtCore
+import code
+import sys
+import traceback
+
 from ..functions import mkBrush
+from ..Qt import QtCore, QtGui, QtWidgets
 from .CmdInput import CmdInput
 
 
@@ -124,7 +127,6 @@ class ReplWidget(QtWidgets.QWidget):
 
         cursor = self.output.textCursor()
         cursor.movePosition(QtGui.QTextCursor.MoveOperation.End)
-        self.output.setTextCursor(cursor)
 
         sb = self.output.verticalScrollBar()
         scroll = sb.value()
@@ -216,4 +218,3 @@ class StdoutInterceptor:
         sys.stderr = self._orig_stderr
         self._orig_stdout = None
         self._orig_stderr = None
-


### PR DESCRIPTION
Despite having `scrollToBottom='auto'` in `ReplWidget` set to auto, the TextEdit scroll area would always scroll to the bottom, to most recently inserted text. 
Desired behavior: have the scroll view stay in place if not at the bottom.
I messed around with lots of things trying to get it to work as expected. I found that moving the text cursor to the end also scrolled the view. There is no mention of this behavior in the QT docs. It does not seem to matter whether `QTextEdit.moveCursor()` is used, or first getting a reference, moving the cursor, and setting again using `QTextEdit.setCursor()` (as was being used here before. This issue was made especially hard to diagnose because the cursor is not visible. 

The `QTextEdit.insertPlainText()` method does work as expected, and moves the cursor to the end of the inserted text. This does *not* scroll the view (unlike `append()`).

I eventually settled on just removing the line that moves the cursor to the end near the beginning of ReplWidget.write(). This fixed the issue, and I only had to change the one other place the QTextEdit has text added to use insert instead of set in order to update the cursor position to the right place upon initialization (in `ConsoleWidget.__init__()`).

The other changes are just pre-commit auto formatting.