### PR TITLE
connect darkMode slots only once

### DIFF
--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -345,6 +345,7 @@ App = QtWidgets.QApplication
 # subclassing QApplication causes segfaults on PySide{2, 6} / Python 3.8.7+
 
 QAPP = None
+_pgAppInitialized = False
 def mkQApp(name=None):
     """
     Creates new QApplication or returns current instance if existing.
@@ -355,6 +356,7 @@ def mkQApp(name=None):
     ============== ========================================================
     """
     global QAPP
+    global _pgAppInitialized
 
     QAPP = QtWidgets.QApplication.instance()
     if QAPP is None:
@@ -407,30 +409,21 @@ def mkQApp(name=None):
             ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(my_app_id)
         QAPP.setWindowIcon(applicationIcon)
 
-    # determine if dark mode
-    try:
-        # this only works in Qt 6.5+
-        darkMode = QAPP.styleHints().colorScheme() == QtCore.Qt.ColorScheme.Dark
-        with contextlib.suppress(TypeError):
-            # some qt bindings raise a TypeError when using a UniqueConnection
-            # to an already connected signal/slot
-            QAPP.styleHints().colorSchemeChanged.connect(
-                _onColorSchemeChange,
-                type=QtCore.Qt.ConnectionType.UniqueConnection
-            )
-    except AttributeError:
-        palette = QAPP.palette()
-        windowTextLightness = palette.color(QtGui.QPalette.ColorRole.WindowText).lightness()
-        windowLightness = palette.color(QtGui.QPalette.ColorRole.Window).lightness()
-        darkMode = windowTextLightness > windowLightness
-        with contextlib.suppress(TypeError):
-            # some qt bindings raise a TypeError when using a UniqueConnection
-            # to an already connected signal/slot
-            QAPP.paletteChanged.connect(
-                _onPaletteChange,
-                type=QtCore.Qt.ConnectionType.UniqueConnection
-            )
-    QAPP.setProperty("darkMode", darkMode)
+    if not _pgAppInitialized:
+        _pgAppInitialized = True
+
+        # determine if dark mode
+        try:
+            # this only works in Qt 6.5+
+            darkMode = QAPP.styleHints().colorScheme() == QtCore.Qt.ColorScheme.Dark
+            QAPP.styleHints().colorSchemeChanged.connect(_onColorSchemeChange)
+        except AttributeError:
+            palette = QAPP.palette()
+            windowTextLightness = palette.color(QtGui.QPalette.ColorRole.WindowText).lightness()
+            windowLightness = palette.color(QtGui.QPalette.ColorRole.Window).lightness()
+            darkMode = windowTextLightness > windowLightness
+            QAPP.paletteChanged.connect(_onPaletteChange)
+        QAPP.setProperty("darkMode", darkMode)
 
     if name is not None:
         QAPP.setApplicationName(name)


### PR DESCRIPTION
fixes #3143

In PySide6 > 6.7.2, it is no longer possible to use `UniqueConnection` with free-standing functions. The end result of supplying that mode is that no connection will be made at all.

This can be worked-around by manually keeping track of whether a connection has already been made.

In fact, the original code has a recursion issue. In the slot, `mkQApp()` is called, which then attempts to connect the slot again, relying on `UniqueConnection` to mask out this recursion.