### PR TITLE
prevent grid lines from getting mouse events

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -660,6 +660,13 @@ class AxisItem(GraphicsWidget):
         else:
             return self.mapRectFromParent(self.geometry()) | linkedView.mapRectToItem(self, linkedView.boundingRect())
 
+    def shape(self):
+        # override shape() to exclude grid lines from getting mouse events
+        rect = self.mapRectFromParent(self.geometry())
+        path = QtGui.QPainterPath()
+        path.addRect(rect)
+        return path
+
     def paint(self, p, opt, widget):
         profiler = debug.Profiler()
         if self.picture is None:


### PR DESCRIPTION
fixes #2062

Override `shape()` so that grid lines are not considered for the purposes of collision detection / mouse event delivery.

Grid lines are drawn by `AxisItem` as part of an extended tick line. As `AxisItem`s are given a zValue of +0.5 vs `ViewBox`'s  _negative_ 100, children of `ViewBox` get stacked underneath `AxisItem`s.
When grid lines are enabled, this has the side effect of mouse events getting delivered to the `AxisItem` before any other items.
