### PR TITLE
Fix codecoverage, remove mambaforge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,12 @@ on:
     branches-ignore: ["dependabot/**"]
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
 
-concurrency: 
+concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
@@ -18,24 +18,24 @@ jobs:
   make_dash_docset:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-        cache: pip
-    - name: Install Build Dependencies
-      run: |
-        python -m pip install --upgrade doc2dash setuptools -r doc/requirements.txt 
-    - name: Build docset
-      run: |
-        make -C doc dash
-    - run: tar --exclude='.DS_Store' -cvzf pyqtgraph.tgz doc/pyqtgraph.docset
-    - name: Upload docset
-      uses: actions/upload-artifact@v4
-      with:
-        name: pyqtgraph.docset
-        path: pyqtgraph.tgz
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
+      - name: Install Build Dependencies
+        run: |
+          python -m pip install --upgrade doc2dash setuptools -r doc/requirements.txt
+      - name: Build docset
+        run: |
+          make -C doc dash
+      - run: tar --exclude='.DS_Store' -cvzf pyqtgraph.tgz doc/pyqtgraph.docset
+      - name: Upload docset
+        uses: actions/upload-artifact@v4
+        with:
+          name: pyqtgraph.docset
+          path: pyqtgraph.tgz
   run-mypy:
     runs-on: ubuntu-latest
     steps:
@@ -82,80 +82,81 @@ jobs:
             python-version: "3.10"
             qt-lib: "pyside"
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
-    - name: "Install Windows-Mesa OpenGL DLL"
-      if: runner.os == 'Windows'
-      run: |
-        curl -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/24.0.6/mesa3d-24.0.6-release-msvc.7z
-        7z x mesa.7z -o*
-        powershell.exe mesa\systemwidedeploy.cmd 1
-    - name: Install Dependencies
-      run: |
-        python -m pip install -r .github/workflows/etc/requirements.txt ${{ matrix.qt-version }} . "coverage[toml]"
-    - name: "Install Linux VirtualDisplay"
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update -y --allow-releaseinfo-change
-        sudo apt-get install --no-install-recommends -y \
-          libxkbcommon-x11-0 \
-          x11-utils \
-          libyaml-dev \
-          libegl1-mesa \
-          libxcb-icccm4 \
-          libxcb-image0 \
-          libxcb-keysyms1 \
-          libxcb-randr0 \
-          libxcb-render-util0 \
-          libxcb-xinerama0 \
-          libopengl0 \
-          libxcb-cursor0
-    - name: 'Debug Info'
-      run: |
-        echo python location: `which python`
-        echo python version: `python --version`
-        echo pytest location: `which pytest`
-        echo installed packages
-        python -m pip list
-        echo pyqtgraph system info
-        python -c "import pyqtgraph as pg; pg.systemInfo()"
-      shell: bash
-      env:
-        QT_DEBUG_PLUGINS: 1
-    - name: 'XVFB Display Info'
-      run: |
-        xvfb-run --server-args="-screen 0, 1920x1200x24 -ac +extension GLX +render -noreset" python -m pyqtgraph.util.glinfo
-        xvfb-run --server-args="-screen 0, 1920x1200x24 -ac +extension GLX +render -noreset" python -m pyqtgraph.util.get_resolution
-      if: runner.os == 'Linux'
-    - name: 'Display Info'
-      run: |
-        python -m pyqtgraph.util.glinfo
-        python -m pyqtgraph.util.get_resolution
-      if: runner.os != 'Linux'
-    - name: Run Tests
-      run: |
-        mkdir "$SCREENSHOT_DIR"
-        coverage run -m pytest tests -v
-        pytest pyqtgraph/examples -v -n 2
-      shell: bash
-    - name: Upload coverage data
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-data-${{ matrix.python-version }}-${{ matrix.qt-lib }}-${{ matrix.os }}
-        path: .coverage.*
-        if-no-files-found: ignore
-    - name: Upload Screenshots
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: Screenshots (Python ${{ matrix.python-version }} - Qt-Bindings ${{ matrix.qt-lib }} - OS ${{ matrix.os }})
-        path: ${{ env.SCREENSHOT_DIR }}
-        if-no-files-found: ignore
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: "Install Windows-Mesa OpenGL DLL"
+        if: runner.os == 'Windows'
+        run: |
+          curl -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/24.0.6/mesa3d-24.0.6-release-msvc.7z
+          7z x mesa.7z -o*
+          powershell.exe mesa\systemwidedeploy.cmd 1
+      - name: Install Dependencies
+        run: |
+          python -m pip install -r .github/workflows/etc/requirements.txt ${{ matrix.qt-version }} . "coverage[toml]"
+      - name: "Install Linux VirtualDisplay"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -y --allow-releaseinfo-change
+          sudo apt-get install --no-install-recommends -y \
+            libxkbcommon-x11-0 \
+            x11-utils \
+            libyaml-dev \
+            libegl1-mesa \
+            libxcb-icccm4 \
+            libxcb-image0 \
+            libxcb-keysyms1 \
+            libxcb-randr0 \
+            libxcb-render-util0 \
+            libxcb-xinerama0 \
+            libopengl0 \
+            libxcb-cursor0
+      - name: "Debug Info"
+        run: |
+          echo python location: `which python`
+          echo python version: `python --version`
+          echo pytest location: `which pytest`
+          echo installed packages
+          python -m pip list
+          echo pyqtgraph system info
+          python -c "import pyqtgraph as pg; pg.systemInfo()"
+        shell: bash
+        env:
+          QT_DEBUG_PLUGINS: 1
+      - name: "XVFB Display Info"
+        run: |
+          xvfb-run --server-args="-screen 0, 1920x1200x24 -ac +extension GLX +render -noreset" python -m pyqtgraph.util.glinfo
+          xvfb-run --server-args="-screen 0, 1920x1200x24 -ac +extension GLX +render -noreset" python -m pyqtgraph.util.get_resolution
+        if: runner.os == 'Linux'
+      - name: "Display Info"
+        run: |
+          python -m pyqtgraph.util.glinfo
+          python -m pyqtgraph.util.get_resolution
+        if: runner.os != 'Linux'
+      - name: Run Tests
+        run: |
+          mkdir "$SCREENSHOT_DIR"
+          coverage run -m pytest tests -v
+          pytest pyqtgraph/examples -v -n 2
+        shell: bash
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-${{ matrix.python-version }}-${{ matrix.qt-lib }}-${{ matrix.os }}
+          path: .coverage.*
+          if-no-files-found: ignore
+          include-hidden-files: true
+      - name: Upload Screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Screenshots (Python ${{ matrix.python-version }} - Qt-Bindings ${{ matrix.qt-lib }} - OS ${{ matrix.os }})
+          path: ${{ env.SCREENSHOT_DIR }}
+          if-no-files-found: ignore
     env:
       SCREENSHOT_DIR: screenshots
 
@@ -176,77 +177,75 @@ jobs:
           - qt-lib: pyside
             environment-file: .github/workflows/etc/environment-pyside.yml
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        miniforge-version: latest
-        miniforge-variant: Mambaforge
-        environment-file: ${{ matrix.environment-file }}
-        auto-update-conda: false
-        python-version: "3.12"
-        use-mamba: true
-    - name: "Install Test Framework"
-      run: pip install pytest pytest-xdist
-    - name: "Install Windows-Mesa OpenGL DLL"
-      if: runner.os == 'Windows'
-      run: |
-        curl -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/24.0.6/mesa3d-24.0.6-release-msvc.7z
-        7z x mesa.7z -o*
-        powershell.exe mesa\systemwidedeploy.cmd 1
-      shell: pwsh
-    - name: "Install Linux VirtualDisplay"
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update -y --allow-releaseinfo-change
-        sudo apt-get install -y --no-install-recommends \
-          libxkbcommon-x11-0 \
-          x11-utils \
-          libyaml-dev \
-          libegl1-mesa \
-          libxcb-icccm4 \
-          libxcb-image0 \
-          libxcb-keysyms1 \
-          libxcb-randr0 \
-          libxcb-render-util0 \
-          libxcb-xinerama0 \
-          libopengl0 \
-          libxcb-cursor0
-        pip install pytest-xvfb
-    - name: 'Debug Info'
-      run: |
-        echo python location: `which python`
-        echo python version: `python --version`
-        echo pytest location: `which pytest`
-        echo installed packages
-        conda list
-        pip list
-        echo pyqtgraph system info
-        python -c "import pyqtgraph as pg; pg.systemInfo()"
-      env:
-        QT_DEBUG_PLUGINS: 1
-    - name: 'XVFB Display Info'
-      run: |
-        xvfb-run --server-args="-screen 0, 1920x1200x24 -ac +extension GLX +render -noreset" python -m pyqtgraph.util.glinfo
-        xvfb-run --server-args="-screen 0, 1920x1200x24 -ac +extension GLX +render -noreset" python -m pyqtgraph.util.get_resolution
-      if: runner.os == 'Linux'
-    - name: 'Display Info'
-      run: |
-        python -m pyqtgraph.util.glinfo
-        python -m pyqtgraph.util.get_resolution
-      if: runner.os != 'Linux'
-    - name: Run Tests
-      run: |
-        mkdir "$SCREENSHOT_DIR"
-        pytest tests -v
-        pytest pyqtgraph/examples -v -n 2
-    - name: Upload Screenshots
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: Screenshots (Conda - Qt-Bindings ${{ matrix.qt-lib }} - OS ${{ matrix.os }})
-        path: ${{ env.SCREENSHOT_DIR }}
-        if-no-files-found: ignore
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          environment-file: ${{ matrix.environment-file }}
+          auto-update-conda: false
+          python-version: "3.12"
+      - name: "Install Test Framework"
+        run: pip install pytest pytest-xdist
+      - name: "Install Windows-Mesa OpenGL DLL"
+        if: runner.os == 'Windows'
+        run: |
+          curl -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/24.0.6/mesa3d-24.0.6-release-msvc.7z
+          7z x mesa.7z -o*
+          powershell.exe mesa\systemwidedeploy.cmd 1
+        shell: pwsh
+      - name: "Install Linux VirtualDisplay"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -y --allow-releaseinfo-change
+          sudo apt-get install -y --no-install-recommends \
+            libxkbcommon-x11-0 \
+            x11-utils \
+            libyaml-dev \
+            libegl1-mesa \
+            libxcb-icccm4 \
+            libxcb-image0 \
+            libxcb-keysyms1 \
+            libxcb-randr0 \
+            libxcb-render-util0 \
+            libxcb-xinerama0 \
+            libopengl0 \
+            libxcb-cursor0
+          pip install pytest-xvfb
+      - name: "Debug Info"
+        run: |
+          echo python location: `which python`
+          echo python version: `python --version`
+          echo pytest location: `which pytest`
+          echo installed packages
+          conda list
+          pip list
+          echo pyqtgraph system info
+          python -c "import pyqtgraph as pg; pg.systemInfo()"
+        env:
+          QT_DEBUG_PLUGINS: 1
+      - name: "XVFB Display Info"
+        run: |
+          xvfb-run --server-args="-screen 0, 1920x1200x24 -ac +extension GLX +render -noreset" python -m pyqtgraph.util.glinfo
+          xvfb-run --server-args="-screen 0, 1920x1200x24 -ac +extension GLX +render -noreset" python -m pyqtgraph.util.get_resolution
+        if: runner.os == 'Linux'
+      - name: "Display Info"
+        run: |
+          python -m pyqtgraph.util.glinfo
+          python -m pyqtgraph.util.get_resolution
+        if: runner.os != 'Linux'
+      - name: Run Tests
+        run: |
+          mkdir "$SCREENSHOT_DIR"
+          pytest tests -v
+          pytest pyqtgraph/examples -v -n 2
+      - name: Upload Screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Screenshots (Conda - Qt-Bindings ${{ matrix.qt-lib }} - OS ${{ matrix.os }})
+          path: ${{ env.SCREENSHOT_DIR }}
+          if-no-files-found: ignore
     env:
       SCREENSHOT_DIR: screenshots
 
@@ -258,7 +257,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
           cache: pip
       - name: Build Wheel
         run: |
@@ -269,7 +268,7 @@ jobs:
         with:
           name: wheel
           path: dist/*.whl
-  
+
   analyze:
     name: analyze
     runs-on: ubuntu-latest
@@ -278,27 +277,27 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-        cache: pip
-    - name: Install Dependencies
-      run: |
-        python -m pip install PyQt5 numpy scipy
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: 'python'
-        queries: +security-and-quality
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install Dependencies
+        run: |
+          python -m pip install PyQt5 numpy scipy
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: "python"
+          queries: +security-and-quality
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
 
   coverage:
     name: combine & check coverage


### PR DESCRIPTION
Mambaforge usage in setup-miniconda has been deprecated and no longer needed since we already specify use of miniforge.

Also fixup the breakage in include-hidden-files with the github upload artifact action.