### PR TITLE
Update LinearRegionItem.py

### DIFF
--- a/pyqtgraph/graphicsItems/LinearRegionItem.py
+++ b/pyqtgraph/graphicsItems/LinearRegionItem.py
@@ -320,11 +320,11 @@ class LinearRegionItem(GraphicsObject):
         if not self.moving:
             return
             
-        self.lines[0].blockSignals(True)  # only want to update once
+        self.blockLineSignal = True  # only want to update once
         for i, l in enumerate(self.lines):
             l.setPos(self.cursorOffsets[i] + ev.pos())
-        self.lines[0].blockSignals(False)
         self.prepareGeometryChange()
+        self.blockLineSignal = False
         
         if ev.isFinish():
             self.moving = False


### PR DESCRIPTION
fix bug in Examples/InfiniteLine.py
```
lr = pg.LinearRegionItem(values=[70, 80])
p1.addItem(lr)
label = pg.InfLineLabel(lr.lines[1], "region 1", position=0.95, rotateAxis=(1,0), anchor=(1, 1))
```
if change ```lr.lines[1]``` to ```lr.lines[0]```,  label moved in drag event. Don't block InfiLine Signal directly while draging event?