### PR TITLE
pcmi opengl: discard nan fragments

### DIFF
--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -626,7 +626,7 @@ class OpenGLState(QtCore.QObject):
         uniform mat4 u_mvp;
         uniform vec2 u_rescale;
         void main() {
-            v_luminance = clamp(u_rescale.x * (a_luminance - u_rescale.y), 0.0, 1.0);
+            v_luminance = u_rescale.x * (a_luminance - u_rescale.y);
             gl_Position = u_mvp * a_position;
         }
     """
@@ -634,7 +634,9 @@ class OpenGLState(QtCore.QObject):
         varying mediump float v_luminance;
         uniform mediump sampler2D u_texture;
         void main() {
-            gl_FragColor = texture2D(u_texture, vec2(v_luminance, 0));
+            if (isnan(v_luminance)) discard;
+            float s = clamp(v_luminance, 0.0, 1.0);
+            gl_FragColor = texture2D(u_texture, vec2(s, 0));
         }
     """
 
@@ -645,7 +647,7 @@ class OpenGLState(QtCore.QObject):
         uniform mat4 u_mvp;
         uniform vec2 u_rescale;
         void main() {
-            v_luminance = clamp(u_rescale.x * (a_luminance - u_rescale.y), 0.0, 1.0);
+            v_luminance = u_rescale.x * (a_luminance - u_rescale.y);
             gl_Position = u_mvp * a_position;
         }
     """
@@ -657,7 +659,9 @@ class OpenGLState(QtCore.QObject):
         out vec4 FragColor;
         uniform sampler2D u_texture;
         void main() {
-            FragColor = texture(u_texture, vec2(v_luminance, 0));
+            if (isnan(v_luminance)) discard;
+            float s = clamp(v_luminance, 0.0, 1.0);
+            FragColor = texture(u_texture, vec2(s, 0));
         }
     """
 


### PR DESCRIPTION
#3114 defined nan values in PCMI to be transparent.
Update the OpenGL code-path to have the same behavior.

What this PR *doesn't* do:
* In non-OpenGL code-path, cell borders are drawn together with the cell. Thus when a cell containing a nan is not filled, its border doesn't get drawn
* In OpenGL code-path, cell borders are drawn as a grid using polylines. Thus even if a cell containing a nan is not filled, its border still gets drawn

Arguably, the non-OpenGL code-path behavior was just an accident. Either behavior makes sense.

Sample code adapted from #3090 to demonstrate nan pixels being transparent.
```python
import importlib
import sys

import numpy as np

import pyqtgraph as pg
from pyqtgraph.Qt import QtCore, QtGui
from pyqtgraph.examples.utils import FrameCounter

width = 128
pngfile = importlib.resources.files("pyqtgraph.icons.peegee") / f"peegee_{width}px.png"
qimage = QtGui.QImage.fromData(pngfile.read_bytes())
qimage_gray = qimage.convertedTo(QtGui.QImage.Format.Format_Grayscale8)
qimage_alpha = qimage.convertedTo(QtGui.QImage.Format.Format_Alpha8)
z = pg.functions.ndarray_from_qimage(qimage_gray)
a = pg.functions.ndarray_from_qimage(qimage_alpha)

z = z.astype(np.float32)
z[a < 255] = np.nan

Z = z
ny, nx = Z.shape
x = np.linspace(0, nx, nx+1, endpoint=True)
y = np.linspace(0, ny, ny+1, endpoint=True)
X, Y = np.meshgrid(x, y)
X += (ny * 0.025) * np.sin(2*np.pi*2*np.linspace(0, 1, ny+1))[:, np.newaxis]
Y += (nx * 0.025) * np.sin(2*np.pi*2*np.linspace(0, 1, nx+1))

pg.setConfigOptions(useOpenGL=True, enableExperimental=True)
pg.setConfigOption('background', pg.mkColor(0, 0, 100))

pg.mkQApp()
win = pg.PlotWidget()
win.invertY(True)
cmap = pg.colormap.ColorMap(None, [0.0, 1.0])
pcmi = pg.PColorMeshItem(X, Y, Z, colorMap=cmap)
win.addItem(pcmi)
win.setTitle('')
win.show()

cnt = 0
def update():
    global cnt
    cnt = (cnt + 1) % z.shape[1]
    Z = np.roll(z, cnt, axis=1)
    pcmi.setData(None, None, Z)
    framecnt.update()

timer = QtCore.QTimer()
timer.timeout.connect(update)
timer.start()

framecnt = FrameCounter()
framecnt.sigFpsUpdate.connect(lambda fps: win.setTitle(f'{fps:.1f} fps'))

pg.exec()
```