### PR TITLE
initialize the pressPos attribute with default value to prevent error

### DIFF
--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -272,6 +272,7 @@ class DockLabel(VerticalLabel):
         self.updateStyle()
         self.setAutoFillBackground(False)
         self.mouseMoved = False
+        self.pressPos = QtCore.QPointF(0, 0)
 
         self.closeButton = None
         if closable:


### PR DESCRIPTION
This will solve #2921

The pressPos attribute of the DockLabel object is not initialized in the __init__. Therefore when the mouse is hovering on a DockLabel it triggers an error. Adding a default value for this attribute in the __init__ method solves it.