### PR TITLE
fix: minor improvements to the visibility of the colormap button

### DIFF
--- a/pyqtgraph/widgets/ColorMapButton.py
+++ b/pyqtgraph/widgets/ColorMapButton.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from .ColorMapMenu import ColorMapMenu
 from .. import colormap
 from .. import functions as fn
 from ..Qt import QtCore, QtGui, QtWidgets
+from .ColorMapMenu import ColorMapMenu
 
 __all__ = ['ColorMapButton']
 
@@ -74,20 +74,12 @@ class ColorMapDisplayMixin:
         # get an estimate of the lightness of the colormap
         # from its center element
         lightness = image.pixelColor(image.rect().center()).lightnessF()
-        if lightness >= 0.5:
-            # light: draw text with dark pen
-            pens = [wpen, bpen]
-        else:
-            # dark: draw text with light pen
-            pens = [bpen, wpen]
+        pen = bpen if lightness >= 0.55 else wpen
 
         AF = QtCore.Qt.AlignmentFlag
         trect = painter.boundingRect(rect, AF.AlignCenter, text)
-        # draw a background shadow
-        painter.setPen(pens[0])
-        painter.drawText(trect, 0, text)
         # draw the foreground text
-        painter.setPen(pens[1])
+        painter.setPen(pen)
         painter.drawText(trect.adjusted(1,0,1,0), 0, text)
 
         painter.restore()

--- a/pyqtgraph/widgets/ColorMapButton.py
+++ b/pyqtgraph/widgets/ColorMapButton.py
@@ -80,7 +80,7 @@ class ColorMapDisplayMixin:
         trect = painter.boundingRect(rect, AF.AlignCenter, text)
         # draw the foreground text
         painter.setPen(pen)
-        painter.drawText(trect.adjusted(1,0,1,0), 0, text)
+        painter.drawText(trect, text)
 
         painter.restore()
 


### PR DESCRIPTION
Hello!

If you are interested: some minor modifications to the visibility of the colormap button

* Removed shadow
* Increased threshold slightly. As it is intended to be printed on top of colors, I think the threshold should not be exactly at 0.5.


Some examples after applying the changes:
<img width="312" alt="image" src="https://github.com/user-attachments/assets/5fab2758-4b20-4f33-b088-3db0789726e2">
<img width="312" alt="image" src="https://github.com/user-attachments/assets/c112919d-299f-4fb0-bc69-0c691517a9d2">


And here the same colormap buttons with the old settings:
<img width="312" alt="image" src="https://github.com/user-attachments/assets/be74991c-a5cf-45cf-affa-7845aec9b94e">

<img width="312" alt="image" src="https://github.com/user-attachments/assets/17d33993-ba31-456d-a9ca-e9664b03cb8a">

