### PR TITLE
Fix bug in PlotItem.setAxisItem when called befor scene is set

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -312,7 +312,8 @@ class PlotItem(GraphicsWidget):
                 # Remove old axis
                 oldAxis = self.axes[k]['item']
                 self.layout.removeItem(oldAxis)
-                oldAxis.scene().removeItem(oldAxis)
+                if oldAxis.scene() is not None:
+                    oldAxis.scene().removeItem(oldAxis)
                 oldAxis.unlinkFromView()
             
             # Create new axis


### PR DESCRIPTION
Calling PlotItem.setAxisIten before the Plot is added to a scene will cause an AttributeError exception to be raises.
E.g. in this example. This pullrequest avoids that.

```python
import numpy as np
import pyqtgraph as pg

w = pg.GraphicsLayoutWidget()
x = np.linspace(0, 6, 1000)
y = np.sin(x)
p = pg.PlotItem(x=x, y=y)
p.setAxisItems({'bottom': pg.AxisItem(orientation='bottom', pen='r')})
w.addItem(p)
w.show()

if __name__ == '__main__':
    print(pg.__version__)
    pg.exec()

```