### PR TITLE
REPL fonts should be consistently monospaced

### DIFF
--- a/pyqtgraph/console/repl_widget.py
+++ b/pyqtgraph/console/repl_widget.py
@@ -33,10 +33,12 @@ class ReplWidget(QtWidgets.QWidget):
         outputFirstLineBlockFormat = QtGui.QTextBlockFormat(outputBlockFormat)
         outputFirstLineBlockFormat.setTopMargin(5)
         outputCharFormat = QtGui.QTextCharFormat()
+        outputCharFormat.setFont(self.output.font())
         outputCharFormat.setFontWeight(QtGui.QFont.Weight.Normal)
         cmdBlockFormat = QtGui.QTextBlockFormat()
         cmdBlockFormat.setBackground(mkBrush("#335" if isDark else "#CCF"))
         cmdCharFormat = QtGui.QTextCharFormat()
+        cmdCharFormat.setFont(self.output.font())
         cmdCharFormat.setFontWeight(QtGui.QFont.Weight.Bold)
         self.textStyles = {
             'command': (cmdCharFormat, cmdBlockFormat),
@@ -55,7 +57,7 @@ class ReplWidget(QtWidgets.QWidget):
 
         self.output = QtWidgets.QTextEdit(self)
         font = QtGui.QFont("monospace")
-        font.setStyleHint(QtGui.QFont.StyleHint.TypeWriter, QtGui.QFont.StyleStrategy.PreferAntialias)
+        # font.setStyleHint(QtGui.QFont.StyleHint.TypeWriter, QtGui.QFont.StyleStrategy.PreferAntialias)
         self.output.setFont(font)
         self.output.setReadOnly(True)
         self.layout.addWidget(self.output)
@@ -68,6 +70,7 @@ class ReplWidget(QtWidgets.QWidget):
         self.inputLayout.setContentsMargins(0, 0, 0, 0)
 
         self.input = CmdInput(parent=self)
+        self.input.setFont(font)
         self.inputLayout.addWidget(self.input)
         if self._allowNonGuiExecution:
             self.guiCheckbox = QtWidgets.QCheckBox("Exec in GUI", self)

--- a/pyqtgraph/console/repl_widget.py
+++ b/pyqtgraph/console/repl_widget.py
@@ -57,7 +57,6 @@ class ReplWidget(QtWidgets.QWidget):
 
         self.output = QtWidgets.QTextEdit(self)
         font = QtGui.QFont("monospace")
-        # font.setStyleHint(QtGui.QFont.StyleHint.TypeWriter, QtGui.QFont.StyleStrategy.PreferAntialias)
         self.output.setFont(font)
         self.output.setReadOnly(True)
         self.layout.addWidget(self.output)


### PR DESCRIPTION
Current REPL fonts are not consistent cross-platform and/or between input and output.

These changes make the fonts monospaced cross-platform and consistent between the REPL input and output, at least for windows and macOS.

Thanks, Kevin

 ---
code change comments:

set output char format to self.output.font for consistency 
set input font to be the same as the output font for consistency 
drop "TypeWriter" style hint, it seems to map to "American Typewriter" on macos, which is NOT fixed-width...
