### PR TITLE
Introducing PyQtGraph Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ PyQtGraph
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/pyqtgraph.svg)](https://anaconda.org/conda-forge/pyqtgraph)
 [![Build Status](https://github.com/pyqtgraph/pyqtgraph/workflows/main/badge.svg)](https://github.com/pyqtgraph/pyqtgraph/actions/?query=workflow%3Amain)
 [![Documentation Status](https://readthedocs.org/projects/pyqtgraph/badge/?version=latest)](https://pyqtgraph.readthedocs.io/en/latest/?badge=latest)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20PyQtGraph%20Guru-006BFF)](https://gurubase.io/g/pyqtgraph)
 
 A pure-Python graphics library for PyQt5/PyQt6/PySide2/PySide6
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [PyQtGraph Guru](https://gurubase.io/g/pyqtgraph) to Gurubase. PyQtGraph Guru uses the data from this repo and data from the [docs](https://pyqtgraph.readthedocs.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "PyQtGraph Guru", which highlights that PyQtGraph now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable PyQtGraph Guru in Gurubase, just let me know that's totally fine.
