### PR TITLE
Fix bug causing DateTimeAxis to not display tick labels #3185

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1275,7 +1275,8 @@ class AxisItem(GraphicsWidget):
                 #p.drawText(rect, textFlags, vstr)
 
                 br = self.boundingRect()
-                if not br.contains(rect):
+                # br.contains(rect) suffers from floating point rounding errors
+                if not br & rect == rect:
                     continue
 
                 textSpecs.append((rect, textFlags, vstr))


### PR DESCRIPTION
This pull-request fixes the tick-labels not being displayed part of Issue #3185

I found that the bug in due to a floating point rounding error, which is not being taken into account in the QRectF.contains method. But the equality operator does take floating point rounding into account.

### Demonstration of floating point rounding errer and work-around using ```intersected``` and ```==```
 ```python 
In [41]: QtCore.QRectF(0, -5, 600, 19.77).contains(QtCore.QRectF(300, 2, 30, 12.77))
Out[41]: True
In [42]: QtCore.QRectF(0, -5, 600, 19.775).contains(QtCore.QRectF(300, 2, 30, 12.775))
Out[42]: False
In [46]: QtCore.QRectF(0, -5, 600, 19.775) & QtCore.QRectF(300, 2, 30, 12.775) == QtCore.QRectF(300, 2, 30, 12 .775)
Out[46]: True
```