### PR TITLE
Removes GraphicsScene.mouseMoveEvent duplicate events

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -179,8 +179,7 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
             # Next Deliver our own Hover Events
             self.sendHoverEvents(ev)
             if ev.buttons():
-                # button is pressed' send mouseMoveEvents and mouseDragEvents
-                super().mouseMoveEvent(ev)
+                # button is pressed' send mouseDragEvents
                 if self.mouseGrabberItem() is None:
                     now = perf_counter()
                     init = False


### PR DESCRIPTION
This PR removes the duplicate calls to base class implementation of `mouseMoveEvent` in `GraphicsScene.mouseMoveEvent` method as per https://github.com/pyqtgraph/pyqtgraph/issues/3011.