### PR TITLE
assume matplotlib supports Qt6

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,8 @@ faulthandler_timeout = 60
 qt_log_level_fail = WARNING
 qt_log_ignore =
     QXcbConnection: XCB error
+    # ignore PySide6 warnings in Matplotlib < 3.10.1
+    Registering dynamic slot.*FigureCanvasQTAgg
 markers =
     qt_log_ignore: fallback if pytest-qt is not installed
     qt_no_exception_capture: fallback if pytest-qt is not installed

--- a/tests/exporters/test_matplotlib.py
+++ b/tests/exporters/test_matplotlib.py
@@ -6,20 +6,10 @@ import pyqtgraph as pg
 from pyqtgraph.exporters import MatplotlibExporter
 
 pytest.importorskip("matplotlib")
-import matplotlib
 from packaging.version import Version, parse
 
 
 app = pg.mkQApp()
-
-skip_qt6 = pytest.mark.skipif(
-    # availability of QtAgg signifies Qt6 support
-    pg.Qt.QT_LIB in ["PySide6", "PyQt6"] and "QtAgg" not in matplotlib.rcsetup.interactive_bk,
-    reason= (
-        "installed version of Matplotlib does not support Qt6, "
-        "see https://github.com/matplotlib/matplotlib/pull/19255"
-    )
-)
 
 # see https://github.com/matplotlib/matplotlib/pull/24172
 if (
@@ -33,7 +23,6 @@ if (
     )
 
 
-@skip_qt6
 def test_MatplotlibExporter():
     plt = pg.PlotWidget()
     plt.show()
@@ -48,7 +37,6 @@ def test_MatplotlibExporter():
     exp = MatplotlibExporter(plt.getPlotItem())
     exp.export()
 
-@skip_qt6
 def test_MatplotlibExporter_nonplotitem():
     # attempting to export something other than a PlotItem raises an exception
     plt = pg.PlotWidget()
@@ -58,7 +46,6 @@ def test_MatplotlibExporter_nonplotitem():
     with pytest.raises(Exception):
         exp.export()
 
-@skip_qt6
 @pytest.mark.parametrize('scale', [1e10, 1e-9])
 def test_MatplotlibExporter_siscale(scale):
     # coarse test to verify that plot data is scaled before export when


### PR DESCRIPTION
Since https://github.com/matplotlib/matplotlib/pull/27948, pyqtgraph's test suite has been skipping matplotlib tests on Qt6.

As pyqtgraph had added support for Qt6 earlier than matplotlib, pyqtgraph's CI would skip matplotlib tests if it was determined that the installed version of matplotlib did not support Qt6. This was done by testing for the presence of the backend "QtAgg" in matplotlib.

Since https://github.com/matplotlib/matplotlib/pull/27948, matplotlib backend names have been changed to lower-case and this results in "QtAgg" not being a match.

In addition, pyqtgraph's method of detection was also deprecated, resulting in the following warning:
```
  C:\work\repos\pyqtgraph\tests\exporters\test_matplotlib.py:17: MatplotlibDeprecationWarning: The interactive_bk attribute was deprecated in Matplotlib 3.9 and will be removed in 3.11. Use ``matplotlib.backends.backend_registry.list_builtin(matplotlib.backends.BackendFilter.INTERACTIVE)`` instead.
    pg.Qt.QT_LIB in ["PySide6", "PyQt6"] and "QtAgg" not in matplotlib.rcsetup.interactive_bk,
```

This PR fixes the above-mentioned issues by removing the conditional testing and simply assuming that matplotlib supports Qt6.