### PR TITLE
use native c++ construction of QPixmap from QImage

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -327,7 +327,7 @@ class SymbolAtlas(object):
         else:
             img = fn.ndarray_to_qimage(self._data,
                 QtGui.QImage.Format.Format_ARGB32_Premultiplied)
-            pm = QtGui.QPixmap(img)
+            pm = QtGui.QPixmap.fromImage(img)
         return pm
 
 


### PR DESCRIPTION
There is one instance in the pyqtgraph library where a `QPixmap` is created from a `QImage` via `QPixmap`'s "constructor".
Except that C++ Qt doesn't have such a constructor. Some digging shows that this "constructor" is actually an emulation by the various Python Qt bindings. This emulation can be measured to be very slightly slower than calling the official conversion API: `QPixmap::fromImage`

```python
from time import perf_counter
from PySide6 import QtCore, QtGui

app = QtGui.QGuiApplication([])

qimg = QtGui.QImage(100, 100, QtGui.QImage.Format.Format_ARGB32_Premultiplied)
qimg.fill(QtCore.Qt.GlobalColor.transparent)

niters = 10_000

t0 = perf_counter()
for _ in range(niters):
    px = QtGui.QPixmap(qimg)
t1 = perf_counter()
print(t1 - t0)

t0 = perf_counter()
for _ in range(niters):
    px = QtGui.QPixmap.fromImage(qimg)
t1 = perf_counter()
print(t1 - t0)
```

On PySide6:
```
0.016223200000240467
0.011742000000594999
```

On PyQt6
```
0.022723099999893748
0.007624599999871862
```
