### PR TITLE
fixed the dark shading issue with changing the light source position

### DIFF
--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -227,7 +227,7 @@ def initShaders():
                 varying vec4 v_color;
                 varying vec3 normal;
                 void main() {
-                    float p = dot(normal, normalize(vec3(1.0, -1.0, -1.0)));
+                    float p = dot(normal, normalize(vec3(1.0, 1.0, 1.0)));
                     p = p < 0. ? 0. : p * 0.8;
                     vec4 color = v_color;
                     color.x = color.x * (0.2 + p);


### PR DESCRIPTION
# Issue:
The light source position for the fragment shading is providing a dark shading of meshed STL files when we are using 'shaded' shading program.

A detail description of issue is providing below:
[Setting a better light source position for Pyqtgraph: GLMeshItem shaderProgram called 'shaded' #3212](https://github.com/pyqtgraph/pyqtgraph/issues/3212)

## Changes:

### Fix:
In the opengl ShaderProgram 'shaded'. The fragment shading normalized vector from where the light source is reflected should be x,y,z: (1,1,1) for a bright shading of the STL mesh. 

### current problem:
Instead currently the normalized vector which is emitting light is in the position of x,y,z (1,-1,-1) which makes the light source coming from below and making things look like a dark shading as below image:
![image](https://github.com/user-attachments/assets/879ef8c3-66d3-4b3b-ae6a-340876c7c8cb)

## Result after fixing:
The red axis is X, Green axis is Y and Blue axis is Z. Once I have changed the normalized vector of shaded fragmnetshader to x,y,z: (1,1,1). The light source seems to emit from a croner as you see below and provides you a better shadded look than having a dark shaded mesh.
![image](https://github.com/user-attachments/assets/80eeb7fb-44c4-41b7-9368-1962a05edecd)

## Tested environment(s)
 * PyQtGraph version: pyqtgraph-0.13.7 
 * Qt Python binding: PyQT5
 * Python version: 3.10.12
 * NumPy version: 1.26.4
 * Operating system: Ubuntu 22.0.04

## Future References:
Thank you Author for PyQTgraph library and I am very happy to be a contributor. I work in computer graphics domain. In future I will keep contributing to your Pyqtgraph community and library for custom light source positioning and better shading programs.  
