### PR TITLE
fixed the issue where x and y column would be added regardless of the columnMode while exporting to csv

### DIFF
--- a/pyqtgraph/exporters/CSVExporter.py
+++ b/pyqtgraph/exporters/CSVExporter.py
@@ -75,7 +75,6 @@ class CSVExporter(Exporter):
         if cd[0] is None:
             # no data found, break out...
             return None
-        self.data.append(cd)
 
         index = next(self.index_counter)
         if plotDataItem.name() is not None:
@@ -88,8 +87,10 @@ class CSVExporter(Exporter):
         appendAllX = self.params['columnMode'] == '(x,y) per plot'
         if appendAllX or index == 0:
             self.header.extend([xName, yName])
+            self.data.append(cd)
         else:
             self.header.extend([yName])
+            self.data.append([cd[1]])
         return None
 
     def export(self, fileName=None):


### PR DESCRIPTION
## Issue

fixed the issue where x and y column would be added regardless of the columnMode while exporting to csv.

Basically fixes #2747.

### Tested environment(s)
PyQtGraph version: pyqtgraph-0.13.7
Qt Python binding: PyQT6
Python version: 3.12.7
NumPy version: 2.1.2
Operating system: Windows 11

