### PR TITLE
GLLinePlotItem: restore changes to state

### DIFF
--- a/pyqtgraph/opengl/MeshData.py
+++ b/pyqtgraph/opengl/MeshData.py
@@ -99,10 +99,10 @@ class MeshData(object):
         return self._edges
         
     def setFaces(self, faces):
-        """Set the (Nf, 3) array of faces. Each rown in the array contains
+        """Set the (Nf, 3) array of faces. Each row in the array contains
         three indexes into the vertex array, specifying the three corners 
         of a triangular face."""
-        self._faces = faces
+        self._faces = np.ascontiguousarray(faces, dtype=np.uint32)
         self._edges = None
         self._vertexFaces = None
         self._vertexesIndexedByFaces = None

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -129,7 +129,9 @@ class GLLinePlotItem(GLGraphicsItem):
 
         glLineWidth(self.width)
 
-        if self.antialias and not context.isOpenGLES():
+        enable_aa = self.antialias and not context.isOpenGLES()
+
+        if enable_aa:
             glEnable(GL_LINE_SMOOTH)
             glEnable(GL_BLEND)
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
@@ -148,6 +150,9 @@ class GLLinePlotItem(GLGraphicsItem):
 
         for loc in enabled_locs:
             glDisableVertexAttribArray(loc)
- 
-    
+
+        if enable_aa:
+            glDisable(GL_LINE_SMOOTH)
+            glDisable(GL_BLEND)
         
+        glLineWidth(1.0)


### PR DESCRIPTION
Issue: when running the `GLMeshItem` example, the line edges and wireframe can be seen to be thicker than before (e.g. 0.13.7)

Reason:
Drawing the grid enables anti-aliasing which is not disabled after. Thus when drawing the edges of the meshes, anti-aliasing is also enabled, where previously it was not.

For compatibility with OpenGL ES and also Core profile, ecab72bc257686fdb2b1a3d8d4083b9e5f525869 removed calls to `glPushAttrib` and `glPopAttrib`. Those calls wrapped around the rendering of each `GLGraphicsItem`, effectively allowing each item to make changes to the global OpenGL state without restoring them.

Fix:
Restore the global state to their initial defaults in `GLLinePlotItem`.