### PR TITLE
GraphicsLayout: Fix removeItem() regression

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsLayout.py
+++ b/pyqtgraph/graphicsItems/GraphicsLayout.py
@@ -182,10 +182,6 @@ class GraphicsLayout(GraphicsWidget):
         # Clear the row and column where the item was
         for r, c in self.items[item]:
             del self.rows[r][c]
-            
-            # Adjust the layout by updating row/column stretch factors
-            self.layout.setRowStretchFactor(r, 0)
-            self.layout.setColumnStretchFactor(c, 0)
         
         # Clean up the references to the removed item
         del self.items[item]


### PR DESCRIPTION
This fixes a regression introduced in
54efcbd2398c0f39a11ec1d14fe8f7f3f3a6b901, where the stretch factors for the row/column previously containing a removed item were zeroed. In general, this is of course incorrect, as there will be other items sharing the same row/column that should not be disturbed. The intention behind that part of the change is not clear to me; this commit simply reverts it.

Fixes #3195.