### PR TITLE
Fix libegl1 not found

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
             libxkbcommon-x11-0 \
             x11-utils \
             libyaml-dev \
-            libegl1-mesa \
+            libegl1 \
             libxcb-icccm4 \
             libxcb-image0 \
             libxcb-keysyms1 \
@@ -202,7 +202,7 @@ jobs:
             libxkbcommon-x11-0 \
             x11-utils \
             libyaml-dev \
-            libegl1-mesa \
+            libegl1 \
             libxcb-icccm4 \
             libxcb-image0 \
             libxcb-keysyms1 \


### PR DESCRIPTION
Also address a conda warning by explicitly removing the `defaults` channel.