### PR TITLE
GLMeshItem: allow ubyte color buffers

### DIFF
--- a/pyqtgraph/opengl/MeshData.py
+++ b/pyqtgraph/opengl/MeshData.py
@@ -224,7 +224,15 @@ class MeshData(object):
             return self._vertexNormals[self.faces()]
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
-        
+
+    @staticmethod
+    def _ensure_colors_dtype(colors):
+        if isinstance(colors, np.ndarray) and colors.dtype == np.uint8:
+            dtype = np.uint8
+        else:
+            dtype = np.float32
+        return np.ascontiguousarray(colors, dtype=dtype)
+
     def vertexColors(self, indexed=None):
         """
         Return an array (Nv, 4) of vertex colors.
@@ -246,12 +254,13 @@ class MeshData(object):
         If indexed=='faces', then the array will be interpreted
         as indexed and should have shape (Nf, 3, 4)
         """
+        colors = self._ensure_colors_dtype(colors)
         if indexed is None:
-            self._vertexColors = np.ascontiguousarray(colors, dtype=np.float32)
+            self._vertexColors = colors
             self._vertexColorsIndexedByFaces = None
         elif indexed == 'faces':
             self._vertexColors = None
-            self._vertexColorsIndexedByFaces = np.ascontiguousarray(colors, dtype=np.float32)
+            self._vertexColorsIndexedByFaces = colors
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
         
@@ -279,12 +288,13 @@ class MeshData(object):
         If indexed=='faces', then the array will be interpreted
         as indexed and should have shape (Nf, 3, 4)
         """
+        colors = self._ensure_colors_dtype(colors)
         if indexed is None:
-            self._faceColors = np.ascontiguousarray(colors, dtype=np.float32)
+            self._faceColors = colors
             self._faceColorsIndexedByFaces = None
         elif indexed == 'faces':
             self._faceColors = None
-            self._faceColorsIndexedByFaces = np.ascontiguousarray(colors, dtype=np.float32)
+            self._faceColorsIndexedByFaces = colors
         else:
             raise Exception("Invalid indexing mode. Accepts: None, 'faces'")
         

--- a/pyqtgraph/opengl/items/GLMeshItem.py
+++ b/pyqtgraph/opengl/items/GLMeshItem.py
@@ -238,7 +238,10 @@ class GLMeshItem(GLGraphicsItem):
                     glVertexAttrib4f(loc, *color)
                 else:
                     self.m_vbo_color.bind()
-                    glVertexAttribPointer(loc, 4, GL_FLOAT, False, 0, None)
+                    if self.colors.dtype == np.uint8:
+                        glVertexAttribPointer(loc, 4, GL_UNSIGNED_BYTE, True, 0, None)
+                    else:
+                        glVertexAttribPointer(loc, 4, GL_FLOAT, False, 0, None)
                     self.m_vbo_color.release()
                     enabled_locs.append(loc)
 


### PR DESCRIPTION
When specifying colors for a large number of vertices, keeping colors as `float32` (16-bytes) instead of `uint8` (4-bytes) can be wasteful in memory and bandwidth.

Furthermore, `trimesh` colors are retrieved as `uint8`, which then requires conversion before being able to be used in `pyqtgraph`. (See the example in #3230)

`MeshData` doesn't do any computation on the colors besides indexing and reshaping. i.e. it is actually agnostic to the dtype.
`GLMeshItem` only needs to tell OpenGL whether the VBO is float32 or uint8. 