### PR TITLE
shaded shader: allow setting light direction

### DIFF
--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -144,16 +144,18 @@ def initShaders():
                 #ifdef GL_ES
                 precision mediump float;
                 #endif
+                uniform float lightDirection[3];
                 varying vec4 v_color;
                 varying vec3 v_normal;
                 void main() {
-                    float p = dot(v_normal, normalize(vec3(1.0, -1.0, -1.0)));
+                    vec3 dirn = vec3(lightDirection[0], lightDirection[1], lightDirection[2]);
+                    float p = dot(v_normal, normalize(dirn));
                     p = p < 0. ? 0. : p * 0.8;
                     vec3 rgb = v_color.rgb * (0.2 + p);
                     gl_FragColor = vec4(rgb, v_color.a);
                 }
             """)
-        ]),
+        ], uniforms={'lightDirection': [1.0, -1.0, -1.0]}),
         
         ## colors get brighter near edges of object
         ShaderProgram('edgeHilight', [   


### PR DESCRIPTION
The `shaded` shader has a hardcoded light direction of `[1.0, -1.0, -1.0]`. This value is coupled with the faces that the library generates. For meshes loaded from external mesh files, the hardcoded value gives a dark look. (See the various screenshots in #3213) 

Exposing the light direction as a configurable uniform allows the previously hardcoded value to be overridden while maintaining existing library compatibility.

fixes #3212 
overrides #3213

Example usage:
```python
import pyqtgraph as pg
import pyqtgraph.opengl as gl
import trimesh

pg.mkQApp()

win = gl.GLViewWidget(rotationMethod='quaternion')
win.show()

shader = gl.shaders.getShaderProgram('shaded')

# note that uniform data is global to all objects using the same shader.
# this is a limitation of pyqtgraph.

# comment the following line to use default of [1, -1, -1]
shader.setUniformData('lightDirection', [-1, 1, 1])

# the two spheres drawn below will appear to have different lighting
# due to their difference in face directions

# pyqtgraph sphere (red)
md1 = gl.MeshData.sphere(rows=19, cols=36)
mi1 = gl.GLMeshItem(meshdata=md1, shader=shader, color=(1.0, 0.0, 0.0, 1.0))
mi1.translate(-2, 0, 0)
win.addItem(mi1)

# trimesh sphere (green)
s2 = trimesh.primitives.Sphere()
md2 = gl.MeshData(vertexes=s2.vertices, faces=s2.faces)
mi2 = gl.GLMeshItem(meshdata=md2, shader=shader, color=(0.0, 1.0, 0.0, 1.0))
mi2.translate(2, 0, 0)
win.addItem(mi2)

pg.exec()
```