### PR TITLE
fix GLIsosurface overflow warning on numpy 2

### DIFF
--- a/pyqtgraph/examples/GLIsosurface.py
+++ b/pyqtgraph/examples/GLIsosurface.py
@@ -38,12 +38,11 @@ data = np.abs(np.fromfunction(psi, (50,50,100)))
 print("Generating isosurface..")
 verts, faces = pg.isosurface(data, data.max()/4.)
 
-md = gl.MeshData(vertexes=verts, faces=faces)
-
-colors = np.ones((md.faceCount(), 4), dtype=np.float32)
+colors = np.ones((len(verts), 4), dtype=np.float32)
 colors[:,3] = 0.2
 colors[:,2] = np.linspace(0, 1, colors.shape[0])
-md.setFaceColors(colors)
+md = gl.MeshData(vertexes=verts, faces=faces, vertexColors=colors)
+
 m1 = gl.GLMeshItem(meshdata=md, smooth=False, shader='balloon')
 m1.setGLOptions('additive')
 

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -2833,7 +2833,7 @@ def isosurface(data, level):
     cutEdges = np.zeros([x+1 for x in index.shape]+[3], dtype=np.uint32)
     edges = edgeTable[index]
     for i, shift in enumerate(edgeShifts[:12]):        
-        slices = [slice(shift[j],cutEdges.shape[j]+(shift[j]-1)) for j in range(3)]
+        slices = [slice(int(shift[j]),cutEdges.shape[j]+(int(shift[j])-1)) for j in range(3)]
         cutEdges[slices[0], slices[1], slices[2], shift[3]] += edges & 2**i
     
     ## for each cut edge, interpolate to see where exactly the edge is cut and generate vertex positions


### PR DESCRIPTION
`pg.isosurface()` relies on NumPy < 2.0 promotion behavior.
An overflow warning occurs on NumPy >= 2.0.
Fix by explicitly promoting to an `int`.

```python
In [1]: import numpy as np
In [2]: val = np.arange(10, dtype=np.uint16)[0] - 1
In [3]: val, val.dtype
Out[3]: (-1, dtype('int32'))
In [4]: np.__version__
Out[4]: '1.26.4'
```

```python
In [1]: import numpy as np
In [2]: val = np.arange(10, dtype=np.uint16)[0] - 1
<ipython-input-2-04d47eed1b3c>:1: RuntimeWarning: overflow encountered in scalar subtract
  val = np.arange(10, dtype=np.uint16)[0] - 1
In [3]: val, val.dtype
Out[3]: (np.uint16(65535), dtype('uint16'))
In [4]: np.__version__
Out[4]: '2.2.1'
```