### PR TITLE
Use filtfilt for bidirectional filtering

### DIFF
--- a/pyqtgraph/flowchart/library/functions.py
+++ b/pyqtgraph/flowchart/library/functions.py
@@ -39,7 +39,7 @@ def applyFilter(data, b, a, padding=100, bidir=True):
         d1 = np.hstack([d1[:padding], d1, d1[-padding:]])
     
     if bidir:
-        d1 = scipy.signal.lfilter(b, a, scipy.signal.lfilter(b, a, d1)[::-1])[::-1]
+        d1 = scipy.signal.filtfilt(b, a, d1)
     else:
         d1 = scipy.signal.lfilter(b, a, d1)
     


### PR DESCRIPTION
using filtfilt instead of two interleaved lfilter calls to scipy.signal is more elegant and easier to understand. we want to make use of this functionality