### PR TITLE
calculate distance to camera the OpenGL way

### DIFF
--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -95,10 +95,10 @@ class GLScatterPlotItem(GLGraphicsItem):
         mat_mvp = self.mvpMatrix()
         mat_mvp = np.array(mat_mvp.data(), dtype=np.float32)
 
-        if not (view := self.view()):
-            view = self.parentItem().view()
-        mat_viewTransform = np.array(self.viewTransform().data(), dtype=np.float32)
-        vec_cameraPosition = list(view.cameraPosition())
+        mat_modelview = self.modelViewMatrix()
+        mat_modelview = np.array(mat_modelview.data(), dtype=np.float32)
+
+        view = self.view()
         if self.pxMode:
             scale = 0
         else:
@@ -159,8 +159,7 @@ class GLScatterPlotItem(GLGraphicsItem):
         with shader:
             glUniformMatrix4fv(shader.uniform("u_mvp"), 1, False, mat_mvp)
 
-            glUniformMatrix4fv(shader.uniform("u_viewTransform"), 1, False, mat_viewTransform)
-            glUniform3f(shader.uniform("u_cameraPosition"), *vec_cameraPosition)
+            glUniformMatrix4fv(shader.uniform("u_modelview"), 1, False, mat_modelview)
             glUniform1f(shader.uniform("u_scale"), scale)
 
             glDrawArrays(GL_POINTS, 0, len(self.pos))

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -16,10 +16,8 @@ import re
 ##
 ##
 POINT_SPRITE_VERT_SRC = """
-    uniform mat4 u_viewTransform;
-    uniform vec3 u_cameraPosition;
     uniform float u_scale;
-
+    uniform mat4 u_modelview;
     uniform mat4 u_mvp;
     attribute vec4 a_position;
     attribute vec4 a_color;
@@ -33,8 +31,10 @@ POINT_SPRITE_VERT_SRC = """
 
         if (u_scale != 0.0) {
             // pxMode=False
-            vec4 gpos = u_viewTransform * a_position;
-            float dist = distance(u_cameraPosition, gpos.xyz);
+            // the modelview matrix transforms the vertex to
+            // camera space, where the camera is at (0, 0, 0).
+            vec4 cpos = u_modelview * a_position;
+            float dist = length(cpos.xyz);
             // equations:
             //   xDist = dist * 2.0 * tan(0.5 * fov)
             //   pxSize = xDist / view_width


### PR DESCRIPTION
The current ModelView matrix already encodes both the camera position and the view transforms.
It transforms a vertex to camera space, with the camera residing at the origin.

The distance from the vertex to the camera can thus be computed with the ModelView matrix instead of the camera position and the transform matrices.
This is a more OpenGL-nic way compared to the previous straight cpu-code translation.
