### PR TITLE
create a default VAO if using Core profile

### DIFF
--- a/pyqtgraph/examples/GLGraphItem.py
+++ b/pyqtgraph/examples/GLGraphItem.py
@@ -2,10 +2,20 @@
 Demonstrates use of GLGraphItem
 """
 
+import sys
+
 import numpy as np
 
 import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
 import pyqtgraph.opengl as gl
+
+if 'darwin' in sys.platform:
+    fmt = QtGui.QSurfaceFormat()
+    fmt.setRenderableType(fmt.RenderableType.OpenGL)
+    fmt.setProfile(fmt.OpenGLContextProfile.CoreProfile)
+    fmt.setVersion(4, 1)
+    QtGui.QSurfaceFormat.setDefaultFormat(fmt)
 
 app = pg.mkQApp("GLGraphItem Example")
 w = gl.GLViewWidget()

--- a/pyqtgraph/examples/GLImageItem.py
+++ b/pyqtgraph/examples/GLImageItem.py
@@ -4,11 +4,20 @@ Use GLImageItem to display image data on rectangular planes.
 In this example, the image data is sampled from a volume and the image planes 
 placed as if they slice through the volume.
 """
+import sys
 
 import numpy as np
 
 import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
 import pyqtgraph.opengl as gl
+
+if 'darwin' in sys.platform:
+    fmt = QtGui.QSurfaceFormat()
+    fmt.setRenderableType(fmt.RenderableType.OpenGL)
+    fmt.setProfile(fmt.OpenGLContextProfile.CoreProfile)
+    fmt.setVersion(4, 1)
+    QtGui.QSurfaceFormat.setDefaultFormat(fmt)
 
 app = pg.mkQApp("GLImageItem Example")
 w = gl.GLViewWidget()

--- a/pyqtgraph/examples/GLLinePlotItem.py
+++ b/pyqtgraph/examples/GLLinePlotItem.py
@@ -1,11 +1,20 @@
 """
 Demonstrate use of GLLinePlotItem to draw cross-sections of a surface.
 """
+import sys
 
 import numpy as np
 
 import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
 import pyqtgraph.opengl as gl
+
+if 'darwin' in sys.platform:
+    fmt = QtGui.QSurfaceFormat()
+    fmt.setRenderableType(fmt.RenderableType.OpenGL)
+    fmt.setProfile(fmt.OpenGLContextProfile.CoreProfile)
+    fmt.setVersion(4, 1)
+    QtGui.QSurfaceFormat.setDefaultFormat(fmt)
 
 app = pg.mkQApp("GLLinePlotItem Example")
 w = gl.GLViewWidget()

--- a/pyqtgraph/examples/GLScatterPlotItem.py
+++ b/pyqtgraph/examples/GLScatterPlotItem.py
@@ -1,13 +1,22 @@
 """
 Demonstrates use of GLScatterPlotItem with rapidly-updating plots.
 """
+import sys
 
 import numpy as np
 
 import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
 import pyqtgraph.opengl as gl
 from pyqtgraph import functions as fn
 from pyqtgraph.Qt import QtCore
+
+if 'darwin' in sys.platform:
+    fmt = QtGui.QSurfaceFormat()
+    fmt.setRenderableType(fmt.RenderableType.OpenGL)
+    fmt.setProfile(fmt.OpenGLContextProfile.CoreProfile)
+    fmt.setVersion(4, 1)
+    QtGui.QSurfaceFormat.setDefaultFormat(fmt)
 
 app = pg.mkQApp("GLScatterPlotItem Example")
 w = gl.GLViewWidget()

--- a/pyqtgraph/examples/GLVolumeItem.py
+++ b/pyqtgraph/examples/GLVolumeItem.py
@@ -1,12 +1,21 @@
 """
 Demonstrates GLVolumeItem for displaying volumetric data.
 """
+import sys
 
 import numpy as np
 
 import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
 import pyqtgraph.opengl as gl
 from pyqtgraph import functions as fn
+
+if 'darwin' in sys.platform:
+    fmt = QtGui.QSurfaceFormat()
+    fmt.setRenderableType(fmt.RenderableType.OpenGL)
+    fmt.setProfile(fmt.OpenGLContextProfile.CoreProfile)
+    fmt.setVersion(4, 1)
+    QtGui.QSurfaceFormat.setDefaultFormat(fmt)
 
 app = pg.mkQApp("GLVolumeItem Example")
 w = gl.GLViewWidget()

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -1,4 +1,3 @@
-from OpenGL.GL import *  # noqa
 from OpenGL import GL
 
 from .. import Transform3D
@@ -6,21 +5,21 @@ from ..Qt import QtCore, QtGui
 
 GLOptions = {
     'opaque': {
-        GL_DEPTH_TEST: True,
-        GL_BLEND: False,
-        GL_CULL_FACE: False,
+        GL.GL_DEPTH_TEST: True,
+        GL.GL_BLEND: False,
+        GL.GL_CULL_FACE: False,
     },
     'translucent': {
-        GL_DEPTH_TEST: True,
-        GL_BLEND: True,
-        GL_CULL_FACE: False,
-        'glBlendFunc': (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA),
+        GL.GL_DEPTH_TEST: True,
+        GL.GL_BLEND: True,
+        GL.GL_CULL_FACE: False,
+        'glBlendFunc': (GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA),
     },
     'additive': {
-        GL_DEPTH_TEST: False,
-        GL_BLEND: True,
-        GL_CULL_FACE: False,
-        'glBlendFunc': (GL_SRC_ALPHA, GL_ONE),
+        GL.GL_DEPTH_TEST: False,
+        GL.GL_BLEND: True,
+        GL.GL_CULL_FACE: False,
+        'glBlendFunc': (GL.GL_SRC_ALPHA, GL.GL_ONE),
     },
 }    
 
@@ -256,9 +255,9 @@ class GLGraphicsItem(QtCore.QObject):
                 func(*v)
             else:
                 if v is True:
-                    glEnable(k)
+                    GL.glEnable(k)
                 else:
-                    glDisable(k)
+                    GL.glDisable(k)
     
     def paint(self):
         """

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -114,10 +114,10 @@ class GLViewMixin:
                 RuntimeWarning,
                 stacklevel=2
             )
-        if fmt.version() < (2, 0):
+        elif fmt.version() < (2, 1):
             verString = GL.glGetString(GL.GL_VERSION)
             raise RuntimeError(
-                "pyqtgraph.opengl: Requires >= OpenGL 2.0; Found %s" % verString
+                "pyqtgraph.opengl: Requires >= OpenGL 2.1; Found %s" % verString
             )
 
         # Core profile requires a non-default VAO

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -1,8 +1,8 @@
-from OpenGL.GL import *  # noqa
 from math import cos, radians, sin, tan
 import importlib
 import warnings
 
+from OpenGL import GL
 import numpy as np
 
 from .. import Vector
@@ -115,7 +115,7 @@ class GLViewMixin:
                 stacklevel=2
             )
         if fmt.version() < (2, 0):
-            verString = glGetString(GL_VERSION)
+            verString = GL.glGetString(GL.GL_VERSION)
             raise RuntimeError(
                 "pyqtgraph.opengl: Requires >= OpenGL 2.0; Found %s" % verString
             )
@@ -199,16 +199,16 @@ class GLViewMixin:
         viewport = self.getViewport()
         
         #buf = np.zeros(100000, dtype=np.uint)
-        buf = glSelectBuffer(100000)
+        buf = GL.glSelectBuffer(100000)
         try:
-            glRenderMode(GL_SELECT)
-            glInitNames()
-            glPushName(0)
+            GL.glRenderMode(GL.GL_SELECT)
+            GL.glInitNames()
+            GL.glPushName(0)
             self._itemNames = {}
             self.paint(region=region, viewport=viewport, useItemNames=True)
             
         finally:
-            hits = glRenderMode(GL_RENDER)
+            hits = GL.glRenderMode(GL.GL_RENDER)
             
         items = [(h.near, h.names[0]) for h in hits]
         items.sort(key=lambda i: i[0])
@@ -228,8 +228,8 @@ class GLViewMixin:
         self.setProjection(region, viewport)
         self.setModelview()
         bgcolor = self.opts['bgcolor']
-        glClearColor(*bgcolor)
-        glClear( GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT )
+        GL.glClearColor(*bgcolor)
+        GL.glClear( GL.GL_DEPTH_BUFFER_BIT | GL.GL_COLOR_BUFFER_BIT )
         self.drawItemTree(useItemNames=useItemNames)
         
     def drawItemTree(self, item=None, useItemNames=False):
@@ -245,7 +245,7 @@ class GLViewMixin:
             if i is item:
                 try:
                     if useItemNames:
-                        glLoadName(i._id)
+                        GL.glLoadName(i._id)
                         self._itemNames[i._id] = i
 
                     # The GLGraphicsItem(s) making use of QPainter end
@@ -507,7 +507,7 @@ class GLViewMixin:
         """
         return self.grabFramebuffer()
         
-    def renderToArray(self, size, format=GL_BGRA, type=GL_UNSIGNED_BYTE, textureSize=1024, padding=256):
+    def renderToArray(self, size, format=GL.GL_BGRA, type=GL.GL_UNSIGNED_BYTE, textureSize=1024, padding=256):
         w,h = map(int, size)
         
         self.makeCurrent()
@@ -516,7 +516,7 @@ class GLViewMixin:
 
         fbo = QtOpenGL.QOpenGLFramebufferObject(texwidth, texwidth,
                     QtOpenGL.QOpenGLFramebufferObject.Attachment.CombinedDepthStencil,
-                    GL_TEXTURE_2D)
+                    GL.GL_TEXTURE_2D)
 
         output = np.empty((h, w, 4), dtype=np.ubyte)
         data = np.empty((texwidth, texwidth, 4), dtype=np.ubyte)
@@ -531,11 +531,11 @@ class GLViewMixin:
                     h2 = y2-y
                     
                     fbo.bind()
-                    glViewport(0, 0, w2, h2)
+                    GL.glViewport(0, 0, w2, h2)
                     self.paint(region=(x, h-y-h2, w2, h2), viewport=(0, 0, w, h))  # only render sub-region
                     
                     fbo.bind()
-                    glReadPixels(0, 0, texwidth, texwidth, format, type, data)
+                    GL.glReadPixels(0, 0, texwidth, texwidth, format, type, data)
                     data_yflip = data[::-1, ...]
                     output[y+padding:y2-padding, x+padding:x2-padding] = data_yflip[-(h2-padding):-padding, padding:w2-padding]
                     

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -1,11 +1,11 @@
 import importlib
 
-from OpenGL.GL import *  # noqa
+from OpenGL import GL
+from OpenGL.GL import shaders
 import numpy as np
 
 from ...Qt import QtGui, QT_LIB
 from ... import functions as fn
-from .. import shaders
 from ..GLGraphicsItem import GLGraphicsItem
 
 if QT_LIB in ["PyQt5", "PySide2"]:
@@ -17,7 +17,9 @@ __all__ = ['GLLinePlotItem']
 
 class GLLinePlotItem(GLGraphicsItem):
     """Draws line plots in 3D."""
-    
+
+    _shaderProgram = None
+
     def __init__(self, parentItem=None, **kwds):
         """All keyword arguments are passed to setData()"""
         super().__init__()
@@ -88,6 +90,42 @@ class GLLinePlotItem(GLGraphicsItem):
         vbo.allocate(arr, arr.nbytes)
         vbo.release()
 
+    @staticmethod
+    def getShaderProgram():
+        klass = GLLinePlotItem
+
+        if klass._shaderProgram is not None:
+            return klass._shaderProgram
+
+        ctx = QtGui.QOpenGLContext.currentContext()
+        fmt = ctx.format()
+
+        if ctx.isOpenGLES():
+            if fmt.version() >= (3, 0):
+                glsl_version = "#version 300 es\n"
+                sources = SHADER_CORE
+            else:
+                glsl_version = ""
+                sources = SHADER_LEGACY
+        else:
+            if fmt.version() >= (3, 1):
+                glsl_version = "#version 140\n"
+                sources = SHADER_CORE
+            else:
+                glsl_version = ""
+                sources = SHADER_LEGACY
+
+        compiled = [shaders.compileShader([glsl_version, v], k) for k, v in sources.items()]
+        program = shaders.compileProgram(*compiled)
+
+        # bind generic vertex attrib 0 to "a_position" so that
+        # vertex attrib 0 definitely gets enabled later.
+        GL.glBindAttribLocation(program, 0, "a_position")
+        GL.glLinkProgram(program)
+
+        klass._shaderProgram = program
+        return program
+
     def paint(self):
         if self.pos is None:
             return
@@ -103,20 +141,20 @@ class GLLinePlotItem(GLGraphicsItem):
             if isinstance(self.color, np.ndarray):
                 self.upload_vbo(self.m_vbo_color, self.color)
 
-        shader = shaders.getShaderProgram(None)
+        program = self.getShaderProgram()
 
         enabled_locs = []
 
-        if (loc := glGetAttribLocation(shader.program(), "a_position")) != -1:
+        if (loc := GL.glGetAttribLocation(program, "a_position")) != -1:
             self.m_vbo_position.bind()
-            glVertexAttribPointer(loc, 3, GL_FLOAT, False, 0, None)
+            GL.glVertexAttribPointer(loc, 3, GL.GL_FLOAT, False, 0, None)
             self.m_vbo_position.release()
             enabled_locs.append(loc)
 
-        if (loc := glGetAttribLocation(shader.program(), "a_color")) != -1:
+        if (loc := GL.glGetAttribLocation(program, "a_color")) != -1:
             if isinstance(self.color, np.ndarray):
                 self.m_vbo_color.bind()
-                glVertexAttribPointer(loc, 4, GL_FLOAT, False, 0, None)
+                GL.glVertexAttribPointer(loc, 4, GL.GL_FLOAT, False, 0, None)
                 self.m_vbo_color.release()
                 enabled_locs.append(loc)
             else:
@@ -125,34 +163,88 @@ class GLLinePlotItem(GLGraphicsItem):
                     color = fn.mkColor(color)
                 if isinstance(color, QtGui.QColor):
                     color = color.getRgbF()
-                glVertexAttrib4f(loc, *color)
-
-        glLineWidth(self.width)
+                GL.glVertexAttrib4f(loc, *color)
 
         enable_aa = self.antialias and not context.isOpenGLES()
 
         if enable_aa:
-            glEnable(GL_LINE_SMOOTH)
-            glEnable(GL_BLEND)
-            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
-            glHint(GL_LINE_SMOOTH_HINT, GL_NICEST)
+            GL.glEnable(GL.GL_LINE_SMOOTH)
+            GL.glEnable(GL.GL_BLEND)
+            GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
+            GL.glHint(GL.GL_LINE_SMOOTH_HINT, GL.GL_NICEST)
+
+        # clamp to supported line widths
+        if (width := self.width) != 1.0:
+            kind = GL.GL_ALIASED_LINE_WIDTH_RANGE if not enable_aa else GL.GL_SMOOTH_LINE_WIDTH_RANGE
+            pair = (GL.GLint * 2)()
+            GL.glGetIntegerv(kind, pair)
+            width = fn.clip_scalar(width, pair[0], pair[1])
+
+        GL.glLineWidth(width)
 
         for loc in enabled_locs:
-            glEnableVertexAttribArray(loc)
+            GL.glEnableVertexAttribArray(loc)
 
-        with shader:
-            glUniformMatrix4fv(shader.uniform("u_mvp"), 1, False, mat_mvp)
+        with program:
+            loc = GL.glGetUniformLocation(program, "u_mvp")
+            GL.glUniformMatrix4fv(loc, 1, False, mat_mvp)
 
             if self.mode == 'line_strip':
-                glDrawArrays(GL_LINE_STRIP, 0, len(self.pos))
+                GL.glDrawArrays(GL.GL_LINE_STRIP, 0, len(self.pos))
             elif self.mode == 'lines':
-                glDrawArrays(GL_LINES, 0, len(self.pos))
+                GL.glDrawArrays(GL.GL_LINES, 0, len(self.pos))
 
         for loc in enabled_locs:
-            glDisableVertexAttribArray(loc)
+            GL.glDisableVertexAttribArray(loc)
 
         if enable_aa:
-            glDisable(GL_LINE_SMOOTH)
-            glDisable(GL_BLEND)
+            GL.glDisable(GL.GL_LINE_SMOOTH)
+            GL.glDisable(GL.GL_BLEND)
         
-        glLineWidth(1.0)
+        GL.glLineWidth(1.0)
+
+
+SHADER_LEGACY = {
+    GL.GL_VERTEX_SHADER : """
+        uniform mat4 u_mvp;
+        attribute vec4 a_position;
+        attribute vec4 a_color;
+        varying vec4 v_color;
+        void main() {
+            v_color = a_color;
+            gl_Position = u_mvp * a_position;
+        }
+    """,
+    GL.GL_FRAGMENT_SHADER : """
+        #ifdef GL_ES
+        precision mediump float;
+        #endif
+        varying vec4 v_color;
+        void main() {
+            gl_FragColor = v_color;
+        }
+    """,
+}
+
+SHADER_CORE = {
+    GL.GL_VERTEX_SHADER : """
+        uniform mat4 u_mvp;
+        in vec4 a_position;
+        in vec4 a_color;
+        out vec4 v_color;
+        void main() {
+            v_color = a_color;
+            gl_Position = u_mvp * a_position;
+        }
+    """,
+    GL.GL_FRAGMENT_SHADER : """
+        #ifdef GL_ES
+        precision mediump float;
+        #endif
+        in vec4 v_color;
+        out vec4 fragColor;
+        void main() {
+            fragColor = v_color;
+        }
+    """,
+}

--- a/pyqtgraph/opengl/items/GLVolumeItem.py
+++ b/pyqtgraph/opengl/items/GLVolumeItem.py
@@ -1,11 +1,11 @@
 import ctypes
 import importlib
 
-from OpenGL.GL import *  # noqa
+from OpenGL import GL
+from OpenGL.GL import shaders
 import numpy as np
 
 from ...Qt import QtGui, QT_LIB
-from .. import shaders
 from ..GLGraphicsItem import GLGraphicsItem
 
 if QT_LIB in ["PyQt5", "PySide2"]:
@@ -22,6 +22,7 @@ class GLVolumeItem(GLGraphicsItem):
     Displays volumetric data. 
     """
     
+    _shaderProgram = None
     
     def __init__(self, data, sliceDensity=1, smooth=True, glOptions='translucent', parentItem=None):
         """
@@ -51,28 +52,26 @@ class GLVolumeItem(GLGraphicsItem):
         
     def _uploadData(self):
         if self.texture is None:
-            self.texture = glGenTextures(1)
-        glBindTexture(GL_TEXTURE_3D, self.texture)
-        if self.smooth:
-            glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
-            glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
-        else:
-            glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
-            glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
-        glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER)
-        glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER)
-        glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_BORDER)
+            self.texture = GL.glGenTextures(1)
+        GL.glBindTexture(GL.GL_TEXTURE_3D, self.texture)
+        filt = GL.GL_LINEAR if self.smooth else GL.GL_NEAREST
+        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_MIN_FILTER, filt)
+        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_MAG_FILTER, filt)
+        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_BORDER)
+        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_BORDER)
+        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_R, GL.GL_CLAMP_TO_BORDER)
         shape = self.data.shape
 
         context = QtGui.QOpenGLContext.currentContext()
         if not context.isOpenGLES():
             ## Test texture dimensions first
-            glTexImage3D(GL_PROXY_TEXTURE_3D, 0, GL_RGBA, shape[0], shape[1], shape[2], 0, GL_RGBA, GL_UNSIGNED_BYTE, None)
-            if glGetTexLevelParameteriv(GL_PROXY_TEXTURE_3D, 0, GL_TEXTURE_WIDTH) == 0:
+            GL.glTexImage3D(GL.GL_PROXY_TEXTURE_3D, 0, GL.GL_RGBA, shape[0], shape[1], shape[2], 0, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, None)
+            if GL.glGetTexLevelParameteriv(GL.GL_PROXY_TEXTURE_3D, 0, GL.GL_TEXTURE_WIDTH) == 0:
                 raise Exception("OpenGL failed to create 3D texture (%dx%dx%d); too large for this hardware." % shape[:3])
         
         data = np.ascontiguousarray(self.data.transpose((2,1,0,3)))
-        glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, shape[0], shape[1], shape[2], 0, GL_RGBA, GL_UNSIGNED_BYTE, data)
+        GL.glTexImage3D(GL.GL_TEXTURE_3D, 0, GL.GL_RGBA, shape[0], shape[1], shape[2], 0, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, data)
+        GL.glBindTexture(GL.GL_TEXTURE_3D, 0)
         
         all_vertices = []
 
@@ -92,6 +91,42 @@ class GLVolumeItem(GLGraphicsItem):
         vbo.release()
         
         self._needUpload = False
+
+    @staticmethod
+    def getShaderProgram():
+        klass = GLVolumeItem
+
+        if klass._shaderProgram is not None:
+            return klass._shaderProgram
+
+        ctx = QtGui.QOpenGLContext.currentContext()
+        fmt = ctx.format()
+
+        if ctx.isOpenGLES():
+            if fmt.version() >= (3, 0):
+                glsl_version = "#version 300 es\n"
+                sources = SHADER_CORE
+            else:
+                glsl_version = ""
+                sources = SHADER_LEGACY
+        else:
+            if fmt.version() >= (3, 1):
+                glsl_version = "#version 140\n"
+                sources = SHADER_CORE
+            else:
+                glsl_version = ""
+                sources = SHADER_LEGACY
+
+        compiled = [shaders.compileShader([glsl_version, v], k) for k, v in sources.items()]
+        program = shaders.compileProgram(*compiled)
+
+        # bind generic vertex attrib 0 to "a_position" so that
+        # vertex attrib 0 definitely gets enabled later.
+        GL.glBindAttribLocation(program, 0, "a_position")
+        GL.glLinkProgram(program)
+
+        klass._shaderProgram = program
+        return program
         
     def paint(self):
         if self.data is None:
@@ -114,35 +149,31 @@ class GLVolumeItem(GLGraphicsItem):
         d = 1 if cam[ax] > 0 else -1
         offset, num_vertices = self.lists[(ax,d)]
 
-        context = QtGui.QOpenGLContext.currentContext()
-        if context.isOpenGLES():
-            shader_name = 'texture3d-es3'
-        else:
-            shader_name = 'texture3d'
-        shader = shaders.getShaderProgram(shader_name)
+        program = self.getShaderProgram()
 
-        loc_pos = glGetAttribLocation(shader.program(), "a_position")
-        loc_tex = glGetAttribLocation(shader.program(), "a_texcoord")
+        loc_pos = GL.glGetAttribLocation(program, "a_position")
+        loc_tex = GL.glGetAttribLocation(program, "a_texcoord")
         self.m_vbo_position.bind()
-        glVertexAttribPointer(loc_pos, 3, GL_FLOAT, False, 6*4, None)
-        glVertexAttribPointer(loc_tex, 3, GL_FLOAT, False, 6*4, ctypes.c_void_p(3*4))
+        GL.glVertexAttribPointer(loc_pos, 3, GL.GL_FLOAT, False, 6*4, None)
+        GL.glVertexAttribPointer(loc_tex, 3, GL.GL_FLOAT, False, 6*4, ctypes.c_void_p(3*4))
         self.m_vbo_position.release()
         enabled_locs = [loc_pos, loc_tex]
 
-        glBindTexture(GL_TEXTURE_3D, self.texture)
+        GL.glBindTexture(GL.GL_TEXTURE_3D, self.texture)
 
         for loc in enabled_locs:
-            glEnableVertexAttribArray(loc)
+            GL.glEnableVertexAttribArray(loc)
 
-        with shader:
-            glUniformMatrix4fv(shader.uniform("u_mvp"), 1, False, mat_mvp)
+        with program:
+            loc = GL.glGetUniformLocation(program, "u_mvp")
+            GL.glUniformMatrix4fv(loc, 1, False, mat_mvp)
 
-            glDrawArrays(GL_TRIANGLES, offset, num_vertices)
+            GL.glDrawArrays(GL.GL_TRIANGLES, offset, num_vertices)
 
         for loc in enabled_locs:
-            glDisableVertexAttribArray(loc)
+            GL.glDisableVertexAttribArray(loc)
 
-        glBindTexture(GL_TEXTURE_3D, 0)
+        GL.glBindTexture(GL.GL_TEXTURE_3D, 0)
 
     def drawVolume(self, ax, d):
         imax = [0,1,2]
@@ -197,3 +228,51 @@ class GLVolumeItem(GLGraphicsItem):
                 vertices.append(vtx)
 
         return vertices
+
+
+SHADER_LEGACY = {
+    GL.GL_VERTEX_SHADER : """
+        uniform mat4 u_mvp;
+        attribute vec4 a_position;
+        attribute vec3 a_texcoord;
+        varying vec3 v_texcoord;
+        void main() {
+            gl_Position = u_mvp * a_position;
+            v_texcoord = a_texcoord;
+        }
+    """,
+    GL.GL_FRAGMENT_SHADER : """
+        uniform sampler3D u_texture;
+        varying vec3 v_texcoord;
+        void main()
+        {
+            gl_FragColor = texture3D(u_texture, v_texcoord);
+        }
+    """,
+}
+
+SHADER_CORE = {
+    GL.GL_VERTEX_SHADER : """
+        uniform mat4 u_mvp;
+        in vec4 a_position;
+        in vec3 a_texcoord;
+        out vec3 v_texcoord;
+        void main() {
+            gl_Position = u_mvp * a_position;
+            v_texcoord = a_texcoord;
+        }
+    """,
+    GL.GL_FRAGMENT_SHADER : """
+        #ifdef GL_ES
+        precision mediump float;
+        precision lowp sampler3D;
+        #endif
+        uniform sampler3D u_texture;
+        in vec3 v_texcoord;
+        out vec4 fragColor;
+        void main()
+        {
+            fragColor = texture(u_texture, v_texcoord);
+        }
+    """,
+}

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -58,52 +58,6 @@ def initShaders():
             """)
         ]),
 
-        ShaderProgram('texture3d', [
-            VertexShader("""
-                uniform mat4 u_mvp;
-                attribute vec4 a_position;
-                attribute vec3 a_texcoord;
-                varying vec3 v_texcoord;
-                void main() {
-                    gl_Position = u_mvp * a_position;
-                    v_texcoord = a_texcoord;
-                }
-            """),
-            FragmentShader("""
-                uniform sampler3D u_texture;
-                varying vec3 v_texcoord;
-                void main()
-                {
-                    gl_FragColor = texture3D(u_texture, v_texcoord);
-                }
-            """)
-        ]),
-
-        ShaderProgram('texture3d-es3', [
-            VertexShader("""
-                #version 300 es
-                uniform mat4 u_mvp;
-                in vec4 a_position;
-                in vec3 a_texcoord;
-                out vec3 v_texcoord;
-                void main() {
-                    gl_Position = u_mvp * a_position;
-                    v_texcoord = a_texcoord;
-                }
-            """),
-            FragmentShader("""
-                #version 300 es
-                precision mediump float;
-                uniform lowp sampler3D u_texture;
-                in vec3 v_texcoord;
-                out vec4 fragColor;
-                void main()
-                {
-                    fragColor = texture(u_texture, v_texcoord);
-                }
-            """)
-        ]),
-
         ## increases fragment alpha as the normal turns orthogonal to the view
         ## this is useful for viewing shells that enclose a volume (such as isosurfaces)
         ShaderProgram('balloon', [

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -34,30 +34,6 @@ def initShaders():
             """)
         ]),
 
-        ShaderProgram('texture2d', [
-            VertexShader("""
-                uniform mat4 u_mvp;
-                attribute vec4 a_position;
-                attribute vec2 a_texcoord;
-                varying vec2 v_texcoord;
-                void main() {
-                    gl_Position = u_mvp * a_position;
-                    v_texcoord = a_texcoord;
-                }
-            """),
-            FragmentShader("""
-                #ifdef GL_ES
-                precision mediump float;
-                #endif
-                uniform sampler2D u_texture;
-                varying vec2 v_texcoord;
-                void main()
-                {
-                    gl_FragColor = texture2D(u_texture, v_texcoord);
-                }
-            """)
-        ]),
-
         ## increases fragment alpha as the normal turns orthogonal to the view
         ## this is useful for viewing shells that enclose a volume (such as isosurfaces)
         ShaderProgram('balloon', [

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -9,58 +9,6 @@ import re
 
 ## For centralizing and managing vertex/fragment shader programs.
 
-## See:
-##
-##  http://stackoverflow.com/questions/9609423/applying-part-of-a-texture-sprite-sheet-texture-map-to-a-point-sprite-in-ios
-##  http://stackoverflow.com/questions/3497068/textured-points-in-opengl-es-2-0
-##
-##
-POINT_SPRITE_VERT_SRC = """
-    uniform mat4 u_viewTransform;
-    uniform vec3 u_cameraPosition;
-    uniform float u_scale;
-
-    uniform mat4 u_mvp;
-    attribute vec4 a_position;
-    attribute vec4 a_color;
-    attribute float a_size;
-    varying vec4 v_color;
-
-    void main() {
-        gl_Position = u_mvp * a_position;
-        v_color = a_color;
-        gl_PointSize = a_size;
-
-        if (u_scale != 0.0) {
-            // pxMode=False
-            vec4 gpos = u_viewTransform * a_position;
-            float dist = distance(u_cameraPosition, gpos.xyz);
-            // equations:
-            //   xDist = dist * 2.0 * tan(0.5 * fov)
-            //   pxSize = xDist / view_width
-            // let:
-            //   u_scale = 2.0 * tan(0.5 * fov) / view_width
-            // then:
-            //   pxSize = dist * u_scale
-            float pxSize = dist * u_scale;
-            gl_PointSize /= pxSize;
-        }
-    }
-"""
-POINT_SPRITE_FRAG_SRC = """
-    #ifdef GL_ES
-    precision mediump float;
-    #endif
-
-    varying vec4 v_color;
-    void main()
-    {
-        vec2 xy = (gl_PointCoord - 0.5) * 2.0;
-        float mask = step(-1.0, -dot(xy, xy));
-        gl_FragColor = vec4(v_color.rgb, v_color.a * mask);
-    }
-"""
-
 def initShaders():
     global Shaders
     Shaders = [
@@ -370,15 +318,6 @@ def initShaders():
             """),
         ], uniforms={'colorMap': [1, 1, 1, 1, 0.5, 1, 1, 0, 1]}),
 
-        ShaderProgram('pointSprite', [   ## allows specifying point size using attribute "a_size"
-            VertexShader("\n".join(["#version 120", POINT_SPRITE_VERT_SRC])),
-            FragmentShader("\n".join(["#version 120", POINT_SPRITE_FRAG_SRC])),
-        ]),
-
-        ShaderProgram('pointSprite-es2', [
-            VertexShader(POINT_SPRITE_VERT_SRC),
-            FragmentShader(POINT_SPRITE_FRAG_SRC),
-        ]),
     ]
 
 


### PR DESCRIPTION
This PR makes it more likely for pyqtgraph's OpenGL code to run if the user had made `GLViewWidget` use a Core profile.

In Core profiles, the default VAO is removed and it is mandatory to make use of user-created VAOs.
`glDrawArrays` and `glDrawElements` fail automatically if a user-created VAO is not bound.
One workaround is to create a global VAO and leave it bound throughout the program.

One issue encountered is that `GLTextItem` and `GLGradientLegendItem` make use of `QPainter`, which internally unbinds any existing VAO at the end of its execution. To workaround this, we simply rebind our global VAO before calling each `GLGraphicsItem`'s `paint()`.

Note that this PR is not a sufficient condition for `pyqtgraph` to run on any system using the Core profile. An implementation of the Core profile is not required to support the GLSL 120 syntax that `pyqtgraph` uses.
