### PR TITLE
fix: isnan is not available in OpenGL 2.1 nor OpenGL ES 2.0

### DIFF
--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -631,8 +631,11 @@ class OpenGLState(QtCore.QObject):
         }
     """
     FRAG_SRC_COMPAT = """
-        varying mediump float v_luminance;
-        uniform mediump sampler2D u_texture;
+        #ifdef GL_ES
+        precision mediump float;
+        #endif
+        varying float v_luminance;
+        uniform sampler2D u_texture;
         void main() {
             if (!(v_luminance == v_luminance)) discard;
             float s = clamp(v_luminance, 0.0, 1.0);

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -634,7 +634,7 @@ class OpenGLState(QtCore.QObject):
         varying mediump float v_luminance;
         uniform mediump sampler2D u_texture;
         void main() {
-            if (isnan(v_luminance)) discard;
+            if (!(v_luminance == v_luminance)) discard;
             float s = clamp(v_luminance, 0.0, 1.0);
             gl_FragColor = texture2D(u_texture, vec2(s, 0));
         }


### PR DESCRIPTION
#3170 added checks for `nan` in the shader code.
The "COMPAT" shader code is intended for running on OpenGL 2.1 and OpenGL ES 2.0, and in those versions, `isnan` is not defined. Fix by replacing `isnan` with a self comparison.

Notes:
1) On my system, even when forcing it to use the "COMPAT" shader code, the use of `isnan` doesn't trigger an error. An error is only triggered if the GLSL version is explicitly specified as `#version 120`. i.e. the shader compiler can be permissive and support functions that appear in newer GLSL versions.
2) It was not possible to test the shader errors on the CI, because even if illegal keywords were put into the shader code, the CI did not detect that there was a shader compilation error.
3) Windows and Linux are not going to be affected by this bug because they will take the modern shader code path. 
4) macOS is possibly affected by this bug as its default OpenGL version is 2.1.

A simple script to exercise the shader code.
```python
import numpy as np
import pyqtgraph as pg

pg.setConfigOptions(useOpenGL=True, enableExperimental=True, background='w')

Z = np.linspace(0, 1, 12).reshape((3, 4))
Z[1,1] = np.nan

pg.mkQApp()
win = pg.PlotWidget()
pcmi = pg.PColorMeshItem(Z)
win.addItem(pcmi)
win.show()
pg.exec()
```