### PR TITLE
Make shaders in shaders.py run on macOS OpenGL 4.1 Core

### DIFF
--- a/pyqtgraph/examples/GLMeshItem.py
+++ b/pyqtgraph/examples/GLMeshItem.py
@@ -84,7 +84,7 @@ colors = np.ones((md.faceCount(), 4), dtype=np.float32)
 colors[::2,0] = 0
 colors[:,1] = np.linspace(0, 1, colors.shape[0])
 md.setFaceColors(colors)
-m3 = gl.GLMeshItem(meshdata=md, smooth=False)#, shader='balloon')
+m3 = gl.GLMeshItem(meshdata=md, smooth=False)
 
 m3.translate(5, -5, 0)
 w.addItem(m3)
@@ -106,12 +106,12 @@ colors = np.ones((len(md.vertexes()), 4), dtype=np.float32)
 colors[::2,0] = 0
 colors[:,1] = np.linspace(0, 1, colors.shape[0])
 md.setVertexColors(colors)
-m5 = gl.GLMeshItem(meshdata=md, smooth=True, drawEdges=True, edgeColor=(1,0,0,1), shader='balloon')
+m5 = gl.GLMeshItem(meshdata=md, smooth=True, drawEdges=True, edgeColor=(1,0,0,1))
 colors = np.ones((len(md2.vertexes()), 4), dtype=np.float32)
 colors[::2,0] = 0
 colors[:,1] = np.linspace(0, 1, colors.shape[0])
 md2.setVertexColors(colors)
-m6 = gl.GLMeshItem(meshdata=md2, smooth=True, drawEdges=False, shader='balloon')
+m6 = gl.GLMeshItem(meshdata=md2, smooth=True, drawEdges=False)
 m6.translate(0,0,7.5)
 
 m6.rotate(0., 0, 1, 1)

--- a/pyqtgraph/examples/GLMeshItem.py
+++ b/pyqtgraph/examples/GLMeshItem.py
@@ -1,10 +1,18 @@
 """
 Simple examples demonstrating the use of GLMeshItem.
 """
-
+import sys
 
 import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
 import pyqtgraph.opengl as gl
+
+if 'darwin' in sys.platform:
+    fmt = QtGui.QSurfaceFormat()
+    fmt.setRenderableType(fmt.RenderableType.OpenGL)
+    fmt.setProfile(fmt.OpenGLContextProfile.CoreProfile)
+    fmt.setVersion(4, 1)
+    QtGui.QSurfaceFormat.setDefaultFormat(fmt)
 
 app = pg.mkQApp("GLMeshItem Example")
 w = gl.GLViewWidget()

--- a/pyqtgraph/examples/GLSurfacePlot.py
+++ b/pyqtgraph/examples/GLSurfacePlot.py
@@ -1,12 +1,21 @@
 """
 This example demonstrates the use of GLSurfacePlotItem.
 """
+import sys
 
 import numpy as np
 
 import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
 import pyqtgraph.opengl as gl
 from pyqtgraph.Qt import QtCore
+
+if 'darwin' in sys.platform:
+    fmt = QtGui.QSurfaceFormat()
+    fmt.setRenderableType(fmt.RenderableType.OpenGL)
+    fmt.setProfile(fmt.OpenGLContextProfile.CoreProfile)
+    fmt.setVersion(4, 1)
+    QtGui.QSurfaceFormat.setDefaultFormat(fmt)
 
 ## Create a GL View widget to display data
 app = pg.mkQApp("GLSurfacePlot Example")

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -1,4 +1,4 @@
-from OpenGL.GL import *  # noqa
+from OpenGL import GL
 from OpenGL.GL import shaders  # noqa
 try:
     from OpenGL import NullFunctionError
@@ -303,11 +303,11 @@ class Shader(object):
 
 class VertexShader(Shader):
     def __init__(self, code):
-        Shader.__init__(self, GL_VERTEX_SHADER, code)
+        Shader.__init__(self, GL.GL_VERTEX_SHADER, code)
         
 class FragmentShader(Shader):
     def __init__(self, code):
-        Shader.__init__(self, GL_FRAGMENT_SHADER, code)
+        Shader.__init__(self, GL.GL_FRAGMENT_SHADER, code)
         
         
         
@@ -370,13 +370,13 @@ class ShaderProgram(object):
                 self.prog = -1
                 raise
             # bind generic vertex attrib 0 to "a_position" and relink
-            glBindAttribLocation(self.prog, 0, "a_position")
-            glLinkProgram(self.prog)
+            GL.glBindAttribLocation(self.prog, 0, "a_position")
+            GL.glLinkProgram(self.prog)
         return self.prog
         
     def __enter__(self):
         if len(self.shaders) > 0 and self.program() != -1:
-            glUseProgram(self.program())
+            GL.glUseProgram(self.program())
             
             try:
                 ## load uniform values into program
@@ -384,7 +384,7 @@ class ShaderProgram(object):
                     loc = self.uniform(uniformName)
                     if loc == -1:
                         raise Exception('Could not find uniform variable "%s"' % uniformName)
-                    glUniform1fv(loc, len(data), np.array(data, dtype=np.float32))
+                    GL.glUniform1fv(loc, len(data), np.array(data, dtype=np.float32))
                     
                 ### bind buffer data to program blocks
                 #if len(self.blockData) > 0:
@@ -414,18 +414,18 @@ class ShaderProgram(object):
                         ### bind buffer to the same binding point
                         #glBindBufferBase(GL_UNIFORM_BUFFER, bindPoint, buf)
             except:
-                glUseProgram(0)
+                GL.glUseProgram(0)
                 raise
                     
             
         
     def __exit__(self, *args):
         if len(self.shaders) > 0:
-            glUseProgram(0)
+            GL.glUseProgram(0)
         
     def uniform(self, name):
         """Return the location integer for a uniform variable in this program"""
-        return glGetUniformLocation(self.program(), name.encode('utf_8'))
+        return GL.glGetUniformLocation(self.program(), name.encode('utf_8'))
 
     #def uniformBlockInfo(self, blockName):
         #blockIndex = glGetUniformBlockIndex(self.program(), blockName)

--- a/pyqtgraph/opengl/shaders.py
+++ b/pyqtgraph/opengl/shaders.py
@@ -44,10 +44,9 @@ def initShaders():
                 attribute vec3 a_normal;
                 attribute vec4 a_color;
                 varying vec4 v_color;
-                varying vec3 normal;
+                varying vec3 v_normal;
                 void main() {
-                    // compute here for use in fragment shader
-                    normal = normalize(u_normal * a_normal);
+                    v_normal = normalize(u_normal * a_normal);
                     v_color = a_color;
                     gl_Position = u_mvp * a_position;
                 }
@@ -57,10 +56,10 @@ def initShaders():
                 precision mediump float;
                 #endif
                 varying vec4 v_color;
-                varying vec3 normal;
+                varying vec3 v_normal;
                 void main() {
                     vec4 color = v_color;
-                    color.w = min(color.w + 2.0 * color.w * pow(normal.x*normal.x + normal.y*normal.y, 5.0), 1.0);
+                    color.w = min(color.w + 2.0 * color.w * pow(v_normal.x*v_normal.x + v_normal.y*v_normal.y, 5.0), 1.0);
                     gl_FragColor = color;
                 }
             """)
@@ -76,10 +75,9 @@ def initShaders():
                 attribute vec3 a_normal;
                 attribute vec4 a_color;
                 varying vec4 v_color;
-                varying vec3 normal;
+                varying vec3 v_normal;
                 void main() {
-                    // compute here for use in fragment shader
-                    normal = normalize(u_normal * a_normal);
+                    v_normal = normalize(u_normal * a_normal);
                     v_color = a_color;
                     gl_Position = u_mvp * a_position;
                 }
@@ -89,13 +87,10 @@ def initShaders():
                 precision mediump float;
                 #endif
                 varying vec4 v_color;
-                varying vec3 normal;
+                varying vec3 v_normal;
                 void main() {
-                    vec4 color = v_color;
-                    color.x = (normal.x + 1.0) * 0.5;
-                    color.y = (normal.y + 1.0) * 0.5;
-                    color.z = (normal.z + 1.0) * 0.5;
-                    gl_FragColor = color;
+                    vec3 rgb = (v_normal + 1.0) * 0.5;
+                    gl_FragColor = vec4(rgb, v_color.a);
                 }
             """)
         ]),
@@ -108,10 +103,9 @@ def initShaders():
                 attribute vec3 a_normal;
                 attribute vec4 a_color;
                 varying vec4 v_color;
-                varying vec3 normal;
+                varying vec3 v_normal;
                 void main() {
-                    // compute here for use in fragment shader
-                    normal = normalize(a_normal);
+                    v_normal = normalize(a_normal);
                     v_color = a_color;
                     gl_Position = u_mvp * a_position;
                 }
@@ -121,13 +115,10 @@ def initShaders():
                 precision mediump float;
                 #endif
                 varying vec4 v_color;
-                varying vec3 normal;
+                varying vec3 v_normal;
                 void main() {
-                    vec4 color = v_color;
-                    color.x = (normal.x + 1.0) * 0.5;
-                    color.y = (normal.y + 1.0) * 0.5;
-                    color.z = (normal.z + 1.0) * 0.5;
-                    gl_FragColor = color;
+                    vec3 rgb = (v_normal + 1.0) * 0.5;
+                    gl_FragColor = vec4(rgb, v_color.a);
                 }
             """)
         ]),
@@ -142,10 +133,9 @@ def initShaders():
                 attribute vec3 a_normal;
                 attribute vec4 a_color;
                 varying vec4 v_color;
-                varying vec3 normal;
+                varying vec3 v_normal;
                 void main() {
-                    // compute here for use in fragment shader
-                    normal = normalize(u_normal * a_normal);
+                    v_normal = normalize(u_normal * a_normal);
                     v_color = a_color;
                     gl_Position = u_mvp * a_position;
                 }
@@ -155,15 +145,12 @@ def initShaders():
                 precision mediump float;
                 #endif
                 varying vec4 v_color;
-                varying vec3 normal;
+                varying vec3 v_normal;
                 void main() {
-                    float p = dot(normal, normalize(vec3(1.0, -1.0, -1.0)));
+                    float p = dot(v_normal, normalize(vec3(1.0, -1.0, -1.0)));
                     p = p < 0. ? 0. : p * 0.8;
-                    vec4 color = v_color;
-                    color.x = color.x * (0.2 + p);
-                    color.y = color.y * (0.2 + p);
-                    color.z = color.z * (0.2 + p);
-                    gl_FragColor = color;
+                    vec3 rgb = v_color.rgb * (0.2 + p);
+                    gl_FragColor = vec4(rgb, v_color.a);
                 }
             """)
         ]),
@@ -177,10 +164,9 @@ def initShaders():
                 attribute vec3 a_normal;
                 attribute vec4 a_color;
                 varying vec4 v_color;
-                varying vec3 normal;
+                varying vec3 v_normal;
                 void main() {
-                    // compute here for use in fragment shader
-                    normal = normalize(u_normal * a_normal);
+                    v_normal = normalize(u_normal * a_normal);
                     v_color = a_color;
                     gl_Position = u_mvp * a_position;
                 }
@@ -190,14 +176,11 @@ def initShaders():
                 precision mediump float;
                 #endif
                 varying vec4 v_color;
-                varying vec3 normal;
+                varying vec3 v_normal;
                 void main() {
-                    vec4 color = v_color;
-                    float s = pow(normal.x*normal.x + normal.y*normal.y, 2.0);
-                    color.x = color.x + s * (1.0-color.x);
-                    color.y = color.y + s * (1.0-color.y);
-                    color.z = color.z + s * (1.0-color.z);
-                    gl_FragColor = color;
+                    float s = pow(v_normal.x*v_normal.x + v_normal.y*v_normal.y, 2.0);
+                    vec3 rgb = v_color.rgb + s * (1.0-v_color.rgb);
+                    gl_FragColor = vec4(rgb, v_color.a);
                 }
             """)
         ]),


### PR DESCRIPTION
This is a continuation of #3246 for `GLMeshItem` and its dependencies.

As there are quite a number of remaining shaders in `shaders.py` (all used by GLMeshItem only), an alternate method than #3246 was used to make the shaders run on macOS OpenGL 4.1 Core. Since macOS OpenGL 4.1 Core has the ARB_ES2_compatibility extension, it is able to run ES2 shaders, with the proviso that they are marked as such with `#version 100`.