### PR TITLE
Make PlotCurveItem and PColorMeshItem work in Core Profile

### DIFF
--- a/pyqtgraph/Qt/OpenGLHelpers.py
+++ b/pyqtgraph/Qt/OpenGLHelpers.py
@@ -114,10 +114,13 @@ class GraphicsViewGLWidget(QtOpenGLWidgets.QOpenGLWidget):
             frag_src = "void main() { gl_FragColor = vec4(1.0); }"
 
         program = QtOpenGL.QOpenGLShaderProgram()
-        program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Vertex, vert_src)
-        program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Fragment, frag_src)
+        if not program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Vertex, vert_src):
+            raise RuntimeError(program.log())
+        if not program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Fragment, frag_src):
+            raise RuntimeError(program.log())
         program.bindAttributeLocation("a_pos", 0)
-        program.link()
+        if not program.link():
+            raise RuntimeError(program.log())
         self.storeProgram("Stencil", program)
 
         self.m_vao.create()

--- a/pyqtgraph/Qt/OpenGLHelpers.py
+++ b/pyqtgraph/Qt/OpenGLHelpers.py
@@ -105,15 +105,17 @@ class GraphicsViewGLWidget(QtOpenGLWidgets.QOpenGLWidget):
         self.m_vbo.destroy()
         self._functions = None
 
+        ctx = self.context()
+        if not ctx.isOpenGLES() and ctx.format().version() >= (3, 1):
+            vert_src = "#version 140\nin vec4 a_pos; void main() { gl_Position = a_pos; }"
+            frag_src = "#version 140\nout vec4 fragColor; void main() { fragColor = vec4(1.0); }"
+        else:
+            vert_src = "attribute vec4 a_pos; void main() { gl_Position = a_pos; }"
+            frag_src = "void main() { gl_FragColor = vec4(1.0); }"
+
         program = QtOpenGL.QOpenGLShaderProgram()
-        program.addShaderFromSourceCode(
-            QtOpenGL.QOpenGLShader.ShaderTypeBit.Vertex,
-            "attribute vec4 a_pos; void main() { gl_Position = a_pos; }"
-        )
-        program.addShaderFromSourceCode(
-            QtOpenGL.QOpenGLShader.ShaderTypeBit.Fragment,
-            "void main() { gl_FragColor = vec4(1.0); }"
-        )
+        program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Vertex, vert_src)
+        program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Fragment, frag_src)
         program.bindAttributeLocation("a_pos", 0)
         program.link()
         self.storeProgram("Stencil", program)

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -715,11 +715,14 @@ class OpenGLState(QtCore.QObject):
         program = glwidget.retrieveProgram("PColorMeshItem")
         if program is None:
             program = QtOpenGL.QOpenGLShaderProgram()
-            program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Vertex, VERT_SRC)
-            program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Fragment, FRAG_SRC)
+            if not program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Vertex, VERT_SRC):
+                raise RuntimeError(program.log())
+            if not program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Fragment, FRAG_SRC):
+                raise RuntimeError(program.log())
             program.bindAttributeLocation("a_position", 0)
             program.bindAttributeLocation("a_luminance", 1)
-            program.link()
+            if not program.link():
+                raise RuntimeError(program.log())
         glwidget.storeProgram("PColorMeshItem", program)
 
         self.m_vao.create()

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -86,10 +86,13 @@ class OpenGLState(QtCore.QObject):
                 vert_src = OpenGLState.VERT_SRC
                 frag_src = OpenGLState.FRAG_SRC
 
-            program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Vertex, vert_src)
-            program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Fragment, frag_src)
+            if not program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Vertex, vert_src):
+                raise RuntimeError(program.log())
+            if not program.addShaderFromSourceCode(QtOpenGL.QOpenGLShader.ShaderTypeBit.Fragment, frag_src):
+                raise RuntimeError(program.log())
             program.bindAttributeLocation("a_position", 0)
-            program.link()
+            if not program.link():
+                raise RuntimeError(program.log())
             glwidget.storeProgram("PlotCurveItem", program)
 
         self.m_vao.create()

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -176,8 +176,8 @@ class GLLinePlotItem(GLGraphicsItem):
         # clamp to supported line widths
         if (width := self.width) != 1.0:
             kind = GL.GL_ALIASED_LINE_WIDTH_RANGE if not enable_aa else GL.GL_SMOOTH_LINE_WIDTH_RANGE
-            pair = (GL.GLint * 2)()
-            GL.glGetIntegerv(kind, pair)
+            pair = (GL.GLfloat * 2)()
+            GL.glGetFloatv(kind, pair)
             width = fn.clip_scalar(width, pair[0], pair[1])
 
         GL.glLineWidth(width)


### PR DESCRIPTION
There are 3 shaders involved:
1) Stencil
2) PlotCurveItem
3) PColorMeshItem

(3) by itself already has a non-legacy code path, but since it depends on (1), it also doesn't work.

The `ARB_ES2_compatibility` trick doesn't quite work due to the use of `QOpenGLShader` which does some mangling of its own.
 