### PR TITLE
Various OpenGL fixes

### DIFF
--- a/pyqtgraph/examples/GLGraphItem.py
+++ b/pyqtgraph/examples/GLGraphItem.py
@@ -19,7 +19,7 @@ if 'darwin' in sys.platform:
 
 app = pg.mkQApp("GLGraphItem Example")
 w = gl.GLViewWidget()
-w.setCameraPosition(distance=20)
+w.setCameraPosition(distance=5)
 w.show()
 
 edges = np.array([
@@ -45,7 +45,8 @@ gi = gl.GLGraphItem(
     edges=edges,
     nodePositions=nodes,
     edgeWidth=1.,
-    nodeSize=10.
+    nodeSize=0.1,
+    pxMode=False
 )
 
 w.addItem(gi)

--- a/pyqtgraph/examples/GLViewWidget.py
+++ b/pyqtgraph/examples/GLViewWidget.py
@@ -20,6 +20,7 @@ b = gl.GLBoxItem()
 w.addItem(b)
 
 ax2 = gl.GLAxisItem()
+ax2.setSize(1.5, 1.5, 1.5)
 ax2.setParentItem(b)
 
 b.translate(1,1,1)

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -34,7 +34,7 @@ class GLGraphicsItem(QtCore.QObject):
         
         self.__parent: GLGraphicsItem | None = None
         self.__view = None
-        self.__children: set[GLGraphicsItem] = set()
+        self.__children: list[GLGraphicsItem] = list()
         self.__transform = Transform3D()
         self.__visible = True
         self.__initialized = False

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -48,12 +48,15 @@ class GLGraphicsItem(QtCore.QObject):
             self.__parent.__children.remove(self)
         if item is not None:
             item.__children.add(self)
+
+        # if we had a __view, we were a top level object
+        if self.__view is not None:
+            self.__view.removeItem(self)
+
+        # we are now either a child or an orphan.
+        # either way, we don't have our own __view
         self.__parent = item
-        
-        if self.__parent is not None and self.view() is not self.__parent.view():
-            if self.view() is not None:
-                self.view().removeItem(self)
-            self.__parent.view().addItem(self)
+        self.__view = None
     
     def setGLOptions(self, opts):
         """
@@ -113,7 +116,12 @@ class GLGraphicsItem(QtCore.QObject):
         self.__view = v
         
     def view(self):
-        return self.__view
+        if self.__parent is None:
+            # top level object
+            return self.__view
+        else:
+            # recurse
+            return self.__parent.view()
         
     def setDepthValue(self, value):
         """
@@ -302,25 +310,16 @@ class GLGraphicsItem(QtCore.QObject):
         return tr.inverted()[0].map(point)
 
     def modelViewMatrix(self) -> QtGui.QMatrix4x4:
-        topobj = self
-        while (view := topobj.view()) is None:
-            topobj = topobj.parentItem()
-            if topobj is None:
-                return QtGui.QMatrix4x4()
+        if (view := self.view()) is None:
+            return QtGui.QMatrix4x4()
         return view.currentModelView()
 
     def projectionMatrix(self) -> QtGui.QMatrix4x4:
-        topobj = self
-        while (view := topobj.view()) is None:
-            topobj = topobj.parentItem()
-            if topobj is None:
-                return QtGui.QMatrix4x4()
+        if (view := self.view()) is None:
+            return QtGui.QMatrix4x4()
         return view.currentProjection()
 
     def mvpMatrix(self) -> QtGui.QMatrix4x4:
-        topobj = self
-        while (view := topobj.view()) is None:
-            topobj = topobj.parentItem()
-            if topobj is None:
-                return QtGui.QMatrix4x4()
+        if (view := self.view()) is None:
+            return QtGui.QMatrix4x4()
         return view.currentProjection() * view.currentModelView()

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -47,7 +47,7 @@ class GLGraphicsItem(QtCore.QObject):
         if self.__parent is not None:
             self.__parent.__children.remove(self)
         if item is not None:
-            item.__children.add(self)
+            item.__children.append(self)
 
         # if we had a __view, we were a top level object
         if self.__view is not None:

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -173,14 +173,15 @@ class GLLinePlotItem(GLGraphicsItem):
             GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
             GL.glHint(GL.GL_LINE_SMOOTH_HINT, GL.GL_NICEST)
 
-        # clamp to supported line widths
-        if (width := self.width) != 1.0:
-            kind = GL.GL_ALIASED_LINE_WIDTH_RANGE if not enable_aa else GL.GL_SMOOTH_LINE_WIDTH_RANGE
-            pair = (GL.GLfloat * 2)()
-            GL.glGetFloatv(kind, pair)
-            width = fn.clip_scalar(width, pair[0], pair[1])
-
-        GL.glLineWidth(width)
+        sfmt = context.format()
+        core_forward_compatible = (
+            sfmt.profile() == sfmt.OpenGLContextProfile.CoreProfile
+            and not sfmt.testOption(sfmt.FormatOption.DeprecatedFunctions)
+        )
+        if not core_forward_compatible:
+            # Core Forward Compatible profiles will return error for
+            # any width that is not 1.0
+            GL.glLineWidth(self.width)
 
         for loc in enabled_locs:
             GL.glEnableVertexAttribArray(loc)


### PR DESCRIPTION
1) A regression was introduced in 176817533248bdd036f82f21e8e55cfaf93cac19. The bug gets triggered if a `GLGraphItem` uses `pxMode=False`.

    In the original code, the view would be queried from the parent if the `GLScatterPlotItem` didn't have a view itself. This adhoc logic was implemented by #1721, in the very first implementation of `GLGraphItem`. i.e. `GLGraphItem` was the first `GLGraphicsItem` to use `GLScatterPlotItem` as a child.

    The fix is to implement `GLGraphicsItem::view()` such that it will automatically return the top level object's view for all its children.

2) `GLGraphicsItem` was storing its children in an _unordered_ set. Thus for any `GLGraphicsItem` with more than 1 child, the rendering would occur in a random order from run-to-run. This includes `GLGraphItem`, which has 2 children.

3) For non-macOS platforms set to Core _Forward Compatible_ profiles, the logic to clamp widths to the permitted range failed. By definition, Core _Forward Compatible_ profiles support only widths of 1.0. For all other profiles, it is not an error to provide a (positive) line width that is out of range. The driver will just clamp the value to its supported range.