### PR TITLE
Convert PlotItem and AxisItem to use numpydoc Docstring Style

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -20,6 +20,16 @@
   font-family: "no-parens", sans-serif;
 }
 
+/* set the article contents to take the max width */
+.bd-page-width {
+  max-width: 100rem;  /* default is 88rem */
+}
+
+.bd-main .bd-content .bd-article-container {
+  max-width: 100%;
+  /* default is 60em */
+}
+
 /* Retrieved from https://codepen.io/jonneal/pen/bXLEdB (MIT)
    It replaces (, ) with a zero-width font. This version is lighter than
    the original font from Adobe.

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -16,15 +16,39 @@ __all__ = ['AxisItem']
 class AxisItem(GraphicsWidget):
     """
     GraphicsItem showing a single plot axis with ticks, values, and label.
-    Can be configured to fit on any side of a plot,
-    Can automatically synchronize its displayed scale with ViewBox items.
-    Ticks can be extended to draw a grid.
+    
+    Can be configured to fit on any side of a plot, automatically synchronize its
+    displayed scale with ViewBox items. Ticks can be extended to draw a grid.
+    
     If maxTickLength is negative, ticks point into the plot.
-    """
 
+    Parameters
+    ----------
+    orientation : {'left', 'right', 'top', 'bottom'}
+        The side of the plot the axis is attached to.
+    pen : QPen or None
+        Pen used when drawing axis and (by default) ticks.
+    textPen : QPen or None
+        Pen used when drawing tick labels.
+    tickPen : QPen or None
+        Pen used when drawing ticks.
+    linkView : ViewBox or None
+        Causes the range of values displayed in the axis to be linked to the visible
+        range of a ViewBox.
+    parent : QtWidgets.QGraphicsItem or None
+        Parent Qt object to set to. End users are not expected to set, pyqtgraph should
+        set correctly on its own.
+    maxTickLength : int
+        Maximum length of ticks to draw in pixels. Negative values draw into the
+        plot, positive values draw outward.  Default -5.
+    showValues : bool
+        Whether to display values adjacent to ticks. Default true.
+    **args
+        All additional keyword arguments are passed to :func:`setLabel`.
+    """
     def __init__(
             self,
-            orientation,
+            orientation: str,
             pen=None,
             textPen=None,
             tickPen = None,
@@ -34,41 +58,22 @@ class AxisItem(GraphicsWidget):
             showValues=True,
             **args,
     ):
-        """
-        Parameters
-        ----------
-        orientation : str
-            one of 'left', 'right', 'top', or 'bottom'
-        maxTickLength : int
-            (px) maximum length of ticks to draw. Negative values draw into the plot, positive values draw outward.
-        linkView : ViewBox
-            causes the range of values displayed in the axis to be linked to the visible range of a ViewBox.
-        showValues : bool
-            Whether to display values adjacent to ticks
-        pen : QPen
-            Pen used when drawing axis and (by default) ticks
-        textPen : QPen
-            Pen used when drawing tick labels.
-        tickPen : QPen
-            Pen used when drawing ticks.
-        **args
-            All additional keyword arguments are passed to :func:`setLabel`
-        """
-
-        GraphicsWidget.__init__(self, parent)
+        super().__init__(parent)
         self.label = QtWidgets.QGraphicsTextItem(self)
         self.picture = None
         self.orientation = orientation
-        if orientation not in ['left', 'right', 'top', 'bottom']:
-            raise ValueError("Orientation argument must be one of 'left', 'right', 'top', or 'bottom'.")
-        if orientation in ['left', 'right']:
+
+        if orientation in {'left', 'right'}:
             self.label.setRotation(-90)
             # allow labels on vertical axis to extend above and below the length of the axis
             hide_overlapping_labels = False
-        else:
+        elif orientation in {'top', 'bottom'}:
             # stop labels on horizontal axis from overlapping so vertical axis labels have room
             hide_overlapping_labels = True
-
+        else:
+            raise ValueError(
+                "Orientation argument must be one of 'left', 'right', 'top', or 'bottom'."
+            )
         self.style = {
             'tickTextOffset': [5, 2],  ## (horizontal, vertical) spacing between text and axis
             'tickTextWidth': 30,  ## space reserved for tick text
@@ -83,7 +88,7 @@ class AxisItem(GraphicsWidget):
                 (2, 0.6),    ## If we already have 2 ticks with text, fill no more than 60% of the axis
                 (4, 0.4),    ## If we already have 4 ticks with text, fill no more than 40% of the axis
                 (6, 0.2),    ## If we already have 6 ticks with text, fill no more than 20% of the axis
-                ],
+            ],
             'showValues': showValues,
             'tickLength': maxTickLength,
             'maxTickLevel': 2,
@@ -141,66 +146,120 @@ class AxisItem(GraphicsWidget):
 
         #self.setCacheMode(self.DeviceCoordinateCache)
 
-    def setStyle(self, **kwds):
+    def setStyle(self, **kwargs):
         """
         Set various style options.
 
-        ===================== =======================================================
-        Keyword Arguments:
-        tickLength            (int) The maximum length of ticks in pixels.
-                              Positive values point toward the text; negative
-                              values point away.
-        tickTextOffset        (int) reserved spacing between text and axis in px
-        tickTextWidth         (int) Horizontal space reserved for tick text in px
-        tickTextHeight        (int) Vertical space reserved for tick text in px
-        autoExpandTextSpace   (bool) Automatically expand text space if the tick
-                              strings become too long.
-        autoReduceTextSpace   (bool) Automatically shrink the axis if necessary
-        hideOverlappingLabels (bool or int)
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Here are a list of supported arguments.
 
-                              * *True*  (default for horizontal axis): Hide tick labels which extend beyond the AxisItem's geometry rectangle.
-                              * *False* (default for vertical axis): Labels may be drawn extending beyond the extent of the axis.
-                              * *(int)* sets the tolerance limit for how many pixels a label is allowed to extend beyond the axis. Defaults to 15 for `hideOverlappingLabels = False`.
+            ===================== ======================================================
+            Property              Description
+            ===================== ======================================================
+            tickLength            ``int``
+                                  The maximum length of ticks in pixels. Positive values
+                                  point toward the text; negative values point away.
 
-        tickFont              (QFont or None) Determines the font used for tick
-                              values. Use None for the default font.
-        stopAxisAtTick        (tuple: (bool min, bool max)) If True, the axis
-                              line is drawn only as far as the last tick.
-                              Otherwise, the line is drawn to the edge of the
-                              AxisItem boundary.
-        textFillLimits        (list of (tick #, % fill) tuples). This structure
-                              determines how the AxisItem decides how many ticks
-                              should have text appear next to them. Each tuple in
-                              the list specifies what fraction of the axis length
-                              may be occupied by text, given the number of ticks
-                              that already have text displayed. For example::
+            tickTextOffset        ``int`` 
+                                  Reserved spacing between text and axis in pixels.
 
-                                  [(0, 0.8), # Never fill more than 80% of the axis
-                                   (2, 0.6), # If we already have 2 ticks with text,
-                                             # fill no more than 60% of the axis
-                                   (4, 0.4), # If we already have 4 ticks with text,
-                                             # fill no more than 40% of the axis
-                                   (6, 0.2)] # If we already have 6 ticks with text,
-                                             # fill no more than 20% of the axis
+            tickTextWidth         ``int``
+                                  Horizontal space reserved for tick text in pixels.
 
-        showValues            (bool) indicates whether text is displayed adjacent
-                              to ticks.
-        tickAlpha             (float or int or None) If None, pyqtgraph will draw the
-                              ticks with the alpha it deems appropriate.  Otherwise,
-                              the alpha will be fixed at the value passed.  With int,
-                              accepted values are [0..255].  With value of type
-                              float, accepted values are from [0..1].
-        ===================== =======================================================
+            tickTextHeight        ``int``
+                                  Vertical space reserved for tick text in pixels.
 
-        Added in version 0.9.9
+            autoExpandTextSpace   ``bool``
+                                  Automatically expand text space if the tick strings
+                                  become too long.
+
+            autoReduceTextSpace   ``bool``
+                                  Automatically shrink the axis if necessary.
+
+            hideOverlappingLabels ``bool`` or ``int``
+
+                                  - ``True``  (default for horizontal axis): Hide tick
+                                    labels which extend beyond the AxisItem's geometry
+                                    rectangle.
+                                  - ``False`` (default for vertical axis): Labels may be
+                                    drawn extending beyond the extent of the axis.
+                                  - ``int`` sets the tolerance limit for how many pixels
+                                    a label is allowed to extend beyond the axis.
+                                    Defaults to 15 for
+                                    ``hideOverlappingLabels = False``.
+
+            tickFont              :class:`QFont` or ``None``
+                                  Determines the font used for tick values. Use None for
+                                  the default font.
+            
+            stopAxisAtTick        tuple of ``bool, bool`` 
+                                  The first element represents the horizontal axis, the
+                                  second element represents the vertical axis.
+
+                                  - ``True`` - The axis line is drawn only as far as the
+                                    last tick.
+                                  - ``False`` - The line is drawn to the edge of the
+                                    :class:`~pyqtgraph.AxisItem` boundary.
+
+            textFillLimits        list of ``(int, float)``
+                                  This structure determines how the AxisItem decides how
+                                  many ticks should have text appear next to them.
+                                  The first value corresponds to the tick number.  The
+                                  second value corresponds to the fill percentage. Each
+                                  tuple in the list specifies what fraction of the axis
+                                  length may be occupied by text, given the number of
+                                  ticks that already have text displayed.
+                                  
+                                  For example ::
+
+                                    [
+                                        # Never fill more than 80% of the axis
+                                        (0, 0.8),
+                                        # If we already have 2 ticks with text, fill no
+                                        # more than 60% of the axis
+                                        (2, 0.6), 
+                                        # If we already have 4 ticks with text, fill no
+                                        # more than 40% of the axis
+                                        (4, 0.4), 
+                                        # If we already have 6 ticks with text, fill no
+                                        # more than 20% of the axis
+                                        (6, 0.2)
+                                    ]
+                                                
+            showValues            ``bool``
+                                  indicates whether text is displayed adjacent to ticks.
+            
+            tickAlpha             ``float``,``int`` or ``None`` 
+                                  If ``None``, pyqtgraph will draw the ticks with the
+                                  alpha it deems appropriate. Otherwise, the alpha will
+                                  be fixed at the value passed. With ``int``, accepted
+                                  values are [0..255]. With value of type ``float``,
+                                  accepted values are from [0..1].
+            ===================== ======================================================
+
+        Raises
+        ------
+        NameError
+            Raised when the name of a keyword argument is not recognized.
+        TypeError
+            Raised when a value for a keyword argument is of the wrong type.
         """
-        for kwd,value in kwds.items():
+        for kwd, value in kwargs.items():
             if kwd not in self.style:
-                raise NameError("%s is not a valid style argument." % kwd)
+                raise NameError(f"{kwd} is not a valid style argument.")
 
-            if kwd in ('tickLength', 'tickTextOffset', 'tickTextWidth', 'tickTextHeight'):
-                if not isinstance(value, int):
-                    raise ValueError("Argument '%s' must be int" % kwd)
+            if (
+                kwd in (
+                    'tickLength',
+                    'tickTextOffset',
+                    'tickTextWidth',
+                    'tickTextHeight'
+                ) and 
+                not isinstance(value, int)
+            ):
+                raise TypeError(f"Argument '{kwd}' must be int")
 
             if kwd == 'tickTextOffset':
                 if self.orientation in ('left', 'right'):
@@ -208,10 +267,10 @@ class AxisItem(GraphicsWidget):
                 else:
                     self.style['tickTextOffset'][1] = value
             elif kwd == 'stopAxisAtTick':
-                try:
-                    assert len(value) == 2 and isinstance(value[0], bool) and isinstance(value[1], bool)
-                except:
-                    raise ValueError("Argument 'stopAxisAtTick' must have type (bool, bool)")
+                if len(value) != 2 or not all(isinstance(val, bool) for val in value):
+                    raise TypeError(
+                        "Argument 'stopAxisAtTick' must have type (bool, bool)"
+                    )
                 self.style[kwd] = value
             else:
                 self.style[kwd] = value
@@ -225,30 +284,64 @@ class AxisItem(GraphicsWidget):
         self.label = None
         self.scene().removeItem(self)
 
-    def setGrid(self, grid):
-        """Set the alpha value (0-255) for the grid, or False to disable.
-
-        When grid lines are enabled, the axis tick lines are extended to cover
-        the extent of the linked ViewBox, if any.
+    def setGrid(self, grid: int | float | bool):
         """
+        Set the alpha value for the grid, or ``False`` to disable.
+
+        When grid lines are enabled, the axis tick lines are extended to cover the
+        extent of the linked ViewBox, if any.
+
+        Parameters
+        ----------
+        grid : bool or int or float
+            Alpha value to apply to :class:`~pyqtgraph.GridItem`.
+            
+            - ``False`` - Disable the grid.
+            - ``int`` - Values between [0, 255] to set the alpha of the grid to.
+            - ``float`` - Values between [0..1] to set the alpha of the grid to.
+        """
+        if isinstance(grid, float):
+            grid = int(grid * 255)
+            grid = min(grid, 255)
+            grid = max(grid, 0)
         self.grid = grid
         self.picture = None
         self.prepareGeometryChange()
         self.update()
 
-    def setLogMode(self, *args, **kwargs):
+    def setLogMode(
+        self,
+        *args: tuple[bool] | tuple[bool, bool] | None,
+        **kwargs: dict[str, bool] | None
+    ):
         """
-        Set log scaling for x and/or y axes.
+        Set log scaling for x and / or y axes.
 
         If two positional arguments are provided, the first will set log scaling
         for the x axis and the second for the y axis. If a single positional
         argument is provided, it will set the log scaling along the direction of
         the AxisItem. Alternatively, x and y can be passed as keyword arguments.
 
-        If an axis is set to log scale, ticks are displayed on a logarithmic scale
-        and values are adjusted accordingly. (This is usually accessed by changing
-        the log mode of a :func:`PlotItem <pyqtgraph.PlotItem.setLogMode>`.) The
-        linked ViewBox will be informed of the change.
+        If an axis is set to log scale, ticks are displayed on a logarithmic scale and
+        values are adjusted accordingly. The linked ViewBox will be informed of the
+        change.
+
+        Parameters
+        ----------
+        *args : tuple of bool
+            If length 1, sets log mode regardless of orientation.  If length 2, the
+            first element toggles log mode for x-axis, and the second element toggles
+            log mode for the y-axis.
+        **kwargs : dict
+            Pass a dictionary with keys `x` and `y`, where the values are ``bool`` to
+            set the log mode for the respective `x` or `y` axis.  Trying to set the `y`
+            axis log mode while this axis item is horizontal (or vice versa) will be
+            ignored.
+
+        See Also
+        --------
+        :meth:`~pyqtgraph.PlotItem.setLogMode`
+            The method called to shift the values of the data.
         """
         if len(args) == 1:
             self.logMode = args[0]
@@ -264,6 +357,7 @@ class AxisItem(GraphicsWidget):
             if y is not None and self.orientation in ('left', 'right'):
                 self.logMode = y
 
+        # inform the linked views of the change
         if self._linkedView is not None:
             if self.orientation in ('top', 'bottom'):
                 self._linkedView().setLogMode('x', self.logMode)
@@ -271,27 +365,28 @@ class AxisItem(GraphicsWidget):
                 self._linkedView().setLogMode('y', self.logMode)
 
         self.picture = None
-
         self.update()
 
-    def setTickFont(self, font):
+    def setTickFont(self, font: QtGui.QFont | None):
         """
-        (QFont or None) Determines the font used for tick values.
-        Use None for the default font.
+        Set the font used for tick values.
+        
+        Parameters
+        ----------
+        font : QtGui.QFont or None
+            The font to use for the tick values. Set to ``None`` for the default font.
         """
         self.style['tickFont'] = font
         self.picture = None
         self.prepareGeometryChange()
-        ## Need to re-allocate space depending on font size?
-
+        # Need to re-allocate space depending on font size?
         self.update()
 
     def resizeEvent(self, ev=None):
-        #s = self.size()
-
-        ## Set the position of the label
+        # Set the position of the label
         nudge = 5
-        if self.label is None: # self.label is set to None on close, but resize events can still occur.
+        # self.label is set to None on close, but resize events can still occur.
+        if self.label is None:
             self.picture = None
             return
 
@@ -312,9 +407,15 @@ class AxisItem(GraphicsWidget):
         self.label.setPos(p)
         self.picture = None
 
-    def showLabel(self, show=True):
-        """Show/hide the label text for this axis."""
-        #self.drawLabel = show
+    def showLabel(self, show: bool=True):
+        """
+        Show or hide the label text for this axis.
+
+        Parameters
+        ----------
+        show : bool, optional
+            Show the label text, by default True.
+        """
         self.label.setVisible(show)
         if self.orientation in ['left', 'right']:
             self._updateWidth()
@@ -323,25 +424,36 @@ class AxisItem(GraphicsWidget):
         if self.autoSIPrefix:
             self.updateAutoSIPrefix()
 
-    def setLabel(self, text=None, units=None, unitPrefix=None, siPrefixEnableRanges=None, **args):
-        """Set the text displayed adjacent to the axis.
+    def setLabel(
+        self,
+        text: str | None=None,
+        units: str | None=None,
+        unitPrefix: str | None=None,
+        siPrefixEnableRanges: tuple[tuple[float, float], ...] | None=None,
+        **kwargs
+    ):
+        """
+        Set the text displayed adjacent to the axis.
 
         Parameters
         ----------
         text : str
             The text (excluding units) to display on the label for this axis.
         units : str
-            The units for this axis. Units should generally be given without any scaling prefix (eg, 'V' instead of
-            'mV'). The scaling prefix will be automatically prepended based on the range of data displayed.
+            The units for this axis. Units should generally be given without any scaling
+            prefix (eg, 'V' instead of 'mV'). The scaling prefix will be automatically
+            prepended based on the range of data displayed.
         unitPrefix : str
             An extra prefix to prepend to the units.
-        siPrefixEnableRanges : tuple[tuple[float, float], ...]
-            The ranges in which automatic SI prefix scaling is enabled. Defaults to everywhere, unless units is empty,
-            in which case it defaults to ((0, 1), (1e9, inf)).
-        **args
-            All extra keyword arguments become CSS style options for the <span> tag which will surround the axis label
-            and units. Note that CSS attributes are not always valid python arguments. Examples: `color='#FFF'`,
-            `**{'font-size': '14pt'}`.
+        siPrefixEnableRanges : tuple of tuple of float, float, Optional
+            The ranges in which automatic SI prefix scaling is enabled. Defaults to
+            everywhere, unless units is empty, in which case it defaults to
+            ``((0., 1.), (1e9, inf))``.
+        **kwargs
+            All extra keyword arguments become CSS style options for the ``<span>`` tag
+            which will surround the axis label and units. Note that CSS attributes are
+            not always valid python arguments. Examples: ``color='#FFF'``,
+            ``**{'font-size': '14pt'}``.
 
         Notes
         -----
@@ -349,12 +461,11 @@ class AxisItem(GraphicsWidget):
 
             <span style="...args...">{text} (prefix{units})</span>
         """
-        # `None` input is kept for backward compatibility!
         self.labelText = text or ""
         self.labelUnits = units or ""
         self.labelUnitPrefix = unitPrefix or ""
-        if len(args) > 0:
-            self.labelStyle = args
+        if kwargs:
+            self.labelStyle = kwargs
         self.setSIPrefixEnableRanges(siPrefixEnableRanges)
         # Account empty string and `None` for units and text
         visible = bool(text or units)
@@ -362,24 +473,56 @@ class AxisItem(GraphicsWidget):
         self._updateLabel()
 
     def setSIPrefixEnableRanges(self, ranges=None):
+        """
+        Set the ranges in which automatic SI prefix scaling is enabled.
+
+        This function allows you to define specific ranges where SI prefixes will be
+        used. By default, SI prefix scaling is enabled everywhere, unless units are
+        empty, in which case it defaults to ``((0., 1.), (1e9, inf))``.
+
+        Parameters
+        ----------
+        ranges : tuple of tuple of float, float, optional
+            A tuple of ranges where SI prefix scaling is enabled. Each range is a tuple
+            containing two floats representing the start and end of the range.
+        """
         self._siPrefixEnableRanges = ranges
 
     def getSIPrefixEnableRanges(self):
+        """
+        Get the ranges in which automatic SI prefix scaling is enabled.
+
+        Returns
+        -------
+        tuple of tuple of float, float
+            A tuple of ranges where SI prefix scaling is enabled. Each range is a tuple
+            containing two floats representing the start and end of the range. If no
+            custom ranges are set, then the default ranges are returned. The default
+            ranges are ``((0., 1.), (1e9, inf))`` if units are empty, and 
+            ``((0., inf))`` otherwise.
+        """
         if self._siPrefixEnableRanges is not None:
             return self._siPrefixEnableRanges
         elif self.labelUnits == '':
-            return (0, 1), (1e9, float('inf'))
+            return (0., 1.), (1e9, float('inf'))
         else:
-            return ((0, float('inf')),)
+            return ((0., float('inf')),)
 
     def _updateLabel(self):
-        """Internal method to update the label according to the text"""
         self.label.setHtml(self.labelString())
         self._adjustSize()
         self.picture = None
         self.update()
 
-    def labelString(self):
+    def labelString(self) -> str:
+        """
+        Generate the label string based on current label, units, and prefix.
+
+        Returns
+        -------
+        str
+            The complete label string, including units and any prefixes.
+        """
         if self.labelUnits == '':
             if not self.autoSIPrefix or self.autoSIPrefixScale == 1.0:
                 units = ''
@@ -394,10 +537,10 @@ class AxisItem(GraphicsWidget):
 
         return f"<span style='{style}'>{s}</span>"
 
-    def _updateMaxTextSize(self, x):
+    def _updateMaxTextSize(self, x: int):
         ## Informs that the maximum tick size orthogonal to the axis has
         ## changed; we use this to decide whether the item needs to be resized
-        ## to accomodate.
+        ## to accommodate.
         if self.orientation in ['left', 'right']:
             if self.style["autoReduceTextSpace"]:
                 if x > self.textWidth or x < self.textWidth - 10:
@@ -426,69 +569,90 @@ class AxisItem(GraphicsWidget):
         else:
             self._updateHeight()
 
-    def setHeight(self, h=None):
-        """Set the height of this axis reserved for ticks and tick labels.
+    def setHeight(self, h: int | None=None):
+        """
+        Set the height of this axis reserved for ticks and tick labels.
+
         The height of the axis label is automatically added.
 
-        If *height* is None, then the value will be determined automatically
-        based on the size of the tick text."""
+        Parameters
+        ----------
+        h : int or None, optional
+            If ``None``, then the value will be determined automatically based on the
+            size of the tick text, by default None.
+        """
         self.fixedHeight = h
         self._updateHeight()
 
     def _updateHeight(self):
         if not self.isVisible():
             h = 0
-        else:
-            if self.fixedHeight is None:
-                if not self.style['showValues']:
-                    h = 0
-                elif self.style['autoExpandTextSpace']:
-                    h = self.textHeight
-                else:
-                    h = self.style['tickTextHeight']
-                h += self.style['tickTextOffset'][1] if self.style['showValues'] else 0
-                h += max(0, self.style['tickLength'])
-                if self.label.isVisible():
-                    h += self.label.boundingRect().height() * 0.8
+        elif self.fixedHeight is None:
+            if not self.style['showValues']:
+                h = 0
+            elif self.style['autoExpandTextSpace']:
+                h = self.textHeight
             else:
-                h = self.fixedHeight
+                h = self.style['tickTextHeight']
+            h += self.style['tickTextOffset'][1] if self.style['showValues'] else 0
+            h += max(0, self.style['tickLength'])
+            if self.label.isVisible():
+                h += self.label.boundingRect().height() * 0.8
+        else:
+            h = self.fixedHeight
 
         self.setMaximumHeight(h)
         self.setMinimumHeight(h)
         self.picture = None
 
-    def setWidth(self, w=None):
-        """Set the width of this axis reserved for ticks and tick labels.
+    def setWidth(self, w: int | None=None):
+        """
+        Set the width of this axis reserved for ticks and tick labels.
+
         The width of the axis label is automatically added.
 
-        If *width* is None, then the value will be determined automatically
-        based on the size of the tick text."""
+        Parameters
+        ----------
+        w : int or None, optional
+            If ``None``, then the value will be determined automatically based on the
+            size of the tick text, by default None.
+        """        
         self.fixedWidth = w
         self._updateWidth()
 
     def _updateWidth(self):
         if not self.isVisible():
             w = 0
-        else:
-            if self.fixedWidth is None:
-                if not self.style['showValues']:
-                    w = 0
-                elif self.style['autoExpandTextSpace']:
-                    w = self.textWidth
-                else:
-                    w = self.style['tickTextWidth']
-                w += self.style['tickTextOffset'][0] if self.style['showValues'] else 0
-                w += max(0, self.style['tickLength'])
-                if self.label.isVisible():
-                    w += self.label.boundingRect().height() * 0.8  ## bounding rect is usually an overestimate
+        elif self.fixedWidth is None:
+            if not self.style['showValues']:
+                w = 0
+            elif self.style['autoExpandTextSpace']:
+                w = self.textWidth
             else:
-                w = self.fixedWidth
+                w = self.style['tickTextWidth']
+            w += self.style['tickTextOffset'][0] if self.style['showValues'] else 0
+            w += max(0, self.style['tickLength'])
+            if self.label.isVisible():
+                w += self.label.boundingRect().height() * 0.8  ## bounding rect is usually an overestimate
+        else:
+            w = self.fixedWidth
 
         self.setMaximumWidth(w)
         self.setMinimumWidth(w)
         self.picture = None
 
-    def pen(self):
+    def pen(self) -> QtGui.QPen:
+        """
+        Get the pen used for drawing text, axes, ticks, and grid lines.
+
+        If no custom pen has been set, this method will return a pen with the
+        default foreground color.
+
+        Returns
+        -------
+        QPen
+            The pen used to draw text, axes, ticks, and grid lines.
+        """
         if self._pen is None:
             return fn.mkPen(getConfigOption('foreground'))
         return fn.mkPen(self._pen)
@@ -496,9 +660,21 @@ class AxisItem(GraphicsWidget):
     def setPen(self, *args, **kwargs):
         """
         Set the pen used for drawing text, axes, ticks, and grid lines.
-        If no arguments are given, the default foreground color will be used
-        (see :func:`setConfigOption <pyqtgraph.setConfigOption>`).
-        """
+        
+        If no arguments given, the default foreground color will be used.
+
+        Parameters
+        ----------
+        *args : tuple
+            Arguments relayed to :func:`~pyqtgraph.mkPen`.
+        **kwargs : dict
+            Arguments relayed to `:func:`~pyqtgraph.mkPen`.
+
+        See Also
+        --------
+        :func:`setConfigOption <pyqtgraph.setConfigOption>`
+            Option to change the default foreground color.
+        """        
         self.picture = None
         if args or kwargs:
             self._pen = fn.mkPen(*args, **kwargs)
@@ -507,7 +683,18 @@ class AxisItem(GraphicsWidget):
         self.labelStyle['color'] = self._pen.color().name() #   #RRGGBB
         self._updateLabel()
 
-    def textPen(self):
+    def textPen(self) -> QtGui.QPen:
+        """
+        Get the pen used for drawing text.
+
+        If no custom text pen has been set, this method will return a pen with the
+        default foreground color.
+
+        Returns
+        -------
+        QPen
+            The pen used to draw text.
+        """
         if self._textPen is None:
             return fn.mkPen(getConfigOption('foreground'))
         return fn.mkPen(self._textPen)
@@ -515,8 +702,21 @@ class AxisItem(GraphicsWidget):
     def setTextPen(self, *args, **kwargs):
         """
         Set the pen used for drawing text.
-        If no arguments are given, the default foreground color will be used.
-        """
+
+        If no arguments given, the default foreground color will be used.
+        
+        Parameters
+        ----------
+        *args : tuple
+            Arguments relayed to :func:`~pyqtgraph.mkPen`.
+        **kwargs : dict
+            Arguments relayed to `:func:`~pyqtgraph.mkPen`.
+
+        See Also
+        --------
+        :func:`setConfigOption <pyqtgraph.setConfigOption>`
+            Option to change the default foreground color.
+        """     
         self.picture = None
         if args or kwargs:
             self._textPen = fn.mkPen(*args, **kwargs)
@@ -525,32 +725,54 @@ class AxisItem(GraphicsWidget):
         self.labelStyle['color'] = self._textPen.color().name() #   #RRGGBB
         self._updateLabel()
 
-    def tickPen(self):
-        if self._tickPen is None:
-            return self.pen() # Default to the main pen
-        else:
-            return fn.mkPen(self._tickPen)
+    def tickPen(self) -> QtGui.QPen:
+        """
+        Get the pen used for drawing ticks.
+
+        If no custom tick pen has been set, this method will return the axis's
+        main pen.
+
+        Returns
+        -------
+        QPen
+            The pen used to draw tick marks.
+        """
+        return self.pen() if self._tickPen is None else fn.mkPen(self._tickPen)
 
     def setTickPen(self, *args, **kwargs):
         """
-        Set the pen used for drawing tick marks.
-        If no arguments are given, the default pen will be used.
-        """
-        self.picture = None
-        if args or kwargs:
-            self._tickPen = fn.mkPen(*args, **kwargs)
-        else:
-            self._tickPen = None
+        Set the pen used for drawing ticks.
 
+        If no arguments given, the default foreground color will be used.
+        
+        Parameters
+        ----------
+        *args : tuple
+            Arguments relayed to :func:`~pyqtgraph.mkPen`.
+        **kwargs : dict
+            Arguments relayed to `:func:`~pyqtgraph.mkPen`.
+
+        See Also
+        --------
+        :func:`setConfigOption <pyqtgraph.setConfigOption>`
+            Option to change the default foreground color.
+        """   
+        self.picture = None
+        self._tickPen = fn.mkPen(*args, **kwargs) if args or kwargs else None
         self._updateLabel()
 
-    def setScale(self, scale=None):
+    def setScale(self, scale=1.0):
         """
         Set the value scaling for this axis.
 
-        Setting this value causes the axis to draw ticks and tick labels as if
-        the view coordinate system were scaled. By default, the axis scaling is
-        1.0.
+        Setting this value causes the axis to draw ticks and tick labels as if the view
+        coordinate system were scaled.
+
+        Parameters
+        ----------
+        scale : float, optional
+            Value to scale the drawing of ticks and tick labels as if the view
+            coordinate system was scaled, by default 1.0.
         """
         if scale != self.scale:
             self.scale = scale
@@ -570,7 +792,13 @@ class AxisItem(GraphicsWidget):
 
         This feature is enabled by default, and is only available when a suffix
         (unit string) is provided to display on the label.
+
+        Parameters
+        ----------
+        enable : bool, optional
+            Enable Auto SI prefix, by default True.
         """
+
         self.autoSIPrefix = enable
         self.updateAutoSIPrefix()
 
@@ -578,10 +806,7 @@ class AxisItem(GraphicsWidget):
         scale = 1.0
         prefix = ''
         if self.label.isVisible():
-            if self.logMode:
-                _range = 10**np.array(self.range)
-            else:
-                _range = self.range
+            _range = 10**np.array(self.range) if self.logMode else self.range
             scaling_value = max(abs(_range[0]), abs(_range[1])) * self.scale
             if any(low <= scaling_value <= high for low, high in self.getSIPrefixEnableRanges()):
                 (scale, prefix) = fn.siScale(scaling_value)
@@ -590,9 +815,26 @@ class AxisItem(GraphicsWidget):
         self.labelUnitPrefix = prefix
         self._updateLabel()
 
-    def setRange(self, mn, mx):
-        """Set the range of values displayed by the axis.
-        Usually this is handled automatically by linking the axis to a ViewBox with :func:`linkToView <pyqtgraph.AxisItem.linkToView>`"""
+    def setRange(self, mn: float, mx: float):
+        """
+        Set the range of values displayed by the axis.
+
+        Usually this is handled automatically by linking the axis to a ViewBox with
+        :func:`linkToView <pyqtgraph.AxisItem.linkToView>`.
+
+        Parameters
+        ----------
+        mn : float
+            Bottom value to set the range to.
+        mx : float
+            Top value to set the range to.
+
+        Raises
+        ------
+        ValueError
+            When non-finite values are passed.
+        """
+
         if not isfinite(mn) or not isfinite(mx):
             raise ValueError(f"Not setting range to [{mn}, {mx}]")
         self.range = [mn, mx]
@@ -604,11 +846,15 @@ class AxisItem(GraphicsWidget):
             self.update()
 
     def linkedView(self):
-        """Return the ViewBox this axis is linked to."""
-        if self._linkedView is None:
-            return None
-        else:
-            return self._linkedView()
+        """
+        Return the ViewBox linked to this axis.
+
+        Returns
+        -------
+        ViewBox
+            The linked ViewBox, or ``None`` if there is no ViewBox linked.
+        """
+        return None if self._linkedView is None else self._linkedView()
 
     def _linkToView_internal(self, view):
         # We need this code to be available without override,
@@ -623,26 +869,44 @@ class AxisItem(GraphicsWidget):
         view.sigResized.connect(self.linkedViewChanged)
 
     def linkToView(self, view):
-        """Link this axis to a ViewBox, causing its displayed range to match the visible range of the view."""
+        """
+        Link to a ViewBox, causing its displayed range to match the view range.
+
+        This is usually called automatically by the ViewBox.
+
+        Parameters
+        ----------
+        view : ViewBox
+            The view to link to.
+        """
         self._linkToView_internal(view)
 
     def unlinkFromView(self):
-        """Unlink this axis from a ViewBox."""
+        """
+        Unlink this axis from its linked ViewBox.
+        """
         oldView = self.linkedView()
         self._linkedView = None
-        if self.orientation in ['right', 'left']:
-            if oldView is not None:
-                oldView.sigYRangeChanged.disconnect(self.linkedViewChanged)
-        else:
-            if oldView is not None:
-                oldView.sigXRangeChanged.disconnect(self.linkedViewChanged)
-
         if oldView is not None:
             oldView.sigResized.disconnect(self.linkedViewChanged)
+            if self.orientation in ['right', 'left']:
+                oldView.sigYRangeChanged.disconnect(self.linkedViewChanged)
+            else:
+                oldView.sigXRangeChanged.disconnect(self.linkedViewChanged)
 
     @QtCore.Slot(object)
     @QtCore.Slot(object, object)
     def linkedViewChanged(self, view, newRange=None):
+        """
+        Call when the linked view range has changed.
+
+        Parameters
+        ----------
+        view : ViewBox
+            The view whose range has changed.
+        newRange : tuple of float, float, optional
+            The new range of the view, by default None.
+        """
         if self.orientation in ['right', 'left']:
             if newRange is None:
                 newRange = view.viewRange()[1]
@@ -671,22 +935,24 @@ class AxisItem(GraphicsWidget):
             except ValueError: pass # ignore any non-numeric value
 
         linkedView = self.linkedView()
-        if linkedView is None or self.grid is False:
-            rect = self.mapRectFromParent(self.geometry())
-            ## extend rect if ticks go in negative direction
-            ## also extend to account for text that flows past the edges
-            tl = self.style['tickLength']
-            if self.orientation == 'left':
-                rect = rect.adjusted(0, -m, -min(0,tl), m)
-            elif self.orientation == 'right':
-                rect = rect.adjusted(min(0,tl), -m, 0, m)
-            elif self.orientation == 'top':
-                rect = rect.adjusted(-m, 0, m, -min(0,tl))
-            elif self.orientation == 'bottom':
-                rect = rect.adjusted(-m, min(0,tl), m, 0)
-            return rect
-        else:
-            return self.mapRectFromParent(self.geometry()) | linkedView.mapRectToItem(self, linkedView.boundingRect())
+        if linkedView is not None and self.grid is not False:
+            return (
+                self.mapRectFromParent(self.geometry()) | 
+                linkedView.mapRectToItem(self, linkedView.boundingRect())
+            )
+        rect = self.mapRectFromParent(self.geometry())
+        ## extend rect if ticks go in negative direction
+        ## also extend to account for text that flows past the edges
+        tl = self.style['tickLength']
+        if self.orientation == 'left':
+            rect = rect.adjusted(0, -m, -min(0,tl), m)
+        elif self.orientation == 'right':
+            rect = rect.adjusted(min(0,tl), -m, 0, m)
+        elif self.orientation == 'top':
+            rect = rect.adjusted(-m, 0, m, -min(0,tl))
+        elif self.orientation == 'bottom':
+            rect = rect.adjusted(-m, min(0,tl), m, 0)
+        return rect
 
     def shape(self):
         # override shape() to exclude grid lines from getting mouse events
@@ -711,90 +977,157 @@ class AxisItem(GraphicsWidget):
             finally:
                 painter.end()
             self.picture = picture
-        #p.setRenderHint(p.RenderHint.Antialiasing, False)   ## Sometimes we get a segfault here ???
-        #p.setRenderHint(p.RenderHint.TextAntialiasing, True)
         self.picture.play(p)
 
 
     def setTickDensity(self, density=1.0):
         """
-        The default behavior is to show at least two major ticks for axes of up to 300 pixels in length,
-        then add additional major ticks, spacing them out further as the available room increases.
-        (Internally, the targeted number of major ticks grows with the square root of the axes length.)
+        Set the density of ticks displayed on the axis.
 
-        Setting a tick density different from the default value of `density = 1.0` scales the number of
-        major ticks that is targeted for display. This only affects the automatic generation of ticks.
+        A higher density value means that more ticks will be displayed. The density
+        value is used in conjunction with the tickSpacing method to determine the
+        actual tick locations.
+
+        Parameters
+        ----------
+        density : float, optional
+            Density of ticks to display, by default 1.0.
         """
         self._tickDensity = density
         self.picture = None
         self.update()
 
 
-    def setTicks(self, ticks):
-        """Explicitly determine which ticks to display.
-        This overrides the behavior specified by tickSpacing(), tickValues(), and tickStrings()
+    def setTicks(
+        self,
+        ticks: list[list[tuple[float, str]]] | None
+    ):
+        """
+        Explicitly determine which ticks to display.
+
+        This overrides the behavior specified by
+        :meth:`~pyqtgraph.AxisItem.tickSpacing`, :meth:`~pyqtgraph.AxisItem.tickValues`,
+        and :meth:`~pyqtgraph.AxisItem.tickStrings`.
+        
         The format for *ticks* looks like::
 
             [
-                [ (majorTickValue1, majorTickString1), (majorTickValue2, majorTickString2), ... ],
-                [ (minorTickValue1, minorTickString1), (minorTickValue2, minorTickString2), ... ],
+                [
+                    (majorTickValue1, majorTickString1),
+                    (majorTickValue2, majorTickString2),
+                    ...
+                ],
+                [
+                    (minorTickValue1, minorTickString1),
+                    (minorTickValue2, minorTickString2),
+                    ...
+                ],
                 ...
             ]
+        
+        The two levels of major and minor ticks are expected. A third tier of additional
+        ticks is optional. If *ticks* is ``None``, then the default tick system will be
+        used.
 
-        The two levels of major and minor ticks are expected. A third tier of additional ticks is optional.
-        If *ticks* is None, then the default tick system will be used instead.
-        """
+        Parameters
+        ----------
+        ticks : list of list of float, str or None
+            Explicitly set tick display information.
+        
+        See Also
+        --------
+        :meth:`~pyqtgraph.AxisItem.tickSpacing`
+            How tick spacing is configured.
+        :meth:`~pyqtgraph.AxisItem.tickValues`
+            How tick values are set.
+        :meth:`~pyqtgraph.AxisItem.tickStrings`
+            How tick strings are specified.
+        """        
+
         self._tickLevels = ticks
         self.picture = None
         self.update()
 
-    def setTickSpacing(self, major=None, minor=None, levels=None):
+    def setTickSpacing(
+        self,
+        major: float | None=None,
+        minor: float | None=None,
+        levels: list[tuple[float, float]] | None=None
+    ):
         """
-        Explicitly determine the spacing of major and minor ticks. This
-        overrides the default behavior of the tickSpacing method, and disables
+        Explicitly determine the spacing of major and minor ticks.
+
+        This overrides the default behavior of the tickSpacing method, and disables
         the effect of setTicks(). Arguments may be either *major* and *minor*,
-        or *levels* which is a list of (spacing, offset) tuples for each
-        tick level desired.
+        or *levels* which is a list of ``(spacing, offset)`` tuples for each
+        tick level desired. If no arguments are given, then the default
+        behavior of tickSpacing is enabled.
 
-        If no arguments are given, then the default behavior of tickSpacing
-        is enabled.
+        Parameters
+        ----------
+        major : float, optional
+            Spacing for major ticks, by default None.
+        minor : float, optional
+            Spacing for minor ticks, by default None.
+        levels : list of tuple of float, float, optional
+            A list of (spacing, offset) tuples for each tick level, by default None.
 
-        Examples::
+        Examples
+        --------
+        .. code-block:: python
 
             # two levels, all offsets = 0
-            axis.setTickSpacing(5, 1)
+            axis.setTickSpacing(5., 1.)
             # three levels, all offsets = 0
-            axis.setTickSpacing(levels=[(3, 0), (1, 0), (0.25, 0)])
+            axis.setTickSpacing(levels=[(3., 0.), (1., 0.), (0.25, 0.)])
             # reset to default
             axis.setTickSpacing()
         """
 
         if levels is None:
-            if major is None:
-                levels = None
-            else:
-                levels = [(major, 0), (minor, 0)]
+            levels = None if major is None else [(major, 0.), (minor, 0.)]
         self._tickSpacing = levels
         self.picture = None
         self.update()
 
-
-    def tickSpacing(self, minVal, maxVal, size):
-        """Return values describing the desired spacing and offset of ticks.
+    def tickSpacing(self, minVal: float, maxVal: float, size: float):
+        """
+        Determine the spacing of ticks on the axis.
 
         This method is called whenever the axis needs to be redrawn and is a
         good method to override in subclasses that require control over tick locations.
 
-        The return value must be a list of tuples, one for each set of ticks::
+        Parameters
+        ----------
+        minVal : float
+            Minimum value being displayed on the axis.
+        maxVal : float
+            Maximum value being displayed on the axis.
+        size : float
+            Length of the axis in pixels.
 
-            [
-                (major tick spacing, offset),
-                (minor tick spacing, offset),
-                (sub-minor tick spacing, offset),
-                ...
-            ]
+        Returns
+        -------
+        list of tuple of float, float
+            A list of tuples, one for each tick level.
+            Each tuple contains two values: ``(spacing, offset)``.  The spacing value
+            is the distance between ticks, and the offset is the first tick relative to
+            *minVal*. For example, if ``result[0]`` is ``(10, 0)``, then major ticks 
+            will be displayed every 10 units and the first major tick will correspond to
+            ``minVal``. If instead ``result[0]`` is ``(10, 5)``, then major ticks will
+            be displayed every 10 units, but the first major tick will correspond to
+            ``minVal + 5``.
+
+            .. code-block:: python
+
+                [
+                    (major_tick_spacing, offset),
+                    (minor_tick_spacing, offset),
+                    (sub_minor_tick_spacing, offset),
+                    ...
+                ]
         """
-        # First check for override tick spacing
+        # First check for explicit tick spacing
         if self._tickSpacing is not None:
             return self._tickSpacing
 
@@ -834,10 +1167,7 @@ class AxisItem(GraphicsWidget):
         # manual sanity check: print(f"{majorMaxSpacing:.2e} > {majorInterval:.2e} = {majorScaleFactor:.2e} x {p10unit:.2e}")
 
         minorMinSpacing = 2 * dif/size   # no more than one minor tick per two pixels
-        if majorScaleFactor == 10:
-            trials = (5, 10) # if major interval is 1.0, try minor interval of 0.5, fall back to same as major interval
-        else:
-            trials = (10, 20, 50) # if major interval is 2.0 or 5.0, try minor interval of 1.0, increase as needed
+        trials = (5, 10) if majorScaleFactor == 10 else (10, 20, 50)
         for minorScaleFactor in trials:
             minorInterval = minorScaleFactor * p10unit
             if minorInterval >= minorMinSpacing:
@@ -866,25 +1196,35 @@ class AxisItem(GraphicsWidget):
         return levels
 
 
-    def tickValues(self, minVal, maxVal, size):
+    def tickValues(self, minVal:float, maxVal:float, size: float):
         """
-        Return the values and spacing of ticks to draw::
+        Return the values and spacing of ticks to draw.
 
-            [
-                (spacing, [major ticks]),
-                (spacing, [minor ticks]),
-                ...
-            ]
+        The values returned are essentially the same as those returned by
+        :meth:`~pyqtgraph.AxisItem.tickSpacing`, but with the addition of
+        explicit tick values for each tick level. This method is a good
+        method to override in subclasses.
 
-        By default, this method calls tickSpacing to determine the correct tick locations.
-        This is a good method to override in subclasses.
+        Parameters
+        ----------
+        minVal : float
+            Minimum value to generate tick values for.
+        maxVal : float
+            Maximum value to generate tick values for.
+        size : float
+            The length of the axis in pixels.
+
+        Returns
+        -------
+        list of tuple of float, list of float
+            A list of tuples, one for each tick level. Each tuple contains two
+            values: ``(spacing, values)``, where *spacing* is the distance between
+            ticks and *values* is a list of tick values.
         """
         minVal, maxVal = sorted((minVal, maxVal))
 
-
         minVal *= self.scale
         maxVal *= self.scale
-        #size *= self.scale
 
         ticks = []
         tickLevels = self.tickSpacing(minVal, maxVal, size)
@@ -902,66 +1242,88 @@ class AxisItem(GraphicsWidget):
             ## we assume here that if the difference between a tick value and a previously seen tick value
             ## is less than spacing/100, then they are 'equal' and we can ignore the new tick.
             close = np.any(
-                np.isclose(allValues, values[:, np.newaxis], rtol=0, atol=spacing/self.scale*0.01)
-                , axis=-1
+                np.isclose(
+                    allValues,
+                    values[:, np.newaxis],
+                    rtol=0,
+                    atol=spacing/self.scale*0.01
+                ),
+                axis=-1
             )
             values = values[~close]
             allValues = np.concatenate([allValues, values])
             ticks.append((spacing/self.scale, values.tolist()))
-
         if self.logMode:
             return self.logTickValues(minVal, maxVal, size, ticks)
-
-
-        #nticks = []
-        #for t in ticks:
-            #nvals = []
-            #for v in t[1]:
-                #nvals.append(v/self.scale)
-            #nticks.append((t[0]/self.scale,nvals))
-        #ticks = nticks
-
         return ticks
 
     def logTickValues(self, minVal, maxVal, size, stdTicks):
+        """
+        Return tick values for log-scale axes.
+
+        This method is called by :meth:`~pyqtgraph.AxisItem.tickValues` when the axis
+        is in logarithmic mode. It is a good method to override in subclasses.
+
+        Parameters
+        ----------
+        minVal : float
+            Minimum value to generate tick values for.
+        maxVal : float
+            Maximum value to generate tick values for.
+        size : float
+            The length of the axis in pixels.
+        stdTicks : list of tuple of float, float
+            The tick values generated by the standard
+            :meth:`~pyqtgraph.AxisItem.tickValues` method.
+
+        Returns
+        -------
+        list of tuple of float, float or list of tuple of None, float
+            A list of tuples, one for each tick level. Each tuple contains two
+            values: ``(spacing, values)``, where *spacing* is the distance between
+            ticks and *values* is a list of tick values.
+        """
 
         ## start with the tick spacing given by tickValues().
         ## Any level whose spacing is < 1 needs to be converted to log scale
-
-        ticks = []
-        for (spacing, t) in stdTicks:
-            if spacing >= 1.0:
-                ticks.append((spacing, t))
-
+        ticks = [(spacing, t) for spacing, t in stdTicks if spacing >= 1.0]
         if len(ticks) < 3:
             v1 = int(floor(minVal))
             v2 = int(ceil(maxVal))
-            #major = list(range(v1+1, v2))
 
+            # minor = [v + np.log10(np.arange(1, 10)) for v in range(v1, v2)]
             minor = []
             for v in range(v1, v2):
                 minor.extend(v + np.log10(np.arange(1, 10)))
-            minor = [x for x in minor if x>minVal and x<maxVal]
+            minor = [x for x in minor if x > minVal and x < maxVal]
             ticks.append((None, minor))
         return ticks
 
-    def tickStrings(self, values, scale, spacing):
-        """Return the strings that should be placed next to ticks. This method is called
-        when redrawing the axis and is a good method to override in subclasses.
-        The method is called with a list of tick values, a scaling factor (see below), and the
-        spacing between ticks (this is required since, in some instances, there may be only
-        one tick and thus no other way to determine the tick spacing)
-
-        The scale argument is used when the axis label is displaying units which may have an SI scaling prefix.
-        When determining the text to display, use value*scale to correctly account for this prefix.
-        For example, if the axis label's units are set to 'V', then a tick value of 0.001 might
-        be accompanied by a scale value of 1000. This indicates that the label is displaying 'mV', and
-        thus the tick should display 0.001 * 1000 = 1.
+    def tickStrings(self, values: list[float], scale: float, spacing: float):
         """
+        Return the strings that should be displayed at each tick value.
+
+        This method is used to generate tick strings, and is called automatically.
+
+        Parameters
+        ----------
+        values : list of float
+            List of tick values.
+        scale : float
+            The scaling factor for tick values.
+        spacing : float
+            The spacing between ticks.
+
+        Returns
+        -------
+        list of str
+            List of strings to display at each tick value.
+        """
+
         if self.logMode:
             return self.logTickStrings(values, scale, spacing)
 
-        places = max(0, ceil(-log10(spacing*scale)))
+        places = max(0, ceil(-log10(spacing * scale)))
         strings = []
         for v in values:
             vs = v * scale
@@ -972,8 +1334,31 @@ class AxisItem(GraphicsWidget):
             strings.append(vstr)
         return strings
 
-    def logTickStrings(self, values, scale, spacing):
-        estrings = ["%0.1g"%x for x in 10 ** np.array(values).astype(float) * np.array(scale)]
+    def logTickStrings(self, values: list[float], scale: float, spacing: float):
+        """
+        Return the strings that should be displayed at each tick value in log mode.
+
+        This method is called by :meth:`~pyqtgraph.AxisItem.tickStrings` when the axis
+        is in logarithmic mode. It is a good method to override in subclasses.
+
+        Parameters
+        ----------
+        values : list of float
+            List of tick values.
+        scale : float
+            The scaling factor for tick values.
+        spacing : float
+            The spacing between ticks.
+
+        Returns
+        -------
+        list of str
+            List of strings to display at each tick value.
+        """
+        estrings = [
+            "%0.1g"%x
+            for x in 10 ** np.array(values).astype(float) * np.array(scale)
+        ]
         convdict = {"0": "⁰",
                     "1": "¹",
                     "2": "²",
@@ -991,20 +1376,40 @@ class AxisItem(GraphicsWidget):
                 v, p = e.split("e")
                 sign = "⁻" if p[0] == "-" else ""
                 pot = "".join([convdict[pp] for pp in p[1:].lstrip("0")])
-                if v == "1":
-                    v = ""
-                else:
-                    v = v + "·"
-                dstrings.append(v + "10" + sign + pot)
+                v = "" if v == "1" else f"{v}·"
+                dstrings.append(f"{v}10{sign}{pot}")
             else:
                 dstrings.append(e)
         return dstrings
 
     def generateDrawSpecs(self, p):
         """
-        Calls tickValues() and tickStrings() to determine where and how ticks should
-        be drawn, then generates from this a set of drawing commands to be
-        interpreted by drawPicture().
+        Generate the drawing specifications for the axis, ticks, and labels.
+
+        This method determines all the coordinates and other information needed to draw
+        the axis, including tick positions, tick labels, and axis label. It returns a
+        tuple of values that are used to draw the axis. This is a good method to
+        override in subclasses that need more control over the appearance of the axis.
+
+        Parameters
+        ----------
+        p : QPainter
+            The painter used to draw the axis.
+
+        Returns
+        -------
+        tuple
+            A tuple containing the drawing specifications for the axis, ticks, and
+            labels. The tuple contains the following values:
+
+            - ``axisSpec``: A tuple containing the pen, start point, and end point of
+              the axis line.
+            - ``tickSpecs``: A list of tuples, one for each tick. Each tuple contains
+              the pen, start point, and end point of the tick line.
+            - ``textSpecs``: A list of tuples, one for each tick label. Each tuple
+              contains the bounding rectangle, alignment flags, and text of the label.
+        
+        :meta private:
         """
         profiler = debug.Profiler()
         if self.style['tickFont'] is not None:
@@ -1050,9 +1455,9 @@ class AxisItem(GraphicsWidget):
             tickDir = 1
             axis = 1
         else:
-            raise ValueError("self.orientation must be in ('left', 'right', 'top', 'bottom')")
-        #print tickStart, tickStop, span
-
+            raise ValueError(
+                "self.orientation must be in {'left', 'right', 'top', 'bottom'}"
+            )
         ## determine size of this item in pixels
         points = list(map(self.mapToDevice, span))
         if None in points:
@@ -1083,13 +1488,12 @@ class AxisItem(GraphicsWidget):
         if dif == 0:
             xScale = 1
             offset = 0
+        elif axis == 0:
+            xScale = -bounds.height() / dif
+            offset = self.range[0] * xScale - bounds.height()
         else:
-            if axis == 0:
-                xScale = -bounds.height() / dif
-                offset = self.range[0] * xScale - bounds.height()
-            else:
-                xScale = bounds.width() / dif
-                offset = self.range[0] * xScale
+            xScale = bounds.width() / dif
+            offset = self.range[0] * xScale
 
         xRange = [x * xScale - offset for x in self.range]
         xMin = min(xRange)
@@ -1168,13 +1572,6 @@ class AxisItem(GraphicsWidget):
 
 
         textOffset = self.style['tickTextOffset'][axis]  ## spacing between axis and text
-        #if self.style['autoExpandTextSpace'] is True:
-            #textWidth = self.textWidth
-            #textHeight = self.textHeight
-        #else:
-            #textWidth = self.style['tickTextWidth'] ## space allocated for horizontal text
-            #textHeight = self.style['tickTextHeight'] ## space allocated for horizontal text
-
         textSize2 = 0
         lastTextSize2 = 0
         textRects = []
@@ -1214,7 +1611,7 @@ class AxisItem(GraphicsWidget):
                     rects.append(br)
                     textRects.append(rects[-1])
 
-            if len(textRects) > 0:
+            if textRects:
                 ## measure all text, make sure there's enough room
                 if axis == 0:
                     textSize = np.sum([r.height() for r in textRects])
@@ -1241,19 +1638,15 @@ class AxisItem(GraphicsWidget):
 
             lastTextSize2 = textSize2
 
-            #spacing, values = tickLevels[best]
-            #strings = self.tickStrings(values, self.scale, spacing)
             # Determine exactly where tick text should be drawn
             for j in range(len(strings)):
                 vstr = strings[j]
                 if vstr is None: ## this tick was ignored because it is out of bounds
                     continue
                 x = tickPositions[i][j]
-                #textRect = p.boundingRect(QtCore.QRectF(0, 0, 100, 100), QtCore.Qt.AlignmentFlag.AlignCenter, vstr)
                 textRect = rects[j]
                 height = textRect.height()
                 width = textRect.width()
-                #self.textHeight = height
                 offset = max(0,self.style['tickLength']) + textOffset
 
                 rect = QtCore.QRectF()
@@ -1271,12 +1664,10 @@ class AxisItem(GraphicsWidget):
                     rect = QtCore.QRectF(x-width/2., tickStop+offset, width, height)
 
                 textFlags = alignFlags | QtCore.Qt.TextFlag.TextDontClip
-                #p.setPen(self.pen())
-                #p.drawText(rect, textFlags, vstr)
-
                 br = self.boundingRect()
+
                 # br.contains(rect) suffers from floating point rounding errors
-                if not br & rect == rect:
+                if br & rect != rect:
                     continue
 
                 textSpecs.append((rect, textFlags, vstr))
@@ -1285,7 +1676,7 @@ class AxisItem(GraphicsWidget):
         ## update max text size if needed.
         self._updateMaxTextSize(lastTextSize2)
 
-        return (axisSpec, tickSpecs, textSpecs)
+        return axisSpec, tickSpecs, textSpecs
 
     def drawPicture(self, p, axisSpec, tickSpecs, textSpecs):
         profiler = debug.Profiler()
@@ -1317,14 +1708,14 @@ class AxisItem(GraphicsWidget):
         profiler('draw text')
 
     def show(self):
-        GraphicsWidget.show(self)
+        super().show()
         if self.orientation in ['left', 'right']:
             self._updateWidth()
         else:
             self._updateHeight()
 
     def hide(self):
-        GraphicsWidget.hide(self)
+        super().hide()
         if self.orientation in ['left', 'right']:
             self._updateWidth()
         else:

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -3,6 +3,8 @@ import os
 import warnings
 import weakref
 
+from typing import Iterable
+
 import numpy as np
 
 from ... import functions as fn
@@ -18,7 +20,6 @@ from ..LabelItem import LabelItem
 from ..LegendItem import LegendItem
 from ..PlotCurveItem import PlotCurveItem
 from ..PlotDataItem import PlotDataItem
-from ..ScatterPlotItem import ScatterPlotItem
 from ..ViewBox import ViewBox
 
 translate = QtCore.QCoreApplication.translate
@@ -29,13 +30,14 @@ __all__ = ['PlotItem']
 
 
 class PlotItem(GraphicsWidget):
-    """GraphicsWidget implementing a standard 2D plotting area with axes.
+    """
+    GraphicsWidget implementing a standard 2D plotting area with axes.
 
     **Bases:** :class:`GraphicsWidget <pyqtgraph.GraphicsWidget>`
     
     This class provides the ViewBox-plus-axes that appear when using
     :func:`pg.plot() <pyqtgraph.plot>`, :class:`PlotWidget <pyqtgraph.PlotWidget>`,
-    and :func:`GraphicsLayout.addPlot() <pyqtgraph.GraphicsLayout.addPlot>`.
+    and :meth :`GraphicsLayout.addPlot() <pyqtgraph.GraphicsLayout.addPlot>`.
 
     It's main functionality is:
 
@@ -71,13 +73,51 @@ class PlotItem(GraphicsWidget):
     
     The ViewBox itself can be accessed by calling :func:`getViewBox() <pyqtgraph.PlotItem.getViewBox>` 
     
-    ======================= =======================================================================
-    **Signals:**
-    sigYRangeChanged        wrapped from :class:`ViewBox <pyqtgraph.ViewBox>`
-    sigXRangeChanged        wrapped from :class:`ViewBox <pyqtgraph.ViewBox>`
-    sigRangeChanged         wrapped from :class:`ViewBox <pyqtgraph.ViewBox>`
-    sigRangeChangedManually wrapped from :class:`ViewBox <pyqtgraph.ViewBox>`
-    ======================= =======================================================================
+    Parameters
+    ----------
+    parent : QObject or None, default None
+        Parent :class:`QObject` assign to the :class:`~pyqtgraph.PlotItem`.
+    name : str or None, default None
+        Register the value for this view so that others may link to it.
+    labels :  dict of str or None, default None
+        A dictionary specifying the axis labels to display
+
+        .. code-block:: python
+                   
+            {'left': (args), 'bottom': (args), ...}
+        
+        The name of each axis and the corresponding arguments are passed to 
+        :meth:`PlotItem.setLabel() <pyqtgraph.PlotItem.setLabel>`
+        Optionally, PlotItem my also be initialized with the keyword arguments left,
+        right, top, or bottom to achieve the same effect.
+    title : str
+        Text to set the title of the PlotItem to.
+    viewBox : :class:`~pyqtgraph.ViewBox` or None, default None
+        Have the PlotItem use the provided :class:`~pyqtgraph.ViewBox`. If not
+        specified, the PlotItem will be constructed with this as its ViewBox.
+    axisItems : dict of {'left', 'bottom', 'right', 'top } and AxisItem or None
+        Pass pre-constructed :class:`~pyqtgraph.AxisItem` objects to be used for the
+        `left`, `bottom`, `right` or `top` axis.  Default is None.
+    enableMenu : bool
+        Toggle the enabling or disabling of the right-click context menu.
+    **kwargs : dict, optional
+        Any extra keyword arguments are passed to
+        :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>`.
+    
+    Signals
+    -------
+    sigYRangeChanged : Signal
+        Signal is emitted when the range on the y-axis changes. Signal contains a
+        reference to the :class:`~pyqtgraph.ViewBox`, and tuple of (xmin, xmax).
+    sigXRangeChanged : Signal
+        Signal is emitted when the range on the x-axis changes. Signal contains a
+        reference to the :class:`~pyqtgraph.ViewBox`, and tuple of (ymin, ymax).
+    sigRangeChanged : Signal
+        Signal is emitted when the range on either x or y-axis changes. Signal contains
+        a reference to the :class:`~pyqtgraph.ViewBox`, a list of lists of the form,
+        ``[[x_min, x_max], [y_min, y_max]]`` and a list of two booleans, indicating if
+        the range on which axis has changed of the form 
+        ``[x_range_changed, y_range_changed]``.
     """
     
     sigRangeChanged = QtCore.Signal(object, object)    ## Emitted when the ViewBox range has changed
@@ -87,41 +127,31 @@ class PlotItem(GraphicsWidget):
         
     lastFileDir = None
     
-    def __init__(self, parent=None, name=None, labels=None, title=None, viewBox=None, axisItems=None, enableMenu=True, **kargs):
-        """
-        Create a new PlotItem. All arguments are optional.
-        Any extra keyword arguments are passed to :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>`.
-        
-        ==============  ==========================================================================================
-        **Arguments:**
-        *title*         Title to display at the top of the item. Html is allowed.
-        *labels*        A dictionary specifying the axis labels to display::
-                   
-                            {'left': (args), 'bottom': (args), ...}
-                     
-                        The name of each axis and the corresponding arguments are passed to 
-                        :func:`PlotItem.setLabel() <pyqtgraph.PlotItem.setLabel>`
-                        Optionally, PlotItem my also be initialized with the keyword arguments left,
-                        right, top, or bottom to achieve the same effect.
-        *name*          Registers a name for this view so that others may link to it
-        *viewBox*       If specified, the PlotItem will be constructed with this as its ViewBox.
-        *axisItems*     Optional dictionary instructing the PlotItem to use pre-constructed items
-                        for its axes. The dict keys must be axis names ('left', 'bottom', 'right', 'top')
-                        and the values must be instances of AxisItem (or at least compatible with AxisItem).
-        ==============  ==========================================================================================
-        """
-        
-        GraphicsWidget.__init__(self, parent)
-        
-        self.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding)
-        
+    def __init__(
+        self,
+        parent : QtCore.QObject | None = None,
+        name: str | None = None,
+        labels: dict[str, str] | None = None,
+        title: str | None = None,
+        viewBox: ViewBox | None = None,
+        axisItems: dict[str, AxisItem] | None = None,
+        enableMenu: bool = True,
+        **kwargs
+    ):  
+        super().__init__(parent)
+
+        self.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding,
+            QtWidgets.QSizePolicy.Policy.Expanding
+        )
+
         ## Set up control buttons
         self.autoBtn = ButtonItem(icons.getGraphPixmap('auto'), 14, self)
         self.autoBtn.mode = 'auto'
         self.autoBtn.clicked.connect(self.autoBtnClicked)
-        self.buttonsHidden = False ## whether the user has requested buttons to be hidden
+        self.buttonsHidden = False  # has the user has requested buttons to be hidden?
         self.mouseHovering = False
-        
+
         self.layout = QtWidgets.QGraphicsGridLayout()
         self.layout.setContentsMargins(1,1,1,1)
         self.setLayout(self.layout)
@@ -135,35 +165,35 @@ class PlotItem(GraphicsWidget):
 
         # Enable or disable plotItem menu
         self.setMenuEnabled(enableMenu, None)
-        
+
         if name is not None:
             self.vb.register(name)
         self.vb.sigRangeChanged.connect(self.sigRangeChanged)
         self.vb.sigXRangeChanged.connect(self.sigXRangeChanged)
         self.vb.sigYRangeChanged.connect(self.sigYRangeChanged)
         self.vb.sigRangeChangedManually.connect(self.sigRangeChangedManually)
-        
+
         self.layout.addItem(self.vb, 2, 1)
         self.alpha = 1.0
         self.autoAlpha = True
         self.spectrumMode = False
-        
+
         self.legend = None
-        
+
         # Initialize axis items
         self.axes = {}
         self.setAxisItems(axisItems)
-        
+
         self.titleLabel = LabelItem('', size='11pt', parent=self)
         self.layout.addItem(self.titleLabel, 0, 1)
         self.setTitle(None)  ## hide
-        
+
         for i in range(4):
             self.layout.setRowPreferredHeight(i, 0)
             self.layout.setRowMinimumHeight(i, 0)
             self.layout.setRowSpacing(i, 0)
             self.layout.setRowStretchFactor(i, 1)
-            
+
         for i in range(3):
             self.layout.setColumnPreferredWidth(i, 0)
             self.layout.setColumnMinimumWidth(i, 0)
@@ -171,7 +201,7 @@ class PlotItem(GraphicsWidget):
             self.layout.setColumnStretchFactor(i, 1)
         self.layout.setRowStretchFactor(2, 100)
         self.layout.setColumnStretchFactor(1, 100)
-        
+
 
         self.items = []
         self.curves = []
@@ -179,16 +209,16 @@ class PlotItem(GraphicsWidget):
         self.dataItems = []
         self.paramList = {}
         self.avgCurves = {}
-        # Change these properties to adjust the appearance of the averged curve:
-        self.avgPen = fn.mkPen([0, 200, 0])
-        self.avgShadowPen = fn.mkPen([0, 0, 0], width=4) # the previous default of [0,0,0,100] prevent fast drawing of the wide shadow line
+        # Change these properties to adjust the appearance of the averaged curve:
+        self.avgPen = fn.mkPen((0, 200, 0))
+        self.avgShadowPen = fn.mkPen((0, 0, 0), width=4)
 
         ### Set up context menu
-        
+
         w = QtWidgets.QWidget()
         self.ctrl = c = ui_template.Ui_Form()
         c.setupUi(w)
-        
+
         menuItems = [
             (translate("PlotItem", 'Transforms'), c.transformGroup),
             (translate("PlotItem", 'Downsample'), c.decimateGroup),
@@ -197,8 +227,7 @@ class PlotItem(GraphicsWidget):
             (translate("PlotItem", 'Grid'), c.gridGroup),
             (translate("PlotItem", 'Points'), c.pointsGroup),
         ]
-        
-        
+
         self.ctrlMenu = QtWidgets.QMenu(translate("PlotItem", 'Plot Options'))
 
         for name, grp in menuItems:
@@ -206,13 +235,13 @@ class PlotItem(GraphicsWidget):
             act = QtWidgets.QWidgetAction(self)
             act.setDefaultWidget(grp)
             sm.addAction(act)
-        
+
         self.stateGroup = WidgetGroup()
         for name, w in menuItems:
             self.stateGroup.autoAdd(w)
-        
+
         self.fileDialog = None
-        
+
         c.alphaGroup.toggled.connect(self.updateAlpha)
         c.alphaSlider.valueChanged.connect(self.updateAlpha)
         c.autoAlphaCheck.toggled.connect(self.updateAlpha)
@@ -236,42 +265,53 @@ class PlotItem(GraphicsWidget):
 
         self.ctrl.avgParamList.itemClicked.connect(self.avgParamListClicked)
         self.ctrl.averageGroup.toggled.connect(self.avgToggled)
-        
+
         self.ctrl.maxTracesCheck.toggled.connect(self._handle_max_traces_toggle)
         self.ctrl.forgetTracesCheck.toggled.connect(self.updateDecimation)
         self.ctrl.maxTracesSpin.valueChanged.connect(self.updateDecimation)
-        
+
         if labels is None:
             labels = {}
         for label in list(self.axes.keys()):
-            if label in kargs:
-                labels[label] = kargs[label]
-                del kargs[label]
+            if label in kwargs:
+                labels[label] = kwargs[label]
+                del kwargs[label]
         for k in labels:
             if isinstance(labels[k], str):
                 labels[k] = (labels[k],)
             self.setLabel(k, *labels[k])
-                
+
         if title is not None:
             self.setTitle(title)
-        
-        if len(kargs) > 0:
-            self.plot(**kargs)        
+
+        if kwargs:
+            self.plot(**kwargs)        
         
     def implements(self, interface=None):
         return interface in ['ViewBoxWrapper']
 
-    def getViewBox(self):
-        """Return the :class:`ViewBox <pyqtgraph.ViewBox>` contained within."""
+    def getViewBox(self) -> ViewBox:
+        """
+        Return the embedded :class:`~pyqtgraph.ViewBox`.
+
+        Returns
+        -------
+        ViewBox 
+            The :class:`ViewBox <pyqtgraph.ViewBox>` that this PlotItem uses.
+        """
         return self.vb
     
-    ## Wrap a few methods from viewBox. 
-    #Important: don't use a settattr(m, getattr(self.vb, m)) as we'd be leaving the viebox alive
-    #because we had a reference to an instance method (creating wrapper methods at runtime instead).
-    for m in ['setXRange', 'setYRange', 'setXLink', 'setYLink', 'setAutoPan',         # NOTE: 
-              'setAutoVisible', 'setDefaultPadding', 'setRange', 'autoRange', 'viewRect', 'viewRange',     # If you update this list, please 
-              'setMouseEnabled', 'setLimits', 'enableAutoRange', 'disableAutoRange',  # update the class docstring 
-              'setAspectLocked', 'invertY', 'invertX', 'register', 'unregister']:                # as well.
+    # Wrap a few methods from viewBox. 
+    # Important: don't use settattr(m, getattr(self.vb, m)) as we'd be leaving the
+    # viewbox alive because we had a reference to an instance method (creating wrapper
+    # methods at runtime instead).
+
+    # Note: If you update this list, please update the class docstring as well
+    for m in ['setXRange', 'setYRange', 'setXLink', 'setYLink', 'setAutoPan',
+              'setAutoVisible', 'setDefaultPadding', 'setRange', 'autoRange',
+              'viewRect', 'viewRange', 'setMouseEnabled', 'setLimits',
+              'enableAutoRange', 'disableAutoRange', 'setAspectLocked', 'invertY',
+              'invertX', 'register', 'unregister']:
                 
         def _create_method(name):
             def method(self, *args, **kwargs):
@@ -283,26 +323,29 @@ class PlotItem(GraphicsWidget):
         
     del _create_method
     
-    def setAxisItems(self, axisItems=None):
+    def setAxisItems(self, axisItems: 'dict[str, AxisItem] | None' = None) -> None:
         """
-        Place axis items as given by `axisItems`. Initializes non-existing axis items.
-        
-        ==============  ==========================================================================================
-        **Arguments:**
-        *axisItems*     Optional dictionary instructing the PlotItem to use pre-constructed items
-                        for its axes. The dict keys must be axis names ('left', 'bottom', 'right', 'top')
-                        and the values must be instances of AxisItem (or at least compatible with AxisItem).
-        ==============  ==========================================================================================
+        Place axis items and initializes non-existing axis items.
+
+        Parameters
+        ----------
+        axisItems : dict of str and AxisItem or None
+            Optional dictionary instructing the PlotItem to use pre-constructed items
+            for its axes. The dict keys must be axis names
+            {'left', 'bottom', 'right', 'top'} and the values must be instances of
+            :class:`~pyqtgraph.AxisItem`.
         """
         
         if axisItems is None:
             axisItems = {}
         
         # Array containing visible axis items
-        # Also containing potentially hidden axes, but they are not touched so it does not matter
+        # Also containing potentially hidden axes, but they are not touched so it does
+        # not matter
         visibleAxes = ['left', 'bottom']
-        visibleAxes.extend(axisItems.keys()) # Note that it does not matter that this adds
-                                             # some values to visibleAxes a second time
+        # Note that it does not matter that this adds
+        # some values to visibleAxes a second time
+        visibleAxes.extend(axisItems.keys()) 
         
         for k, pos in (('top', (1,1)), ('bottom', (3,1)), ('left', (2,0)), ('right', (2,2))):
             if k in self.axes:
@@ -319,12 +362,15 @@ class PlotItem(GraphicsWidget):
             # Create new axis
             if k in axisItems:
                 axis = axisItems[k]
-                if axis.scene() is not None:
-                    if k not in self.axes or axis != self.axes[k]["item"]:
-                        raise RuntimeError(
-                            "Can't add an axis to multiple plots. Shared axes"
-                            " can be achieved with multiple AxisItem instances"
-                            " and set[X/Y]Link.")
+                if (
+                    axis.scene() is not None 
+                    and (k not in self.axes or axis != self.axes[k]["item"])
+                ):
+                    raise RuntimeError(
+                        "Can't add an axis to multiple plots. Shared axes "
+                        "can be achieved with multiple AxisItem instances "
+                        "and set[X/Y]Link."
+                    )
             else:
                 axis = AxisItem(orientation=k, parent=self)
             
@@ -332,22 +378,34 @@ class PlotItem(GraphicsWidget):
             axis.linkToView(self.vb)
             self.axes[k] = {'item': axis, 'pos': pos}
             self.layout.addItem(axis, *pos)
-            # place axis above images at z=0, items that want to draw over the axes should be placed at z>=1:
+            # place axis above images at z=0, items that want to draw over the axes 
+            # should be placed at z>=1
             axis.setZValue(0.5) 
-            axis.setFlag(axis.GraphicsItemFlag.ItemNegativeZStacksBehindParent)           
+            axis.setFlag(
+                QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemNegativeZStacksBehindParent
+            )           
             axisVisible = k in visibleAxes
             self.showAxis(k, axisVisible)
         
     def setLogMode(self, x=None, y=None):
         """
         Set log scaling for `x` and/or `y` axes.
-        This informs PlotDataItems to transform logarithmically and switches
-        the axes to use log ticking. 
+
+        This informs PlotDataItems to transform logarithmically and switches the axes to
+        use log ticking.
+
+        Parameters
+        ----------
+        x : bool or None
+            If ``True``, set the x-axis to log mode. A value of ``None`` is ignored.
+        y : bool or None
+            If ``True``, set the y-axis to log mode. A value of ``None`` is ignored.
         
-        Note that *no other items* in the scene will be affected by
-        this; there is (currently) no generic way to redisplay a GraphicsItem
-        with log coordinates.
-        
+        Notes
+        -----
+        No other items, in the scene will be affected by this; there is (currently) 
+        no generic way to redisplay a :class:`~pyqtgraph.GraphicsItem` with log
+        coordinates.
         """
         if x is not None:
             self.ctrl.logXCheck.setChecked(x)
@@ -357,16 +415,19 @@ class PlotItem(GraphicsWidget):
     def showGrid(self, x=None, y=None, alpha=None):
         """
         Show or hide the grid for either axis.
-        
-        ==============  =====================================
-        **Arguments:**
-        x               (bool) Whether to show the X grid
-        y               (bool) Whether to show the Y grid
-        alpha           (0.0-1.0) Opacity of the grid
-        ==============  =====================================
+
+        Parameters
+        ----------
+        x : bool or None
+            Show the X grid, a value of ``None`` is ignored.
+        y : bool or None
+            Show the Y grid, a value of ``None`` is ignored.
+        alpha : float or None
+            Opacity of the grid, float values need to be between [0.0, 1.0].
         """
         if x is None and y is None and alpha is None:
-            raise Exception("Must specify at least one of x, y, or alpha.")  ## prevent people getting confused if they just call showGrid()
+            # prevent people getting confused if they just call showGrid()
+            raise ValueError("Must specify at least one of x, y, or alpha.")
         
         if x is not None:
             self.ctrl.xGridCheck.setChecked(x)
@@ -410,8 +471,15 @@ class PlotItem(GraphicsWidget):
         self.getAxis('left').setGrid(y)
         self.getAxis('right').setGrid(y)
 
-    def viewGeometry(self):
-        """Return the screen geometry of the viewbox"""
+    def viewGeometry(self) -> QtCore.QRectF:
+        """
+        Return the screen geometry of the viewbox.
+
+        Returns
+        -------
+        QRectF
+            The QRectF instance that contains the view area.
+        """
         v = self.scene().views()[0]
         b = self.vb.mapRectToScene(self.vb.boundingRect())
         wr = v.mapFromScene(b).boundingRect()
@@ -420,7 +488,7 @@ class PlotItem(GraphicsWidget):
         return wr
 
     @QtCore.Slot(bool)
-    def avgToggled(self, b):
+    def avgToggled(self, b: bool):
         if b:
             self.recomputeAverages()
         for k in self.avgCurves:
@@ -444,23 +512,24 @@ class PlotItem(GraphicsWidget):
         
     def addAvgCurve(self, curve):
         ## Add a single curve into the pool of curves averaged together
-        
+
         ## If there are plot parameters, then we need to determine which to average together.
         remKeys = []
         addKeys = []
         if self.ctrl.avgParamList.count() > 0:
-        
-            ### First determine the key of the curve to which this new data should be averaged
+
+            # First determine the key of the curve to which this new data should be averaged
             for i in range(self.ctrl.avgParamList.count()):
                 item = self.ctrl.avgParamList.item(i)
                 if item.checkState() == QtCore.Qt.CheckState.Checked:
                     remKeys.append(str(item.text()))
                 else:
                     addKeys.append(str(item.text()))
-                    
-            if len(remKeys) < 1:  ## In this case, there would be 1 average plot for each data plot; not useful.
+
+            if not remKeys:
+                # In this case,there would be 1 avg plot for each data plot; not useful
                 return
-                
+
         p = self.itemMeta.get(curve,{}).copy()
         for k in p:
             if type(k) is tuple:
@@ -473,7 +542,7 @@ class PlotItem(GraphicsWidget):
             if ak not in p:
                 p[ak] = None
         key = tuple(p.items())
-        
+
         ### Create a new curve if needed
         if key not in self.avgCurves:
             plot = PlotDataItem()
@@ -485,7 +554,7 @@ class PlotItem(GraphicsWidget):
             self.avgCurves[key] = [0, plot]
         self.avgCurves[key][0] += 1
         (n, plot) = self.avgCurves[key]
-        
+
         ### Average data together
         (x, y) = curve.getData()
         stepMode = curve.opts['stepMode']
@@ -509,35 +578,60 @@ class PlotItem(GraphicsWidget):
     def viewStateChanged(self):
         self.updateButtons()
 
-    def addItem(self, item, *args, **kargs):
+    def addItem(self, item, *args, **kwargs):
         """
-        Add a graphics item to the view box. 
+        Add a :class:`~pyqtgraph.GraphicsItem` to the :class:`~pyqtgraph.ViewBox`.
+        
         If the item has plot data (:class:`PlotDataItem <pyqtgraph.PlotDataItem>` , 
-        :class:`~pyqtgraph.PlotCurveItem` , :class:`~pyqtgraph.ScatterPlotItem` ), 
-        it may be included in analysis performed by the PlotItem.
+        :class:`~pyqtgraph.PlotCurveItem`, :class:`~pyqtgraph.ScatterPlotItem` ), it may
+        be included in analysis performed by the PlotItem.
+
+        Parameters
+        ----------
+        item : GraphicsItem
+            Item to add to the ViewBox.
+        *args : tuple
+            Arguments relayed to :meth:`~pyqtgraph.ViewBox.addItem`.
+        **kwargs : dict
+            Keyword arguments for adding an item.  Supported arguments include.
+
+            ============ ===============================================================
+            Property     Description
+            ============ ===============================================================
+            ignoreBounds ``bool`` - Keyword argument relayed to 
+                         :meth:`~pyqtgraph.ViewBox.addItem`.
+            
+            skipAverage  ``bool`` - If ``True``, do not use curve to compute average
+                         curves.
+            ============ ===============================================================
+
+        See Also
+        --------
+        :meth:`~pyqtgraph.ViewBox.addItem`
+            See method for supported arguments to be passed.
         """
         if item in self.items:
             warnings.warn('Item already added to PlotItem, ignoring.')
             return
         self.items.append(item)
         vbargs = {}
-        if 'ignoreBounds' in kargs:
-            vbargs['ignoreBounds'] = kargs['ignoreBounds']
+        if 'ignoreBounds' in kwargs:
+            vbargs['ignoreBounds'] = kwargs['ignoreBounds']
         self.vb.addItem(item, *args, **vbargs)
         name = None
         if hasattr(item, 'implements') and item.implements('plotData'):
             name = item.name()
-            self.dataItems.append(item)
-            #self.plotChanged()
-            
-            params = kargs.get('params', {})
+            self.dataItems.append(item)            
+            params = kwargs.get('params', {})
             self.itemMeta[item] = params
-            #item.setMeta(params)
             self.curves.append(item)
-            #self.addItem(c)
-            
+        
+        # Toggle log mode if item implements setLogMode and selected in the context menu
         if hasattr(item, 'setLogMode'):
-            item.setLogMode(self.ctrl.logXCheck.isChecked(), self.ctrl.logYCheck.isChecked())
+            item.setLogMode(
+                self.ctrl.logXCheck.isChecked(),
+                self.ctrl.logYCheck.isChecked()
+            )
             
         if isinstance(item, PlotDataItem):
             ## configure curve for this plot
@@ -554,33 +648,48 @@ class PlotItem(GraphicsWidget):
             self.updateParamList()
             if self.ctrl.averageGroup.isChecked() and 'skipAverage' not in kargs:
                 self.addAvgCurve(item)
-                
-            #c.connect(c, QtCore.SIGNAL('plotChanged'), self.plotChanged)
-            #item.sigPlotChanged.connect(self.plotChanged)
-            #self.plotChanged()
-        #name = kargs.get('name', getattr(item, 'opts', {}).get('name', None))
+
+        # conditionally add item to the legend
         if name is not None and hasattr(self, 'legend') and self.legend is not None:
             self.legend.addItem(item, name=name)            
 
     def listDataItems(self):
-        """Return a list of all data items (:class:`~pyqtgraph.PlotDataItem`,
-        :class:`~pyqtgraph.PlotCurveItem` , :class:`~pyqtgraph.ScatterPlotItem` , etc)
-        contained in this PlotItem."""
+        """
+        Return a list of all data items current plotted.
+
+        Returns
+        -------
+        list of PlotCurveItem, ScatterPlotItem or PlotDataItem
+            A copy of a list of the data items.
+        """
         return self.dataItems[:]
 
-    def addLine(self, x=None, y=None, z=None, **kwds):
+    def addLine(self, x=None, y=None, z=None, **kwargs):
         """
-        Create an :class:`~pyqtgraph.InfiniteLine` and add to the plot. 
+        Create a new :class:`~pyqtgraph.InfiniteLine` and add it to the plot.
+
+        Parameters
+        ----------
+        x : float or None
+            Position in the x-axis to draw the line. If specified, the line will be 
+            vertical. Default ``None``.
+        y : float or None
+            Position in the y-axis to draw the line. If specified, the line will be
+            horizontal. Default ``None``.
+        z : int or None
+            Z value to set the line to. This is used to determine which items are on top
+            of the other.  See :meth:`~QtWidgets.QGraphicsItem.setZValue`.
+        **kwargs : dict
+            Keyword arguments to pass to the :class:`~pyqtgraph.InfiniteLine` instance.
         
-        If `x` is specified,
-        the line will be vertical. If `y` is specified, the line will be
-        horizontal. All extra keyword arguments are passed to
-        :func:`InfiniteLine.__init__() <pyqtgraph.InfiniteLine.__init__>`.
-        Returns the item created.
+        Returns
+        -------
+        InfiniteLine
+            The new :class:`~pyqtgraph.InfiniteLine` added.
         """
-        kwds['pos'] = kwds.get('pos', x if x is not None else y)
-        kwds['angle'] = kwds.get('angle', 0 if x is None else 90)
-        line = InfiniteLine(**kwds)
+        kwargs['pos'] = kwargs.get('pos', x if x is not None else y)
+        kwargs['angle'] = kwargs.get('angle', 0 if x is None else 90)
+        line = InfiniteLine(**kwargs)
         self.addItem(line)
         if z is not None:
             line.setZValue(z)
@@ -588,16 +697,21 @@ class PlotItem(GraphicsWidget):
 
     def removeItem(self, item):
         """
-        Remove an item from the PlotItem's :class:`~pyqtgraph.ViewBox`.
+        Remove an item from the plot.
+
+        Parameters
+        ----------
+        item : GraphicsItem
+            The item to remove.
         """
-        if not item in self.items:
+        if item not in self.items:
             return
         self.items.remove(item)
         if item in self.dataItems:
             self.dataItems.remove(item)
-            
+
         self.vb.removeItem(item)
-        
+
         if item in self.curves:
             self.curves.remove(item)
             self.updateDecimation()
@@ -615,29 +729,48 @@ class PlotItem(GraphicsWidget):
         self.avgCurves = {}
     
     def clearPlots(self):
+        """
+        Remove all curves from the PlotItem's :class:`~pyqtgraph.ViewBox`.
+        """
         for i in self.curves[:]:
             self.removeItem(i)
         self.avgCurves = {}        
     
-    def plot(self, *args, **kargs):
-#        **Additional arguments:**
+    def plot(self, *args, **kwargs):
         """
-        Add and return a new plot. See :class:`PlotDataItem` for data arguments
-        
-        **Additional allowed arguments**
-        
-        ========= =================================================================
-        `clear`   clears all plots before displaying new data
-        `params`  sets meta-parameters to associate with this data
-        ========= =================================================================
+        Add and return a new :class:`~pyqtgraph.PlotDataItem`.
+
+        Parameters
+        ----------
+        *args : tuple, optional
+            Arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
+            constructor.
+        **kwargs : dict, optional
+            Keyword arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
+            constructor.  In addition, the following keyword arguments are accepted.
+
+            =========== ================================================================
+            Property    Description
+            =========== ================================================================
+            clear       ``bool`` - Call :meth:`~pyqtgraph.PlotItem.clear` prior to
+                        creating the new plot instance.
+            
+            params      ``dict`` or ``None`` - Arguments to passed as the `params`
+                        argument to :meth:`~pyqtgraph.PlotItem.addItem`.
+            =========== ================================================================
+
+        Returns
+        -------
+        PlotDataItem
+            The newly created :class:`~pyqtgraph.PlotDataItem`.
         """
-        clear = kargs.get('clear', False)
-        params = kargs.get('params', None)
+        clear = kwargs.get('clear', False)
+        params = kwargs.get('params')
           
         if clear:
             self.clear()
             
-        item = PlotDataItem(*args, **kargs)
+        item = PlotDataItem(*args, **kwargs)
             
         if params is None:
             params = {}
@@ -647,43 +780,65 @@ class PlotItem(GraphicsWidget):
 
     def addLegend(self, offset=(30, 30), **kwargs):
         """
-        Create a new :class:`~pyqtgraph.LegendItem` and anchor it over the internal 
+        Add a new :class:`~pyqtgraph.LegendItem`.
+         
+        After the LegendItem is created, it is anchored in the internal 
         :class:`~pyqtgraph.ViewBox`. Plots added after this will be automatically 
         displayed in the legend if they are created with a 'name' argument.
 
         If a :class:`~pyqtgraph.LegendItem` has already been created using this method, 
         that item will be returned rather than creating a new one.
 
-        Accepts the same arguments as :func:`~pyqtgraph.LegendItem.__init__`.
+        Parameters
+        ----------
+        offset : tuple of int, int
+            The distance to offset the LegendItem, defaults to ``(30, 30)``.
+        **kwargs : dict, optional
+            Keyword argument passed to the :class:`~pyqtgraph.LegendItem` constructor.
+        
+        Returns
+        -------
+        LegendItem
+            The instance of :class:`~pyqtgraph.LegendItem` that was constructed.
         """
-
         if self.legend is None:
             self.legend = LegendItem(offset=offset, **kwargs)
             self.legend.setParentItem(self.vb)
         return self.legend
         
-    def addColorBar(self, image, **kargs):
+    def addColorBar(self, image, **kwargs):
         """
-        Adds a color bar linked to the ImageItem specified by `image`.
-        AAdditional parameters will be passed to the `pyqtgraph.ColorBarItem`.
+        Add a ColorBarItem and set to the provided image.
         
-        A call like `plot.addColorBar(img, colorMap='viridis')` is a convenient
+        A call like ``plot.addColorBar(img, colorMap='viridis')`` is a convenient
         method to assign and show a color map.
+
+        Parameters
+        ----------
+        image : ImageItem or list of ImageItem
+            See :meth:`~pyqtgraph.ColorBarItem.setImageItem` for details.
+        **kwargs : dict, optional
+            Keyword arguments passed to the :class:`~pyqtgraph.ColorBarItem`
+            constructor.
+        
+        Returns
+        -------
+        ColorBarItem
+            The newly created :class:`~pyqtgraph.ColorBarItem` instance.
         """
         from ..ColorBarItem import ColorBarItem  # avoid circular import
-        bar = ColorBarItem(**kargs)
+        bar = ColorBarItem(**kwargs)
         bar.setImageItem( image, insert_in=self )
         return bar
 
     def multiDataPlot(self, *, x=None, y=None, constKwargs=None, **kwargs):
         """
-        Allow plotting multiple curves on the same plot, changing some kwargs
-        per curve.
+        Allow plotting multiple curves on the same plot in one call.
 
         Parameters
         ----------
-        x, y: array_like
-            can be in the following formats:
+        x, y : array_like
+            Can be in the following formats:
               - {x or y} = [n1, n2, n3, ...]: The named argument iterates through
                 ``n`` curves, while the unspecified argument is range(len(n)) for
                 each curve.
@@ -691,16 +846,21 @@ class PlotItem(GraphicsWidget):
               - [x1, x2, x3, ...], [y1, y2, y3, ...]
               - [x1, x2, x3, ...], y
 
-              where ``x_n`` and ``y_n`` are ``ndarray`` data for each curve. Since
-              ``x`` and ``y`` values are matched using ``zip``, unequal lengths mean
-              the longer array will be truncated. Note that 2D matrices for either x
-              or y are considered lists of curve
-              data.
-        constKwargs: dict, optional
+            where ``x_n`` and ``y_n`` are ``ndarray`` data for each curve. Since
+            ``x`` and ``y`` values are matched using ``zip``, unequal lengths mean
+            the longer array will be truncated. Note that 2D matrices for either x
+            or y are considered lists of curve data.
+        constKwargs : dict, optional
             A dict of {str: value} passed to each curve during ``plot()``.
-        kwargs: dict, optional
+        **kwargs : dict, optional
             A dict of {str: iterable} where the str is the name of a kwarg and the
             iterable is a list of values, one for each plotted curve.
+        
+        Returns
+        -------
+        list of PlotDataItem
+            Returns a list of the newly constructed :class:`~pyqtgraph.PlotDataItem`
+            instances representing the new curves.
         """
         if (x is not None and not len(x)) or (y is not None and not len(y)):
             # Nothing to plot -- either x or y array will bail out early from
@@ -716,9 +876,9 @@ class PlotItem(GraphicsWidget):
             )
         curves = []
         constKwargs = constKwargs or {}
-        xy: 'dict[str, list | None]' = dict(x=x, y=y)
+        xy: dict[str, list | None] = dict(x=x, y=y)
         for key, oppositeVal in zip(('x', 'y'), [y, x]):
-            oppositeVal: 'Iterable | None'
+            oppositeVal: Iterable | None
             val = xy[key]
             if val is None:
                 # Other curve has all data, make range that supports longest chain
@@ -736,25 +896,58 @@ class PlotItem(GraphicsWidget):
                         f"Expected {ii + 1:d} (number of curves to plot), got"
                         f" {len(kwargs[kk]):d}"
                     )
-            kwargsi = {kk: kwargs[kk][ii] for kk in kwargs}
-            constKwargs.update(kwargsi)
+            kwargs_i = {kk: kwargs[kk][ii] for kk in kwargs}
+            constKwargs.update(kwargs_i)
             curves.append(self.plot(xi, yi, **constKwargs))
         return curves
 
-    def scatterPlot(self, *args, **kargs):
-        if 'pen' in kargs:
-            kargs['symbolPen'] = kargs['pen']
-        kargs['pen'] = None
-            
-        if 'brush' in kargs:
-            kargs['symbolBrush'] = kargs['brush']
-            del kargs['brush']
-            
-        if 'size' in kargs:
-            kargs['symbolSize'] = kargs['size']
-            del kargs['size']
+    def scatterPlot(self, *args, **kwargs):
+        """
+        Create a :class:`~pyqtgraph.PlotDataItem` and add it to the plot.
 
-        return self.plot(*args, **kargs)
+        The :class:`~pyqtgraph.PlotDataItem` instance will render the underlying data
+        in a scatter plot form.
+
+        Parameters
+        ----------
+        *args : tuple, optional
+            Arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
+            constructor.
+        **kwargs : dict, optional
+            Keyword arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
+            constructor.  In addition, the following keyword arguments are accepted.
+
+            =========== ================================================================
+            Property    Description
+            =========== ================================================================
+            pen         ``QPen`` - Sets the pen used to draw lines or symbols for the
+                        plot.  Equivalent to ``symbolPen``.
+
+            brush       ``QBrush`` - Sets the brush used to fill symbols for the plot.
+                        Equivalent to ``symbolBrush``.
+
+            size        ``float`` - Sets the symbol size for the plot. Equivalent to
+                        ``symbolSize``.
+            =========== ================================================================
+
+        Returns
+        -------
+        PlotDataItem
+            The newly created :class:`~pyqtgraph.PlotDataItem`.
+        """
+        if 'pen' in kwargs:
+            kwargs['symbolPen'] = kwargs['pen']
+        kwargs['pen'] = None
+            
+        if 'brush' in kwargs:
+            kwargs['symbolBrush'] = kwargs['brush']
+            del kwargs['brush']
+            
+        if 'size' in kwargs:
+            kwargs['symbolSize'] = kwargs['size']
+            del kwargs['size']
+
+        return self.plot(*args, **kwargs)
                 
     def replot(self):
         self.update()
@@ -766,22 +959,30 @@ class PlotItem(GraphicsWidget):
             for p in list(self.itemMeta.get(c, {}).keys()):
                 if type(p) is tuple:
                     p = '.'.join(p)
-                    
-                ## If the parameter is not in the list, add it.
-                matches = self.ctrl.avgParamList.findItems(p, QtCore.Qt.MatchFlag.MatchExactly)
-                if len(matches) == 0:
+
+                if matches := self.ctrl.avgParamList.findItems(
+                    p, QtCore.Qt.MatchFlag.MatchExactly
+                ):
+                    i = matches[0]
+                else:
                     i = QtWidgets.QListWidgetItem(p)
                     if p in self.paramList and self.paramList[p] is True:
                         i.setCheckState(QtCore.Qt.CheckState.Checked)
                     else:
                         i.setCheckState(QtCore.Qt.CheckState.Unchecked)
                     self.ctrl.avgParamList.addItem(i)
-                else:
-                    i = matches[0]
-                    
                 self.paramList[p] = (i.checkState() == QtCore.Qt.CheckState.Checked)
 
     def writeSvg(self, fileName=None):
+        """
+        Write the plot content to an SVG file.
+
+        Parameters
+        ----------
+        fileName : str, optional
+            The name of the file to write to. If not specified, a file dialog will be
+            opened.
+        """
         if fileName is None:
             self._chooseFilenameDialog(handler=self.writeSvg)
             return
@@ -794,6 +995,15 @@ class PlotItem(GraphicsWidget):
         ex.export(fileName)
         
     def writeImage(self, fileName=None):
+        """
+        Write the plot content to an image file.
+
+        Parameters
+        ----------
+        fileName : str, optional
+            The name of the file to write to. If not specified, a file dialog will be
+            opened.
+        """
         if fileName is None:
             self._chooseFilenameDialog(handler=self.writeImage)
             return
@@ -803,6 +1013,15 @@ class PlotItem(GraphicsWidget):
         ex.export(fileName)
         
     def writeCsv(self, fileName=None):
+        """
+        Write the plot data to a CSV file.
+
+        Parameters
+        ----------
+        fileName : str, optional
+            The name of the file to write to. If not specified, a file dialog will be
+            opened.
+        """
         if fileName is None:
             self._chooseFilenameDialog(handler=self.writeCsv)
             return
@@ -908,26 +1127,34 @@ class PlotItem(GraphicsWidget):
         
     def setDownsampling(self, ds=None, auto=None, mode=None):
         """
-        Changes the default downsampling mode for all :class:`~pyqtgraph.PlotDataItem` managed by this plot.
+        Set the downsampling mode for the PlotItem.
+
+        Downsampling reduces the number of samples drawn to improve performance.
+        The downsampling mode can be set to 'subsample', 'mean', 'peak', or None.
+        If downsampling is enabled, the view will display downsampled data when zoomed out,
+        but will display original data at high zoom levels.
+
+        Parameters
+        ----------
+        ds : int or bool or None, optional
+            The downsampling factor. If ``None``, the downsampling factor is not
+            changed. If ``True``, the downsampling factor is set to the value in the
+            downsampling spin box. If ``False``, downsampling is disabled. If an
+            integer, the downsampling factor is set to this value. Default is ``None``.
+        auto : bool or None, optional
+            If ``True``, automatic downsampling is enabled. If ``False``, automatic
+            downsampling is disabled. If ``None``, the automatic downsampling setting
+            is not changed. Default is ``None``.
+        mode : {'subsample', 'mean', 'peak'} or None, optional
+            The downsampling mode. If ``None``, the downsampling mode is not changed.
+            Default is ``None``.
         
-        =============== ====================================================================
-        **Arguments:**
-        ds              (int) Reduce visible plot samples by this factor, or
-
-                        (bool) To enable/disable downsampling without changing the value.
-
-        auto            (bool) If `True`, automatically pick ``ds`` based on visible range
-
-        mode            'subsample': Downsample by taking the first of N samples. This 
-                        method is fastest but least accurate.
-
-                        'mean': Downsample by taking the mean of N samples.
-
-                        'peak': Downsample by drawing a saw wave that follows the min and 
-                        max of the original data. This method produces the best visual 
-                        representation of the data but is slower.
-        =============== ====================================================================
+        Raises
+        ------
+        ValueError
+            Raised if the specified downsample mode is not recognized.
         """
+
         if ds is not None:
             if ds is False:
                 self.ctrl.downsampleCheck.setChecked(False)
@@ -950,7 +1177,9 @@ class PlotItem(GraphicsWidget):
             elif mode == 'peak':
                 self.ctrl.peakRadio.setChecked(True)
             else:
-                raise ValueError("mode argument must be 'subsample', 'mean', or 'peak'.")
+                raise ValueError(
+                    "mode argument must be 'subsample', 'mean', or 'peak'."
+                )
             
     @QtCore.Slot()
     def updateDownsampling(self):
@@ -961,13 +1190,16 @@ class PlotItem(GraphicsWidget):
             c.setClipToView(clip)
         self.recomputeAverages()
         
-    def downsampleMode(self):
+    def downsampleMode(self) -> tuple[int, bool, str]:
         if self.ctrl.downsampleCheck.isChecked():
             ds = self.ctrl.downsampleSpin.value()
         else:
             ds = 1
             
-        auto = self.ctrl.downsampleCheck.isChecked() and self.ctrl.autoDownsampleCheck.isChecked()
+        auto = (
+            self.ctrl.downsampleCheck.isChecked() and 
+            self.ctrl.autoDownsampleCheck.isChecked()
+        )
             
         if self.ctrl.subsampleRadio.isChecked():
             method = 'subsample' 
@@ -976,17 +1208,33 @@ class PlotItem(GraphicsWidget):
         elif self.ctrl.peakRadio.isChecked():
             method = 'peak'
         else:
-            raise ValueError("one of the method radios must be selected for: 'subsample', 'mean', or 'peak'.")
-        
+            raise ValueError(
+                "One of the method radios must be selected for: 'subsample', 'mean', "
+                "'peak'."
+            )
         return ds, auto, method
         
     def setClipToView(self, clip):
-        """Set the default clip-to-view mode for all :class:`~pyqtgraph.PlotDataItem` s managed by this plot.
-        If *clip* is `True`, then PlotDataItems will attempt to draw only points within the visible
-        range of the ViewBox."""
+        """
+        Set the default clip-to-view mode for new curves.
+
+        Parameters
+        ----------
+        clip : bool
+            If ``True``, new curves will be clipped to the view box.
+        """
         self.ctrl.clipToViewCheck.setChecked(clip)
         
-    def clipToViewMode(self):
+    def clipToViewMode(self) -> bool:
+        """
+        Return whether clip-to-view mode is enabled.
+
+        Returns
+        -------
+        bool
+            ``True`` if clip-to-view mode is enabled, ``False`` otherwise.
+        """
+        
         return self.ctrl.clipToViewCheck.isChecked()
     
     @QtCore.Slot(bool)
@@ -1000,15 +1248,21 @@ class PlotItem(GraphicsWidget):
     @QtCore.Slot()
     def updateDecimation(self):
         """
-        Reduce or increase number of visible curves according to value set by the `Max Traces` spinner,
-        if `Max Traces` is checked in the context menu. Destroy curves that are not visible if 
-        `forget traces` is checked. In most cases, this function is called automaticaly when the 
-        `Max Traces` GUI elements are triggered. It is also alled when the state of PlotItem is updated,
-        its state is restored, or new items added added/removed.
+        Update the number of visible curves.
+
+        Reduce or increase number of visible curves according to value set by the 
+        `Max Traces` spinner, if `Max Traces` is checked in the context menu. Destroy
+        curves that are not visible if `forget traces` is checked. In most cases, this
+        function is called automatically when the `Max Traces` GUI elements are
+        triggered. It is also called when the state of :class:`~pyqtgraph.PlotItem` is
+        updated, its state is restored, or new items added added/removed.
         
-        This can cause an unexpected or conflicting state of curve visibility (or destruction) if curve
-        visibilities are controlled externally. In the case of external control it is advised to disable
-        the `Max Traces` checkbox (or context menu) to prevent unexpected curve state changes.
+        This can cause an unexpected or conflicting state of curve visibility
+        (or destruction) if curve visibilities are controlled externally. In the case of
+        external control it is advised to disable the `Max Traces` checkbox (or context
+        menu) to prevent unexpected curve state changes.
+
+        :meta private:
         """
         if not self.ctrl.maxTracesCheck.isChecked():
             return
@@ -1046,13 +1300,9 @@ class PlotItem(GraphicsWidget):
 
     def pointMode(self):
         if self.ctrl.pointsGroup.isChecked():
-            if self.ctrl.autoPointsCheck.isChecked():
-                mode = None
-            else:
-                mode = True
+            return None if self.ctrl.autoPointsCheck.isChecked() else True
         else:
-            mode = False
-        return mode
+            return False
 
     def resizeEvent(self, ev):
         if self.autoBtn is None:  ## already closed down
@@ -1074,8 +1324,20 @@ class PlotItem(GraphicsWidget):
     def setMenuEnabled(self, enableMenu=True, enableViewBoxMenu='same'):
         """
         Enable or disable the context menu for this PlotItem.
-        By default, the ViewBox's context menu will also be affected.
-        (use ``enableViewBoxMenu=None`` to leave the ViewBox unchanged)
+
+        By default, the ViewBox's context menu will also be affected. Use 
+        ``enableViewBoxMenu=None`` to leave the ViewBox unchanged.
+
+        Parameters
+        ----------
+        enableMenu : bool, optional
+            Whether to enable or disable the context menu, by default True.
+        enableViewBoxMenu : str or bool, optional
+            Whether to enable or disable the ViewBox context menu.
+            If 'same', the ViewBox menu will be enabled or disabled as *enableMenu*.
+            If ``True`` or ``False``, the ViewBox menu will be set accordingly.
+            If ``None``, the ViewBox menu will not be changed.
+            By default 'same'.
         """
         self._menuEnabled = enableMenu
         if enableViewBoxMenu is None:
@@ -1085,21 +1347,27 @@ class PlotItem(GraphicsWidget):
         self.vb.setMenuEnabled(enableViewBoxMenu)
     
     def menuEnabled(self):
+        """
+        Return whether the context menu is enabled.
+
+        Returns
+        -------
+        bool
+            ``True`` if the context menu is enabled, ``False`` otherwise.
+        """
         return self._menuEnabled
 
     def setContextMenuActionVisible(self, name : str, visible : bool) -> None:
         """
-        Changes the context menu action visibility
+        Change the context menu action visibility.
 
         Parameters
         ----------
-        name: str
-            Action name
-            must be one of 'Transforms', 'Downsample', 'Average','Alpha', 'Grid', or 'Points'
-        visible: bool
-            Determines if action will be display
-            True action is visible
-            False action is invisible.
+        name : {'Transforms', 'Downsample', 'Average', 'Alpha', 'Grid', 'Points'}
+            Action name.
+        visible : bool
+            Determines if action will be display. ``True`` action is visible, ``False``
+            action is invisible.
         """
         translated_name = translate("PlotItem", name)
         for action in self.ctrlMenu.actions():
@@ -1120,40 +1388,65 @@ class PlotItem(GraphicsWidget):
         
     def _checkScaleKey(self, key):
         if key not in self.axes:
-            raise Exception("Scale '%s' not found. Scales are: %s" % (key, str(list(self.axes.keys()))))
+            raise KeyError(
+                f"Scale '{key}' not found. Scales are: {list(self.axes.keys())}"
+            )
         
     def getScale(self, key):
         return self.getAxis(key)
         
     def getAxis(self, name):
-        """Return the specified AxisItem. 
-        *name* should be 'left', 'bottom', 'top', or 'right'."""
+        """
+        Return the specified AxisItem.
+
+        Parameters
+        ----------
+        name : {'left', 'bottom', 'right', 'top'}
+            The name of the axis to return.
+
+        Returns
+        -------
+        AxisItem
+            The :class:`~pyqtgraph.AxisItem`.
+
+        Raises
+        ------
+        KeyError
+            If the specified axis is not present.
+        """
         self._checkScaleKey(name)
         return self.axes[name]['item']
         
-    def setLabel(self, axis, *args, **kwds):
+    def setLabel(self, axis: str, *args, **kwargs):
         """
-        Sets the label for an axis. Basic HTML is allowed. See :func:`AxisItem.setLabel` for
-        formatting options.
+        Set the label for an axis.
+        
+        Basic HTML is allowed. See :func:`AxisItem.setLabel` for formatting options.
         
         Parameters
         ----------
-        axis : str
-            Which axis to label. Must be one of 'left', 'bottom', 'right', or 'top'
-        **args
-            All extra arguments are passed to :func:`AxisItem.setLabel`
-
+        axis : {'left', 'bottom', 'right', 'top'}
+            Specify which :class:`~pyqtgraph.AxisItem` to set the label for.
+        *args : tuple, optional
+            All extra arguments are passed to :meth:`~pyqtgraph.AxisItem.setLabel`.
+        **kwargs : dict, optional
+            Keyword arguments are passed to :meth:`~pyqtgraph.AxisItem.setLabel`.
         """
-        self.getAxis(axis).setLabel(*args, **kwds)
+        self.getAxis(axis).setLabel(*args, **kwargs)
         self.showAxis(axis)
         
-    def setLabels(self, **kwds):
+    def setLabels(self, **kwargs):
         """
-        Convenience function allowing multiple labels and/or title to be set in one call.
-        Keyword arguments can be 'title', 'left', 'bottom', 'right', or 'top'.
-        Values may be strings or a tuple of arguments to pass to :func:`setLabel`.
+        Set the axis labels of the plot.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Keyword arguments are passed to  :meth:`~pyqtgraph.AxisItem.setLabel`.  The
+            special keyword ``title`` can be used to set the plot title using
+            :meth:`~pyqtgraph.PlotItem.setTitle`.
         """
-        for k,v in kwds.items():
+        for k, v in kwargs.items():
             if k == 'title':
                 self.setTitle(v)
             else:
@@ -1163,15 +1456,29 @@ class PlotItem(GraphicsWidget):
         
     def showLabel(self, axis, show=True):
         """
-        Show or hide one of the plot's axis labels (the axis itself will be unaffected).
-        axis must be one of 'left', 'bottom', 'right', or 'top'
+        Show or hide one of the plot's axis labels.
+
+        Parameters
+        ----------
+        axis : {'left', 'bottom', 'right', 'top'}
+            The axis label to show or hide.
+        show : bool, optional
+            Whether to show or hide the label, by default True.
         """
         self.getScale(axis).showLabel(show)
 
     def setTitle(self, title=None, **args):
         """
-        Set the title of the plot. Basic HTML formatting is allowed.
-        If title is None, then the title will be hidden.
+        Set the title of the plot.
+
+        Parameters
+        ----------
+        title : str, optional
+            The title text. If ``None``, the title will be hidden. The default is
+            ``None``.
+        **args : dict
+            Additional keyword arguments are passed to
+            :meth:`~pyqtgraph.LabelItem.setText`.
         """
         if title is None:
             self.titleLabel.setVisible(False)
@@ -1183,10 +1490,16 @@ class PlotItem(GraphicsWidget):
             self.titleLabel.setVisible(True)
             self.titleLabel.setText(title, **args)
 
-    def showAxis(self, axis, show=True):
+    def showAxis(self, axis: str, show: bool=True):
         """
-        Show or hide one of the plot's axes.
-        axis must be one of 'left', 'bottom', 'right', or 'top'
+        Show or hide an axis.
+
+        Parameters
+        ----------
+        axis : {'left', 'bottom', 'right', 'top'}
+            The axis to show or hide.
+        show : bool, optional
+            Whether to show or hide the axis, by default True.
         """
         s = self.getScale(axis)
         if show:
@@ -1195,7 +1508,14 @@ class PlotItem(GraphicsWidget):
             s.hide()
             
     def hideAxis(self, axis):
-        """Hide one of the PlotItem's axes. ('left', 'bottom', 'right', or 'top')"""
+        """
+        Hide an axis.
+
+        Parameters
+        ----------
+        axis : {'left', 'bottom', 'right', 'top'}
+            The axis to hide.
+        """
         self.showAxis(axis, False)
         
     def showAxes(self, selection, showValues=True, size=False):
@@ -1204,24 +1524,22 @@ class PlotItem(GraphicsWidget):
         
         Parameters
         ----------
-        selection: bool or tuple of bool 
-            Determines which AxisItems will be displayed.
-            If in tuple form, order is (left, top, right, bottom)
-            A single boolean value will set all axes, 
-            so that ``showAxes(True)`` configures the axes to draw a frame.
-        showValues: bool or tuple of bool, optional
-            Determines if values will be displayed for the ticks of each axis.
-            True value shows values for left and bottom axis (default).
-            False shows no values.
-            If in tuple form, order is (left, top, right, bottom)
-            None leaves settings unchanged.
-            If not specified, left and bottom axes will be drawn with values.
-        size: float or tuple of float, optional
-            Reserves as fixed amount of space (width for vertical axis, height for horizontal axis)
-            for each axis where tick values are enabled. If only a single float value is given, it
-            will be applied for both width and height. If `None` is given instead of a float value,
-            the axis reverts to automatic allocation of space.
-            If in tuple form, order is (width, height)
+        selection : bool or tuple of bool 
+            Determines which AxisItems will be displayed. If in tuple form, order is
+            (left, top, right, bottom). A single boolean value will set all axes, so
+            that ``showAxes(True)`` configures the axes to draw a frame.
+        showValues : bool or tuple of bool, optional
+            Determines if values will be displayed for the ticks of each axis. ``True``
+            value shows values for left and bottom axis (default). ``False`` shows no
+            values. If in tuple form, order is (left, top, right, bottom). ``None``
+            leaves settings unchanged. If not specified, left and bottom axes will be
+            drawn with values.
+        size : float or tuple of float, optional
+            Reserves as fixed amount of space (width for vertical axis, height for
+            horizontal axis) for each axis where tick values are enabled. If only a
+            single float value is given, it will be applied for both width and height.
+            If ``None`` is given instead of a float value, the axis reverts to automatic
+            allocation of space. If in tuple form, order is ``(width, height)``.
         """
         if selection is True: # shortcut: enable all axes, creating a frame
             selection = (True, True, True, True)
@@ -1238,15 +1556,11 @@ class PlotItem(GraphicsWidget):
 
         all_axes = ('left','top','right','bottom')
         for show_axis, show_value, axis_key in zip(selection, showValues, all_axes):
-            if show_axis is None:
-                pass # leave axis display as it is.
-            else:
+            if show_axis is not None:
                 if show_axis: self.showAxis(axis_key)
                 else        : self.hideAxis(axis_key)
-                
-            if show_value is None:
-                pass # leave value display as it is.
-            else:
+
+            if show_value is not None:
                 ax = self.getAxis(axis_key)
                 ax.setStyle(showValues=show_value)
                 if size is not False: # size adjustment is requested
@@ -1258,14 +1572,17 @@ class PlotItem(GraphicsWidget):
                         else         : ax.setHeight( None )
   
     def hideButtons(self):
-        """Causes auto-scale button ('A' in lower-left corner) to be hidden for this PlotItem"""
-        #self.ctrlBtn.hide()
+        """
+        Hide auto-scale button ('A' in lower-left corner).
+        """
+    
         self.buttonsHidden = True
         self.updateButtons()
         
     def showButtons(self):
-        """Causes auto-scale button ('A' in lower-left corner) to be visible for this PlotItem"""
-        #self.ctrlBtn.hide()
+        """
+        Show auto-scale button ('A' in lower-left corner).
+        """
         self.buttonsHidden = False
         self.updateButtons()
         
@@ -1280,16 +1597,30 @@ class PlotItem(GraphicsWidget):
             
     def _plotArray(self, arr, x=None, **kargs):
         if arr.ndim != 1:
-            raise Exception("Array must be 1D to plot (shape is %s)" % arr.shape)
+            raise ValueError(f"Array must be 1D to plot (shape is {arr.shape})")
         if x is None:
             x = np.arange(arr.shape[0])
         if x.ndim != 1:
-            raise Exception("X array must be 1D to plot (shape is %s)" % x.shape)
-        c = PlotCurveItem(arr, x=x, **kargs)
-        return c
+            raise ValueError(f"X array must be 1D to plot (shape is {x.shape})")
+        return PlotCurveItem(arr, x=x, **kargs)
 
-    def setExportMode(self, export, opts=None):
-        GraphicsWidget.setExportMode(self, export, opts)
+    def setExportMode(self, export: bool, opts=None):
+        """
+        Set whether the item will allow export via screenshots or image files.
+
+        If export mode is enabled, then the item will allow export and the export
+        options dock will be displayed. If export mode is disabled, then no export
+        options will be available and the export dock will be hidden.
+
+        Parameters
+        ----------
+        export : bool
+            If ``True``, the item will allow export.
+        opts : dict or None, optional
+            A dictionary of export options. If ``None``, the default export
+            options will be used. By default, ``None``.
+        """
+        super().setExportMode(export, opts)
         self.updateButtons()
     
     def _chooseFilenameDialog(self, handler):


### PR DESCRIPTION
Convert the docstrings of `PlotItem.py` and `AxisItem.py` to conform to numpydoc codestyle.

Due to the extensive use of `*args` and `**kwargs`, the best way I could figure out to render the supported options was through a table.  Because of this, `numpydoc lint` often complains that:

> Parameter "**kwargs" description should finish with "."

Furthermore, because we have a custom section, `Signals`, there is a bogus errors for sections being in the wrong order.

I attempted to cross-link objects where appropriate.  A review through the rendered result and feedback would be greatly appreciated.