### PR TITLE
Fix parameter item compare unpack order

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes/checklist.py
+++ b/pyqtgraph/parametertree/parameterTypes/checklist.py
@@ -274,7 +274,7 @@ class ChecklistParameter(GroupParameter):
         # Could be replaced by "value in self.reverse[0]" and "reverse[0].index",
         # but this allows for using pg.eq to cover more diverse value options
         for val in values:
-            for limitName, limitValue in zip(*self.reverse):
+            for limitValue, limitName in zip(*self.reverse):
                 if fn.eq(limitValue, val):
                     allowedNames.append(limitName)
                     allowedValues.append(val)

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -189,6 +189,34 @@ def test_checklist_show_hide():
     pi.setHidden.assert_called_with(False)
     assert p.opts["visible"]
 
+@pytest.mark.parametrize("limits,value",[
+    ([1, 2, 3], [1, 2, 3]),
+    ([1, 2, 3],  []),
+    (['a', 'b', 'c'], ['a', 'b', 'c']),
+    (['a', 'b', 'c'], []),
+])
+def test_checklist_check_and_clear_all(limits, value):
+    p = pt.Parameter.create(name='checklist', type='checklist', limits=limits, value=value)
+    pi = ChecklistParameterItem(p, 0)
+
+    clearButton = pi.metaBtns['Clear']
+    selectButton = pi.metaBtns['Select']
+    
+    # ensure only the specified ones are selected by default
+    assert pi.param.value() == value
+
+    # make all are selected after selecting all
+    selectButton.clicked.emit()
+    assert pi.param.value() == limits
+
+    # make sure they all get cleared when hitting clear all
+    clearButton.clicked.emit()
+    assert pi.param.value() == []
+
+    # make sure all are selected again
+    selectButton.clicked.emit()
+    assert pi.param.value() == limits
+
 
 def test_pen_settings():
     # Option from constructor
@@ -200,6 +228,7 @@ def test_pen_settings():
     # Opts from changing child
     p["width"] = 10
     assert p.pen.width() == 10
+
 
 def test_recreate_from_savestate():
     from pyqtgraph.examples import _buildParamTypes


### PR DESCRIPTION
Fixes #3229 

Thank you @Qi-henry for reporting the issue and diagnosing the cause.  Added a test case that caught this error.

Funny enough, this error did not occur when using `str` types for values instead of `int` types.