### PR TITLE
Allow OpenGL without enableExperimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Through 3rd party libraries, additional functionality may be added to PyQtGraph,
 | Library        | Added functionality |
 |----------------|-|
 | [`scipy`]      | <ul><li> Image processing through [`ndimage`]</li><li> Data array filtering through [`signal`] </li><ul> |
-| [`pyopengl`]   | <ul><li> 3D graphics </li><li> Faster image processing </li></ul> |
+| [`pyopengl`]   | <ul><li> 3D graphics </li></ul> |
 | [`h5py`]       | <ul><li> Export in hdf5 format </li></ul> |
 | [`colorcet`]   | <ul><li> Add a collection of perceptually uniform colormaps </li></ul> |
 | [`matplotlib`] | <ul><li> Export of PlotItem in matplotlib figure </li><li> Add matplotlib collection of colormaps </li></ul> |

--- a/doc/source/api_reference/config_options.rst
+++ b/doc/source/api_reference/config_options.rst
@@ -31,8 +31,6 @@ useCupy            bool                False              Use cupy to perform ca
                                                           ImageItem and its associated functions.
 useNumba           bool                False              Use numba acceleration where implemented.
 enableExperimental bool                False              Enable experimental features (the curious can search for this key in the code).
-                                                          In combination with useOpenGL, this makes PlotCurveItem use PyOpenGL
-                                                          for curve drawing.
                                                           
 
                                                           **Caveats**

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -27,18 +27,8 @@ from .Qt import mkQApp
               ## (import here to avoid massive error dump later on if numpy is not available)
 
 
-## in general openGL is poorly supported with Qt+GraphicsView.
-## we only enable it where the performance benefit is critical.
-## Note this only applies to 2D graphics; 3D graphics always use OpenGL.
-if 'linux' in sys.platform:  ## linux has numerous bugs in opengl implementation
-    useOpenGL = False
-elif 'darwin' in sys.platform: ## openGL can have a major impact on mac, but also has serious bugs
-    useOpenGL = False
-else:
-    useOpenGL = False  ## on windows there's a more even performance / bugginess tradeoff.
-
 CONFIG_OPTIONS = {
-    'useOpenGL': useOpenGL, ## by default, this is platform-dependent (see widgets/GraphicsView). Set to True or False to explicitly enable/disable opengl.
+    'useOpenGL': False, ## Set to True or False to explicitly enable/disable opengl.
     'leftButtonPan': True,  ## if false, left button drags a rubber band for zooming in viewbox
     # foreground/background take any arguments to the 'mkColor' in /pyqtgraph/functions.py
     'foreground': 'd',  ## default foreground color for axes, labels, etc.

--- a/pyqtgraph/examples/MouseSelection.py
+++ b/pyqtgraph/examples/MouseSelection.py
@@ -29,8 +29,12 @@ curves = [
               
 def plotClicked(curve):
     for i, c in enumerate(curves):
-        width = 3 if c is curve else 1
-        c.setPen('rgcy'[i], width=width)
+        width = 1
+        color = pg.mkColor('rgcy'[i])
+        if c is curve:
+            width = 4
+            color = color.darker()
+        c.setPen(color, width=width)
     
 for c in curves:
     plt.addItem(c)

--- a/pyqtgraph/examples/MouseSelection.py
+++ b/pyqtgraph/examples/MouseSelection.py
@@ -6,9 +6,9 @@ import numpy as np
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtWidgets
-pg.setConfigOptions(useOpenGL=True, enableExperimental=True)
+pg.setConfigOptions(useOpenGL=True)
 
-app = pg.mkQApp()
+app = pg.mkQApp("MouseSelection Example")
 plt = pg.PlotWidget()
 plt.setWindowTitle('pyqtgraph example: Plot data selection')
 # shift plot area by adding title to test that the OpenGL code handles it

--- a/pyqtgraph/examples/PColorMeshItem.py
+++ b/pyqtgraph/examples/PColorMeshItem.py
@@ -8,7 +8,7 @@ import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore
 from utils import FrameCounter
 
-# pg.setConfigOptions(useOpenGL=True, enableExperimental=True)
+# pg.setConfigOptions(useOpenGL=True)
 app = pg.mkQApp("PColorMesh Example")
 
 ## Create window with GraphicsView widget

--- a/pyqtgraph/examples/PlotSpeedTest.py
+++ b/pyqtgraph/examples/PlotSpeedTest.py
@@ -37,7 +37,6 @@ args = parser.parse_args()
 
 if args.use_opengl is not None:
     pg.setConfigOption('useOpenGL', args.use_opengl)
-    pg.setConfigOption('enableExperimental', args.use_opengl)
 use_opengl = pg.getConfigOption('useOpenGL')
 
 # don't limit frame rate to vsync
@@ -152,7 +151,7 @@ def updateOptions(
     curvePen=pg.mkPen(),
     plotMethod='pyqtgraph',
     fillLevel=False,
-    enableExperimental=use_opengl,
+    enableExperimental=False,
     useOpenGL=use_opengl,
 ):
     pg.setConfigOption('enableExperimental', enableExperimental)

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -399,8 +399,7 @@ class PColorMeshItem(GraphicsObject):
             return
 
         if (
-            getConfigOption('enableExperimental')
-            and isinstance(widget, OpenGLHelpers.GraphicsViewGLWidget)
+            isinstance(widget, OpenGLHelpers.GraphicsViewGLWidget)
             and self.cmap is not None   # don't support setting colormap by setLookupTable
         ):
             if self.glstate is None:

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -1199,7 +1199,7 @@ class PlotCurveItem(GraphicsObject):
         if aa:
             glf.glEnable(GLC.GL_LINE_SMOOTH)
             glf.glEnable(GLC.GL_BLEND)
-            glf.glBlendFunc(GLC.GL_SRC_ALPHA, GLC.GL_ONE_MINUS_SRC_ALPHA)
+            glf.glBlendFuncSeparate(GLC.GL_SRC_ALPHA, GLC.GL_ONE_MINUS_SRC_ALPHA, 1, GLC.GL_ONE_MINUS_SRC_ALPHA)
             glf.glHint(GLC.GL_LINE_SMOOTH_HINT, GLC.GL_NICEST)
         else:
             glf.glDisable(GLC.GL_LINE_SMOOTH)

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -877,8 +877,8 @@ class PlotCurveItem(GraphicsObject):
         # Set suitable chunk size for current configuration:
         #   * Without OpenGL split in small chunks
         #   * With OpenGL split in rather big chunks
-        #     Note, the present code is used only if config option 'enableExperimental' is False,
-        #     otherwise the 'paintGL' method is used.
+        #     Note: when OpenGL mode is enabled, we should normally be using the
+        #     'paintGL' method, and should not even reach here.
         # Values were found using 'PlotSpeedTest.py' example, see #2257.
         chunksize = 50 if not isinstance(widget, QtWidgets.QOpenGLWidget) else 5000
 
@@ -958,8 +958,7 @@ class PlotCurveItem(GraphicsObject):
         )
 
         if (
-            getConfigOption('enableExperimental')
-            and isinstance(widget, OpenGLHelpers.GraphicsViewGLWidget)
+            isinstance(widget, OpenGLHelpers.GraphicsViewGLWidget)
             and opengl_supported_fill
             and not self.opts['stepMode']
         ):

--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -13,7 +13,8 @@ GLOptions = {
         GL.GL_DEPTH_TEST: True,
         GL.GL_BLEND: True,
         GL.GL_CULL_FACE: False,
-        'glBlendFunc': (GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA),
+        'glBlendFuncSeparate': (GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA,
+                                GL.GL_ONE, GL.GL_ONE_MINUS_SRC_ALPHA),
     },
     'additive': {
         GL.GL_DEPTH_TEST: False,

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -170,7 +170,8 @@ class GLLinePlotItem(GLGraphicsItem):
         if enable_aa:
             GL.glEnable(GL.GL_LINE_SMOOTH)
             GL.glEnable(GL.GL_BLEND)
-            GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
+            GL.glBlendFuncSeparate(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA,
+                                   GL.GL_ONE, GL.GL_ONE_MINUS_SRC_ALPHA)
             GL.glHint(GL.GL_LINE_SMOOTH_HINT, GL.GL_NICEST)
 
         sfmt = context.format()

--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -285,8 +285,8 @@ SHADER_LEGACY = {
         void main()
         {
             vec2 xy = (gl_PointCoord - 0.5) * 2.0;
-            float mask = step(-1.0, -dot(xy, xy));
-            gl_FragColor = vec4(v_color.rgb, v_color.a * mask);
+            if (dot(xy, xy) <= 1.0) gl_FragColor = v_color;
+            else discard;
         }
     """
 }
@@ -335,8 +335,8 @@ SHADER_CORE = {
         void main()
         {
             vec2 xy = (gl_PointCoord - 0.5) * 2.0;
-            float mask = step(-1.0, -dot(xy, xy));
-            fragColor = vec4(v_color.rgb, v_color.a * mask);
+            if (dot(xy, xy) <= 1.0) fragColor = v_color;
+            else discard;
         }
     """
 }

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -156,12 +156,8 @@ class GraphicsView(QtWidgets.QGraphicsView):
         new_vp = None
 
         if b:
-            try:
-                GraphicsViewGLWidget = getattr(OpenGLHelpers, "GraphicsViewGLWidget")
-            except AttributeError:
-                raise RuntimeError("Requested to use OpenGL with QGraphicsView, but QOpenGLWidget is not available.")
-            if not isinstance(old_vp, GraphicsViewGLWidget):
-                new_vp = GraphicsViewGLWidget()
+            if not isinstance(old_vp, OpenGLHelpers.GraphicsViewGLWidget):
+                new_vp = OpenGLHelpers.GraphicsViewGLWidget()
         else:
             if not type(old_vp) is QtWidgets.QWidget:
                 new_vp = QtWidgets.QWidget()


### PR DESCRIPTION
There are currently two `GraphicsItem`s that have an OpenGL implementation:
- `PlotCurveItem`
- `PColorMeshItem`

Their use was conditional on `useOpenGL` and `enableExperimental`.

Originally, the OpenGL implementation for `PlotCurveItem` was limited to a small subset of the `PlotCurveItem` api. Now that it supports most of the common use cases, it should be fine to remove it from "experimental" status.
(The example `MouseSelection` exercises much of the implemented functionality)

`PColorMeshItem`'s implementation was complete from the beginning, but it also required `enableExperimental`, but only to follow `PlotCurveItem`.

Note that `PyOpenGL` is not required at all to use this OpenGL mode.