### PR TITLE
Fix recarray support in PlotDataItem

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -1160,7 +1160,12 @@ class PlotDataItem(GraphicsObject):
             elif dt == 'Nx2array':
                 x = data[:, 0]
                 y = data[:, 1]
-            elif dt == 'recarray' or dt == 'dictOfLists':
+            elif dt == 'recarray':
+                if "x" in data.dtype.names:
+                    x = data["x"]
+                if "y" in data.dtype.names:
+                    y = data["y"]
+            elif dt == 'dictOfLists':
                 if 'x' in data:
                     x = np.array(data['x'])
                 if 'y' in data:

--- a/tests/graphicsItems/test_PlotDataItem.py
+++ b/tests/graphicsItems/test_PlotDataItem.py
@@ -81,7 +81,19 @@ def test_setData():
     pdi.setData([],[])
     assert pdi.xData is None
     assert pdi.yData is None
-    
+
+    # recarray (issue #3275)
+    data = np.recarray((10,), dtype=[('x', float), ('y', float)])
+    pdi.setData(data)
+    assert all(pdi.xData == data["x"])
+    assert all(pdi.yData == data["y"])
+
+    # array with named fields
+    data = np.array([(1, 2), (3, 4), (5, 6)], dtype=[("x", float), ("y", float)])
+    pdi.setData(data)
+    assert all(pdi.xData == data["x"])
+    assert all(pdi.yData == data["y"])
+
 def test_nonfinite():
     def _assert_equal_arrays(a1, a2):
         assert a1.shape == a2.shape

--- a/tests/graphicsItems/test_PlotDataItem.py
+++ b/tests/graphicsItems/test_PlotDataItem.py
@@ -84,6 +84,8 @@ def test_setData():
 
     # recarray (issue #3275)
     data = np.recarray((10,), dtype=[('x', float), ('y', float)])
+    data["x"] = np.linspace(0, 1, len(data))
+    data["y"] = np.linspace(10, 20, len(data))
     pdi.setData(data)
     assert all(pdi.xData == data["x"])
     assert all(pdi.yData == data["y"])


### PR DESCRIPTION
Fixes #3275 

I'm not sure if this ever worked. As far as I know, `recarray` hasn't supported this kind of membership check, and it doesn't make sense semantically for normal `ndarray`.

During my testing, I figured normal arrays with named fields might also be worth supporting. The `dataType` helper function identifies them as "recarray", so the modified code path handles both. Only the `recarray` subclass implements attribute access to the fields, otherwise `getattr(data, "x", None)` would've been slightly more concise. 