### PR TITLE
DO NOT MERGE - Fix ParameterTree warnings

### DIFF
--- a/pyqtgraph/examples/_buildParamTypes.py
+++ b/pyqtgraph/examples/_buildParamTypes.py
@@ -43,7 +43,7 @@ def makeMetaChild(name, cfgDict):
     children = []
     for chName, chOpts in cfgDict.items():
         if not isinstance(chOpts, dict):
-            ch = Parameter.create(name=chName, type=chName, value=chOpts)
+            ch = Parameter.create(name=chName, type=chName, default=chOpts)
         else:
             ch = Parameter.create(name=chName, **chOpts)
         _encounteredTypes.add(ch.type())

--- a/pyqtgraph/examples/_paramtreecfg.py
+++ b/pyqtgraph/examples/_paramtreecfg.py
@@ -31,31 +31,31 @@ cfg = {
         },
         'relativeTo': {
             'type': 'str',
-            'value': None
+            'default': None
         },
         'directory': {
             'type': 'str',
-            'value': None
+            'default': None
         },
         'windowTitle': {
             'type': 'str',
-            'value': None
+            'default': None
         },
         'nameFilter': {
             'type': 'str',
-            'value': None
+            'default': None
         }
     },
     'float': {
         'Float Information': {
             'type': 'str',
             'readonly': True,
-            'value': 'Note that all options except "finite" also apply to "int" parameters',
+            'default': 'Note that all options except "finite" also apply to "int" parameters',
         },
         'step': {
             'type': 'float',
             'limits': [0, None],
-            'value': 1,
+            'default': 1,
         },
         'limits': {
             'type': 'list',
@@ -67,19 +67,19 @@ cfg = {
         },
         'siPrefix': {
             'type': 'bool',
-            'value': True
+            'default': True
         },
         'finite': {
             'type': 'bool',
-            'value': True,
+            'default': True,
         },
         'dec': {
             'type': 'bool',
-            'value': False,
+            'default': False,
         },
         'minStep': {
             'type': 'float',
-            'value': 1.0e-12,
+            'default': 1.0e-12,
         },
     },
 
@@ -90,11 +90,11 @@ cfg = {
         },
         'exclusive': {
             'type': 'bool',
-            'value': False,
+            'default': False,
         },
         'delay': {
             'type': 'float',
-            'value': 1.0,
+            'default': 1.0,
             'limits': [0, None]
         }
     },
@@ -102,6 +102,7 @@ cfg = {
     'pen': {
         'Pen Information': {
             'type': 'str',
+            'default': "",
             'value': 'Click the button to see options',
             'readonly': True,
         },
@@ -111,14 +112,14 @@ cfg = {
         'step': {
             'type': 'float',
             'limits': [0, None],
-            'value': 1, },
+            'default': 1, },
         'format': {
             'type': 'str',
-            'value': '{0:>3}',
+            'default': '{0:>3}',
         },
         'precision': {
             'type': 'int',
-            'value': 2,
+            'default': 2,
             'limits': [1, None],
         },
         'span': {
@@ -135,11 +136,11 @@ cfg = {
     'action': {
         'shortcut': {
             'type': 'str',
-            'value': "Ctrl+Shift+P",
+            'default': "Ctrl+Shift+P",
         },
         'icon': {
             'type': 'file',
-            'value': None,
+            'default': None,
             'nameFilter': "Images (*.png *.jpg *.bmp *.jpeg *.svg)",
         },
     },
@@ -147,7 +148,7 @@ cfg = {
     'calendar': {
         'format': {
             'type': 'str',
-            'value': 'MM DD',
+            'default': 'MM DD',
         }
     },
 
@@ -160,24 +161,24 @@ cfg = {
         },
         'readonly': {
             'type': 'bool',
-            'value': True,
+            'default': True,
         },
         'removable': {
             'type': 'bool',
             'tip': 'Adds a context menu option to remove this parameter',
-            'value': False,
+            'default': False,
         },
         'visible': {
             'type': 'bool',
-            'value': True,
+            'default': True,
         },
         'disabled': {
             'type': 'bool',
-            'value': False,
+            'default': False,
         },
         'title': {
             'type': 'str',
-            'value': 'Meta Options',
+            'default': 'Meta Options',
         },
         'default': {
             'tip': 'The default value that gets set when clicking the arrow in the right column',
@@ -185,7 +186,7 @@ cfg = {
         },
         'expanded': {
             'type': 'bool',
-            'value': True,
+            'default': True,
         },
     },
 

--- a/pyqtgraph/exporters/CSVExporter.py
+++ b/pyqtgraph/exporters/CSVExporter.py
@@ -19,14 +19,26 @@ class CSVExporter(Exporter):
     def __init__(self, item):
         Exporter.__init__(self, item)
         self.params = Parameter.create(name='params', type='group', children=[
-            {'name': 'separator', 'title': translate("Exporter", 'separator'), 'type': 'list', 'value': 'comma', 'limits': ['comma', 'tab']},
-            {'name': 'precision', 'title': translate("Exporter", 'precision'), 'type': 'int', 'value': 10, 'limits': [0, None]},
+            {
+                'name': 'separator',
+                'title': translate("Exporter", 'separator'),
+                'type': 'list',
+                'limits': ['comma', 'tab'],
+                'default': 'comma'
+            },
+            {
+                'name': 'precision',
+                'title': translate("Exporter", 'precision'),
+                'type': 'int',
+                'default': 10,
+                'limits': [0, None]
+            },
             {
                 'name': 'columnMode',
                 'title': translate("Exporter", 'columnMode'),
                 'type': 'list',
                 'limits': ['(x,y) per plot', '(x,y,y,y) for all plots'],
-                'value': '(x,y) per plot',
+                'default': '(x,y) per plot'
             }
         ])
 

--- a/pyqtgraph/exporters/ImageExporter.py
+++ b/pyqtgraph/exporters/ImageExporter.py
@@ -27,13 +27,38 @@ class ImageExporter(Exporter):
             bg.setAlpha(0)
 
         self.params = Parameter.create(name='params', type='group', children=[
-            {'name': 'width', 'title': translate("Exporter", 'width'), 'type': 'int', 'value': int(tr.width()),
-             'limits': (0, None)},
-            {'name': 'height', 'title': translate("Exporter", 'height'), 'type': 'int', 'value': int(tr.height()),
-             'limits': (0, None)},
-            {'name': 'antialias', 'title': translate("Exporter", 'antialias'), 'type': 'bool', 'value': True},
-            {'name': 'background', 'title': translate("Exporter", 'background'), 'type': 'color', 'value': bg},
-            {'name': 'invertValue', 'title': translate("Exporter", 'invertValue'), 'type': 'bool', 'value': False}
+            {
+                'name':'width',
+                'title': translate("Exporter", 'width'),
+                'type': 'int',
+                'default': int(tr.width()),
+                'limits': (0, None)
+            },
+            {
+                'name': 'height',
+                'title': translate("Exporter", 'height'),
+                'type': 'int',
+                'default': int(tr.height()),
+                'limits': (0, None)
+            },
+            {
+                'name': 'antialias',
+                'title': translate("Exporter", 'antialias'),
+                'type': 'bool',
+                'default': True,
+            },
+            {
+                'name': 'background',
+                'title': translate("Exporter", 'background'),
+                'type': 'color',
+                'default': bg
+            },
+            {
+                'name': 'invertValue',
+                'title': translate("Exporter", 'invertValue'),
+                'type': 'bool',
+                'default': False,
+            }
         ])
         self.params.param('width').sigValueChanged.connect(self.widthChanged)
         self.params.param('height').sigValueChanged.connect(self.heightChanged)

--- a/pyqtgraph/exporters/SVGExporter.py
+++ b/pyqtgraph/exporters/SVGExporter.py
@@ -29,18 +29,33 @@ class SVGExporter(Exporter):
             bg.setAlpha(0)
 
         self.params = Parameter.create(name='params', type='group', children=[
-            {'name': 'background', 'title': translate("Exporter", 'background'), 'type': 'color', 'value': bg},
-            {'name': 'width', 'title': translate("Exporter", 'width'), 'type': 'float', 'value': tr.width(),
-             'limits': (0, None)},
-            {'name': 'height', 'title': translate("Exporter", 'height'), 'type': 'float', 'value': tr.height(),
-             'limits': (0, None)},
+            {
+                'name': 'background',
+                'title': translate("Exporter", 'background'),
+                'type': 'color',
+                'default': bg
+            },
+            {
+                'name': 'width',
+                'title': translate("Exporter", 'width'),
+                'type': 'float',
+                'default': tr.width(),
+                'limits': (0, None)
+            },
+            {
+                'name': 'height',
+                'title': translate("Exporter", 'height'),
+                'type': 'float',
+                'default': tr.height(),
+                'limits': (0, None)
+            },
             #{'name': 'viewbox clipping', 'type': 'bool', 'value': True},
             #{'name': 'normalize coordinates', 'type': 'bool', 'value': True},
             {
                 'name': 'scaling stroke',
                 'title': translate("Exporter", 'scaling stroke'),
                 'type': 'bool',
-                'value': False,
+                'default': False,
                 'tip': "If False, strokes are non-scaling, which means that "
                        "they appear the same width on screen regardless of "
                        "how they are scaled or how the view is zoomed."

--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -198,9 +198,15 @@ class Parameter(QtCore.QObject):
             # The following intentionally excluded; each parameter type may have a different data type for limits.
             # 'limits': None,
         }
-        name = opts.get('name', None)
+
+        try:
+            name = opts['name']
+        except KeyError:
+            raise KeyError("Parameter must have a name specified")
+
         if not isinstance(name, str):
             raise TypeError("Parameter must have a string name specified in opts.")
+
         self.opts.update(opts)
         self.opts['name'] = None
 
@@ -216,12 +222,12 @@ class Parameter(QtCore.QObject):
         if 'value' in self.opts and 'default' not in self.opts:
             warnings.warn(
                 "Parameter has no default value. Pass a default, or use setDefault(). This will no longer set "
-                "an implicit default after January 2025.",
+                "an implicit default after August 2025.",
                 DeprecationWarning,
                 stacklevel=2,
             )
             self.opts['default'] = self.opts['value']
-        value = self.opts.get('value', self.opts.get('default', None))
+        value = self.opts.get('value', self.opts.get('default'))
         modified = 'value' in self.opts
         if value is not None:
             self.setValue(value)
@@ -345,11 +351,11 @@ class Parameter(QtCore.QObject):
         if 'value' not in self.opts:
             warnings.warn(
                 "Parameter has no value set. Pass an initial value or default, or use setValue() or setDefault(). "
-                "This will be an error after January 2025.",
+                "This will be an error after August 2025.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-        return self.opts.get('value')
+        return self.opts['value']
 
     def getValues(self):
         """
@@ -471,9 +477,11 @@ class Parameter(QtCore.QObject):
     def defaultValue(self):
         """Return the default value for this parameter. Raises ValueError if no default."""
         if 'default' not in self.opts:
-            warnings.warn("Parameter has no default value. This will be a ValueError after January 2025.",
-                          DeprecationWarning,
-                          stacklevel=2)
+            warnings.warn(
+                "Parameter has no default value. This will be a ValueError after August 2025.",
+                DeprecationWarning,
+                stacklevel=2
+            )
         return self.opts.get('default')
         
     def setDefault(self, val, updatePristineValues=False):

--- a/pyqtgraph/parametertree/interactive.py
+++ b/pyqtgraph/parametertree/interactive.py
@@ -590,7 +590,7 @@ class Interactor:
             # directly from the default Also, maybe override was a value without a
             # type, so give a sensible default
             default = signatureParameter.default
-            signatureDict = {"value": default, "type": type(default).__name__}
+            signatureDict = {"value": default, "default": default, "type": type(default).__name__}
         else:
             signatureDict = {}
         # Doc takes precedence over signature for any value information
@@ -604,12 +604,19 @@ class Interactor:
         pgDict["name"] = name
         # Required function arguments with any override specifications can still be
         # unfilled at this point
-        pgDict.setdefault("value", PARAM_UNSET)
+
+        if "value" not in pgDict:
+            if "default" in pgDict:
+                pgDict["value"] = pgDict["default"]
+            else:
+                pgDict["value"] = PARAM_UNSET
+        pgDict.setdefault("default", pgDict["value"])
 
         # Anywhere a title is specified should take precedence over the default factory
         if self.titleFormat is not None:
             pgDict.setdefault("title", self._nameToTitle(name))
-        pgDict.setdefault("type", type(pgDict["value"]).__name__)
+
+        pgDict.setdefault("type", type(pgDict["default"]).__name__)
         return pgDict
 
     def __str__(self):

--- a/pyqtgraph/parametertree/parameterTypes/checklist.py
+++ b/pyqtgraph/parametertree/parameterTypes/checklist.py
@@ -163,8 +163,9 @@ class ChecklistParameter(GroupParameter):
             )
         self.targetValue = None
         limits = opts.setdefault('limits', [])
+        default = opts.setdefault('default', [])
         self.forward, self.reverse = ListParameter.mapping(limits)
-        value = opts.setdefault('value', limits)
+        value = opts.setdefault('value', default)
         opts.setdefault('exclusive', False)
         super().__init__(**opts)
         # Force 'exclusive' to trigger by making sure value is not the same

--- a/pyqtgraph/parametertree/parameterTypes/list.py
+++ b/pyqtgraph/parametertree/parameterTypes/list.py
@@ -97,7 +97,7 @@ class ListParameter(Parameter):
             opts['limits'] = opts.pop('values')
         if opts.get('limits', None) is None:
             opts['limits'] = []
-        Parameter.__init__(self, **opts)
+        super().__init__(**opts)
         self.setLimits(opts['limits'])
 
     def setLimits(self, limits):

--- a/pyqtgraph/parametertree/parameterTypes/pen.py
+++ b/pyqtgraph/parametertree/parameterTypes/pen.py
@@ -160,12 +160,12 @@ class PenParameter(GroupParameter):
         ps = QtCore.Qt.PenStyle
         param = Parameter.create(
             name='Params', type='group', children=[
-                dict(name='color', type='color', value='k'),
-                dict(name='width', value=1, type='int', limits=[0, None]),
-                QtEnumParameter(ps, name='style', value='SolidLine'),
+                dict(name='color', type='color', default='k'),
+                dict(name='width', default=1, type='int', limits=[0, None]),
+                QtEnumParameter(ps, name='style', deafult='SolidLine'),
                 QtEnumParameter(cs, name='capStyle'),
                 QtEnumParameter(js, name='joinStyle'),
-                dict(name='cosmetic', type='bool', value=True)
+                dict(name='cosmetic', type='bool', default=True)
             ]
             )
 

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -19,12 +19,11 @@ from pyqtgraph.Qt import QtGui
 pg.mkQApp()
 
 def test_parameter_hasdefault():
-    opts = {"name": "param", "type": 'int', "value": 1}
+    opts = {"name": "param", "type": 'int'}
 
     # default unspecified
     p = Parameter.create(**opts)
-    # TODO after January 2025, this next line needs to reverse its assertion
-    assert p.hasDefault()
+    assert p.hasDefault() is False
 
     # default specified
     p = Parameter.create(default=0, **opts)
@@ -46,12 +45,7 @@ def test_parameter_defaults_and_pristineness():
     # init with different value and default
     p = Parameter.create(name="param", type='int', value=1, default=2)
     assert p.valueModifiedSinceResetToDefault() is True
-    # init with value only
-    p = Parameter.create(name="param", type='int', value=1)
-    assert p.valueModifiedSinceResetToDefault() is True
-    # TODO after January 2025, uncomment the following lines
-    # with pytest.raises(ValueError):
-    #     p.setToDefault()
+
     # init with default only
     p = Parameter.create(name="param", type='int', default=1)
     assert p.valueModifiedSinceResetToDefault() is False
@@ -96,7 +90,7 @@ def test_parameter_defaults_and_pristineness():
     # init with neither value nor default
     p = Parameter.create(name="param", type='int')
     assert p.valueModifiedSinceResetToDefault() is False
-    # TODO after January 2025, uncomment the following lines
+    # TODO after August 2025, uncomment the following lines
     # with pytest.raises(ValueError):
     #     p.value()
     # with pytest.raises(ValueError):
@@ -113,26 +107,26 @@ def test_add_child():
         name="test",
         type="group",
         children=[
-            dict(name="ch1", type="bool", value=True),
-            dict(name="ch2", type="bool", value=False),
+            dict(name="ch1", type="bool", default=True),
+            dict(name="ch2", type="bool", default=False),
         ],
     )
     with pytest.raises(ValueError):
-        p.addChild(dict(name="ch1", type="int", value=0))
+        p.addChild(dict(name="ch1", type="int", default=0))
     existing = p.child("ch1")
-    ch = p.addChild(dict(name="ch1", type="int", value=0), existOk=True)
+    ch = p.addChild(dict(name="ch1", type="int", default=0), existOk=True)
     assert ch is existing
 
-    ch = p.addChild(dict(name="ch1", type="int", value=0), autoIncrementName=True)
+    ch = p.addChild(dict(name="ch1", type="int", default=0), autoIncrementName=True)
     assert ch.name() == "ch3"
 
 
 def test_unpack_parameter():
     # test that **unpacking correctly returns child name/value maps
     params = [
-        dict(name="a", type="int", value=1),
-        dict(name="b", type="str", value="2"),
-        dict(name="c", type="float", value=3.0),
+        dict(name="a", type="int", default=1),
+        dict(name="b", type="str", default="2"),
+        dict(name="c", type="float", default=3.0),
     ]
     p = Parameter.create(name="params", type="group", children=params)
     result = dict(**p)
@@ -202,7 +196,7 @@ def test_interact():
     assert value == (10, 100)
 
     with interactor.optsContext(titleFormat=str.upper):
-        host = interactor(a, x={"title": "different", "value": 5})
+        host = interactor(a, x={"title": "different", "default": 5})
         titles = [p.title() for p in host]
         for ch in "different", "Y":
             assert ch in titles
@@ -473,7 +467,7 @@ def test_hookup_extra_params():
 
     interact(a)
 
-    p2 = Parameter.create(name="p2", type="int", value=3)
+    p2 = Parameter.create(name="p2", type="int", default=3)
     a.hookupParameters([p2], clearOld=False)
 
     assert a() == 8

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -18,7 +18,7 @@ def _getWidget(param):
 
 
 def test_typeless_param():
-    p = pt.Parameter.create(name='test', type=None, value=set())
+    p = pt.Parameter.create(name='test', type=None, value=set(), default=set())
     p.setValue(range(4))
 
 
@@ -160,7 +160,7 @@ def test_limits_enforcement(k, v_in, v_out):
 def test_data_race():
     # Ensure widgets don't override user setting of param values whether
     # they connect the signal before or after it's added to a tree
-    p = pt.Parameter.create(name='int', type='int', value=0)
+    p = pt.Parameter.create(name='int', type='int', default=0)
     t = pt.ParameterTree()
 
     def override():
@@ -189,21 +189,21 @@ def test_checklist_show_hide():
     pi.setHidden.assert_called_with(False)
     assert p.opts["visible"]
 
-@pytest.mark.parametrize("limits,value",[
-    ([1, 2, 3], [1, 2, 3]),
+@pytest.mark.parametrize("limits,default",[
     ([1, 2, 3],  []),
-    (['a', 'b', 'c'], ['a', 'b', 'c']),
+    ([1, 2, 3], [1, 2, 3]),
     (['a', 'b', 'c'], []),
+    (['a', 'b', 'c'], ['a', 'b', 'c']),
 ])
-def test_checklist_check_and_clear_all(limits, value):
-    p = pt.Parameter.create(name='checklist', type='checklist', limits=limits, value=value)
+def test_checklist_check_and_clear_all(limits, default):
+    p = pt.Parameter.create(name='checklist', type='checklist', limits=limits, default=default)
     pi = ChecklistParameterItem(p, 0)
 
     clearButton = pi.metaBtns['Clear']
     selectButton = pi.metaBtns['Select']
     
     # ensure only the specified ones are selected by default
-    assert pi.param.value() == value
+    assert pi.param.value() == default
 
     # make all are selected after selecting all
     selectButton.clicked.emit()


### PR DESCRIPTION
Fixes #2994 

A while ago we rolled out a change to Parameter Items that required a `default` value be specified if a `value` was specified.  We emitted warnings when this condition wasn't met; but our own test suite (and library usage in general) did not conform to this new requirement.  I pushed back the deprecation period until August 2025 (previously January 2025).