### PR TITLE
Fix 'GridItem.generatePicture' for cases of invalid size

### DIFF
--- a/pyqtgraph/graphicsItems/GridItem.py
+++ b/pyqtgraph/graphicsItems/GridItem.py
@@ -97,14 +97,20 @@ class GridItem(UIGraphicsItem):
         if self.picture is None:
             #print "no pic, draw.."
             self.generatePicture()
-        p.drawPicture(QtCore.QPointF(0, 0), self.picture)
+        if self.picture is not None:
+            p.drawPicture(QtCore.QPointF(0, 0), self.picture)
         #p.setPen(QtGui.QPen(QtGui.QColor(255,0,0)))
         #p.drawLine(0, -100, 0, 100)
         #p.drawLine(-100, 0, 100, 0)
         #print "drawing Grid."
-        
-        
+
+
     def generatePicture(self):
+        lvr = self.boundingRect()
+        device_transform = self.deviceTransform()
+        if lvr.isNull() or device_transform is None:
+            return
+
         self.picture = QtGui.QPicture()
         p = QtGui.QPainter()
         p.begin(self.picture)
@@ -112,7 +118,6 @@ class GridItem(UIGraphicsItem):
         vr = self.getViewWidget().rect()
         unit = self.pixelWidth(), self.pixelHeight()
         dim = [vr.width(), vr.height()]
-        lvr = self.boundingRect()
         ul = np.array([lvr.left(), lvr.top()])
         br = np.array([lvr.right(), lvr.bottom()])
         
@@ -183,15 +188,14 @@ class GridItem(UIGraphicsItem):
                             x = ul[0] + unit[0]*3
                             y = p1[1] + unit[1]
                         texts.append((QtCore.QPointF(x, y), "%g"%p1[ax]))
-        tr = self.deviceTransform()
-        p.setWorldTransform(fn.invertQTransform(tr))
+        p.setWorldTransform(fn.invertQTransform(device_transform))
 
         if textPen is not None and len(texts) > 0:
             # if there is at least one text, then c is set
             textColor.setAlpha(c * 2)
             p.setPen(QtGui.QPen(textColor))
             for t in texts:
-                x = tr.map(t[0]) + Point(0.5, 0.5)
+                x = device_transform.map(t[0]) + Point(0.5, 0.5)
                 p.drawText(x, t[1])
 
         p.end()


### PR DESCRIPTION
This commit fixes errors in `GridItem` that can occur when the widget is not visible or has an invalid size.

I encountered a
`RuntimeWarning: divide by zero encountered in log10`
in `GridItem.generatePixmap` at this line:
```
d = 10. ** np.floor(np.log10(np.abs(dist/nlTarget)) + 0.5)
```
However, I cannot reproduce this issue. But if the bounding rect is null (`boundingRect()` returns `QtCore.QRectF()`), `dist` becomes zero, triggering the warning.

While trying to reproduce this issue, I encountered another error:
`AttributeError: 'NoneType' object has no attribute 'determinant'`.
This can be reproduced by adding:
```
grid = pg.GridItem()
p1.addItem(grid)
```
to `examples/InfiniteLabel.py` at line 20. Running the example and resizing the window to its minimal possible size will trigger the error.

Both issues occur when the widget is not in a state where it can be safely painted.
This fix prevents drawing in such cases.
