### PR TITLE
Emit sigRegionChanged only once for LinearRegionItem

### DIFF
--- a/pyqtgraph/graphicsItems/LinearRegionItem.py
+++ b/pyqtgraph/graphicsItems/LinearRegionItem.py
@@ -156,10 +156,9 @@ class LinearRegionItem(GraphicsObject):
             return
         self.blockLineSignal = True
         self.lines[0].setValue(rgn[0])
-        self.blockLineSignal = False
         self.lines[1].setValue(rgn[1])
-        #self.blockLineSignal = False
         self.lineMoved(0)
+        self.blockLineSignal = False
         self.lineMoved(1)
         self.lineMoveFinished()
 


### PR DESCRIPTION
`LinearRegionItem` currently fires `sigRegionChanged` three times when `setRegion` is used. This seems to be due to the `blockLineSignal` flag being cleared too early.

I propose to move the flag lower down to fix this - in my testing this results in the signal being fired once instead of thrice.

Minimal code that reproduces this issue in pyqtgraph-0.13.7:
```python
import pyqtgraph as pg
w = pg.PlotWidget()
w.show()
w.plotItem.addItem(region := pg.LinearRegionItem())
region.sigRegionChanged.connect(lambda: print("fired"))
region.setRegion((2, 3))
```