### PR TITLE
Lazy evaluation of mkColor error string

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -267,7 +267,7 @@ def mkColor(*args) -> QtGui.QColor:
      QColor          QColor instance; makes a copy.
     ================ ================================================
     """
-    err = 'Not sure how to make a color from "%s"' % str(args)
+    err = lambda: 'Not sure how to make a color from "%s"' % str(args)
     if len(args) == 1:
         if isinstance(args[0], str):
             c = args[0]
@@ -303,18 +303,18 @@ def mkColor(*args) -> QtGui.QColor:
             elif len(args[0]) == 2:
                 return intColor(*args[0])
             else:
-                raise TypeError(err)
+                raise TypeError(err())
         elif np.issubdtype(type(args[0]), np.integer):
             return intColor(args[0])
         else:
-            raise TypeError(err)
+            raise TypeError(err())
     elif len(args) == 3:
         r, g, b = args
         a = 255
     elif len(args) == 4:
         r, g, b, a = args
     else:
-        raise TypeError(err)
+        raise TypeError(err())
     args = [int(a) if np.isfinite(a) else 0 for a in (r, g, b, a)]
     return QtGui.QColor(*args)
 


### PR DESCRIPTION
At the start of `mkColor`, an error message is constructed just in case an Exception needs to be raised. This is fair enough, as the message is then used in a couple of different places within the function.

Unfortunately this process involves an array to string conversion, and this does add up, especially when setBrush is used on a scatter plot with different colours for every point, where mkColor is called for _every_ point. In my testing with around 200 points, perceptible lag is introduced, and around 50% of the `setBrush` call time is actually used up generating these error messages that never get used.

I propose to switch the error message to lazy evaluation - it's still defined at the top, but only evaluated when the error message needs to be raised.

Only problem I can see with this is if `mkColor` changes the value of `args` at any point, the value shown in the error message will not match the arguments provided by the user. I don't see any code modifying the values in `args` within `mkColor` though.

Example benchmarking code, run within Jupyter for convenience, with the `snakeviz` extension for profiling:
```python
import pyqtgraph as pg
import numpy as np
%load_ext snakeviz
%gui qt

w = pg.PlotWidget()
w.show()

w.addItem(scatter := pg.ScatterPlotItem(
    np.random.random(300),
    np.random.random(300)
))
colours = np.random.random((300, 4))*255
%snakeviz scatter.setBrush(colours)
```
Results: `setBrush` takes 0.170s, of which `mkColor` is 0.117s, and `_array_repr_implementation` is 0.0974s (54% of `setBrush`).