### PR TITLE
don't relink shader program where it is not needed

### DIFF
--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -113,11 +113,6 @@ class GLImageItem(GLGraphicsItem):
         compiled = [shaders.compileShader([glsl_version, v], k) for k, v in sources.items()]
         program = shaders.compileProgram(*compiled)
 
-        # bind generic vertex attrib 0 to "a_position" so that
-        # vertex attrib 0 definitely gets enabled later.
-        GL.glBindAttribLocation(program, 0, "a_position")
-        GL.glLinkProgram(program)
-
         klass._shaderProgram = program
         return program
 

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -1,4 +1,3 @@
-import ctypes
 import importlib
 
 from OpenGL import GL
@@ -131,7 +130,7 @@ class GLImageItem(GLGraphicsItem):
         loc_tex = GL.glGetAttribLocation(program, "a_texcoord")
         self.m_vbo_position.bind()
         GL.glVertexAttribPointer(loc_pos, 2, GL.GL_FLOAT, False, 4*4, None)
-        GL.glVertexAttribPointer(loc_tex, 2, GL.GL_FLOAT, False, 4*4, ctypes.c_void_p(2*4))
+        GL.glVertexAttribPointer(loc_tex, 2, GL.GL_FLOAT, False, 4*4, GL.GLvoidp(2*4))
         self.m_vbo_position.release()
         enabled_locs = [loc_pos, loc_tex]
 

--- a/pyqtgraph/opengl/items/GLVolumeItem.py
+++ b/pyqtgraph/opengl/items/GLVolumeItem.py
@@ -119,11 +119,6 @@ class GLVolumeItem(GLGraphicsItem):
         compiled = [shaders.compileShader([glsl_version, v], k) for k, v in sources.items()]
         program = shaders.compileProgram(*compiled)
 
-        # bind generic vertex attrib 0 to "a_position" so that
-        # vertex attrib 0 definitely gets enabled later.
-        GL.glBindAttribLocation(program, 0, "a_position")
-        GL.glLinkProgram(program)
-
         klass._shaderProgram = program
         return program
         


### PR DESCRIPTION
Explicitly binding vertex attrib 0 and relinking the shader program was a workaround needed for `GLGraphicsItem`s that use constant attribute values. i.e. those that make calls to `glVertexAttrib*`

`GLImageItem` and `GLVolumeItem` do not fall into that category but the workaround was copy-and-pasted into their implementation. This PR removes the unneeded code.