### PR TITLE
fix: GLLinePlotItem uploading vbo perpetually

### DIFF
--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -140,6 +140,7 @@ class GLLinePlotItem(GLGraphicsItem):
             self.upload_vbo(self.m_vbo_position, self.pos)
             if isinstance(self.color, np.ndarray):
                 self.upload_vbo(self.m_vbo_color, self.color)
+            self.vbos_uploaded = True
 
         program = self.getShaderProgram()
 


### PR DESCRIPTION
`GLLinePlotItem` was uploading vbo perpetually as it did not reset its dirty state.