### PR TITLE
fix: blockSignal=True in Parameter.setValue()

### DIFF
--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -311,19 +311,14 @@ class Parameter(QtCore.QObject):
         Set the value of this Parameter; return the actual value that was set.
         (this may be different from the value that was requested)
         """
-        try:
-            if blockSignal is not None:
-                self.sigValueChanged.disconnect(blockSignal)
-            value = self._interpretValue(value)
-            if fn.eq(self.opts.get('value', None), value):
-                return value
-            self._modifiedSinceReset = True
-            self.opts['value'] = value
+        value = self._interpretValue(value)
+        if fn.eq(self.opts.get('value', None), value):
+            return value
+        self._modifiedSinceReset = True
+        self.opts['value'] = value
+        if not blockSignal:
             self.sigValueChanged.emit(self, value)  # value might change after signal is received by tree item
-        finally:
-            if blockSignal is not None:
-                self.sigValueChanged.connect(blockSignal)
-            
+
         return self.opts['value']
 
     def _interpretValue(self, v):


### PR DESCRIPTION
This is a change to the Parameter.setValue() API.

The behaviour of blockSignal isn't specified, but other uses appear to use None/True.  The previous implementation allowed to block a specific signal, but I'd expect most would want to block all signals.

This could be renamed to blockSignals to be more consistent with restoreState().

Both blockSignal and blockSignals could be included as kwargs to maintain both behaviours.