### PR TITLE
Fix bug preventing console showing more than one uncaught exception

### DIFF
--- a/pyqtgraph/console/exception_widget.py
+++ b/pyqtgraph/console/exception_widget.py
@@ -193,7 +193,7 @@ class ExceptionHandlerWidget(QtWidgets.QGroupBox):
             print("Exception in systrace:")
             traceback.print_exc()
         finally:
-            self.inSystrace = False
+            self._inSystrace = False
         return self.systrace
         
     def checkException(self, excType, exc, tb):

--- a/pyqtgraph/examples/console_exception_inspection.py
+++ b/pyqtgraph/examples/console_exception_inspection.py
@@ -73,7 +73,7 @@ def captureStack():
 threadRunQueue = queue.Queue()
 def threadRunner():
     global threadRunQueue
-    # This is necessary to allow installing trace functions in the thread later on
+    # This is necessary in some older versions of python to allow installing trace functions in the thread later on
     sys.settrace(lambda *args: None)
     while True:
         func, args = threadRunQueue.get()


### PR DESCRIPTION
Console has the ability to display tracebacks for caught exceptions, but will ignore all but the first one. 

To test:
- run examples/console_exception_inspection.py 
- uncheck "only uncaught exceptions"
- click "raise and catch exception"; traceback is shown
- click "clear stack"
- click "show next exception"
- click "raise and catch exception" again; traceback _should be_ shown again