### PR TITLE
Speedup default PlotWidget/PlotItem initialization

### DIFF
--- a/pyqtgraph/WidgetGroup.py
+++ b/pyqtgraph/WidgetGroup.py
@@ -190,7 +190,10 @@ class WidgetGroup(QtCore.QObject):
         self._addWidget(w, name, scale)
 
     def findWidget(self, name: str) -> QtCore.QObject | None:
-        return self.widgetList.get(name)
+        for w, wname in self.widgetList.items():
+            if wname == name:
+                return w
+        return None
 
     def interface(self, obj: QtCore.QObject):
         try:

--- a/pyqtgraph/WidgetGroup.py
+++ b/pyqtgraph/WidgetGroup.py
@@ -4,7 +4,7 @@ Copyright 2010  Luke Campagnola
 Distributed under MIT/X11 license. See license.txt for more information.
 
 This class addresses the problem of having to save and restore the state
-of a large group of widgets. 
+of a large group of widgets.
 """
 
 import inspect
@@ -17,7 +17,7 @@ __all__ = ['WidgetGroup']
 def splitterState(w):
     s = w.saveState().toPercentEncoding().data().decode()
     return s
-    
+
 def restoreSplitter(w, s):
     if type(s) is list:
         w.setSizes(s)
@@ -30,7 +30,7 @@ def restoreSplitter(w, s):
             if i > 0:
                 return
         w.setSizes([50] * w.count())
-        
+
 def comboState(w):
     ind = w.currentIndex()
     data = w.itemData(ind)
@@ -46,7 +46,7 @@ def comboState(w):
         return str(w.itemText(ind))
     else:
         return data
-    
+
 def setComboState(w, v):
     if type(v) is int:
         ind = w.findData(v)
@@ -54,7 +54,7 @@ def setComboState(w, v):
             w.setCurrentIndex(ind)
             return
     w.setCurrentIndex(w.findText(str(v)))
-        
+
 
 class WidgetGroup(QtCore.QObject):
     """State manager for groups of widgets.
@@ -64,7 +64,7 @@ class WidgetGroup(QtCore.QObject):
     - Provide a single place for saving / restoring the state of all widgets in the group
     - Provide a single signal for detecting when any of the widgets have changed
     """
-    
+
     # List of widget types that can be handled by WidgetGroup.
     # The value for each type is a tuple (change signal function, get function, set function, [auto-add children])
     # The change signal function that takes an object and returns a signal that is emitted any time the state of the widget changes, not just
@@ -75,12 +75,12 @@ class WidgetGroup(QtCore.QObject):
     classes = {
         QtWidgets.QSpinBox: (
             lambda w: w.valueChanged,
-            QtWidgets.QSpinBox.value, 
+            QtWidgets.QSpinBox.value,
             QtWidgets.QSpinBox.setValue
         ),
         QtWidgets.QDoubleSpinBox: (
             lambda w: w.valueChanged,
-            QtWidgets.QDoubleSpinBox.value, 
+            QtWidgets.QDoubleSpinBox.value,
             QtWidgets.QDoubleSpinBox.setValue
         ),
         QtWidgets.QSplitter: (
@@ -121,17 +121,17 @@ class WidgetGroup(QtCore.QObject):
             QtWidgets.QSlider.setValue
         ),
     }
-    
+
     sigChanged = QtCore.Signal(str, object)
-    
-    
+
+
     def __init__(self, widgetList=None):
         """Initialize WidgetGroup, adding specified widgets into this group.
-        widgetList can be: 
+        widgetList can be:
          - a list of widget specifications (widget, [name], [scale])
          - a dict of name: widget pairs
          - any QObject, and all compatible child widgets will be added recursively.
-        
+
         The 'scale' parameter for each widget allows QSpinBox to display a different value than the value recorded
         in the group state (for example, the program may set a spin box value to 100e-6 and have it displayed as 100 to the user)
         """
@@ -171,7 +171,7 @@ class WidgetGroup(QtCore.QObject):
             signal = WidgetGroup.classes[type(w)][0]
         except KeyError:
             signal = w.widgetGroupInterface()[0]
-            
+
         if signal is not None:
             if inspect.isfunction(signal) or inspect.ismethod(signal):
                 signal = signal(w)
@@ -202,7 +202,7 @@ class WidgetGroup(QtCore.QObject):
         """Return true if we should automatically search the children of this object for more."""
         iface = self.interface(obj)
         return (len(iface) > 3 and iface[3])
-       
+
     def autoAdd(self, obj):
         # Find all children of this object and add them if possible.
         accepted = self.acceptsType(obj)
@@ -234,7 +234,7 @@ class WidgetGroup(QtCore.QObject):
         v2 = self.readWidget(w)
         if v1 != v2:
             self.sigChanged.emit(self.widgetList[w], v2)
-        
+
     def state(self):
         for w in self.uncachedWidgets:
             self.readWidget(w)
@@ -252,14 +252,14 @@ class WidgetGroup(QtCore.QObject):
             getFunc = WidgetGroup.classes[type(w)][1]
         except KeyError:
             getFunc = w.widgetGroupInterface()[1]
-        
+
         if getFunc is None:
             return None
-            
+
         # if the getter function provided in the interface is a bound method,
         # then just call the method directly. Otherwise, pass in the widget as the first arg
         # to the function.
-        if inspect.ismethod(getFunc) and getFunc.__self__ is not None:  
+        if inspect.ismethod(getFunc) and getFunc.__self__ is not None:
             val = getFunc()
         else:
             val = getFunc(w)
@@ -274,12 +274,12 @@ class WidgetGroup(QtCore.QObject):
     def setWidget(self, w, v):
         if self.scales[w] is not None:
             v *= self.scales[w]
-        
+
         if type(w) in WidgetGroup.classes:
             setFunc = WidgetGroup.classes[type(w)][2]
         else:
             setFunc = w.widgetGroupInterface()[2]
-            
+
         # if the setter function provided in the interface is a bound method,
         # then just call the method directly. Otherwise, pass in the widget as the first arg
         # to the function.

--- a/pyqtgraph/flowchart/FlowchartGraphicsView.py
+++ b/pyqtgraph/flowchart/FlowchartGraphicsView.py
@@ -5,26 +5,26 @@ from ..widgets.GraphicsView import GraphicsView
 translate = QtCore.QCoreApplication.translate
 
 class FlowchartGraphicsView(GraphicsView):
-    
+
     sigHoverOver = QtCore.Signal(object)
     sigClicked = QtCore.Signal(object)
-    
+
     def __init__(self, widget, *args):
         GraphicsView.__init__(self, *args, useOpenGL=False)
         self._vb = FlowchartViewBox(widget, lockAspect=True, invertY=True)
         self.setCentralItem(self._vb)
         self.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
-    
+
     def viewBox(self):
         return self._vb
-    
-        
+
+
 class FlowchartViewBox(ViewBox):
-    
+
     def __init__(self, widget, *args, **kwargs):
         ViewBox.__init__(self, *args, **kwargs)
         self.widget = widget
-        
+
     def getMenu(self, ev):
         ## called by ViewBox to create a new context menu
         self._fc_menu = QtWidgets.QMenu()
@@ -32,7 +32,7 @@ class FlowchartViewBox(ViewBox):
         for menu in self._subMenus:
             self._fc_menu.addMenu(menu)
         return self._fc_menu
-    
+
     def getContextMenus(self, ev):
         ## called by scene to add menus on to someone else's context menu
         menu = self.widget.buildMenu(ev.scenePos())

--- a/pyqtgraph/flowchart/FlowchartGraphicsView.py
+++ b/pyqtgraph/flowchart/FlowchartGraphicsView.py
@@ -37,4 +37,4 @@ class FlowchartViewBox(ViewBox):
         ## called by scene to add menus on to someone else's context menu
         menu = self.widget.buildMenu(ev.scenePos())
         menu.setTitle(translate("Context Menu", "Add node"))
-        return [menu, ViewBox.getMenu(self)]
+        return [menu, ViewBox.getMenu(self, ev)]

--- a/pyqtgraph/flowchart/FlowchartGraphicsView.py
+++ b/pyqtgraph/flowchart/FlowchartGraphicsView.py
@@ -37,4 +37,4 @@ class FlowchartViewBox(ViewBox):
         ## called by scene to add menus on to someone else's context menu
         menu = self.widget.buildMenu(ev.scenePos())
         menu.setTitle(translate("Context Menu", "Add node"))
-        return [menu, ViewBox.getMenu(self, ev)]
+        return [menu, ViewBox.getMenu(self)]

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -231,7 +231,7 @@ class AxisItem(GraphicsWidget):
             showValues            ``bool``
                                   indicates whether text is displayed adjacent to ticks.
 
-            tickAlpha             ``float``, ``int`` or ``None``
+            tickAlpha             ``float``,``int`` or ``None``
                                   If ``None``, pyqtgraph will draw the ticks with the
                                   alpha it deems appropriate. Otherwise, the alpha will
                                   be fixed at the value passed. With ``int``, accepted

--- a/pyqtgraph/graphicsItems/LabelItem.py
+++ b/pyqtgraph/graphicsItems/LabelItem.py
@@ -10,11 +10,11 @@ class LabelItem(GraphicsWidgetAnchor, GraphicsWidget):
     """
     GraphicsWidget displaying text.
     Used mainly as axis labels, titles, etc.
-    
+
     Note: To display text inside a scaled view (ViewBox, PlotWidget, etc) use TextItem
     """
-    
-    
+
+
     def __init__(self, text=' ', parent=None, angle=0, **args):
         GraphicsWidget.__init__(self, parent)
         GraphicsWidgetAnchor.__init__(self)
@@ -30,11 +30,11 @@ class LabelItem(GraphicsWidgetAnchor, GraphicsWidget):
         else:
             self.text = text
         self.setAngle(angle)
-            
+
     def setAttr(self, attr, value):
         """Set default text properties. See setText() for accepted parameters."""
         self.opts[attr] = value
-        
+
     def setText(self, text, **args):
         """Set the text and text properties in the label. Accepts optional arguments for auto-generating
         a CSS style string:
@@ -52,9 +52,9 @@ class LabelItem(GraphicsWidgetAnchor, GraphicsWidget):
         opts = self.opts
         for k in args:
             opts[k] = args[k]
-        
+
         optlist = []
-        
+
         color = self.opts['color']
         if color is None:
             color = getConfigOption('foreground')
@@ -74,7 +74,7 @@ class LabelItem(GraphicsWidgetAnchor, GraphicsWidget):
         self.updateMin()
         self.resizeEvent(None)
         self.updateGeometry()
-        
+
     def resizeEvent(self, ev):
         #c1 = self.boundingRect().center()
         #c2 = self.item.mapToParent(self.item.boundingRect().center()) # + self.item.pos()
@@ -85,7 +85,7 @@ class LabelItem(GraphicsWidgetAnchor, GraphicsWidget):
         bounds = self.itemRect()
         left = self.mapFromItem(self.item, QtCore.QPointF(0,0)) - self.mapFromItem(self.item, QtCore.QPointF(1,0))
         rect = self.rect()
-        
+
         if self.opts['justify'] == 'left':
             if left.x() != 0:
                 bounds.moveLeft(rect.left())
@@ -93,7 +93,7 @@ class LabelItem(GraphicsWidgetAnchor, GraphicsWidget):
                 bounds.moveTop(rect.top())
             elif left.y() > 0:
                 bounds.moveBottom(rect.bottom())
-                
+
         elif self.opts['justify'] == 'center':
             bounds.moveCenter(rect.center())
             #bounds = self.itemRect()
@@ -107,22 +107,21 @@ class LabelItem(GraphicsWidgetAnchor, GraphicsWidget):
                 bounds.moveTop(rect.top())
             #bounds = self.itemRect()
             #self.item.setPos(self.width() - bounds.width(), 0)
-            
+
         self.item.setPos(bounds.topLeft() - self.itemRect().topLeft())
         self.updateMin()
-        
+
     def setAngle(self, angle):
         self.angle = angle
         self.item.resetTransform()
         self.item.setRotation(angle)
         self.updateMin()
-        
-        
+
     def updateMin(self):
         bounds = self.itemRect()
         self.setMinimumWidth(bounds.width())
         self.setMinimumHeight(bounds.height())
-        
+
         self._sizeHint = {
             QtCore.Qt.SizeHint.MinimumSize: (bounds.width(), bounds.height()),
             QtCore.Qt.SizeHint.PreferredSize: (bounds.width(), bounds.height()),
@@ -130,18 +129,17 @@ class LabelItem(GraphicsWidgetAnchor, GraphicsWidget):
             QtCore.Qt.SizeHint.MinimumDescent: (0, 0)  ##?? what is this?
         }
         self.updateGeometry()
-        
+
     def sizeHint(self, hint, constraint):
         if hint not in self._sizeHint:
             return QtCore.QSizeF(0, 0)
         return QtCore.QSizeF(*self._sizeHint[hint])
-        
+
     def itemRect(self):
         return self.item.mapRectToParent(self.item.boundingRect())
-        
+
     #def paint(self, p, *args):
         #p.setPen(fn.mkPen('r'))
         #p.drawRect(self.rect())
         #p.setPen(fn.mkPen('g'))
         #p.drawRect(self.itemRect())
-        

--- a/pyqtgraph/graphicsItems/LabelItem.py
+++ b/pyqtgraph/graphicsItems/LabelItem.py
@@ -25,7 +25,10 @@ class LabelItem(GraphicsWidgetAnchor, GraphicsWidget):
         }
         self.opts.update(args)
         self._sizeHint = {}
-        self.setText(text)
+        if text:
+            self.setText(text)
+        else:
+            self.text = text
         self.setAngle(angle)
             
     def setAttr(self, attr, value):

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -34,7 +34,7 @@ class PlotItem(GraphicsWidget):
     GraphicsWidget implementing a standard 2D plotting area with axes.
 
     **Bases:** :class:`GraphicsWidget <pyqtgraph.GraphicsWidget>`
-    
+
     This class provides the ViewBox-plus-axes that appear when using
     :func:`pg.plot() <pyqtgraph.plot>`, :class:`PlotWidget <pyqtgraph.PlotWidget>`,
     and :meth :`GraphicsLayout.addPlot() <pyqtgraph.GraphicsLayout.addPlot>`.
@@ -48,7 +48,7 @@ class PlotItem(GraphicsWidget):
     Use :func:`plot() <pyqtgraph.PlotItem.plot>` to create a new PlotDataItem and
     add it to the view. Use :func:`addItem() <pyqtgraph.PlotItem.addItem>` to
     add any QGraphicsItem to the view.
-    
+
     This class wraps several methods from its internal ViewBox:
       - :func:`setXRange <pyqtgraph.ViewBox.setXRange>`
       - :func:`setYRange <pyqtgraph.ViewBox.setYRange>`
@@ -70,9 +70,9 @@ class PlotItem(GraphicsWidget):
       - :func:`invertX <pyqtgraph.ViewBox.invertX>`
       - :func:`register <pyqtgraph.ViewBox.register>`
       - :func:`unregister <pyqtgraph.ViewBox.unregister>`
-    
-    The ViewBox itself can be accessed by calling :func:`getViewBox() <pyqtgraph.PlotItem.getViewBox>` 
-    
+
+    The ViewBox itself can be accessed by calling :func:`getViewBox() <pyqtgraph.PlotItem.getViewBox>`
+
     Parameters
     ----------
     parent : QObject or None, default None
@@ -83,10 +83,10 @@ class PlotItem(GraphicsWidget):
         A dictionary specifying the axis labels to display
 
         .. code-block:: python
-                   
+
             {'left': (args), 'bottom': (args), ...}
-        
-        The name of each axis and the corresponding arguments are passed to 
+
+        The name of each axis and the corresponding arguments are passed to
         :meth:`PlotItem.setLabel() <pyqtgraph.PlotItem.setLabel>`
         Optionally, PlotItem my also be initialized with the keyword arguments left,
         right, top, or bottom to achieve the same effect.
@@ -103,7 +103,7 @@ class PlotItem(GraphicsWidget):
     **kwargs : dict, optional
         Any extra keyword arguments are passed to
         :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>`.
-    
+
     Signals
     -------
     sigYRangeChanged : Signal
@@ -116,17 +116,17 @@ class PlotItem(GraphicsWidget):
         Signal is emitted when the range on either x or y-axis changes. Signal contains
         a reference to the :class:`~pyqtgraph.ViewBox`, a list of lists of the form,
         ``[[x_min, x_max], [y_min, y_max]]`` and a list of two booleans, indicating if
-        the range on which axis has changed of the form 
+        the range on which axis has changed of the form
         ``[x_range_changed, y_range_changed]``.
     """
-    
+
     sigRangeChanged = QtCore.Signal(object, object)    ## Emitted when the ViewBox range has changed
     sigYRangeChanged = QtCore.Signal(object, object)   ## Emitted when the ViewBox Y range has changed
     sigXRangeChanged = QtCore.Signal(object, object)   ## Emitted when the ViewBox X range has changed
     sigRangeChangedManually = QtCore.Signal(object)    ## Emitted when the ViewBox range is changed via user interaction
-        
+
     lastFileDir = None
-    
+
     def __init__(
         self,
         parent : QtCore.QObject | None = None,
@@ -137,7 +137,7 @@ class PlotItem(GraphicsWidget):
         axisItems: dict[str, AxisItem] | None = None,
         enableMenu: bool = True,
         **kwargs
-    ):  
+    ):
         super().__init__(parent)
 
         self.setSizePolicy(
@@ -287,8 +287,8 @@ class PlotItem(GraphicsWidget):
             self.setTitle(title)
 
         if kwargs:
-            self.plot(**kwargs)        
-        
+            self.plot(**kwargs)
+
     def implements(self, interface=None):
         return interface in ['ViewBoxWrapper']
 
@@ -298,12 +298,12 @@ class PlotItem(GraphicsWidget):
 
         Returns
         -------
-        ViewBox 
+        ViewBox
             The :class:`ViewBox <pyqtgraph.ViewBox>` that this PlotItem uses.
         """
         return self.vb
-    
-    # Wrap a few methods from viewBox. 
+
+    # Wrap a few methods from viewBox.
     # Important: don't use settattr(m, getattr(self.vb, m)) as we'd be leaving the
     # viewbox alive because we had a reference to an instance method (creating wrapper
     # methods at runtime instead).
@@ -314,17 +314,17 @@ class PlotItem(GraphicsWidget):
               'viewRect', 'viewRange', 'setMouseEnabled', 'setLimits',
               'enableAutoRange', 'disableAutoRange', 'setAspectLocked', 'invertY',
               'invertX', 'register', 'unregister']:
-                
+
         def _create_method(name):
             def method(self, *args, **kwargs):
                 return getattr(self.vb, name)(*args, **kwargs)
             method.__name__ = name
             return method
-        
+
         locals()[m] = _create_method(m)
-        
+
     del _create_method
-    
+
     def setAxisItems(self, axisItems: 'dict[str, AxisItem] | None' = None) -> None:
         """
         Place axis items and initializes non-existing axis items.
@@ -337,35 +337,35 @@ class PlotItem(GraphicsWidget):
             {'left', 'bottom', 'right', 'top'} and the values must be instances of
             :class:`~pyqtgraph.AxisItem`.
         """
-        
+
         if axisItems is None:
             axisItems = {}
-        
+
         # Array containing visible axis items
         # Also containing potentially hidden axes, but they are not touched so it does
         # not matter
         visibleAxes = ['left', 'bottom']
         # Note that it does not matter that this adds
         # some values to visibleAxes a second time
-        visibleAxes.extend(axisItems.keys()) 
-        
+        visibleAxes.extend(axisItems.keys())
+
         for k, pos in (('top', (1,1)), ('bottom', (3,1)), ('left', (2,0)), ('right', (2,2))):
             if k in self.axes:
                 if k not in axisItems:
                     continue # Nothing to do here
-                
+
                 # Remove old axis
                 oldAxis = self.axes[k]['item']
                 self.layout.removeItem(oldAxis)
                 if oldAxis.scene() is not None:
                     oldAxis.scene().removeItem(oldAxis)
                 oldAxis.unlinkFromView()
-            
+
             # Create new axis
             if k in axisItems:
                 axis = axisItems[k]
                 if (
-                    axis.scene() is not None 
+                    axis.scene() is not None
                     and (k not in self.axes or axis != self.axes[k]["item"])
                 ):
                     raise RuntimeError(
@@ -375,20 +375,20 @@ class PlotItem(GraphicsWidget):
                     )
             else:
                 axis = AxisItem(orientation=k, parent=self)
-            
+
             # Set up new axis
             axis.linkToView(self.vb)
             self.axes[k] = {'item': axis, 'pos': pos}
             self.layout.addItem(axis, *pos)
-            # place axis above images at z=0, items that want to draw over the axes 
+            # place axis above images at z=0, items that want to draw over the axes
             # should be placed at z>=1
-            axis.setZValue(0.5) 
+            axis.setZValue(0.5)
             axis.setFlag(
                 QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemNegativeZStacksBehindParent
-            )           
+            )
             axisVisible = k in visibleAxes
             self.showAxis(k, axisVisible)
-        
+
     def setLogMode(self, x=None, y=None):
         """
         Set log scaling for `x` and/or `y` axes.
@@ -402,10 +402,10 @@ class PlotItem(GraphicsWidget):
             If ``True``, set the x-axis to log mode. A value of ``None`` is ignored.
         y : bool or None
             If ``True``, set the y-axis to log mode. A value of ``None`` is ignored.
-        
+
         Notes
         -----
-        No other items, in the scene will be affected by this; there is (currently) 
+        No other items, in the scene will be affected by this; there is (currently)
         no generic way to redisplay a :class:`~pyqtgraph.GraphicsItem` with log
         coordinates.
         """
@@ -413,7 +413,7 @@ class PlotItem(GraphicsWidget):
             self.ctrl.logXCheck.setChecked(x)
         if y is not None:
             self.ctrl.logYCheck.setChecked(y)
-        
+
     def showGrid(self, x=None, y=None, alpha=None):
         """
         Show or hide the grid for either axis.
@@ -430,7 +430,7 @@ class PlotItem(GraphicsWidget):
         if x is None and y is None and alpha is None:
             # prevent people getting confused if they just call showGrid()
             raise ValueError("Must specify at least one of x, y, or alpha.")
-        
+
         if x is not None:
             self.ctrl.xGridCheck.setChecked(x)
         if y is not None:
@@ -438,30 +438,30 @@ class PlotItem(GraphicsWidget):
         if alpha is not None:
             v = fn.clip_scalar(alpha, 0, 1) * self.ctrl.gridAlphaSlider.maximum() # slider range 0 to 255
             self.ctrl.gridAlphaSlider.setValue( int(v) )
-        
+
     def close(self):
-        ## Most of this crap is needed to avoid PySide trouble. 
+        ## Most of this crap is needed to avoid PySide trouble.
         ## The problem seems to be whenever scene.clear() leads to deletion of widgets (either through proxies or qgraphicswidgets)
         ## the solution is to manually remove all widgets before scene.clear() is called
         if self.ctrlMenu is None: ## already shut down
             return
         self.ctrlMenu.setParent(None)
         self.ctrlMenu = None
-        
+
         self.autoBtn.setParent(None)
         self.autoBtn = None
-        
+
         for k in self.axes:
             i = self.axes[k]['item']
             i.close()
-            
+
         self.axes = None
         self.scene().removeItem(self.vb)
         self.vb = None
-        
+
     def registerPlot(self, name):   ## for backward compatibility
         self.vb.register(name)
-        
+
     @QtCore.Slot(bool)
     @QtCore.Slot(int)
     def updateGrid(self, *args):
@@ -495,13 +495,13 @@ class PlotItem(GraphicsWidget):
             self.recomputeAverages()
         for k in self.avgCurves:
             self.avgCurves[k][1].setVisible(b)
-        
+
     @QtCore.Slot(QtWidgets.QListWidgetItem)
     def avgParamListClicked(self, item):
         name = str(item.text())
         self.paramList[name] = (item.checkState() == QtCore.Qt.CheckState.Checked)
         self.recomputeAverages()
-        
+
     def recomputeAverages(self):
         if not self.ctrl.averageGroup.isChecked():
             return
@@ -511,7 +511,7 @@ class PlotItem(GraphicsWidget):
         for c in self.curves:
             self.addAvgCurve(c)
         self.replot()
-        
+
     def addAvgCurve(self, curve):
         ## Add a single curve into the pool of curves averaged together
 
@@ -566,7 +566,7 @@ class PlotItem(GraphicsWidget):
             plot.setData(plot.xData, newData, stepMode=stepMode)
         else:
             plot.setData(x, y, stepMode=stepMode)
-        
+
     @QtCore.Slot()
     def autoBtnClicked(self):
         if self.autoBtn.mode == 'auto':
@@ -575,7 +575,7 @@ class PlotItem(GraphicsWidget):
             self.sigRangeChangedManually.emit(self.vb.mouseEnabled()[:])
         else:
             self.disableAutoRange()
-            
+
     @QtCore.Slot()
     def viewStateChanged(self):
         self.updateButtons()
@@ -583,8 +583,8 @@ class PlotItem(GraphicsWidget):
     def addItem(self, item, *args, **kwargs):
         """
         Add a :class:`~pyqtgraph.GraphicsItem` to the :class:`~pyqtgraph.ViewBox`.
-        
-        If the item has plot data (:class:`PlotDataItem <pyqtgraph.PlotDataItem>` , 
+
+        If the item has plot data (:class:`PlotDataItem <pyqtgraph.PlotDataItem>` ,
         :class:`~pyqtgraph.PlotCurveItem`, :class:`~pyqtgraph.ScatterPlotItem` ), it may
         be included in analysis performed by the PlotItem.
 
@@ -600,9 +600,9 @@ class PlotItem(GraphicsWidget):
             ============ ===============================================================
             Property     Description
             ============ ===============================================================
-            ignoreBounds ``bool`` - Keyword argument relayed to 
+            ignoreBounds ``bool`` - Keyword argument relayed to
                          :meth:`~pyqtgraph.ViewBox.addItem`.
-            
+
             skipAverage  ``bool`` - If ``True``, do not use curve to compute average
                          curves.
             ============ ===============================================================
@@ -623,18 +623,18 @@ class PlotItem(GraphicsWidget):
         name = None
         if hasattr(item, 'implements') and item.implements('plotData'):
             name = item.name()
-            self.dataItems.append(item)            
+            self.dataItems.append(item)
             params = kwargs.get('params', {})
             self.itemMeta[item] = params
             self.curves.append(item)
-        
+
         # Toggle log mode if item implements setLogMode and selected in the context menu
         if hasattr(item, 'setLogMode'):
             item.setLogMode(
                 self.ctrl.logXCheck.isChecked(),
                 self.ctrl.logYCheck.isChecked()
             )
-            
+
         if isinstance(item, PlotDataItem):
             ## configure curve for this plot
             (alpha, auto) = self.alphaState()
@@ -643,10 +643,10 @@ class PlotItem(GraphicsWidget):
             item.setFftMode(self.ctrl.fftCheck.isChecked())
             item.setDownsampling(*self.downsampleMode())
             item.setClipToView(self.clipToViewMode())
-            
+
             ## Hide older plots if needed
             self.updateDecimation()
-            
+
             ## Add to average if needed
             self.updateParamList()
             if self.ctrl.averageGroup.isChecked() and 'skipAverage' not in kwargs:
@@ -654,7 +654,7 @@ class PlotItem(GraphicsWidget):
 
         # conditionally add item to the legend
         if name is not None and hasattr(self, 'legend') and self.legend is not None:
-            self.legend.addItem(item, name=name)            
+            self.legend.addItem(item, name=name)
 
     def listDataItems(self):
         """
@@ -674,7 +674,7 @@ class PlotItem(GraphicsWidget):
         Parameters
         ----------
         x : float or None
-            Position in the x-axis to draw the line. If specified, the line will be 
+            Position in the x-axis to draw the line. If specified, the line will be
             vertical. Default ``None``.
         y : float or None
             Position in the y-axis to draw the line. If specified, the line will be
@@ -684,7 +684,7 @@ class PlotItem(GraphicsWidget):
             of the other.  See :meth:`~QtWidgets.QGraphicsItem.setZValue`.
         **kwargs : dict
             Keyword arguments to pass to the :class:`~pyqtgraph.InfiniteLine` instance.
-        
+
         Returns
         -------
         InfiniteLine
@@ -730,15 +730,15 @@ class PlotItem(GraphicsWidget):
         for i in self.items[:]:
             self.removeItem(i)
         self.avgCurves = {}
-    
+
     def clearPlots(self):
         """
         Remove all curves from the PlotItem's :class:`~pyqtgraph.ViewBox`.
         """
         for i in self.curves[:]:
             self.removeItem(i)
-        self.avgCurves = {}        
-    
+        self.avgCurves = {}
+
     def plot(self, *args, **kwargs):
         """
         Add and return a new :class:`~pyqtgraph.PlotDataItem`.
@@ -757,7 +757,7 @@ class PlotItem(GraphicsWidget):
             =========== ================================================================
             clear       ``bool`` - Call :meth:`~pyqtgraph.PlotItem.clear` prior to
                         creating the new plot instance.
-            
+
             params      ``dict`` or ``None`` - Arguments to passed as the `params`
                         argument to :meth:`~pyqtgraph.PlotItem.addItem`.
             =========== ================================================================
@@ -769,27 +769,27 @@ class PlotItem(GraphicsWidget):
         """
         clear = kwargs.get('clear', False)
         params = kwargs.get('params')
-          
+
         if clear:
             self.clear()
-            
+
         item = PlotDataItem(*args, **kwargs)
-            
+
         if params is None:
             params = {}
         self.addItem(item, params=params)
-        
+
         return item
 
     def addLegend(self, offset=(30, 30), **kwargs):
         """
         Add a new :class:`~pyqtgraph.LegendItem`.
-         
-        After the LegendItem is created, it is anchored in the internal 
-        :class:`~pyqtgraph.ViewBox`. Plots added after this will be automatically 
+
+        After the LegendItem is created, it is anchored in the internal
+        :class:`~pyqtgraph.ViewBox`. Plots added after this will be automatically
         displayed in the legend if they are created with a 'name' argument.
 
-        If a :class:`~pyqtgraph.LegendItem` has already been created using this method, 
+        If a :class:`~pyqtgraph.LegendItem` has already been created using this method,
         that item will be returned rather than creating a new one.
 
         Parameters
@@ -798,7 +798,7 @@ class PlotItem(GraphicsWidget):
             The distance to offset the LegendItem, defaults to ``(30, 30)``.
         **kwargs : dict, optional
             Keyword argument passed to the :class:`~pyqtgraph.LegendItem` constructor.
-        
+
         Returns
         -------
         LegendItem
@@ -808,11 +808,11 @@ class PlotItem(GraphicsWidget):
             self.legend = LegendItem(offset=offset, **kwargs)
             self.legend.setParentItem(self.vb)
         return self.legend
-        
+
     def addColorBar(self, image, **kwargs):
         """
         Add a ColorBarItem and set to the provided image.
-        
+
         A call like ``plot.addColorBar(img, colorMap='viridis')`` is a convenient
         method to assign and show a color map.
 
@@ -823,7 +823,7 @@ class PlotItem(GraphicsWidget):
         **kwargs : dict, optional
             Keyword arguments passed to the :class:`~pyqtgraph.ColorBarItem`
             constructor.
-        
+
         Returns
         -------
         ColorBarItem
@@ -858,7 +858,7 @@ class PlotItem(GraphicsWidget):
         **kwargs : dict, optional
             A dict of {str: iterable} where the str is the name of a kwarg and the
             iterable is a list of values, one for each plotted curve.
-        
+
         Returns
         -------
         list of PlotDataItem
@@ -941,17 +941,17 @@ class PlotItem(GraphicsWidget):
         if 'pen' in kwargs:
             kwargs['symbolPen'] = kwargs['pen']
         kwargs['pen'] = None
-            
+
         if 'brush' in kwargs:
             kwargs['symbolBrush'] = kwargs['brush']
             del kwargs['brush']
-            
+
         if 'size' in kwargs:
             kwargs['symbolSize'] = kwargs['size']
             del kwargs['size']
 
         return self.plot(*args, **kwargs)
-                
+
     def replot(self):
         self.update()
 
@@ -992,11 +992,11 @@ class PlotItem(GraphicsWidget):
 
         fileName = str(fileName)
         PlotItem.lastFileDir = os.path.dirname(fileName)
-        
+
         from ...exporters import SVGExporter
         ex = SVGExporter(self)
         ex.export(fileName)
-        
+
     def writeImage(self, fileName=None):
         """
         Write the plot content to an image file.
@@ -1014,7 +1014,7 @@ class PlotItem(GraphicsWidget):
         from ...exporters import ImageExporter
         ex = ImageExporter(self)
         ex.export(fileName)
-        
+
     def writeCsv(self, fileName=None):
         """
         Write the plot data to a CSV file.
@@ -1031,7 +1031,7 @@ class PlotItem(GraphicsWidget):
 
         fileName = str(fileName)
         PlotItem.lastFileDir = os.path.dirname(fileName)
-        
+
         data = [c.getData() for c in self.curves]
         with open(fileName, 'w') as fd:
             i = 0
@@ -1053,27 +1053,27 @@ class PlotItem(GraphicsWidget):
         state['paramList'] = self.paramList.copy()
         state['view'] = self.vb.getState()
         return state
-        
+
     def restoreState(self, state):
         if 'paramList' in state:
             self.paramList = state['paramList'].copy()
-            
+
         self.stateGroup.setState(state)
         self.updateSpectrumMode()
         self.updateSubtractMeanMode()
         self.updateDownsampling()
         self.updateAlpha()
         self.updateDecimation()
-        
+
         if 'powerSpectrumGroup' in state:
             state['fftCheck'] = state['powerSpectrumGroup']
         if 'gridGroup' in state:
             state['xGridCheck'] = state['gridGroup']
             state['yGridCheck'] = state['gridGroup']
-            
+
         self.stateGroup.setState(state)
         self.updateParamList()
-        
+
         if 'view' not in state:
             r = [[float(state['xMinText']), float(state['xMaxText'])], [float(state['yMinText']), float(state['yMaxText'])]]
             state['view'] = {
@@ -1086,7 +1086,7 @@ class PlotItem(GraphicsWidget):
 
     def widgetGroupInterface(self):
         return (None, PlotItem.saveState, PlotItem.restoreState)
-      
+
     @QtCore.Slot(bool)
     def updateSpectrumMode(self, b=None):
         if b is None:
@@ -1118,7 +1118,7 @@ class PlotItem(GraphicsWidget):
         self.getAxis('right').setLogMode(x, y)
         self.enableAutoRange()
         self.recomputeAverages()
-    
+
     @QtCore.Slot()
     def updateDerivativeMode(self):
         d = self.ctrl.derivativeCheck.isChecked()
@@ -1136,8 +1136,8 @@ class PlotItem(GraphicsWidget):
                 i.setPhasemapMode(d)
         self.enableAutoRange()
         self.recomputeAverages()
-        
-        
+
+
     def setDownsampling(self, ds=None, auto=None, mode=None):
         """
         Set the downsampling mode for the PlotItem.
@@ -1161,7 +1161,7 @@ class PlotItem(GraphicsWidget):
         mode : {'subsample', 'mean', 'peak'} or None, optional
             The downsampling mode. If ``None``, the downsampling mode is not changed.
             Default is ``None``.
-        
+
         Raises
         ------
         ValueError
@@ -1176,12 +1176,12 @@ class PlotItem(GraphicsWidget):
             else:
                 self.ctrl.downsampleCheck.setChecked(True)
                 self.ctrl.downsampleSpin.setValue(ds)
-                
+
         if auto is not None:
             if auto and ds is not False:
                 self.ctrl.downsampleCheck.setChecked(True)
             self.ctrl.autoDownsampleCheck.setChecked(auto)
-            
+
         if mode is not None:
             if mode == 'subsample':
                 self.ctrl.subsampleRadio.setChecked(True)
@@ -1193,7 +1193,7 @@ class PlotItem(GraphicsWidget):
                 raise ValueError(
                     "mode argument must be 'subsample', 'mean', or 'peak'."
                 )
-            
+
     @QtCore.Slot()
     def updateDownsampling(self):
         ds, auto, method = self.downsampleMode()
@@ -1202,20 +1202,20 @@ class PlotItem(GraphicsWidget):
             c.setDownsampling(ds, auto, method)
             c.setClipToView(clip)
         self.recomputeAverages()
-        
+
     def downsampleMode(self) -> tuple[int, bool, str]:
         if self.ctrl.downsampleCheck.isChecked():
             ds = self.ctrl.downsampleSpin.value()
         else:
             ds = 1
-            
+
         auto = (
-            self.ctrl.downsampleCheck.isChecked() and 
+            self.ctrl.downsampleCheck.isChecked() and
             self.ctrl.autoDownsampleCheck.isChecked()
         )
-            
+
         if self.ctrl.subsampleRadio.isChecked():
-            method = 'subsample' 
+            method = 'subsample'
         elif self.ctrl.meanRadio.isChecked():
             method = 'mean'
         elif self.ctrl.peakRadio.isChecked():
@@ -1226,7 +1226,7 @@ class PlotItem(GraphicsWidget):
                 "'peak'."
             )
         return ds, auto, method
-        
+
     def setClipToView(self, clip):
         """
         Set the default clip-to-view mode for new curves.
@@ -1237,7 +1237,7 @@ class PlotItem(GraphicsWidget):
             If ``True``, new curves will be clipped to the view box.
         """
         self.ctrl.clipToViewCheck.setChecked(clip)
-        
+
     def clipToViewMode(self) -> bool:
         """
         Return whether clip-to-view mode is enabled.
@@ -1247,9 +1247,9 @@ class PlotItem(GraphicsWidget):
         bool
             ``True`` if clip-to-view mode is enabled, ``False`` otherwise.
         """
-        
+
         return self.ctrl.clipToViewCheck.isChecked()
-    
+
     @QtCore.Slot(bool)
     def _handle_max_traces_toggle(self, check_state):
         if check_state:
@@ -1257,19 +1257,19 @@ class PlotItem(GraphicsWidget):
         else:
             for curve in self.curves:
                 curve.show()
-    
+
     @QtCore.Slot()
     def updateDecimation(self):
         """
         Update the number of visible curves.
 
-        Reduce or increase number of visible curves according to value set by the 
+        Reduce or increase number of visible curves according to value set by the
         `Max Traces` spinner, if `Max Traces` is checked in the context menu. Destroy
         curves that are not visible if `forget traces` is checked. In most cases, this
         function is called automatically when the `Max Traces` GUI elements are
         triggered. It is also called when the state of :class:`~pyqtgraph.PlotItem` is
         updated, its state is restored, or new items added added/removed.
-        
+
         This can cause an unexpected or conflicting state of curve visibility
         (or destruction) if curve visibilities are controlled externally. In the case of
         external control it is advised to disable the `Max Traces` checkbox (or context
@@ -1292,14 +1292,14 @@ class PlotItem(GraphicsWidget):
                 curve.show()
             else:
                 curve.hide()
-      
+
     @QtCore.Slot(bool)
     @QtCore.Slot(int)
     def updateAlpha(self, *args):
         (alpha, auto) = self.alphaState()
         for c in self.curves:
             c.setAlpha(alpha**2, auto)
-     
+
     def alphaState(self):
         enabled = self.ctrl.alphaGroup.isChecked()
         auto = self.ctrl.autoAlphaCheck.isChecked()
@@ -1323,22 +1323,22 @@ class PlotItem(GraphicsWidget):
         btnRect = self.mapRectFromItem(self.autoBtn, self.autoBtn.boundingRect())
         y = self.size().height() - btnRect.height()
         self.autoBtn.setPos(0, y)
-    
+
     def getMenu(self):
         return self.ctrlMenu
-    
+
     def getContextMenus(self, event):
         ## called when another item is displaying its context menu; we get to add extras to the end of the menu.
         if self.menuEnabled():
             return self.ctrlMenu
         else:
             return None
-    
+
     def setMenuEnabled(self, enableMenu=True, enableViewBoxMenu='same'):
         """
         Enable or disable the context menu for this PlotItem.
 
-        By default, the ViewBox's context menu will also be affected. Use 
+        By default, the ViewBox's context menu will also be affected. Use
         ``enableViewBoxMenu=None`` to leave the ViewBox unchanged.
 
         Parameters
@@ -1358,7 +1358,7 @@ class PlotItem(GraphicsWidget):
         if enableViewBoxMenu == 'same':
             enableViewBoxMenu = enableMenu
         self.vb.setMenuEnabled(enableViewBoxMenu)
-    
+
     def menuEnabled(self):
         """
         Return whether the context menu is enabled.
@@ -1387,27 +1387,27 @@ class PlotItem(GraphicsWidget):
             if action.text() == translated_name:
                 action.setVisible(visible)
                 break
-    
+
     def hoverEvent(self, ev):
         if ev.enter:
             self.mouseHovering = True
         if ev.exit:
             self.mouseHovering = False
-            
+
         self.updateButtons()
 
     def getLabel(self, key):
         pass
-        
+
     def _checkScaleKey(self, key):
         if key not in self.axes:
             raise KeyError(
                 f"Scale '{key}' not found. Scales are: {list(self.axes.keys())}"
             )
-        
+
     def getScale(self, key):
         return self.getAxis(key)
-        
+
     def getAxis(self, name):
         """
         Return the specified AxisItem.
@@ -1429,13 +1429,13 @@ class PlotItem(GraphicsWidget):
         """
         self._checkScaleKey(name)
         return self.axes[name]['item']
-        
+
     def setLabel(self, axis: str, *args, **kwargs):
         """
         Set the label for an axis.
-        
+
         Basic HTML is allowed. See :func:`AxisItem.setLabel` for formatting options.
-        
+
         Parameters
         ----------
         axis : {'left', 'bottom', 'right', 'top'}
@@ -1447,7 +1447,7 @@ class PlotItem(GraphicsWidget):
         """
         self.getAxis(axis).setLabel(*args, **kwargs)
         self.showAxis(axis)
-        
+
     def setLabels(self, **kwargs):
         """
         Set the axis labels of the plot.
@@ -1466,7 +1466,7 @@ class PlotItem(GraphicsWidget):
                 if isinstance(v, str):
                     v = (v,)
                 self.setLabel(k, *v)
-        
+
     def showLabel(self, axis, show=True):
         """
         Show or hide one of the plot's axis labels.
@@ -1519,7 +1519,7 @@ class PlotItem(GraphicsWidget):
             s.show()
         else:
             s.hide()
-            
+
     def hideAxis(self, axis):
         """
         Hide an axis.
@@ -1530,14 +1530,14 @@ class PlotItem(GraphicsWidget):
             The axis to hide.
         """
         self.showAxis(axis, False)
-        
+
     def showAxes(self, selection, showValues=True, size=False):
-        """ 
+        """
         Convenience method for quickly configuring axis settings.
-        
+
         Parameters
         ----------
-        selection : bool or tuple of bool 
+        selection : bool or tuple of bool
             Determines which AxisItems will be displayed. If in tuple form, order is
             (left, top, right, bottom). A single boolean value will set all axes, so
             that ``showAxes(True)`` configures the axes to draw a frame.
@@ -1583,22 +1583,22 @@ class PlotItem(GraphicsWidget):
                     elif axis_key in ('top', 'bottom'):
                         if show_value: ax.setHeight(size[1])
                         else         : ax.setHeight( None )
-  
+
     def hideButtons(self):
         """
         Hide auto-scale button ('A' in lower-left corner).
         """
-    
+
         self.buttonsHidden = True
         self.updateButtons()
-        
+
     def showButtons(self):
         """
         Show auto-scale button ('A' in lower-left corner).
         """
         self.buttonsHidden = False
         self.updateButtons()
-        
+
     def updateButtons(self):
         try:
             if self._exportOpts is False and self.mouseHovering and not self.buttonsHidden and not all(self.vb.autoRangeEnabled()):
@@ -1607,7 +1607,7 @@ class PlotItem(GraphicsWidget):
                 self.autoBtn.hide()
         except RuntimeError:
             pass  # this can happen if the plot has been deleted.
-            
+
     def _plotArray(self, arr, x=None, **kargs):
         if arr.ndim != 1:
             raise ValueError(f"Array must be 1D to plot (shape is {arr.shape})")
@@ -1635,7 +1635,7 @@ class PlotItem(GraphicsWidget):
         """
         super().setExportMode(export, opts)
         self.updateButtons()
-    
+
     def _chooseFilenameDialog(self, handler):
         self.fileDialog = FileDialog()
         if PlotItem.lastFileDir is not None:

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -273,10 +273,11 @@ class PlotItem(GraphicsWidget):
 
         if labels is None:
             labels = {}
-        for label in list(self.axes.keys()):
-            if label in kwargs:
-                labels[label] = kwargs[label]
-                del kwargs[label]
+        for label in self.axes:
+            try:
+                labels[label] = kwargs.pop(label)
+            except KeyError:
+                pass
         for k in labels:
             if isinstance(labels[k], str):
                 labels[k] = (labels[k],)

--- a/pyqtgraph/graphicsItems/PlotItem/plotConfigTemplate_generic.py
+++ b/pyqtgraph/graphicsItems/PlotItem/plotConfigTemplate_generic.py
@@ -142,7 +142,6 @@ class Ui_Form(object):
         self.horizontalLayout.addWidget(self.alphaSlider)
 
         self.retranslateUi(Form)
-        QtCore.QMetaObject.connectSlotsByName(Form)
 
     def retranslateUi(self, Form):
         _translate = QtCore.QCoreApplication.translate

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -231,7 +231,7 @@ class ViewBox(GraphicsWidget):
         self._viewPixelSizeCache  = None
 
     @property
-    def menu(self) -> ViewBoxMenu:
+    def menu(self) -> ViewBoxMenu | None:
         if self.menuEnabled() and self._menu is None:
             self._menu = ViewBoxMenu(self)
         return self._menu

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import sys
 import weakref
@@ -220,16 +222,19 @@ class ViewBox(GraphicsWidget):
 
         self.setAspectLocked(lockAspect)
 
-        if enableMenu:
-            self.menu = ViewBoxMenu(self)
-        else:
-            self.menu = None
+        self._menu = None
 
         self.register(name)
         if name is None:
             self.updateViewLists()
 
         self._viewPixelSizeCache  = None
+
+    @property
+    def menu(self) -> ViewBoxMenu:
+        if self.menuEnabled() and self._menu is None:
+            self._menu = ViewBoxMenu(self)
+        return self._menu
 
     @property
     def rbScaleBox(self):
@@ -414,12 +419,12 @@ class ViewBox(GraphicsWidget):
 
     def _applyMenuEnabled(self):
         enableMenu = self.state.get("enableMenu", True)
-        if enableMenu and self.menu is None:
-            self.menu = ViewBoxMenu(self)
+        if enableMenu and self._menu is None:
+            self._menu = ViewBoxMenu(self)
             self.updateViewLists()
-        elif not enableMenu and self.menu is not None:
-            self.menu.setParent(None)
-            self.menu = None
+        elif not enableMenu and self._menu is not None:
+            self._menu.setParent(None)
+            self._menu = None
 
     def addItem(self, item, ignoreBounds=False):
         """
@@ -1768,8 +1773,8 @@ class ViewBox(GraphicsWidget):
         if self in nv:
             nv.remove(self)
 
-        if self.menu is not None:
-            self.menu.setViewList(nv)
+        if self._menu is not None:
+            self._menu.setViewList(nv)
 
         for ax in [0,1]:
             link = self.state['linkedViews'][ax]

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -11,7 +11,7 @@ from ... import debug as debug
 from ... import functions as fn
 from ... import getConfigOption
 from ...Point import Point
-from ...Qt import QtCore, QtGui, QtWidgets, isQObjectAlive, QT_LIB
+from ...Qt import QT_LIB, QtCore, QtGui, QtWidgets, isQObjectAlive
 from ..GraphicsWidget import GraphicsWidget
 from ..ItemGroup import ItemGroup
 
@@ -166,12 +166,12 @@ class ViewBox(GraphicsWidget):
             'wheelScaleFactor': -1.0 / 8.0,
 
             'background': None,
-            
+
             'logMode': [False, False],
 
             # Limits
             # maximum value of double float is 1.7E+308, but internal caluclations exceed this limit before the range reaches it.
-            'limits': { 
+            'limits': {
                 'xLimits': [-1E307, +1E307],   # Maximum and minimum visible X values
                 'yLimits': [-1E307, +1E307],   # Maximum and minimum visible Y values
                 'xRange': [None, None],   # Maximum and minimum X range
@@ -477,7 +477,7 @@ class ViewBox(GraphicsWidget):
 
             self.background.setRect(self.rect())
             self.borderRect.setRect(self.rect())
-        
+
             self.sigStateChanged.emit(self)
             self.sigResized.emit(self)
 
@@ -521,7 +521,7 @@ class ViewBox(GraphicsWidget):
         # This is used during mouse interaction to prevent unpredictable
         # behavior (because the user is unaware of targetRange).
         self.state['targetRange'] = [self.state['viewRange'][0][:], self.state['viewRange'][1][:]]
-            
+
     def _effectiveLimits(self):
         # Determines restricted effective scaling range when in log mapping mode
         if self.state['logMode'][0]:
@@ -531,8 +531,8 @@ class ViewBox(GraphicsWidget):
             )
         else:
             xlimits = self.state['limits']['xLimits']
-        
-        if self.state['logMode'][1]: 
+
+        if self.state['logMode'][1]:
             ylimits = (# constrain to the +1.7E308 to 2.2E-308 range of double float values
                 max( self.state['limits']['yLimits'][0], -307.6 ),
                 min( self.state['limits']['yLimits'][1], +308.2 )
@@ -589,7 +589,7 @@ class ViewBox(GraphicsWidget):
             yOff = False if setRequested[1] else None
             self.enableAutoRange(x=xOff, y=yOff)
             changed.append(True)
-            
+
         limits = self._effectiveLimits()
         # print('rng:limits ', limits) # diagnostic output should reflect additional limit in log mode
         # limits = (self.state['limits']['xLimits'], self.state['limits']['yLimits'])
@@ -613,7 +613,7 @@ class ViewBox(GraphicsWidget):
             # Make sure that the range includes a usable number of quantization steps:
             #    approx. eps  : 3e-16
             #    * min. steps : 10
-            #    * mean value : (mn+mx)*0.5 
+            #    * mean value : (mn+mx)*0.5
             quantization_limit = (mn+mx) * 1.5e-15 # +/-10 discrete steps of double resolution
             if mx-mn < 2*quantization_limit:
                 mn -= quantization_limit
@@ -717,7 +717,7 @@ class ViewBox(GraphicsWidget):
         ==============  =============================================================
         **Arguments:**
         padding         The fraction of the total data range to add on to the final
-                        visible range. By default, this value is set between the 
+                        visible range. By default, this value is set between the
                         default padding and 0.1 depending on the size of the ViewBox.
         items           If specified, this is a list of items to consider when
                         determining the visible range.
@@ -734,7 +734,7 @@ class ViewBox(GraphicsWidget):
     def suggestPadding(self, axis):
         l = self.width() if axis==0 else self.height()
         def_pad = self.state['defaultPadding']
-        if def_pad == 0.: 
+        if def_pad == 0.:
             return def_pad # respect requested zero padding
         max_pad = max(0.1, def_pad) # don't shrink a large default padding
         if l > 0:
@@ -1007,7 +1007,7 @@ class ViewBox(GraphicsWidget):
     def setYLink(self, view):
         """Link this view's Y axis to another view. (see LinkView)"""
         self.linkView(self.YAxis, view)
-        
+
     def setLogMode(self, axis, logMode):
         """Informs ViewBox that log mode is active for the specified axis, so that the view range cen be restricted"""
         if axis == 'x':
@@ -1203,7 +1203,7 @@ class ViewBox(GraphicsWidget):
         """
         self.border = fn.mkPen(*args, **kwds)
         self.borderRect.setPen(self.border)
-    
+
     def setDefaultPadding(self, padding=0.02):
         """
         Sets the fraction of the data range that is used to pad the view range in when auto-ranging.
@@ -1293,7 +1293,7 @@ class ViewBox(GraphicsWidget):
             px, py = [Point(self.mapToView(v) - o) for v in self.pixelVectors()]
             self._viewPixelSizeCache  = (px.length(), py.length())
 
-        return self._viewPixelSizeCache 
+        return self._viewPixelSizeCache
 
     def itemBoundingRect(self, item):
         """Return the bounding rect of the item in view coordinates"""
@@ -1568,8 +1568,8 @@ class ViewBox(GraphicsWidget):
 
     # Including a prepareForPaint call is part of the Qt strategy to
     # defer expensive redraw opertions until requested by a 'sigPrepareForPaint' signal
-    # 
-    # However, as currently implemented, a call to prepareForPaint as part of the regular 
+    #
+    # However, as currently implemented, a call to prepareForPaint as part of the regular
     # 'update' call results in an undesired reset of pan/zoom:
     # https://github.com/pyqtgraph/pyqtgraph/issues/2029
     #
@@ -1590,7 +1590,7 @@ class ViewBox(GraphicsWidget):
         aspect = self.state['aspectLocked']  # size ratio / view ratio
         tr = self.targetRect()
         bounds = self.rect()
-        
+
         limits = self._effectiveLimits()
         # print('upd:limits ', limits) # diagnostic output should reflect additional limit in log mode
         minRng = [self.state['limits']['xRange'][0], self.state['limits']['yRange'][0]]

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBoxMenu.py
@@ -20,10 +20,11 @@ class ViewBoxMenu(QtWidgets.QMenu):
         self.addAction(self.viewAll)
         
         self.ctrl = []
-        self.widgetGroups = []
         self.dv = QtGui.QDoubleValidator(self)
-        for axis in 'XY':
-            m = self.addMenu(f"{axis} {translate('ViewBox', 'axis')}")
+
+        tr_axis = translate('ViewBox', 'axis')
+        for axis in 'xy':
+            m = self.addMenu(f"{axis.upper()} {tr_axis}")
             w = QtWidgets.QWidget()
             ui = ui_template.Ui_Form()
             ui.setupUi(w)
@@ -31,8 +32,6 @@ class ViewBoxMenu(QtWidgets.QMenu):
             a.setDefaultWidget(w)
             m.addAction(a)
             self.ctrl.append(ui)
-            wg = WidgetGroup(w)
-            self.widgetGroups.append(wg)
             
             connects = [
                 (ui.mouseCheck.toggled, 'MouseToggled'),
@@ -47,7 +46,7 @@ class ViewBoxMenu(QtWidgets.QMenu):
             ]
             
             for sig, fn in connects:
-                sig.connect(getattr(self, axis.lower()+fn))
+                sig.connect(getattr(self, axis+fn))
 
         self.ctrl[0].invertCheck.toggled.connect(self.xInvertToggled)
         self.ctrl[1].invertCheck.toggled.connect(self.yInvertToggled)
@@ -246,7 +245,6 @@ class ViewBoxMenu(QtWidgets.QMenu):
                 
             if changed:
                 c.setCurrentIndex(0)
-                c.currentIndexChanged.emit(c.currentIndex())
 
     def _validateRangeText(self, axis):
         """Validate range text inputs. Return current value(s) if invalid."""

--- a/pyqtgraph/graphicsItems/ViewBox/axisCtrlTemplate_generic.py
+++ b/pyqtgraph/graphicsItems/ViewBox/axisCtrlTemplate_generic.py
@@ -61,7 +61,6 @@ class Ui_Form(object):
         self.gridLayout.addWidget(self.autoPanCheck, 4, 2, 1, 2)
 
         self.retranslateUi(Form)
-        QtCore.QMetaObject.connectSlotsByName(Form)
 
     def retranslateUi(self, Form):
         _translate = QtCore.QCoreApplication.translate

--- a/tests/graphicsItems/PlotItem/test_PlotItem.py
+++ b/tests/graphicsItems/PlotItem/test_PlotItem.py
@@ -116,6 +116,7 @@ def test_plotitem_menu_initialize():
     assert item.menuEnabled() is True
     viewbox = item.vb
     assert viewbox is not None
+    assert viewbox._menu is None
     assert viewbox.menu is not None
     assert viewbox.menuEnabled() is True
 
@@ -123,6 +124,7 @@ def test_plotitem_menu_initialize():
     assert item.menuEnabled() is False
     viewbox = item.vb
     assert viewbox is not None
+    assert viewbox._menu is None
     assert viewbox.menu is None
     assert viewbox.menuEnabled() is False
 
@@ -131,6 +133,7 @@ def test_plotitem_menu_initialize():
     assert item.menuEnabled() is False
     viewbox = item.vb
     assert viewbox is not None
+    assert viewbox._menu is None
     assert viewbox.menu is not None
     assert viewbox.menuEnabled() is True
 

--- a/tests/test_WidgetGroup.py
+++ b/tests/test_WidgetGroup.py
@@ -1,0 +1,26 @@
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtWidgets
+
+
+def test_findWidget() -> None:
+    group = QtWidgets.QGroupBox()
+    combo = QtWidgets.QComboBox()
+    spin = QtWidgets.QSpinBox()
+    check = QtWidgets.QCheckBox()
+    line = QtWidgets.QLineEdit()
+    radio = QtWidgets.QRadioButton()
+
+    widget_group = pg.WidgetGroup([
+        (group, "group", None),
+        (combo, "combo", None),
+        (spin, "spin", 3),
+        (check, "check", None),
+        (line, "line_and_radio", None),
+        (radio, "line_and_radio", None),
+    ])
+
+    assert widget_group.findWidget("combo") is combo
+    assert widget_group.findWidget("check") is check
+    assert widget_group.findWidget("spin") is spin
+    assert widget_group.findWidget("line_and_radio") is line
+    assert widget_group.findWidget("nonexistent") is None


### PR DESCRIPTION
I needed to generate a bunch of plots and noticed that it was quite slow. This PR tries to reduce the number of overheads on initializing PlotWidget by implementing several optimizations:
- Don't initialize `ViewBoxMenu` on `PlotWidget` init. Create them on mouse events (or when one wants ot access `menu` property explicitly) instead when needed -- many `setupUi()` calls required to create menu are expensive
- Remove `WidgetGroup` from `ViewBoxMenu` -- they were unused there -- reduces expensive `autoAdd()` method recursions
- Create helper methods to set only necessary `AxisItem` properties and avoid calling `_updateLabel` during initialization (`setHtml` is quite expensive!)
- Don't set `LabelItem` text during initialization if text is empty (since `setHtml` is slow)
- Remove slot connections by name from `AxisItem` and `PlotItem` UI templates (unused) (to avoid generating these calls, pass `-a` option to `uic`)
- Replace some double dict lookups with `try..except` blocks

Here are my benchmarks with this script:
```python
import time

from PyQt6.QtWidgets import QApplication

import pyqtgraph as pg


def main() -> int:
    app = QApplication([])
    start = time.perf_counter()
    for _ in range(20):
        pg.PlotWidget()
    end = time.perf_counter()
    print(end - start)
    return 0


if __name__ == "__main__":
    raise SystemExit(main())
```
- before: `0.5176408999977866`
- after: `0.28181239999685204`

And also `cProfile` results (before and after respectively):
![profile_before](https://github.com/user-attachments/assets/6f5f07d8-62dd-4e1e-b643-1f2b9f1c915c)
![profile_after](https://github.com/user-attachments/assets/a09b12d4-c4b3-49e7-89aa-b0ad1c47c15e)

obtained by running this script:
```python
import cProfile

from PyQt6.QtWidgets import QApplication

import pyqtgraph as pg


def main() -> int:
    app = QApplication([])
    with cProfile.Profile() as pr:
        for _ in range(20):
            pg.PlotWidget()
    pr.dump_stats("profile.pstat")
    return 0


if __name__ == "__main__":
    raise SystemExit(main())
```
and converting results to svg with `yelp-gprof2dot` and `graphviz`