### PR TITLE
Fixed bug that significantly degraded zooming performance for line plots

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -144,7 +144,8 @@ class PlotDataset:
             # are ignored.
             selection = np.isfinite(arr)
             # True if all values are finite, False if there are any non-finites
-            if not selection.all():
+            all_finite = bool(selection.all())
+            if not all_finite:
                 arr = arr[selection]
         
         # here all_finite could be [False, True]


### PR DESCRIPTION
I noticed when going from the latest stable release (13.7) to the development version, that the performance of zooming in a large line plot (using peak auto-downsampling, but I'm unsure if that was relevant) was significantly worse. 
By binary searching commits for the issue, I found that it occured after commit no  d13e2ce, which should be purely about documentation and linting. 
The offending line caused "all_finite" to never be updated, and stay as None forever.