### PR TITLE
ensure comparison returns bool instead of np.bool

### DIFF
--- a/.github/workflows/etc/environment-pyside.yml
+++ b/.github/workflows/etc/environment-pyside.yml
@@ -2,7 +2,7 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - pyside6
+  - pyside6[version='!=6.9.1']
   - numpy
   - nomkl
   - scipy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,13 +76,13 @@ jobs:
             qt-version: "PyQt6"
           - python-version: "3.12"
             qt-lib: "pyside"
-            qt-version: "PySide6-Essentials"
+            qt-version: "PySide6-Essentials!=6.9.1"
           - python-version: "3.13"
             qt-lib: "pyqt"
             qt-version: "PyQt6"
           - python-version: "3.13"
             qt-lib: "pyside"
-            qt-version: "PySide6-Essentials"
+            qt-version: "PySide6-Essentials!=6.9.1"
         exclude:
           - os: macos-latest
             python-version: "3.10"

--- a/pyqtgraph/widgets/TableWidget.py
+++ b/pyqtgraph/widgets/TableWidget.py
@@ -471,6 +471,6 @@ class TableWidgetItem(QtWidgets.QTableWidgetItem):
         if self.sortMode == 'index' and hasattr(other, 'index'):
             return self.index < other.index
         if self.sortMode == 'value' and hasattr(other, 'value'):
-            return self.value < other.value
+            return bool(self.value < other.value)
         else:
             return self.text() < other.text()


### PR DESCRIPTION
Numpy 2.3.0 includes an expired deprecation: https://github.com/numpy/numpy/pull/28254
`'np.bool' scalars can no longer be interpreted as an index (deprecated since 1.19) `

This triggers an error in `pg.TableWidget` when a structured array is used, as demonstrated by the `TableWidget` example itself. (https://github.com/pyqtgraph/pyqtgraph/blob/master/pyqtgraph/examples/TableWidget.py)

On PyQt6:
`TypeError: invalid result from TableWidgetItem.__lt__(), a 'bool' is expected not 'numpy.bool'`

On PySide6:
`TypeError: 'numpy.bool' object cannot be interpreted as an integer`
