### PR TITLE
fix variable name typo

### DIFF
--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -648,7 +648,7 @@ class PlotItem(GraphicsWidget):
             
             ## Add to average if needed
             self.updateParamList()
-            if self.ctrl.averageGroup.isChecked() and 'skipAverage' not in kargs:
+            if self.ctrl.averageGroup.isChecked() and 'skipAverage' not in kwargs:
                 self.addAvgCurve(item)
 
         # conditionally add item to the legend


### PR DESCRIPTION
#3261 changed the spelling of the argument name `kargs` to `kwargs`.
One variable was still left named as `kargs`.

To trigger this bug:
1) run the `crosshair` example
2) right-click on the upper plot to show the context menu
3) check the checkbox Plot Options->Average->Average

Credits to #3337 that found and implemented this fix.
