### PR TITLE
fix aspect-locked zoom with mouse-drag while right-button pressed

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -806,8 +806,12 @@ class ViewBox(GraphicsWidget):
         if self.state['aspectLocked'] is not False:
             if x is None:
                 scale[0] = scale[1]
-            if y is None:
+            elif y is None:
                 scale[1] = scale[0]
+            else:
+                # scale to y if neither x nor y is None.
+                # this path is entered when dragging the mouse with right-button pressed.
+                scale[0] = scale[1]
 
         vr = self.targetRect()
         if center is None:


### PR DESCRIPTION
This fixes issue #3300, a regression bisected to #3100.

This issue arises in the following conditions:
1) aspect-ratio locked
2) mouse zoom by dragging the mouse with right-button pressed
