### PR TITLE
GraphicsItem: don't override Qt methods

### DIFF
--- a/pyqtgraph/graphicsItems/GraphicsObject.py
+++ b/pyqtgraph/graphicsItems/GraphicsObject.py
@@ -1,5 +1,4 @@
-import warnings
-from ..Qt import QT_LIB, QtCore, QtWidgets
+from ..Qt import QtWidgets
 from .GraphicsItem import GraphicsItem
 
 __all__ = ['GraphicsObject']
@@ -9,7 +8,6 @@ class GraphicsObject(GraphicsItem, QtWidgets.QGraphicsObject):
 
     Extension of QGraphicsObject with some useful methods (provided by :class:`GraphicsItem <pyqtgraph.GraphicsItem>`)
     """
-    _qtBaseClass = QtWidgets.QGraphicsObject
     def __init__(self, *args):
         self.__inform_view_on_changes = True
         QtWidgets.QGraphicsObject.__init__(self, *args)
@@ -19,21 +17,7 @@ class GraphicsObject(GraphicsItem, QtWidgets.QGraphicsObject):
     def itemChange(self, change, value):
         ret = super().itemChange(change, value)
         if change in [self.GraphicsItemChange.ItemParentHasChanged, self.GraphicsItemChange.ItemSceneHasChanged]:
-            if self.__class__.__dict__.get('parentChanged') is not None:
-                # user's GraphicsObject subclass has a parentChanged() method
-                warnings.warn(
-                    "parentChanged() is deprecated and will be removed in the future. "
-                    "Use changeParent() instead.",
-                    DeprecationWarning, stacklevel=2
-                )
-                if QT_LIB == 'PySide6' and QtCore.__version_info__ == (6, 2, 2):
-                    # workaround PySide6 6.2.2 issue https://bugreports.qt.io/browse/PYSIDE-1730
-                    # note that the bug exists also in PySide6 6.2.2.1 / Qt 6.2.2
-                    getattr(self.__class__, 'parentChanged')(self)
-                else:
-                    self.parentChanged()
-            else:
-                self.changeParent()
+            self.changeParent()
         try:
             inform_view_on_change = self.__inform_view_on_changes
         except AttributeError:

--- a/pyqtgraph/graphicsItems/GraphicsWidget.py
+++ b/pyqtgraph/graphicsItems/GraphicsWidget.py
@@ -7,9 +7,6 @@ __all__ = ['GraphicsWidget']
 
 
 class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
-    
-    _qtBaseClass = QtWidgets.QGraphicsWidget
-
     def __init__(self, *args, **kwargs):
         """
         **Bases:** :class:`GraphicsItem <pyqtgraph.GraphicsItem>`, :class:`QtWidgets.QGraphicsWidget`

--- a/pyqtgraph/graphicsItems/GridItem.py
+++ b/pyqtgraph/graphicsItems/GridItem.py
@@ -107,7 +107,7 @@ class GridItem(UIGraphicsItem):
 
     def generatePicture(self):
         lvr = self.boundingRect()
-        device_transform = self.deviceTransform()
+        device_transform = self.deviceTransform_()
         if lvr.isNull() or device_transform is None:
             return
 

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -1362,7 +1362,11 @@ class Handle(UIGraphicsItem):
         if deletable:
             self.setAcceptedMouseButtons(QtCore.Qt.MouseButton.RightButton)        
         self.setZValue(11)
-            
+
+    def pos(self):
+        # ROI class assumes that Handle class returns pg.Point
+        return Point(super().pos())
+
     def connectROI(self, roi):
         ### roi is the "parent" roi, i is the index of the handle in roi.handles
         self.rois.append(roi)
@@ -1508,7 +1512,7 @@ class Handle(UIGraphicsItem):
         return self.shape().boundingRect()
             
     def generateShape(self):
-        dt = self.deviceTransform()
+        dt = self.deviceTransform_()
         
         if dt is None:
             self._shape = self.path

--- a/pyqtgraph/graphicsItems/TargetItem.py
+++ b/pyqtgraph/graphicsItems/TargetItem.py
@@ -232,7 +232,7 @@ class TargetItem(UIGraphicsItem):
         return self._shape
 
     def generateShape(self):
-        dt = self.deviceTransform()
+        dt = self.deviceTransform_()
         if dt is None:
             self._shape = self._path
             return None


### PR DESCRIPTION
This PR removes Qt method overrides from `GraphicsItem`, making `GraphicsItem` a pure MixIn for `QGraphicsObject` and `QGraphicsWidget`.

Notes:
1) This removes the need for `_qtBaseClass`.
2) the override of `deviceTransform()` was gratuitous.
3) `Handle` was the only class relying on the override of `pos()`
4) whatever bugs `setParentItem()` and `sceneTransform()` were working around don't seem to apply anymore.

Motivation:
The reason for #3357 has to do with inheritance on the left. The changes in this PR would actually allow the inheritance to be moved to the right, since there are no more method overrides.
Moving the inheritance to the right does make #3357 run without crash.
It is, however, my opinion that MixIns should be inherited on the left, and this PR leaves it so.
