### PR TITLE
Allow SignalProxy to connect with signals that have more that 3 arguments

### DIFF
--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -55,6 +55,7 @@ class SignalProxy(QtCore.QObject):
     @QtCore.Slot()
     @QtCore.Slot(object)
     @QtCore.Slot(object, object)
+    @QtCore.Slot(object, object, object)
     @QtCore.Slot(object, object, object, object)
     @QtCore.Slot(object, object, object, object, object)
     def signalReceived(self, *args):


### PR DESCRIPTION

Adds two more decorators that allow SignalProxy.signalReceived to be used with now up to 5 arguments.