### PR TITLE
Fix signalproxy 3366

### DIFF
--- a/pyqtgraph/SignalProxy.py
+++ b/pyqtgraph/SignalProxy.py
@@ -52,9 +52,10 @@ class SignalProxy(QtCore.QObject):
     def setDelay(self, delay):
         self.delay = delay
 
-    @QtCore.Slot()
-    @QtCore.Slot(object)
-    @QtCore.Slot(object, object)
+    # commented slots because of https://github.com/pyqtgraph/pyqtgraph/issues/3366
+    # @QtCore.Slot()
+    # @QtCore.Slot(object)
+    # @QtCore.Slot(object, object)
     def signalReceived(self, *args):
         """Received signal. Cancel previous timer and store args to be
         forwarded later."""

--- a/tests/test_signalproxy.py
+++ b/tests/test_signalproxy.py
@@ -40,7 +40,7 @@ def test_connect_qt_args():
         print(item)
 
     proxy = SignalProxy(model.itemChanged, slot=my_slot)
-
+    assert isinstance(proxy, SignalProxy)
 
 def test_signal_proxy_slot(qapp):
     """Test the normal work mode of SignalProxy with `signal` and `slot`"""

--- a/tests/test_signalproxy.py
+++ b/tests/test_signalproxy.py
@@ -29,7 +29,7 @@ def qapp():
     yield app
     app.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 100)
 
-def test_connect_qt_args():
+def test_connect_qt_args(qapp):
     """
     Test if we can connect the SignalProxy with signals that return special types
     See https://github.com/pyqtgraph/pyqtgraph/issues/3366

--- a/tests/test_signalproxy.py
+++ b/tests/test_signalproxy.py
@@ -1,7 +1,6 @@
 import pytest
-
 from pyqtgraph import SignalProxy
-from pyqtgraph.Qt import QtCore, mkQApp
+from pyqtgraph.Qt import QtCore, mkQApp, QtGui
 
 
 class Sender(QtCore.QObject):
@@ -29,6 +28,18 @@ def qapp():
         app = mkQApp()
     yield app
     app.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 100)
+
+def test_connect_qt_args():
+    """
+    Test if we can connect the SignalProxy with signals that return special types
+    See https://github.com/pyqtgraph/pyqtgraph/issues/3366
+    """
+    model = QtGui.QStandardItemModel()
+
+    def my_slot(item: QtGui.QStandardItem):
+        print(item)
+
+    proxy = SignalProxy(model.itemChanged, slot=my_slot)
 
 
 def test_signal_proxy_slot(qapp):


### PR DESCRIPTION
This PR provides a test and fix for #3366 
This way the SignalProxy can again be connected to any PyQt signal.