### PR TITLE
invalidate nan locations when downsampling image

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -763,6 +763,8 @@ class ImageItem(GraphicsObject):
             )
             self._imageNanLocations = None
 
+        image = self.image
+
         if self.autoDownsample:
             xds, yds = self._computeDownsampleFactors()
             if xds is None:
@@ -770,15 +772,17 @@ class ImageItem(GraphicsObject):
 
             axes = [1, 0] if self.axisOrder == 'row-major' else [0, 1]
             nan_policy = self._nanPolicy if self._imageHasNans else 'propagate'
-            image = fn.downsample(self.image, xds, axis=axes[0], nanPolicy=nan_policy)
+            image = fn.downsample(image, xds, axis=axes[0], nanPolicy=nan_policy)
             image = fn.downsample(image, yds, axis=axes[1], nanPolicy=nan_policy)
             self._lastDownsample = (xds, yds)
+
+            # changes in view transform cause changes in downsampling factors,
+            # which invalidates any previously calculated nan locations
+            self._imageNanLocations = None
 
             # Check if downsampling reduced the image size to zero due to inf values.
             if image.size == 0:
                 return
-        else:
-            image = self.image
 
         # Convert single-channel image to 2D array
         if image.ndim == 3 and image.shape[-1] == 1:


### PR DESCRIPTION
The ImageItem downsampling factors to use are automatically re-calculated as the user makes changes to the view transform. E.g. zooming, changing window dimensions.
This means that any cached nan locations need to be invalidated.

May fix #3138

MWE that demonstrates the issue. The image dimensions used will trigger auto downsampling.
```python
import numpy as np
import pyqtgraph as pg

rng = np.random.default_rng(0)
data = rng.random(size=(500, 32768), dtype=np.float32)
yval = np.linspace(-1, 1, data.shape[0], endpoint=True)[:, None]
xval = np.linspace(-1, 1, data.shape[1], endpoint=True)
mask = ((yval**2) + xval**2) > 1
data[mask] = np.nan

pg.mkQApp()
win = pg.PlotWidget()
img = pg.ImageItem(data, axisOrder='row-major')
win.addItem(img)
win.show()
pg.exec()
```
