### PR TITLE
Feature/MouseClickEvent in PlotDataItem 

### DIFF
--- a/pyqtgraph/examples/PlotWidget.py
+++ b/pyqtgraph/examples/PlotWidget.py
@@ -72,8 +72,14 @@ curve.curve.setClickable(True)
 curve.setPen('w')  ## white pen
 curve.setShadowPen(pg.mkPen((70,70,30), width=6, cosmetic=True))
 
-def clicked():
-    print("curve clicked")
+def clicked(curve,ev):
+    if ev.button() == QtCore.Qt.MouseButton.LeftButton:
+        print("curve left clicked")
+    elif ev.button() == QtCore.Qt.MouseButton.MiddleButton:
+        print("curve middle clicked")        
+    elif ev.button() == QtCore.Qt.MouseButton.RightButton:
+        print("curve right clicked")
+
 curve.sigClicked.connect(clicked)
 
 lr = pg.LinearRegionItem([1, 30], bounds=[0,100], movable=True)

--- a/pyqtgraph/examples/PlotWidget.py
+++ b/pyqtgraph/examples/PlotWidget.py
@@ -21,7 +21,7 @@ pw = pg.PlotWidget(name='Plot1')  ## giving the plots names allows us to link th
 l.addWidget(pw)
 pw2 = pg.PlotWidget(name='Plot2')
 l.addWidget(pw2)
-pw3 = pg.PlotWidget()
+pw3 = pg.PlotWidget(name='Plot3')
 l.addWidget(pw3)
 
 mw.show()
@@ -66,27 +66,96 @@ for i in range(0, 5):
         yd, xd = rand(10000)
         pw2.plot(y=yd*(j+1), x=xd, params={'iter': i, 'val': j})
 
-## Test large numbers
-curve = pw3.plot(np.random.normal(size=100)*1e0, clickable=True)
-curve.curve.setClickable(True)
-curve.setPen('w')  ## white pen
-curve.setShadowPen(pg.mkPen((70,70,30), width=6, cosmetic=True))
+## Demonstrate multi-button click support with three different examples on pw3
+pw3.setTitle("Multi-button Click Examples")
 
-def clicked(curve,ev):
+n = 100  # Same length for all plots
+
+## Example 1: Scatter plot only with left/right buttons
+scatter1 = pw3.plot(
+    x=np.arange(n),
+    y=np.random.normal(size=n) * 0.5 + 5,
+    pen=None,
+    symbol='o',
+    symbolSize=8,
+    symbolBrush=(100, 100, 255, 200),
+    name='Scatter (L/R)',
+    clickable=True,
+    clickButtons=QtCore.Qt.MouseButton.LeftButton | QtCore.Qt.MouseButton.RightButton
+)
+
+def scatter1_clicked(item, ev):
     if ev.button() == QtCore.Qt.MouseButton.LeftButton:
-        print("curve left clicked")
-    elif ev.button() == QtCore.Qt.MouseButton.MiddleButton:
-        print("curve middle clicked")        
+        print("Scatter 1: Left button clicked")
     elif ev.button() == QtCore.Qt.MouseButton.RightButton:
-        print("curve right clicked")
+        print("Scatter 1: Right button clicked")
 
-curve.sigClicked.connect(clicked)
+def scatter1_points_clicked(item, points, ev):
+    button_name = "Left" if ev.button() == QtCore.Qt.MouseButton.LeftButton else "Right"
+    print(f"Scatter 1: {button_name} clicked on {len(points)} point(s) at x={points[0].pos().x():.2f}")
 
-lr = pg.LinearRegionItem([1, 30], bounds=[0,100], movable=True)
+scatter1.sigClicked.connect(scatter1_clicked)
+scatter1.sigPointsClicked.connect(scatter1_points_clicked)
+
+## Example 2: Curve only with left button
+curve_only = pw3.plot(
+    x=np.arange(n),
+    y=np.sin(np.arange(n) * 0.1),
+    pen=pg.mkPen('w', width=2),
+    name='Curve (L only)',
+    clickable=True,
+    clickButtons=QtCore.Qt.MouseButton.LeftButton
+)
+curve_only.setShadowPen(pg.mkPen((70,70,30), width=6, cosmetic=True))
+
+def curve_clicked(item, ev):
+    print(f"Curve: Left clicked at x={ev.pos().x():.2f}")
+
+curve_only.sigClicked.connect(curve_clicked)
+
+## Example 3: Combined scatter + curve with left/right/middle buttons
+combined = pw3.plot(
+    x=np.arange(n),
+    y=np.cos(np.arange(n) * 0.15) - 3 + np.random.normal(size=n) * 0.2,
+    pen=pg.mkPen('c', width=2),
+    symbol='t',
+    symbolSize=10,
+    symbolBrush=(255, 100, 100, 150),
+    name='Combined (L/R/M)',
+    clickable=True,
+    clickButtons=QtCore.Qt.MouseButton.LeftButton |
+                 QtCore.Qt.MouseButton.RightButton |
+                 QtCore.Qt.MouseButton.MiddleButton
+)
+
+def combined_clicked(item, ev):
+    button_name = {
+        QtCore.Qt.MouseButton.LeftButton: "Left",
+        QtCore.Qt.MouseButton.RightButton: "Right",
+        QtCore.Qt.MouseButton.MiddleButton: "Middle"
+    }.get(ev.button(), "Unknown")
+    print(f"Combined: {button_name} button clicked (curve or scatter)")
+
+def combined_points_clicked(item, points, ev):
+    button_name = {
+        QtCore.Qt.MouseButton.LeftButton: "Left",
+        QtCore.Qt.MouseButton.RightButton: "Right",
+        QtCore.Qt.MouseButton.MiddleButton: "Middle"
+    }.get(ev.button(), "Unknown")
+    print(f"Combined: {button_name} clicked on scatter point at x={points[0].pos().x():.2f}, y={points[0].pos().y():.2f}")
+
+combined.sigClicked.connect(combined_clicked)
+combined.sigPointsClicked.connect(combined_points_clicked)
+
+pw3.addLegend()
+pw3.setXRange(-5, 105)
+pw3.setYRange(-5, 7)
+
+lr = pg.LinearRegionItem([30, 70], bounds=[0, 100], movable=True)
 pw3.addItem(lr)
-line = pg.InfiniteLine(angle=90, movable=True)
+line = pg.InfiniteLine(angle=90, movable=True, pos=50)
 pw3.addItem(line)
-line.setBounds([0,200])
+line.setBounds([0, 100])
 
 if __name__ == '__main__':
     pg.exec()

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -269,6 +269,7 @@ class PlotCurveItem(GraphicsObject):
         if 'pen' not in kargs:
             self.opts['pen'] = fn.mkPen('w')
         self.setClickable(kargs.get('clickable', False))
+        self.clickButtons = kargs.get('clickButtons', QtCore.Qt.MouseButton.LeftButton)
         self.setData(*args, **kargs)
         self.glstate = None
 
@@ -677,6 +678,8 @@ class PlotCurveItem(GraphicsObject):
             self.opts['antialias'] = kargs['antialias']
         if 'skipFiniteCheck' in kargs:
             self.opts['skipFiniteCheck'] = kargs['skipFiniteCheck']
+        if 'clickButtons' in kargs:
+            self.clickButtons = kargs['clickButtons']
 
         profiler('set')
         self.update()
@@ -1265,6 +1268,8 @@ class PlotCurveItem(GraphicsObject):
 
     def mouseClickEvent(self, ev):
         if not self.clickable:
+            return
+        if not (ev.button() & self.clickButtons):
             return
         if self.mouseShape().contains(ev.pos()):
             ev.accept()

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -1264,7 +1264,7 @@ class PlotCurveItem(GraphicsObject):
         return self._mouseShape
 
     def mouseClickEvent(self, ev):
-        if not self.clickable or ev.button() != QtCore.Qt.MouseButton.LeftButton:
+        if not self.clickable:
             return
         if self.mouseShape().contains(ev.pos()):
             ev.accept()

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -626,8 +626,14 @@ class PlotDataItem(GraphicsObject):
             'dynamicRangeLimit': 1e6,
             'dynamicRangeHyst': 3.0,
             'data': None,
+            'clickable': False,
+            'clickButtons': QtCore.Qt.MouseButton.LeftButton,
         }
+        # Update clickButtons from kwargs before setData if provided
+        if 'clickButtons' in kwargs:
+            self.opts['clickButtons'] = kwargs['clickButtons']
         self.setCurveClickable(kwargs.get('clickable', False))
+        self.setScatterClickable(kwargs.get('clickable', False))
         self.setData(*args, **kwargs)
     
     # Fix "NotImplementedError: QGraphicsObject.paint() is abstract and must be overridden"
@@ -685,6 +691,28 @@ class PlotDataItem(GraphicsObject):
             Return if the curve is set to be clickable.
         """
         return self.curve.clickable
+
+    def setScatterClickable(self, state: bool):
+        """
+        Set the attribute for the scatter being clickable.
+
+        Parameters
+        ----------
+        state : bool
+            Set the scatter to be clickable.
+        """
+        self.scatter.opts['clickable'] = state
+
+    def scatterClickable(self) -> bool:
+        """
+        Get the attribute if the scatter is clickable.
+
+        Returns
+        -------
+        bool
+            Return if the scatter is set to be clickable.
+        """
+        return self.scatter.opts['clickable']
 
     def boundingRect(self):
         return QtCore.QRectF()  # let child items handle this
@@ -1357,7 +1385,8 @@ class PlotDataItem(GraphicsObject):
                 ('antialias', 'antialias'),
                 ('connect', 'connect'),
                 ('stepMode', 'stepMode'),
-                ('skipFiniteCheck', 'skipFiniteCheck')
+                ('skipFiniteCheck', 'skipFiniteCheck'),
+                ('clickButtons', 'clickButtons')
             ]:
                 if k in self.opts:
                     curveArgs[v] = self.opts[k]
@@ -1370,7 +1399,9 @@ class PlotDataItem(GraphicsObject):
                 ('data', 'data'),
                 ('pxMode', 'pxMode'),
                 ('antialias', 'antialias'),
-                ('useCache', 'useCache')
+                ('useCache', 'useCache'),
+                ('clickable', 'clickable'),
+                ('clickButtons', 'clickButtons')
             ]:
                 if k in self.opts:
                     scatterArgs[v] = self.opts[k]

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -633,7 +633,7 @@ class PlotDataItem(GraphicsObject):
         if 'clickButtons' in kwargs:
             self.opts['clickButtons'] = kwargs['clickButtons']
         self.setCurveClickable(kwargs.get('clickable', False))
-        self.setScatterClickable(kwargs.get('clickable', False))
+        self.setScatterClickable(kwargs.get('clickable', True))
         self.setData(*args, **kwargs)
     
     # Fix "NotImplementedError: QGraphicsObject.paint() is abstract and must be overridden"

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -690,7 +690,7 @@ class PlotDataItem(GraphicsObject):
         bool
             Return if the curve is set to be clickable.
         """
-        return self.curve.clickable
+        return self.curve.opts["clickable"]
 
     def setScatterClickable(self, state: bool):
         """

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -404,6 +404,8 @@ class ScatterPlotItem(GraphicsObject):
             'brush': fn.mkBrush(100, 100, 150),
             'hoverable': False,
             'tip': 'x: {x:.3g}\ny: {y:.3g}\ndata={data}'.format,
+            'clickable': True,
+            'clickButtons': QtCore.Qt.MouseButton.LeftButton,
         }
         self.opts.update(
             {'hover' + opt.title(): _DEFAULT_STYLE[opt] for opt in ['symbol', 'size', 'pen', 'brush']}
@@ -567,6 +569,10 @@ class ScatterPlotItem(GraphicsObject):
             self.opts['tip'] = kargs['tip']
         if 'useCache' in kargs:
             self.opts['useCache'] = kargs['useCache']
+        if 'clickable' in kargs:
+            self.opts['clickable'] = bool(kargs['clickable'])
+        if 'clickButtons' in kargs:
+            self.opts['clickButtons'] = kargs['clickButtons']
 
         ## Set any extra parameters provided in keyword arguments
         for k in ['pen', 'brush', 'symbol', 'size']:
@@ -1073,6 +1079,10 @@ class ScatterPlotItem(GraphicsObject):
                 & (self.data['y'] - h < b))
 
     def mouseClickEvent(self, ev):
+        if not self.opts['clickable']:
+            return
+        if not (ev.button() & self.opts['clickButtons']):
+            return
         pts = self.pointsAt(ev.pos())
         if len(pts) > 0:
             self.ptsClicked = pts

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -438,10 +438,10 @@ class ScatterPlotItem(GraphicsObject):
                                Otherwise, size is in scene coordinates and the spots scale with the view. To ensure
                                effective caching, QPen and QBrush objects should be reused as much as possible.
                                Default is True
-        *symbol*               can be one (or a list) of symbols. For a list of supported symbols, see 
+        *symbol*               can be one (or a list) of symbols. For a list of supported symbols, see
                                :func:`~ScatterPlotItem.setSymbol`. QPainterPath is also supported to specify custom symbol
                                shapes. To properly obey the position and size, custom symbols should be centered at (0,0) and
-                               width and height of 1.0. Note that it is also possible to 'install' custom shapes by setting 
+                               width and height of 1.0. Note that it is also possible to 'install' custom shapes by setting
                                ScatterPlotItem.Symbols[key] = shape.
         *pen*                  The pen (or list of pens) to use for drawing spot outlines.
         *brush*                The brush (or list of brushes) to use for filling spots.
@@ -466,6 +466,8 @@ class ScatterPlotItem(GraphicsObject):
                                scatter plot (see QPainter::CompositionMode in the Qt documentation).
         *name*                 The name of this item. Names are used for automatically
                                generating LegendItem entries and by some exporters.
+        *clickable*            If True, sigClicked is emitted when points are clicked. Default is True.
+        *clickButtons*         A Qt.MouseButton or combination specifying which mouse buttons
         ====================== ===============================================================================================
         """
         oldData = self.data  ## this causes cached pixmaps to be preserved while new data is registered.

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -1073,16 +1073,13 @@ class ScatterPlotItem(GraphicsObject):
                 & (self.data['y'] - h < b))
 
     def mouseClickEvent(self, ev):
-        if ev.button() == QtCore.Qt.MouseButton.LeftButton:
-            pts = self.pointsAt(ev.pos())
-            if len(pts) > 0:
-                self.ptsClicked = pts
-                ev.accept()
-                self.sigClicked.emit(self, self.ptsClicked, ev)
-            else:
-                #print "no spots"
-                ev.ignore()
+        pts = self.pointsAt(ev.pos())
+        if len(pts) > 0:
+            self.ptsClicked = pts
+            ev.accept()
+            self.sigClicked.emit(self, self.ptsClicked, ev)
         else:
+            #print "no spots"
             ev.ignore()
 
     def hoverEvent(self, ev):


### PR DESCRIPTION
PlotDataItem is made of two principal components related to the display:
- ScatterPlotItem to represent the symbols
- PlotCurveItem to represent the line

Currently, both items only react to left click of mouse (QtCore.Qt.MouseButton.LeftButton).

I propose in this PR to remove this intrinsic filter and leave the control to the user to accept or not the event. 

The PlotWidget.py example has been updated to show the different cases (for single click).
