### PR TITLE
Add tabColor property to pyqtgraph docks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,4 @@ venv.bak/
 dmypy.json
 
 #vscode
-.vscode/settings.json
+.vscode/

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -262,7 +262,27 @@ class DockLabel(VerticalLabel):
     sigClicked = QtCore.Signal(object, object)
     sigCloseClicked = QtCore.Signal()
 
-    def __init__(self, text, closable=False, fontSize="12px"):
+    def __init__(self, text, closable=False, fontSize=12, tabColor='#4a5c96'):
+        self.r = '5px'  # Tab radius
+        if isinstance(tabColor, str) and tabColor.startswith('#') and len(tabColor) ==7:
+            h = tabColor.lstrip('#')      # Remove #
+            r, g, b = tuple(int(h[i:i+2], 16) for i in (0, 2, 4))  # Get 1 color channel per variable (0-255)
+            self.bg = tabColor            # Set tab background color value
+        elif isinstance(tabColor, tuple) and len(tabColor) == 3:
+            r, g, b = tabColor            # Get 1 color channel per variable (0-255)
+            h = f'{r:02x}{g:02x}{b:02x}'  # Get HEX color value from r, g, b
+            self.bg = '#' + h             # Set tab background color value
+        else:
+            raise ValueError(
+                "tabColor must be either a 6-digit HEX color string '#rrggbb'"
+                "or a RGB tuple (r, g, b) with values in 0-255."
+                )
+
+        if (r*0.299 + g*0.587 + b*0.114) > 186:  # Check tab color luminance and set font color accordingly (black or white)
+            self.fg = '#000000'
+        else:
+            self.fg = '#ffffff'
+        
         self.dim = False
         self.fixedWidth = False
         self.fontSize = fontSize
@@ -281,15 +301,12 @@ class DockLabel(VerticalLabel):
             self.closeButton.setIcon(QtWidgets.QApplication.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_TitleBarCloseButton))
 
     def updateStyle(self):
-        r = '3px'
         if self.dim:
+            bg = '#ddd'
             fg = '#aaa'
-            bg = '#44a'
-            border = '#339'
         else:
-            fg = '#fff'
-            bg = '#66c'
-            border = '#55B'
+            bg = self.bg
+            fg = self.fg
 
         if self.orientation == 'vertical':
             self.vStyle = """DockLabel {
@@ -300,11 +317,10 @@ class DockLabel(VerticalLabel):
                 border-bottom-right-radius: 0px;
                 border-bottom-left-radius: %s;
                 border-width: 0px;
-                border-right: 2px solid %s;
                 padding-top: 3px;
                 padding-bottom: 3px;
                 font-size: %s;
-            }""" % (bg, fg, r, r, border, self.fontSize)
+            }""" % (bg, fg, self.r, self.r, str(self.fontSize) + 'px')
             self.setStyleSheet(self.vStyle)
         else:
             self.hStyle = """DockLabel {
@@ -315,11 +331,10 @@ class DockLabel(VerticalLabel):
                 border-bottom-right-radius: 0px;
                 border-bottom-left-radius: 0px;
                 border-width: 0px;
-                border-bottom: 2px solid %s;
                 padding-left: 3px;
                 padding-right: 3px;
                 font-size: %s;
-            }""" % (bg, fg, r, r, border, self.fontSize)
+            }""" % (bg, fg, self.r, self.r, str(self.fontSize) + 'px')
             self.setStyleSheet(self.hStyle)
 
     def setDim(self, d):

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -45,7 +45,7 @@ class Dock(QtWidgets.QWidget):
         self.dockdrop.raiseOverlay()
         self.hStyle = """
         Dock > QWidget {
-            border: 1px solid #000;
+            border: 1px solid #ddd;
             border-radius: 5px;
             border-top-left-radius: 0px;
             border-top-right-radius: 0px;
@@ -53,7 +53,7 @@ class Dock(QtWidgets.QWidget):
         }"""
         self.vStyle = """
         Dock > QWidget {
-            border: 1px solid #000;
+            border: 1px solid #ddd;
             border-radius: 5px;
             border-top-left-radius: 0px;
             border-bottom-left-radius: 0px;

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -243,7 +243,7 @@ class Dock(QtWidgets.QWidget):
         self.sigClosed.emit(self)
 
     def __repr__(self):
-        return "<Dock %s %s>" % (self.name(), self.stretch())
+        return f"<Dock {self.name()} {self.stretch()}>"
 
     def dragEnterEvent(self, *args):
         self.dockdrop.dragEnterEvent(*args)

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -45,7 +45,7 @@ class Dock(QtWidgets.QWidget):
         self.dockdrop.raiseOverlay()
         self.hStyle = """
         Dock > QWidget {
-            border: 1px solid #ddd;
+            border: 1px solid #000;
             border-radius: 5px;
             border-top-left-radius: 0px;
             border-top-right-radius: 0px;
@@ -53,7 +53,7 @@ class Dock(QtWidgets.QWidget):
         }"""
         self.vStyle = """
         Dock > QWidget {
-            border: 1px solid #ddd;
+            border: 1px solid #000;
             border-radius: 5px;
             border-top-left-radius: 0px;
             border-bottom-left-radius: 0px;

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -271,7 +271,9 @@ class DockLabel(VerticalLabel):
         g = self.bg.greenF()
         b = self.bg.blueF()
 
-        if (r*0.299 + g*0.587 + b*0.114) > 186:  # Check tab color luminance and set font color accordingly (black or white)
+        luminance = r*0.299 + g*0.587 + b*0.114  # Luminance value between 0 and 1
+
+        if luminance > 0.7:  # Set font color (black or white) accordingly to background color luminance 
             self.fg = mkColor('k')
         else:
             self.fg = mkColor('w')

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -3,6 +3,7 @@ import warnings
 from ..Qt import QtCore, QtGui, QtWidgets
 from ..widgets.VerticalLabel import VerticalLabel
 from .DockDrop import DockDrop
+from ..functions import mkColor
 
 
 class Dock(QtWidgets.QWidget):
@@ -262,26 +263,18 @@ class DockLabel(VerticalLabel):
     sigClicked = QtCore.Signal(object, object)
     sigCloseClicked = QtCore.Signal()
 
-    def __init__(self, text, closable=False, fontSize="12px", tabColor='#4a5c96'):
-        self.r = '5px'  # Tab radius
-        if isinstance(tabColor, str) and tabColor.startswith('#') and len(tabColor) ==7:
-            h = tabColor.lstrip('#')      # Remove #
-            r, g, b = tuple(int(h[i:i+2], 16) for i in (0, 2, 4))  # Get 1 color channel per variable (0-255)
-            self.bg = tabColor            # Set tab background color value
-        elif isinstance(tabColor, tuple) and len(tabColor) == 3:
-            r, g, b = tabColor            # Get 1 color channel per variable (0-255)
-            h = f'{r:02x}{g:02x}{b:02x}'  # Get HEX color value from r, g, b
-            self.bg = '#' + h             # Set tab background color value
-        else:
-            raise ValueError(
-                "tabColor must be either a 6-digit HEX color string '#rrggbb'"
-                "or a RGB tuple (r, g, b) with values in 0-255."
-                )
+    def __init__(self, text, closable=False, fontSize="12px", tabColor='#55B'):
+        self.r = '3px'  # Tab radius
+        self.bg = mkColor(tabColor)
+
+        r = self.bg.redF()
+        g = self.bg.greenF()
+        b = self.bg.blueF()
 
         if (r*0.299 + g*0.587 + b*0.114) > 186:  # Check tab color luminance and set font color accordingly (black or white)
-            self.fg = '#000000'
+            self.fg = mkColor('k')
         else:
-            self.fg = '#ffffff'
+            self.fg = mkColor('w')
         
         self.dim = False
         self.fixedWidth = False
@@ -302,39 +295,39 @@ class DockLabel(VerticalLabel):
 
     def updateStyle(self):
         if self.dim:
-            bg = '#ddd'
-            fg = '#aaa'
+            bg = mkColor('#ddd')
+            fg = mkColor('#aaa')
         else:
             bg = self.bg
             fg = self.fg
 
         if self.orientation == 'vertical':
-            self.vStyle = """DockLabel {
-                background-color : %s;
-                color : %s;
+            self.vStyle = f"""DockLabel {{
+                background-color : {bg.name()};
+                color : {fg.name()};
                 border-top-right-radius: 0px;
-                border-top-left-radius: %s;
+                border-top-left-radius: {self.r};
                 border-bottom-right-radius: 0px;
-                border-bottom-left-radius: %s;
+                border-bottom-left-radius: {self.r};
                 border-width: 0px;
                 padding-top: 3px;
                 padding-bottom: 3px;
-                font-size: %s;
-            }""" % (bg, fg, self.r, self.r, str(self.fontSize) + 'px')
+                font-size: {self.fontSize};
+            }}"""
             self.setStyleSheet(self.vStyle)
         else:
-            self.hStyle = """DockLabel {
-                background-color : %s;
-                color : %s;
-                border-top-right-radius: %s;
-                border-top-left-radius: %s;
+            self.hStyle = f"""DockLabel {{
+                background-color : {bg.name()};
+                color : {fg.name()};
+                border-top-right-radius: {self.r};
+                border-top-left-radius: {self.r};
                 border-bottom-right-radius: 0px;
                 border-bottom-left-radius: 0px;
                 border-width: 0px;
                 padding-left: 3px;
                 padding-right: 3px;
-                font-size: %s;
-            }""" % (bg, fg, self.r, self.r, str(self.fontSize) + 'px')
+                font-size: {self.fontSize};
+            }}"""
             self.setStyleSheet(self.hStyle)
 
     def setDim(self, d):

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -263,20 +263,25 @@ class DockLabel(VerticalLabel):
     sigClicked = QtCore.Signal(object, object)
     sigCloseClicked = QtCore.Signal()
 
-    def __init__(self, text, closable=False, fontSize="12px", tabColor='#55B'):
+    def __init__(self, text, closable=False, fontSize="12px", fontColor=None, tabColor=None):
         self.r = '3px'  # Tab radius
-        self.bg = mkColor(tabColor)
 
-        r = self.bg.redF()
-        g = self.bg.greenF()
-        b = self.bg.blueF()
+        # Set specific tab color if specified
+        self.bg = mkColor(tabColor) if tabColor else mkColor("#55B")
 
-        luminance = r*0.299 + g*0.587 + b*0.114  # Luminance value between 0 and 1
-
-        if luminance > 0.7:  # Set font color (black or white) accordingly to background color luminance 
-            self.fg = mkColor('k')
+        # Set specific font color if specified
+        if fontColor:
+            self.fg = mkColor(fontColor)
         else:
-            self.fg = mkColor('w')
+            # Check tabColor luminance 
+            r = self.bg.redF()
+            g = self.bg.greenF()
+            b = self.bg.blueF()
+
+            luminance = r*0.299 + g*0.587 + b*0.114  # Luminance value between 0 and 1
+
+            # Set font color (black or white) according to background color luminance
+            self.fg = mkColor('k') if luminance > 0.7 else mkColor('w')
         
         self.dim = False
         self.fixedWidth = False

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -262,7 +262,7 @@ class DockLabel(VerticalLabel):
     sigClicked = QtCore.Signal(object, object)
     sigCloseClicked = QtCore.Signal()
 
-    def __init__(self, text, closable=False, fontSize=12, tabColor='#4a5c96'):
+    def __init__(self, text, closable=False, fontSize="12px", tabColor='#4a5c96'):
         self.r = '5px'  # Tab radius
         if isinstance(tabColor, str) and tabColor.startswith('#') and len(tabColor) ==7:
             h = tabColor.lstrip('#')      # Remove #


### PR DESCRIPTION
Hello pyqtgraph,

I was looking at a way to custom the dock colors, everything but the font size is hard-coded (tab background color, font color, border-radius...). Related to [https://github.com/pyqtgraph/pyqtgraph/issues/218](https://github.com/pyqtgraph/pyqtgraph/issues/218).

- This PR makes it possible to choose the tab color by setting the `tabColor` property to either a 6-digit HEX color string `#rrggbb` or a RGB tuple `(r, g, b)` with 0-255 values.
- The luminance of the tab background color is checked and the tab font color is set to black or white accordingly (see Dock 1 has black font, Docks 2 & 3 have white font)
- When 2 docks are stacked, the selected tab has the `tabColor` color (see Dock 3) and the unselected tab is set to a default light grey color (see Dock 4).


For example:
```python
dock1 = Dock("Dock 1", tabColor=(105, 105, 105))
dock2 = Dock("Dock 2", autoOrientation=False, tabColor='#cb5d40')
dock3 = Dock("Dock 3", autoOrientation=False)
dock4 = Dock("Dock 4", autoOrientation=False)
```

<img width="235" height="244" alt="image" src="https://github.com/user-attachments/assets/21a1baa6-8388-418e-b935-df1f7d327ee4" />

A possible improvement would be to have a `borderRadius` property which could change the look of docks quite a lot (nice for customization).
