### PR TITLE
Parameter: define create as a classmethod

### DIFF
--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -123,8 +123,8 @@ class Parameter(QtCore.QObject):
             #pass
         #return QtCore.QObject.__new__(cls, *args, **opts)
 
-    @staticmethod
-    def create(**opts):
+    @classmethod
+    def create(cls, **opts):
         """
         Static method that creates a new Parameter (or subclass) instance using 
         opts['type'] to select the appropriate class.
@@ -134,10 +134,10 @@ class Parameter(QtCore.QObject):
         """
         typ = opts.get('type', None)
         if typ is None:
-            cls = Parameter
+            klass = cls
         else:
-            cls = PARAM_TYPES[opts['type']]
-        return cls(**opts)
+            klass = PARAM_TYPES[opts['type']]
+        return klass(**opts)
 
     def __init__(self, **opts):
         """


### PR DESCRIPTION
use class method to self define itself allowing the subclassing of Parameter object and creation of the subclass

My issue was that I had to reimplement __getitem__ to override the default behaviour before calling super:

something like

```
class ParameterPatch(Parameter):

    def __getitem__(self, names: Union[str, tuple[str,]]):
        if names == 'multiaxes':
            names = 'controller'
        elif 'multiaxes' in names:
            names = list(names)
            names[names.index('multiaxes')] = 'controller'
            names = tuple(names)
        super().__getitem__(names)

```

but because Parameter are instanciated with the create method hardcoding the use of Parameter, it won't use the modified class. The current solution is to reimplement also the create method. The use of the classmethod decorator in this PR allow to not make this reimplementation