### PR TITLE
allow returned camera params to be set back

### DIFF
--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -32,14 +32,6 @@ class GLViewMixin:
             raise ValueError("Rotation method should be either 'euler' or 'quaternion'")
         
         self.opts = {
-            'center': Vector(0,0,0),  ## will always appear at the center of the widget
-            'rotation' : QtGui.QQuaternion(1,0,0,0), ## camera rotation (quaternion:wxyz)
-            'distance': 10.0,         ## distance of camera from center
-            'fov':  60,               ## horizontal field of view in degrees
-            'elevation': 30,          ## camera's angle of elevation in degrees
-            'azimuth': 45,            ## camera's azimuthal angle in degrees 	
-                                      ## (rotation around z-axis 0 points along x-axis)	
-            'viewport': None,         ## no longer in use
             'rotationMethod': rotationMethod
         }
         self.reset()
@@ -69,10 +61,14 @@ class GLViewMixin:
         self.opts['center'] = Vector(0,0,0)  ## will always appear at the center of the widget
         self.opts['distance'] = 10.0         ## distance of camera from center
         self.opts['fov'] = 60                ## horizontal field of view in degrees
-        self.opts['elevation'] = 30          ## camera's angle of elevation in degrees
-        self.opts['azimuth'] = 45            ## camera's azimuthal angle in degrees 
+
+        if self.opts['rotationMethod'] == 'quaternion':
+            self.opts['rotation'] = QtGui.QQuaternion(1,0,0,0)  ## camera rotation (quaternion:wxyz)
+        else:
+            self.opts['elevation'] = 30      ## camera's angle of elevation in degrees
+            self.opts['azimuth'] = 45        ## camera's azimuthal angle in degrees
                                              ## (rotation around z-axis 0 points along x-axis)
-        self.opts['viewport'] = None         ## no longer in use
+
         self.setBackgroundColor(getConfigOption('background'))
 
     def addItem(self, item):
@@ -332,7 +328,13 @@ class GLViewMixin:
             self.opts['fov'] = kwds['fov']
 
     def cameraParams(self):
-        valid_keys = {'center', 'rotation', 'distance', 'fov', 'elevation', 'azimuth'}
+        valid_keys = ['center', 'distance', 'fov']
+
+        if self.opts['rotationMethod'] == 'quaternion':
+            valid_keys.append('rotation')
+        else:
+            valid_keys.extend(['elevation', 'azimuth'])
+
         return { k : self.opts[k] for k in valid_keys }
 
     def orbit(self, azim, elev):


### PR DESCRIPTION
The return value of `cameraParams()` should be usable to restore the camera state.

Before this PR, the following would need to be done
```python
win = GLViewWidget(rotationMethod='quaternion')
cp = win.cameraParams()
del cp['elevation']
del cp['azimuth']
win.setCameraParams(**cp)
```

After this PR, the following will work
```python
win = GLViewWidget(rotationMethod='quaternion')
cp = win.cameraParams()
win.setCameraParams(**cp)
```

fixes #3407

Additional fixes:
1) `reset()` did not reset the default in `quaternion` mode.

NOTES:
1) Irrespective of the `rotationMode`, either `rotation` or (`elevation`, `azimuth`) can be used to modify camera params. However, `rotationMode` determines which internal state gets modified.
