### PR TITLE
docs: Add BEC Widgets link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Here is a partial listing of some of the applications that make use of PyQtGraph
 * [Antenna Array Analysis](https://github.com/rookiepeng/antenna-array-analysis)
 * [argos](https://github.com/titusjan/argos)
 * [Atomize](https://github.com/Anatoly1010/Atomize)
+* [BEC Widgets](https://github.com/bec-project/bec_widgets)
 * [EnMAP-Box](https://enmap-box.readthedocs.io)
 * [EO Time Series Viewer](https://eo-time-series-viewer.readthedocs.io)
 * [ephyviewer](https://ephyviewer.readthedocs.io)


### PR DESCRIPTION
We’d like to mention our project here in the **Used By** section.

BEC Widgets — a Qt-based GUI library for [Beamline Experimental Control](https://github.com/bec-project/bec), developed at the Paul Scherrer Institute (Switzerland). Uses PyQtGraph for live plotting and diagnostics. [GitHub](https://github.com/bec-project/bec_widgets), [Docs](https://bec.readthedocs.io/projects/bec-widgets/en/latest/).