### PR TITLE
Fix exception when AxisItem is initialized with text argument (fixes #3410)

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -118,10 +118,10 @@ class AxisItem(GraphicsWidget):
         self.labelUnitPrefix = ""
         self.labelStyle = {}
         self._siPrefixEnableRanges = None
+        self.setRange(0, 1)
         self.setLabel(**args)
         self.showLabel(False)
 
-        self.setRange(0, 1)
 
         if pen is None:
             self.setPen()


### PR DESCRIPTION
Fixes exception raised when `AxisItem` is initialized with `text` argument, due to `range` property being referred to before it is initialized.

Fixes #3410 