### PR TITLE
GraphicsWidget: don't override boundingRect and shape

### DIFF
--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -9,6 +9,7 @@ from ..Qt import QtCore, QtGui, QtWidgets
 from ..widgets.SpinBox import SpinBox
 from ..widgets.ColorMapMenu import ColorMapMenu
 from .GraphicsWidget import GraphicsWidget
+from .GraphicsObject import GraphicsObject
 from .GradientPresets import Gradients
 
 translate = QtCore.QCoreApplication.translate
@@ -73,18 +74,14 @@ class TickSliderItem(GraphicsWidget):
         #self.setBackgroundRole(QtGui.QPalette.ColorRole.NoRole)
         #self.setMouseTracking(True)
         
-    #def boundingRect(self):
-        #return self.mapRectFromParent(self.geometry()).normalized()
+    def boundingRect(self):
+        # overriding boundingRect() is needed as this item has set its own transform
+        return self.mapRectFromParent(self.geometry()).normalized()
         
-    #def shape(self):  ## No idea why this is necessary, but rotated items do not receive clicks otherwise.
-        #p = QtGui.QPainterPath()
-        #p.addRect(self.boundingRect())
-        #return p
-        
-    def paint(self, p, opt, widget):
-        #p.setPen(fn.mkPen('g', width=3))
-        #p.drawRect(self.boundingRect())
-        return
+    def shape(self):  ## No idea why this is necessary, but rotated items do not receive clicks otherwise.
+        p = QtGui.QPainterPath()
+        p.addRect(self.boundingRect())
+        return p
         
     def keyPressEvent(self, ev):
         ev.ignore()
@@ -837,19 +834,16 @@ class GradientEditorItem(TickSliderItem):
                 self.sigGradientChanged.disconnect(fn)
 
 
-class Tick(QtWidgets.QGraphicsWidget):  ## NOTE: Making this a subclass of GraphicsObject instead results in
-                                    ## activating this bug: https://bugreports.qt-project.org/browse/PYSIDE-86
+class Tick(GraphicsObject):
     ## private class
-
-    # When making Tick a subclass of QtWidgets.QGraphicsObject as origin,
-    # ..GraphicsScene.items(self, *args) will get Tick object as a
-    # class of QtGui.QMultimediaWidgets.QGraphicsVideoItem in python2.7-PyQt5(5.4.0)
 
     sigMoving = QtCore.Signal(object, object)
     sigMoved = QtCore.Signal(object)
     sigClicked = QtCore.Signal(object, object)
     
     def __init__(self, pos, color, movable=True, scale=10, pen='w', removeAllowed=True):
+        super().__init__()
+
         self.movable = movable
         self.moving = False
         self.scale = scale
@@ -863,7 +857,6 @@ class Tick(QtWidgets.QGraphicsWidget):  ## NOTE: Making this a subclass of Graph
         self.pg.lineTo(QtCore.QPointF(scale/3**0.5, scale))
         self.pg.closeSubpath()
         
-        QtWidgets.QGraphicsWidget.__init__(self)
         self.setPos(pos[0], pos[1])
         if self.movable:
             self.setZValue(1)

--- a/pyqtgraph/graphicsItems/GraphicsWidget.py
+++ b/pyqtgraph/graphicsItems/GraphicsWidget.py
@@ -1,4 +1,4 @@
-from ..Qt import QtCore, QtGui, QtWidgets
+from ..Qt import QtWidgets
 from .GraphicsItem import GraphicsItem
 from ..GraphicsScene.GraphicsScene import GraphicsScene
 from typing import TYPE_CHECKING
@@ -11,36 +11,14 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
         """
         **Bases:** :class:`GraphicsItem <pyqtgraph.GraphicsItem>`, :class:`QtWidgets.QGraphicsWidget`
         
-        Extends QGraphicsWidget with several helpful methods and workarounds for PyQt bugs. 
+        Extends QGraphicsWidget with several helpful methods.
         Most of the extra functionality is inherited from :class:`GraphicsItem <pyqtgraph.GraphicsItem>`.
         """
         QtWidgets.QGraphicsWidget.__init__(self, *args, **kwargs)
         GraphicsItem.__init__(self)
 
-        # cache bounding rect and geometry
-        self._boundingRectCache = self._previousGeometry = None
-        self._painterPathCache = None
-        self.geometryChanged.connect(self._resetCachedProperties)
-
-        # done by GraphicsItem init
-        # GraphicsScene.registerObject(self)  # workaround for pyqt bug in GraphicsScene.items()
     if TYPE_CHECKING:
         def scene(self) -> GraphicsScene: ...
-    # Removed due to https://bugreports.qt-project.org/browse/PYSIDE-86
-    # def itemChange(self, change, value):
-    #     # BEWARE: Calling QGraphicsWidget.itemChange can lead to crashing!
-    #     # ret = QtWidgets.QGraphicsWidget.itemChange(self, change, value)  # segv occurs here
-    #     # The default behavior is just to return the value argument, so we'll do that
-    #     # without calling the original method.
-    #     ret = value
-    #     if change in [self.ItemParentHasChanged, self.ItemSceneHasChanged]:
-    #         self._updateView()
-    #     return ret
-
-    @QtCore.Slot()
-    def _resetCachedProperties(self):
-        self._boundingRectCache = self._previousGeometry = None
-        self._painterPathCache = None
 
     def setFixedHeight(self, h):
         self.setMaximumHeight(h)
@@ -56,20 +34,15 @@ class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):
     def width(self):
         return self.geometry().width()
 
-    def boundingRect(self):
-        geometry = self.geometry()
-        if geometry != self._previousGeometry:
-            self._painterPathCache = None
-            br = self.mapRectFromParent(geometry).normalized()
-            self._boundingRectCache = br
-            self._previousGeometry = geometry
-        else:
-            br = self._boundingRectCache
-        return QtCore.QRectF(br)
+    # The default implementations of boundingRect() and shape()
+    # provided by QGraphicsWidget are sufficient unless your
+    # subclass sets its own transform.
+    # Sample implementations to override in your subclass are shown below.
 
-    def shape(self):
-        p = self._painterPathCache
-        if p is None:
-            self._painterPathCache = p = QtGui.QPainterPath()
-            p.addRect(self.boundingRect())
-        return p
+    # def boundingRect(self):
+    #     return self.mapRectFromParent(self.geometry()).normalized()
+
+    # def shape(self):
+    #     path = QtGui.QPainterPath()
+    #     path.addRect(self.boundingRect())
+    #     return path


### PR DESCRIPTION
This PR would be a breaking change for users who create their own `GraphicsWidget` and can't use the default implementations of `boundingRect()` and `shape()` provided by `QGraphicsWidget`.

Note that #2198 found that overriding `boundingRect()` and `shape()` in Python was hurting performance. 

Within the pyqtgraph library, only `TickSliderItem` (i.e. `GradientEditorItem`) requires the overridden implementation provided by `GraphicsWidget`. Rather than penalize all other `GraphicsWidget`s, we can just let `TickSliderItem` do its own override, which was actually already there in commented out code.

Note: `AxisItem` already provides its own overrides.

This PR is similar to #3359 in that it is removing Qt method overrides from MixIns.