### PR TITLE
fix: drawText generally takes 3 params

### DIFF
--- a/pyqtgraph/widgets/ColorMapButton.py
+++ b/pyqtgraph/widgets/ColorMapButton.py
@@ -65,6 +65,7 @@ class ColorMapDisplayMixin:
         return self._menu
 
     def paintColorMap(self, painter, rect):
+        # rect can be either a QRect or a QRectF
         painter.save()
         image = self.getImage()
         painter.drawImage(rect, image)
@@ -86,7 +87,8 @@ class ColorMapDisplayMixin:
         trect = painter.boundingRect(rect, AF.AlignCenter, text)
         # draw the foreground text
         painter.setPen(pen)
-        painter.drawText(trect, text)
+        # trect has the same type as rect (QRect or QRectF)
+        painter.drawText(trect, 0, text)
 
         painter.restore()
 


### PR DESCRIPTION
This bug crashes the `parametertree` example on PyQt5 and PyQt6.
To trigger it, run the `parametertree` example, expand `No Extra Options`, then scroll down to the parameter `cmaplut`.

This bug originated from #3179. While modifying the `drawText` call, the 3 parameter call was also (accidentally?) modified to 2 parameters.

These are the relevant overloads:
```
drawText(self, rectangle: QRectF, flags: int, text: Optional[str]) -> Optional[QRectF]
drawText(self, rectangle: QRect, flags: int, text: Optional[str]) -> Optional[QRect]
drawText(self, rectangle: QRectF, text: Optional[str], option: QTextOption = QTextOption())
```
The 2 parameter call takes only a `QRectF`, whereas the 3 parameter call takes either a `QRect` or a `QRectF`.

As it didn't crash on PySide6, I can only guess that PySide6 has an automatic promotion of `QRect` to `QRectF`.