### PR TITLE
Fix type saving of Parameter sublcalsses with saveState() / restoreState() (issue #3430)

### DIFF
--- a/pyqtgraph/examples/_paramtreecfg.py
+++ b/pyqtgraph/examples/_paramtreecfg.py
@@ -99,6 +99,9 @@ cfg = {
         }
     },
 
+    'radio': {
+    },
+
     'pen': {
         'Pen Information': {
             'type': 'str',

--- a/pyqtgraph/examples/parametertree.py
+++ b/pyqtgraph/examples/parametertree.py
@@ -16,14 +16,14 @@ from pyqtgraph.Qt import QtWidgets
 
 app = pg.mkQApp("Parameter Tree Example")
 import pyqtgraph.parametertree.parameterTypes as pTypes
-from pyqtgraph.parametertree import Parameter, ParameterTree
+from pyqtgraph.parametertree import Parameter, ParameterTree, registerParameterType
 
 
 ## test subclassing parameters
 ## This parameter automatically generates two child parameters which are always reciprocals of each other
 class ComplexParameter(pTypes.GroupParameter):
     def __init__(self, **opts):
-        opts['type'] = 'bool'
+        opts['type'] = 'complexparam'
         opts['value'] = True
         pTypes.GroupParameter.__init__(self, **opts)
         
@@ -45,7 +45,7 @@ class ComplexParameter(pTypes.GroupParameter):
 ## this group includes a menu allowing the user to add new parameters into its child list
 class ScalableGroup(pTypes.GroupParameter):
     def __init__(self, **opts):
-        opts['type'] = 'group'
+        opts['type'] = 'scalablegroup'
         opts['addText'] = "Add"
         opts['addList'] = ['str', 'float', 'int']
         pTypes.GroupParameter.__init__(self, **opts)
@@ -59,10 +59,13 @@ class ScalableGroup(pTypes.GroupParameter):
         self.addChild(dict(name="ScalableParam %d" % (len(self.childs)+1), type=typ, value=val, removable=True, renamable=True))
 
 
+all_params_types = makeAllParamTypes()
 
+registerParameterType('complexparam', ComplexParameter)
+registerParameterType('scalablegroup', ScalableGroup)
 
 params = [
-    makeAllParamTypes(),
+    all_params_types,
     {'name': 'Save/Restore functionality', 'type': 'group', 'children': [
         {'name': 'Save State', 'type': 'action'},
         {'name': 'Restore State', 'type': 'action', 'children': [

--- a/pyqtgraph/examples/parametertree.py
+++ b/pyqtgraph/examples/parametertree.py
@@ -61,7 +61,7 @@ class ComplexParameter(pTypes.GroupParameter):
 ## this group includes a menu allowing the user to add new parameters into its child list
 class ScalableGroup(pTypes.GroupParameter):
     def __init__(self, **opts):
-        opts["type"] = "group"
+        opts["type"] = "scalablegroup"
         opts["addText"] = "Add"
         # opts['addList'] = ['str', 'float', 'int']
         addMenu = [
@@ -124,12 +124,12 @@ class ScalableGroup(pTypes.GroupParameter):
             )
 
         self.addChild(param_dict)
-
+all_params_types = makeAllParamTypes()
 registerParameterType('complexparam', ComplexParameter)
 registerParameterType('scalablegroup', ScalableGroup)
 
 params = [
-    makeAllParamTypes(),
+    all_params_types,
     {'name': 'Save/Restore functionality', 'type': 'group', 'children': [
         {'name': 'Save State', 'type': 'action'},
         {'name': 'Restore State', 'type': 'action', 'children': [

--- a/pyqtgraph/examples/parametertree.py
+++ b/pyqtgraph/examples/parametertree.py
@@ -129,7 +129,7 @@ registerParameterType('complexparam', ComplexParameter)
 registerParameterType('scalablegroup', ScalableGroup)
 
 params = [
-    all_params_types,
+    makeAllParamTypes(),
     {'name': 'Save/Restore functionality', 'type': 'group', 'children': [
         {'name': 'Save State', 'type': 'action'},
         {'name': 'Restore State', 'type': 'action', 'children': [

--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -213,6 +213,15 @@ class Parameter(QtCore.QObject):
         self.blockTreeChangeEmit = 0
         self.setName(name)
 
+        # Checks that the parameter class and the specified type match the values registered in 'PARAM_TYPES'
+        if not self.check_type():
+            raise TypeError(
+                f"The specified type '{self.type()}' does not match the class registered in 'PARAM_TYPES'."
+                f"\nExpected class: {PARAM_TYPES.get(self.type(), 'Unknown')}, but got: {self.__class__}."
+                f"\nUse the 'registerParameterType' function to register a type with its associated class in "
+                f"'PARAM_TYPES'.")
+
+
         self.addChildren(self.opts.pop('children', []))
         if 'value' in self.opts and 'default' not in self.opts:
             self.opts['default'] = self.opts['value']
@@ -292,6 +301,22 @@ class Parameter(QtCore.QObject):
         if cls is None:
             raise ValueError(f"Type name '{typ}' is not registered.")
         return self.__class__ is cls
+
+    def check_type(self):
+        """
+        Checks if the specified type in the parameter options is valid for the current class.
+        This method checks that:
+            - the type specified (self.opts['type']) is registered in the 'PARAM_TYPES' dictionary
+            - the class associated with the type in 'PARAM_TYPES' matches the current parameter class.
+
+        Returns
+        -------
+        bool: Returns True if the type is valid, False otherwise.
+        """
+        if self.type() and not self.__class__ == PARAM_TYPES[self.type()]:
+            return False
+        return True
+
         
     def childPath(self, child):
         """

--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -306,12 +306,13 @@ class Parameter(QtCore.QObject):
         """
         Checks if the specified type in the parameter options is valid for the current class.
         This method checks that:
-            - the type specified (self.opts['type']) is registered in the 'PARAM_TYPES' dictionary
-            - the class associated with the type in 'PARAM_TYPES' matches the current parameter class.
+
+          - the type specified (self.opts['type']) is registered in the 'PARAM_TYPES' dictionary
+          - the class associated with the type in 'PARAM_TYPES' matches the current parameter class.
 
         Returns
         -------
-        bool: Returns True if the type is valid, False otherwise.
+        bool: True if the type is valid, False otherwise.
         """
         if self.type() and not self.__class__ == PARAM_TYPES[self.type()]:
             return False

--- a/pyqtgraph/parametertree/parameterTypes/checklist.py
+++ b/pyqtgraph/parametertree/parameterTypes/checklist.py
@@ -1,3 +1,5 @@
+
+from ..Parameter import PARAM_TYPES, registerParameterItemType
 from ... import functions as fn
 from ...Qt import QtCore, QtWidgets
 from ...SignalProxy import SignalProxy
@@ -128,15 +130,10 @@ class RadioParameterItem(BoolParameterItem):
         self.emitter.sigChanged.emit(self, val)
 
 
-# Proxy around radio/bool type so the correct item class gets instantiated
-class BoolOrRadioParameter(SimpleParameter):
+class RadioParameter(SimpleParameter):
+    itemClass = RadioParameterItem
 
-    @property
-    def itemClass(self):
-        if self.opts.get('type') == 'bool':
-            return BoolParameterItem
-        else:
-            return RadioParameterItem
+registerParameterItemType('radio', RadioParameterItem, RadioParameter)
 
 
 class ChecklistParameter(GroupParameter):
@@ -217,7 +214,7 @@ class ChecklistParameter(GroupParameter):
         for chName in self.forward:
             # Recycle old values if they match the new limits
             newVal = bool(oldOpts.get(chName, False))
-            child = BoolOrRadioParameter(type=typ, name=chName, value=newVal, default=None)
+            child = PARAM_TYPES[typ](type=typ, name=chName, value=newVal, default=None)
             self.addChild(child)
             # Prevent child from broadcasting tree state changes, since this is handled by self
             child.blockTreeChangeSignal()

--- a/pyqtgraph/parametertree/utils.py
+++ b/pyqtgraph/parametertree/utils.py
@@ -1,0 +1,48 @@
+from collections import OrderedDict
+
+from pyqtgraph.parametertree.Parameter import Parameter
+import pyqtgraph as pg
+
+def get_classes(p: Parameter) -> list:
+    """
+    Get the classes of all the elements of a Parameter in a list.
+
+    Parameters
+    ----------
+    p: Parameter
+    The parameter from which the classes are going to be extracted.
+
+    Returns
+    -------
+    list: A list containing a tree structure with the classes of each parameter elements.
+    """
+    return [p.__class__, [get_classes(c) for c in p.children()]]
+
+def compare_parameters(p1: Parameter, p2: Parameter) -> bool:
+    """
+    Compare two Parameters.
+    Compare the states of the parameters, then recursively compare the class of each parameter's element.
+
+    Parameters
+    ----------
+    p1: Parameter
+    The first parameter to compare.
+
+    p2: Parameter
+    The second parameter to compare.
+
+    Returns
+    -------
+    bool: Return True if both parameters are equal, return False otherwise.
+
+    See Also
+    --------
+    pg.eq, get_classes
+    """
+    p1_state = p1.saveState()
+    p2_state = p2.saveState()
+
+    if not pg.eq(p1_state, p2_state):
+        return False
+
+    return get_classes(p1) == get_classes(p2)

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -5,6 +5,7 @@ import numpy as np
 import pyqtgraph as pg
 import pyqtgraph.parametertree as pt
 from pyqtgraph.functions import eq
+from pyqtgraph.parametertree.utils import compare_parameters
 from pyqtgraph.parametertree.parameterTypes import ChecklistParameterItem
 from pyqtgraph.Qt import QtCore, QtGui
 
@@ -234,3 +235,4 @@ def test_recreate_from_savestate():
     state = created.saveState()
     created2 = pt.Parameter.create(**state)
     assert pg.eq(state, created2.saveState())
+    assert compare_parameters(created, created2)

--- a/tests/parametertree/test_utils.py
+++ b/tests/parametertree/test_utils.py
@@ -1,0 +1,31 @@
+import pyqtgraph.parametertree as pt
+from pyqtgraph.parametertree.utils import compare_parameters
+
+import pytest
+
+def create_simple_param():
+    return pt.Parameter.create(name='params', type='group', children=[
+        dict(name='a', type='int', value=1),
+        dict(name='b', type='float', value=2.0),
+    ])
+
+
+def test_compare_parameters():
+
+    # Test all types
+    from pyqtgraph.examples import _buildParamTypes
+    created1 = _buildParamTypes.makeAllParamTypes()
+    created2 = _buildParamTypes.makeAllParamTypes()
+
+    assert compare_parameters(created1, created2)
+
+    # Test with different types
+    p1 = pt.Parameter.create(name='params', type='group', children=[dict(name='a', type='int', value=1)])
+    p2 = pt.Parameter.create(name='params', type='group', children=[dict(name='a', type='float', value=1)])
+    assert not compare_parameters(p1, p2)
+
+    # Test with different classes
+    p1 = pt.Parameter.create(name='params', type='group', children=[dict(name='a', type='int', value=1), dict(name='b', type='int', value=2)])
+    p2 = pt.Parameter.create(name='params', type='group', children=[dict(name='a', type='float', value=1)])
+    assert not compare_parameters(p1, p2)
+

--- a/tests/parametertree/test_utils.py
+++ b/tests/parametertree/test_utils.py
@@ -3,12 +3,6 @@ from pyqtgraph.parametertree.utils import compare_parameters
 
 import pytest
 
-def create_simple_param():
-    return pt.Parameter.create(name='params', type='group', children=[
-        dict(name='a', type='int', value=1),
-        dict(name='b', type='float', value=2.0),
-    ])
-
 
 def test_compare_parameters():
 


### PR DESCRIPTION
### Description
Resolves #3430

This PR fixes the issue where custom `Parameter` subclasses (e.g. `ComplexParameter` and `ScalableGroup`, defined in examples/parametertree.py) cannot be correctly restored using `saveState()` and `restoreState()`.

The cause of this problem is that these classes overwrite `opts['type']` with existing types (e.g. 'group') already associated to an other `Parameter` subclass. 

Thus, for example, the restore mechanism instantiates a `GroupParameter` instead of the expected subclass `ScalableGroup`. Similarly, it instantiates a `SimpleParameter` instead of a `ComplexParameter`. 

### Summary of changes

**1. Use and register unique parameters types**

We use unique type names ('complexparameter', 'scalablegroup') for the example subclasses `ComplexParameter` and `ScalableGroup` and register them using `registerParameterType()`.

**2. Add a type check in `Parameter`**

Created a new method `check_type()`. It validates that:
- the specified type is registered in `PARAM_TYPES`
- the corresponding registered class matches the actual class.

This method is then called in the `__init__` function of `Parameter`.

**3. Add a `compare_parameters()` function**

Created a new function `compare_parameters()` that allows to compare two parameters. In particular, it checks that the parameters classes are the same.
The existing `eq()` function only compare saved states and cannot compare classes.

**4. Add tests**

- Tests for `compareParameters()`
- Update of test in test_parametertypes.py to check that the restored parameters keep the correct class.

**5. Fix `BoolOrRadioParameter` inconsistency**

A `BoolOrRadioParameter` could represent a 'bool' or a 'radio', but only one class per type can be registered in `PARAM_TYPES`. Thus, it caused inconsistencies. To resolve this:
- Removed the `BoolOrRadioParameter` class.
- Created a new registered class `RadioParameter`, associated to the 'radio' type;
- Updated `ChecklistParameter` so the created list items are either a `BoolParameter` or a `RadioParameter`.

### Conclusion
-  `Parameter` subclasses are now properly saved and restored.
- Type registration is consistent.
- Parameters comparison is now fully coherent.