### PR TITLE
fix PySide6 6.10.1 regression: define holder class ColorMapMenuActionData

### DIFF
--- a/doc/source/dictionaries/pyqtgraph.dic
+++ b/doc/source/dictionaries/pyqtgraph.dic
@@ -702,7 +702,6 @@ Point
 PolyLineROI
 PrimitiveArray
 PrintDetector
-PrivateActionData
 Process
 Profiler
 ProgressBarParameter


### PR DESCRIPTION
this workarounds a regression in PySide6 6.10.1 where a tuple or namedtuple does not round-trip when set as data of a QWidgetAction

```python
import collections
from PySide6 import QtCore, QtGui

print(QtCore.qVersion())

PrivateData = collections.namedtuple("PrivateData", ['x', 'y'])
data = PrivateData(1, 2)
print(data)

app = QtGui.QGuiApplication([])

act = QtGui.QAction()
act.setData(data)
data = act.data()
print(data)
```

6.10.0
PrivateData(x=1, y=2)
PrivateData(x=1, y=2)

6.10.1
PrivateData(x=1, y=2)
[1, 2]

i.e. in PySide6 6.10.1, a `namedtuple` (or even a plain tuple) got returned as a `list`.