### PR TITLE
HistogramLUTItem: add option colorMapMenu

### DIFF
--- a/pyqtgraph/examples/imageAnalysis.py
+++ b/pyqtgraph/examples/imageAnalysis.py
@@ -38,7 +38,13 @@ iso.setParentItem(img)
 iso.setZValue(5)
 
 # Contrast/color control
-hist = pg.HistogramLUTItem()
+
+# use custom colormap menu
+userList = ['viridis', 'cividis', 'magma', 'turbo']
+cmapMenu = pg.ColorMapMenu(userList=userList)
+
+hist = pg.HistogramLUTItem(colorMapMenu=cmapMenu)
+hist.gradient.setColorMap('viridis')
 hist.setImageItem(img)
 win.addItem(hist)
 

--- a/pyqtgraph/graphicsItems/HistogramLUTItem.py
+++ b/pyqtgraph/graphicsItems/HistogramLUTItem.py
@@ -10,6 +10,9 @@ import numpy as np
 
 from .. import debug as debug
 from .. import functions as fn
+from ..colormap import ColorMap
+from ..widgets.ColorMapButton import ColorMapDisplayMixin
+from ..widgets.ColorMapMenu import ColorMapMenu
 from ..Point import Point
 from ..Qt import QtCore, QtGui, QtWidgets
 from .AxisItem import AxisItem
@@ -61,6 +64,8 @@ class HistogramLUTItem(GraphicsWidget):
     orientation : str, optional
         The orientation of the axis along which the histogram is displayed. Either
         'vertical' (default) or 'horizontal'.
+    colorMapMenu: None or `bool` or :class:`~pyqtgraph.ColorMapMenu`, default=None
+        Determines whether colormap menu functionality is enabled.
 
     Attributes
     ----------
@@ -86,7 +91,8 @@ class HistogramLUTItem(GraphicsWidget):
     sigLevelChangeFinished = QtCore.Signal(object)
 
     def __init__(self, image=None, fillHistogram=True, levelMode='mono',
-                 gradientPosition='right', orientation='vertical'):
+                 gradientPosition='right', orientation='vertical',
+                 colorMapMenu=None):
         GraphicsWidget.__init__(self)
         self.lut = None
         self.imageItem = lambda: None  # fake a dead weakref
@@ -114,8 +120,12 @@ class HistogramLUTItem(GraphicsWidget):
             self.vb.setMinimumHeight(45)
             self.vb.setMouseEnabled(x=True, y=False)
 
-        self.gradient = GradientEditorItem(orientation=self.gradientPosition)
-        self.gradient.loadPreset('grey')
+        if colorMapMenu is None:
+            # None means use old behaviour
+            self.gradient = GradientEditorItem(orientation=self.gradientPosition)
+            self.gradient.loadPreset('grey')
+        else:
+            self.gradient = GradientBarItem(orientation=orientation, colorMapMenu=colorMapMenu)
 
         # LinearRegionItem orientation refers to the bounding lines
         regionOrientation = 'horizontal' if self.orientation == 'vertical' else 'vertical'
@@ -483,3 +493,78 @@ class HistogramLUTItem(GraphicsWidget):
             self.setLevelMode(state['mode'])
         self.gradient.restoreState(state['gradient'])
         self.setLevels(*state['levels'])
+
+
+class GradientBarItem(ColorMapDisplayMixin, GraphicsWidget):
+    """
+    implements a compatible replacement for GradientEditorItem for the case
+    where the user doesn't need to edit the gradient
+    """
+
+    sigGradientChanged = QtCore.Signal(object)
+
+    def __init__(self, *, orientation, colorMapMenu):
+        GraphicsWidget.__init__(self)
+        ColorMapDisplayMixin.__init__(self, orientation=orientation)
+
+        if not isinstance(colorMapMenu, (bool, ColorMapMenu)):
+            raise ValueError("colorMapMenu must be either bool or an ColorMapMenu instance")
+        if isinstance(colorMapMenu, ColorMapMenu):
+            self.setMenu(colorMapMenu)
+        self.menuEnabled = colorMapMenu is not False
+
+        self.gradRect = QtWidgets.QGraphicsRectItem(self)
+        self.gradRect.setPen(QtGui.QPen(QtCore.Qt.PenStyle.NoPen))
+        self.setMaximumThickness(15)
+
+    def colorMapChanged(self):
+        # called by ColorMapDisplayMixin
+        if self.horizontal:
+            p1 = QtCore.QPointF(0, 0)
+            p2 = QtCore.QPointF(1, 0)
+        else:
+            # flip vertical coords
+            p1 = QtCore.QPointF(0, 1)
+            p2 = QtCore.QPointF(0, 0)
+        cmap = self.colorMap()
+        grad = cmap.getGradient(p1, p2)
+        grad.setCoordinateMode(QtGui.QGradient.CoordinateMode.ObjectMode)
+        self.gradRect.setBrush(QtGui.QBrush(grad))
+        self.sigGradientChanged.emit(cmap)
+
+    def resizeEvent(self, evt):
+        # to make our bar the same length as GradientEditorItem,
+        # we factor in the tickSize used there
+        rect = self.contentsRect()
+        tickSize = 15
+        if self.horizontal:
+            rect.adjust(tickSize/2, 0, -tickSize/2, 0)
+        else:
+            rect.adjust(0, tickSize/2, 0, -tickSize/2)
+        self.gradRect.setRect(rect)
+
+    def mouseClickEvent(self, ev):
+        if self.menuEnabled and ev.button() == QtCore.Qt.MouseButton.RightButton:
+            self.getMenu().popup(ev.screenPos().toPoint())
+            ev.accept()
+
+
+    # methods defined below implement the GradientEditorItem methods
+    # that are called by HistogramLUTItem
+
+    # loadPreset() is deliberately not implemented.
+    # user should just call setColorMap().
+
+    def getLookupTable(self, nPts, alpha=None):
+        return self.colorMap().getLookupTable(nPts=nPts, alpha=alpha)
+
+    def isLookupTrivial(self):
+        return self.colorMap().isMapTrivial()
+
+    def saveState(self):
+        stops = self.colorMap().getStops()
+        return dict(ticks=stops)
+
+    def restoreState(self, state):
+        pos, color = state['ticks']
+        self.setColorMap(ColorMap(pos, color))

--- a/pyqtgraph/widgets/ColorMapButton.py
+++ b/pyqtgraph/widgets/ColorMapButton.py
@@ -36,6 +36,7 @@ class ColorMapDisplayMixin:
         self._cmap = cmap
         self._image = None
 
+    @QtCore.Slot(object)
     def setColorMap(self, cmap):
         # calls main class methods
         self._setColorMap(cmap)
@@ -58,10 +59,14 @@ class ColorMapDisplayMixin:
                 self._image = qimg.flipped() if hasattr(qimg, 'flipped') else qimg.mirrored()
         return self._image
 
+    def setMenu(self, menu : ColorMapMenu):
+        self._menu = menu
+        self._menu.sigColorMapTriggered.connect(self.setColorMap)
+
     def getMenu(self):
         if self._menu is None:
-            self._menu = ColorMapMenu(showColorMapSubMenus=True)
-            self._menu.sigColorMapTriggered.connect(self.setColorMap)
+            menu = ColorMapMenu(showColorMapSubMenus=True)
+            self.setMenu(menu)
         return self._menu
 
     def paintColorMap(self, painter, rect):


### PR DESCRIPTION
This is a continuation of #2779 and #2955.

#2779 added expanded colormaps to the menu selection in `HistogramLUTItem`.
#2955 added colormaps menu to `ColorBarItem`; and in addition allowed the colormaps menu to be customized.

Usually, the user does not need the functionality of `GradientEditorItem` that allows editing of the gradient. The user just wants to visualize the colormap.
Cons of using `GradientEditorItem`:
1) The ticks rendered by `GradientEditorItem` take up some screen estate.
2) Each tick is a `QGraphicsWidget`. This means that our 256-color colormaps instantiate the same number of ticks, even though they are hidden.

This PR adds the `ColorBarItem` functionality developed in #2955 to `HistogramLUTItem`:
-  None: use the existing `GradientEditorItem` (default)
- `False`: disable change of colormap
- `True`: uses all available colormaps in menu (with the exception of the legacy preset gradients)
- ColorMapMenu: user-provided custom menu.

