### PR TITLE
Fix missing tickvalues on inverted DateTimeAxis

### DIFF
--- a/pyqtgraph/graphicsItems/DateAxisItem.py
+++ b/pyqtgraph/graphicsItems/DateAxisItem.py
@@ -358,6 +358,7 @@ class DateAxisItem(AxisItem):
         return formatStrings
 
     def tickValues(self, minVal, maxVal, size):
+        minVal, maxVal = sorted((minVal, maxVal))
         density = (maxVal - minVal) / size
         self.setZoomLevelForDensity(density)
         values = self.zoomLevel.tickValues(minVal, maxVal, minSpc=self.minSpacing)


### PR DESCRIPTION
This PR fixes a bug where an inverted DateTimeAxis would not display any ticks because minVal and maxVal passed to `tickValues()` were not being sorted.