### PR TITLE
JSON serialization for Parameter

### DIFF
--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from .. import functions as fn
 from ..Qt import QtCore
 from .ParameterItem import ParameterItem
+from .utils import JsonEncoderDecoder
 
 PARAM_TYPES = {}
 PARAM_NAMES = {}
@@ -863,6 +864,43 @@ class Parameter(QtCore.QObject):
             self.treeStateChanges = []
             if len(changes) > 0:
                 self.sigTreeStateChanged.emit(self, changes)
+
+
+    @staticmethod
+    def to_json(parameter: "Parameter") -> str:
+        """
+        Encode a Parameter object into a JSON string.
+
+        Parameters
+        ----------
+        parameter: Parameter
+            The Parameter object to encode.
+
+        Returns
+        -------
+        str
+            A JSON string representing the encoded Parameter.
+        """
+        return JsonEncoderDecoder().encode(parameter.saveState())
+
+
+    @staticmethod
+    def from_json(json_str: str) -> "Parameter":
+        """
+        Decode a JSON string and recreate a corresponding Parameter instance.
+
+        Parameters
+        ----------
+        json_str: str
+            A JSON string representing an encoded Parameter.
+
+        Returns
+        -------
+        Parameter
+            A Parameter instance created from the JSON string.
+        """
+        decoded_state = JsonEncoderDecoder().decode(json_str)
+        return Parameter.create(**decoded_state)
 
 
 class SignalBlocker(object):

--- a/pyqtgraph/parametertree/utils.py
+++ b/pyqtgraph/parametertree/utils.py
@@ -1,0 +1,137 @@
+from typing import Any
+from json import JSONEncoder, JSONDecoder
+import json
+import numpy as np
+
+from ..colormap import ColorMap
+from ..Qt.QtGui import QColor
+
+"""
+This class provides custom JSON encoder and decoder for objects that are not supported by the standard json library.
+
+Parameter objects may contains several data types of objects that cannot be directly serialized into JSON.
+To ensure full serialization and deserialization of Parameter objects, this class introduced custom encoding for:
+	- Numpy ndarray: Not serializable in JSON by default.
+	- ColorMap: Not serializable in JSON by default.
+	- tuple: the json module encodes tuples as lists, so a custom encoding is required to preserve and restore the tuple
+	 type.
+
+We choose to handle JSON encoding in a dedicated class rather than directly inside the Parameter classes. Indeed, many
+Parameter attributes can accept multiple data types, making direct handling tricky. A dedicated encoder ensures a clean
+and maintainable encoding for all Parameter classes.
+"""
+
+
+class JsonEncoderDecoder(JSONEncoder):
+    def default(self, o: Any) -> Any:
+        """
+        Serialize additional objects for JSON encoding.
+        Override the default() method from JSONEncoder to support:
+            - NumPy ndarray,
+            - ColorMap.
+        Returns a serializable object for o, or call the base implementation.
+
+        Parameters
+        ----------
+        o: Any
+            The object to serialize.
+
+        Returns
+        -------
+        Any
+            A serializable representation of the object.
+        """
+        if isinstance(o, np.ndarray):
+            return dict({'__ndarray__': o.tolist()})
+
+        elif isinstance(o, ColorMap):
+            attrs = dict()
+            attrs['pos'] = json.dumps(o.pos, cls=JsonEncoderDecoder)
+            attrs['color'] = o.color
+            attrs['mapping_mode'] = o.mapping_mode
+            attrs['name'] = o.name
+            attrs['stopsCache'] = o.stopsCache
+
+            return dict({'__colormap__': attrs})
+
+        return super().default(o)
+
+    def encode(self, o: Any) -> str:
+        """
+        Encode an object into a JSON string.
+        Extends encode() method from JSONEncoder to support tuples.
+
+        Parameters
+        ----------
+        o: Any
+            The object to encode.
+
+        Returns
+        -------
+        str
+            A JSON string representation of the object.
+        """
+
+        def hint_special(o: Any):
+            if isinstance(o, tuple):
+                return dict({'__tuple__': [hint_special(e) for e in o]})
+            elif isinstance(o, list):
+                return [hint_special(e) for e in o]
+            elif isinstance(o, dict):
+                return {k: hint_special(v) for k, v in o.items()}
+            else:
+                return o
+
+        return super(JsonEncoderDecoder, self).encode(hint_special(o))
+
+    @staticmethod
+    def _decode_hook(dct: dict) -> np.ndarray | ColorMap | tuple | dict:
+        """
+        Decoding hook used for JSON deserialization.
+        Recognizes and reconstructs:
+            - NumPy ndarray,
+            - ColorMap,
+            - tuple.
+
+        Parameters
+        ----------
+        dct: dict
+            The decoded dictionary.
+
+        Returns
+        -------
+        np.ndarray or ColorMap or tuple or dict
+            The deserialized object.
+        """
+        if '__ndarray__' in dct:
+            return np.array(dct['__ndarray__'])
+
+        if '__colormap__' in dct:
+            elt = dct['__colormap__']
+            rgba_color = []
+            for c in elt['color']:
+                rgba_color.append(QColor.fromRgbF(*c))
+
+            return ColorMap(pos=JSONDecoder(object_hook=JsonEncoderDecoder._decode_hook).decode(elt['pos']),
+                            color=rgba_color, mapping=elt['mapping_mode'], name=elt['name'])
+
+        if '__tuple__' in dct:
+            return tuple(dct['__tuple__'])
+
+        return dct
+
+    def decode(self, json_str: str) -> dict:
+        """
+        Decode a JSON string and recreate the corresponding object.
+
+        Parameters
+        ----------
+        json_str: str
+            The JSON string to decode.
+
+        Returns
+        -------
+        dict
+            The decoded object.
+        """
+        return JSONDecoder(object_hook=JsonEncoderDecoder._decode_hook).decode(json_str)

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -7,6 +7,7 @@ import pyqtgraph.parametertree as pt
 from pyqtgraph.functions import eq
 from pyqtgraph.parametertree.parameterTypes import ChecklistParameterItem
 from pyqtgraph.Qt import QtCore, QtGui
+from pyqtgraph.parametertree import Parameter
 
 import pytest
 
@@ -235,4 +236,13 @@ def test_recreate_from_savestate():
     created = _buildParamTypes.makeAllParamTypes()
     state = created.saveState()
     created2 = pt.Parameter.create(**state)
+    assert pg.eq(state, created2.saveState())
+
+
+def test_json_encode_decode():
+    from pyqtgraph.examples import _buildParamTypes
+    created = _buildParamTypes.makeAllParamTypes()
+    state = created.saveState()
+    json_str = Parameter.to_json(created)
+    created2 = pt.Parameter.from_json(json_str)
     assert pg.eq(state, created2.saveState())


### PR DESCRIPTION
### Summary
This PR introduces JSON serialization and deserialization for `Parameter` objects.
### Motivation
The result of `Parameter.saveState()` may contain objects such as numpy arrays and ColorMap that cannot be serialized in JSON. This makes the export of Parameters as JSON structures impossible.
This PR proposes a clean and reusable solution to encode and decode `Parameter` objects in JSON.
### Changes
1. Two new methods in `Parameter`:
- `Parameter.to_json(parameter)`
- `Parameter.from_json(json_str)`
2. A dedicated `JsonEncoderDecoder` class supporting serialization of :
- numpy arrays
- ColorMap
- tuples

Several `Parameter` attributes accept multiple data types. Handling JSON encoding for special cases in a dedicated class keeps the code clean and maintainable.

3. Test for JSON encoder and decoder.