### PR TITLE
allow GLTextItem to render multiple text items

### DIFF
--- a/pyqtgraph/examples/GLTextItem.py
+++ b/pyqtgraph/examples/GLTextItem.py
@@ -5,11 +5,10 @@ Simple examples demonstrating the use of GLTextItem.
 
 import pyqtgraph as pg
 import pyqtgraph.opengl as gl
-from pyqtgraph.Qt import mkQApp, QtCore
+from pyqtgraph.Qt import QtCore
 
-
-def add_origin(view_widget, loc, length=0.5, color='y', width=1):
-    pos = [
+def get_axes_lines(loc, length=0.5):
+    return [
         [loc[0], loc[1], loc[2]],
         [loc[0] + length, loc[1], loc[2]],
         [loc[0], loc[1], loc[2]],
@@ -17,29 +16,8 @@ def add_origin(view_widget, loc, length=0.5, color='y', width=1):
         [loc[0], loc[1], loc[2]],
         [loc[0], loc[1], loc[2] + length],
     ]
-    line = gl.GLLinePlotItem(
-        pos=pos,
-        color=pg.mkColor(color),
-        width=width,
-        mode='lines',
-        antialias=True
-    )
-    view_widget.addItem(line)
 
-
-def add_origin_text(view_widget, pos, alignment, text):
-    txt_item = gl.GLTextItem()
-    txt_item.setData(
-        pos=pos,
-        color=(127, 255, 127, 255),
-        text=text,
-        alignment=alignment
-    )
-    view_widget.addItem(txt_item)
-    add_origin(view_widget, loc=pos)
-
-
-app = mkQApp("GLTextItem Example")
+pg.mkQApp("GLTextItem Example")
 
 gvw = gl.GLViewWidget()
 gvw.show()
@@ -60,20 +38,41 @@ txtitem2 = gl.GLTextItem(pos=(1.0, -1.0, 2.0), color=(127, 255, 127, 255), text=
 gvw.addItem(txtitem2)
 
 af = QtCore.Qt.AlignmentFlag
+hlut = dict(L=af.AlignLeft, C=af.AlignHCenter, R=af.AlignRight)
+vlut = dict(B=af.AlignBottom, C=af.AlignVCenter, T=af.AlignTop)
 
-add_origin_text(gvw, (-3.0, 2.0, 0.0), af.AlignLeft | af.AlignBottom, 'LB')
-add_origin_text(gvw, (-1.0, 2.0, 0.0), af.AlignLeft | af.AlignTop, 'LT')
-add_origin_text(gvw, (+1.0, 2.0, 0.0), af.AlignRight | af.AlignBottom, 'RB')
-add_origin_text(gvw, (+3.0, 2.0, 0.0), af.AlignRight | af.AlignTop, 'RT')
+params = [
+    ((-3.0, 2.0, 0.0), 'LB'),
+    ((-1.0, 2.0, 0.0), 'LT'),
+    ((+1.0, 2.0, 0.0), 'RB'),
+    ((+3.0, 2.0, 0.0), 'RT'),
 
-add_origin_text(gvw, (-3.0, -2.0, 0.0), af.AlignHCenter | af.AlignBottom, 'CB')
-add_origin_text(gvw, (-1.0, -2.0, 0.0), af.AlignHCenter | af.AlignTop, 'CT')
+    ((-3.0, -2.0, 0.0), 'CB'),
+    ((-1.0, -2.0, 0.0), 'CT'),
 
-add_origin_text(gvw, (+1.0, -2.0, 0.0), af.AlignLeft | af.AlignVCenter, 'LC')
-add_origin_text(gvw, (+3.0, -2.0, 0.0), af.AlignRight | af.AlignVCenter, 'RC')
+    ((+1.0, -2.0, 0.0), 'LC'),
+    ((+3.0, -2.0, 0.0), 'RC'),
 
-add_origin_text(gvw, (2.0, +0.0, 0.0), af.AlignHCenter | af.AlignVCenter, 'CC')
+    ((2.0, +0.0, 0.0), 'CC'),
+]
 
+lines = []
+words = []
+for pos, text in params:
+    lines.extend(get_axes_lines(pos))
+    words.append(dict(text=text, pos=pos, alignment=hlut[text[0]] | vlut[text[1]]))
+
+axes_lines = gl.GLLinePlotItem(
+    pos=lines,
+    color=pg.mkColor('y'),
+    width=1.0,
+    mode='lines',
+    antialias=True
+)
+gvw.addItem(axes_lines)
+
+axes_words = gl.GLTextItem(color=(127, 255, 127, 255), items=words)
+gvw.addItem(axes_words)
 
 if __name__ == '__main__':
-  pg.exec()
+    pg.exec()


### PR DESCRIPTION
This PR allows a single `GLTextItem` to render multiple text items. The interface follows the style of `ScatterPlotItem`, where the textitems are specified as a `list` of `dict`s.

This should allow rendering multiple text items to be more efficient.