### PR TITLE
break up fill path only if using SolidPattern

### DIFF
--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -846,13 +846,14 @@ class PlotCurveItem(GraphicsObject):
 
         return path
 
-    def _shouldUseFillPathList(self):
+    def _shouldUseFillPathList(self, brush):
         connect = self.opts['connect']
         return (
             # not meaningful to fill disjoint lines
             isinstance(connect, str) and connect in ['all', 'finite']
             # guard against odd-ball argument 'enclosed'
             and isinstance(self.opts['fillLevel'], (int, float))
+            and brush.style() == QtCore.Qt.BrushStyle.SolidPattern
         )
 
     def _getFillPathList(self, widget):
@@ -986,7 +987,7 @@ class PlotCurveItem(GraphicsObject):
         do_fill_outline = do_fill and self.opts['fillOutline']
 
         if do_fill:
-            if self._shouldUseFillPathList():
+            if self._shouldUseFillPathList(brush):
                 paths = self._getFillPathList(widget)
             else:
                 paths = [self._getFillPath()]


### PR DESCRIPTION
fixes #3459

Similar to `_shouldUseDrawLineSegments()`, breaking up the drawing into smaller chunks should only be done for solid pens and brushes.
