### PR TITLE
draw AxisItem without QPicture intermediary

### DIFF
--- a/pyqtgraph/Qt/QtCore/__init__.py
+++ b/pyqtgraph/Qt/QtCore/__init__.py
@@ -1,0 +1,8 @@
+import importlib
+from .. import QT_LIB
+module = importlib.import_module(f'{QT_LIB}.QtCore')
+
+def __getattr__(name):
+    x = getattr(module, name)
+    globals()[name] = x
+    return x

--- a/pyqtgraph/Qt/QtGui/__init__.py
+++ b/pyqtgraph/Qt/QtGui/__init__.py
@@ -1,0 +1,8 @@
+import importlib
+from .. import QT_LIB
+module = importlib.import_module(f'{QT_LIB}.QtGui')
+
+def __getattr__(name):
+    x = getattr(module, name)
+    globals()[name] = x
+    return x

--- a/pyqtgraph/Qt/QtWidgets/__init__.py
+++ b/pyqtgraph/Qt/QtWidgets/__init__.py
@@ -1,0 +1,8 @@
+import importlib
+from .. import QT_LIB
+module = importlib.import_module(f'{QT_LIB}.QtWidgets')
+
+def __getattr__(name):
+    x = getattr(module, name)
+    globals()[name] = x
+    return x

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -140,10 +140,6 @@ elif QT_LIB == PYQT6:
     except ImportError as err:
         QtSvg = FailedImport(err)
     try:
-        from PyQt6 import QtOpenGLWidgets
-    except ImportError as err:
-        QtOpenGLWidgets = FailedImport(err)
-    try:
         from PyQt6 import QtTest
     except ImportError as err:
         QtTest = FailedImport(err)
@@ -169,10 +165,6 @@ elif QT_LIB == PYSIDE6:
     except ImportError as err:
         QtSvg = FailedImport(err)
     try:
-        from PySide6 import QtOpenGLWidgets
-    except ImportError as err:
-        QtOpenGLWidgets = FailedImport(err)
-    try:
         from PySide6 import QtTest
     except ImportError as err:
         QtTest = FailedImport(err)
@@ -187,12 +179,6 @@ else:
 
 
 if QT_LIB in [PYQT6, PYSIDE6]:
-    # We're using Qt6 which has a different structure so we're going to use a shim to
-    # recreate the Qt5 structure
-
-    if not isinstance(QtOpenGLWidgets, FailedImport):
-        QtWidgets.QOpenGLWidget = QtOpenGLWidgets.QOpenGLWidget
-
     # PySide6 incorrectly placed QFileSystemModel inside QtWidgets
     if QT_LIB == PYSIDE6 and hasattr(QtWidgets, 'QFileSystemModel'):
         module = getattr(QtWidgets, "QFileSystemModel")

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -110,23 +110,10 @@ def _loadUiType(uiFile):
 # To avoid this, we now maintain a local "mirror" of QtCore, QtGui and QtWidgets.
 # Thus, when monkey-patching happens later on in this file, they will only affect
 # the local modules and not the global modules.
-def _copy_attrs(src, dst):
-    for o in dir(src):
-        if not hasattr(dst, o):
-            setattr(dst, o, getattr(src, o))
 
 from . import QtCore, QtGui, QtWidgets, compat
 
 if QT_LIB == PYQT5:
-    # We're using PyQt5 which has a different structure so we're going to use a shim to
-    # recreate the Qt4 structure for Qt5
-    import PyQt5.QtCore
-    import PyQt5.QtGui
-    import PyQt5.QtWidgets
-    _copy_attrs(PyQt5.QtCore, QtCore)
-    _copy_attrs(PyQt5.QtGui, QtGui)
-    _copy_attrs(PyQt5.QtWidgets, QtWidgets)
-
     try:
         from PyQt5 import sip
     except ImportError:
@@ -146,13 +133,6 @@ if QT_LIB == PYQT5:
     VERSION_INFO = 'PyQt5 ' + QtCore.PYQT_VERSION_STR + ' Qt ' + QtCore.QT_VERSION_STR
 
 elif QT_LIB == PYQT6:
-    import PyQt6.QtCore
-    import PyQt6.QtGui
-    import PyQt6.QtWidgets
-    _copy_attrs(PyQt6.QtCore, QtCore)
-    _copy_attrs(PyQt6.QtGui, QtGui)
-    _copy_attrs(PyQt6.QtWidgets, QtWidgets)
-
     from PyQt6 import sip, uic
 
     try:
@@ -171,13 +151,6 @@ elif QT_LIB == PYQT6:
     VERSION_INFO = 'PyQt6 ' + QtCore.PYQT_VERSION_STR + ' Qt ' + QtCore.QT_VERSION_STR
 
 elif QT_LIB == PYSIDE2:
-    import PySide2.QtCore
-    import PySide2.QtGui
-    import PySide2.QtWidgets
-    _copy_attrs(PySide2.QtCore, QtCore)
-    _copy_attrs(PySide2.QtGui, QtGui)
-    _copy_attrs(PySide2.QtWidgets, QtWidgets)
-    
     try:
         from PySide2 import QtSvg
     except ImportError as err:
@@ -191,13 +164,6 @@ elif QT_LIB == PYSIDE2:
     import shiboken2 as shiboken
     VERSION_INFO = 'PySide2 ' + PySide2.__version__ + ' Qt ' + QtCore.__version__
 elif QT_LIB == PYSIDE6:
-    import PySide6.QtCore
-    import PySide6.QtGui
-    import PySide6.QtWidgets
-    _copy_attrs(PySide6.QtCore, QtCore)
-    _copy_attrs(PySide6.QtGui, QtGui)
-    _copy_attrs(PySide6.QtWidgets, QtWidgets)
-
     try:
         from PySide6 import QtSvg
     except ImportError as err:

--- a/pyqtgraph/exporters/SVGExporter.py
+++ b/pyqtgraph/exporters/SVGExporter.py
@@ -419,19 +419,25 @@ def correctCoordinates(node, defs, item, options):
                 ch.setAttribute('points', ' '.join([','.join([str(a) for a in c]) for c in coords]))
             elif ch.tagName == 'path':
                 removeTransform = True
-                newCoords = ''
                 oldCoords = ch.getAttribute('d').strip()
                 if oldCoords == '':
                     continue
+                newCoords = []
                 for c in oldCoords.split(' '):
-                    x,y = c.split(',')
-                    if x[0].isalpha():
-                        t = x[0]
-                        x = x[1:]
+                    tokens = c.split(',')
+                    if len(tokens) == 1:
+                        # this might be a Z
+                        newCoords.append(tokens[0])
                     else:
-                        t = ''
-                    nc = fn.transformCoordinates(tr, np.array([[float(x),float(y)]]), transpose=True)
-                    newCoords += t+str(nc[0,0])+','+str(nc[0,1])+' '
+                        x, y = tokens
+                        if x[0].isalpha():
+                            t = x[0]
+                            x = x[1:]
+                        else:
+                            t = ''
+                        nc = fn.transformCoordinates(tr, np.array([[float(x),float(y)]]), transpose=True)
+                        newCoords.append(t+str(nc[0,0])+','+str(nc[0,1]))
+                newCoords = ' '.join(newCoords)
                 # If coords start with L instead of M, then the entire path will not be rendered.
                 # (This can happen if the first point had nan values in it--Qt will skip it on export)
                 if newCoords[0] != 'M':

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -60,7 +60,7 @@ class AxisItem(GraphicsWidget):
     ):
         super().__init__(parent)
         self.label = QtWidgets.QGraphicsTextItem(self)
-        self.picture = None
+        self.drawSpecs = None
         self.orientation = orientation
 
         if orientation in {'left', 'right'}:
@@ -286,7 +286,7 @@ class AxisItem(GraphicsWidget):
             else:
                 self.style[kwd] = value
 
-        self.picture = None
+        self.drawSpecs = None
         self._adjustSize()
         self.update()
 
@@ -316,7 +316,7 @@ class AxisItem(GraphicsWidget):
             grid = min(grid, 255)
             grid = max(grid, 0)
         self.grid = grid
-        self.picture = None
+        self.drawSpecs = None
         self.prepareGeometryChange()
         self.update()
 
@@ -375,7 +375,7 @@ class AxisItem(GraphicsWidget):
             elif self.orientation in ('left', 'right'):
                 self._linkedView().setLogMode('y', self.logMode)
 
-        self.picture = None
+        self.drawSpecs = None
         self.update()
 
     def setTickFont(self, font: QtGui.QFont | None):
@@ -388,7 +388,7 @@ class AxisItem(GraphicsWidget):
             The font to use for the tick values. Set to ``None`` for the default font.
         """
         self.style['tickFont'] = font
-        self.picture = None
+        self.drawSpecs = None
         self.prepareGeometryChange()
         # Need to re-allocate space depending on font size?
         self.update()
@@ -398,7 +398,7 @@ class AxisItem(GraphicsWidget):
         nudge = 5
         # self.label is set to None on close, but resize events can still occur.
         if self.label is None:
-            self.picture = None
+            self.drawSpecs = None
             return
 
         br = self.label.boundingRect()
@@ -416,7 +416,7 @@ class AxisItem(GraphicsWidget):
             p.setX(int(self.size().width()/2. - br.width()/2.))
             p.setY(int(self.size().height()-br.height()+nudge))
         self.label.setPos(p)
-        self.picture = None
+        self.drawSpecs = None
 
     def showLabel(self, show: bool=True):
         """
@@ -530,7 +530,7 @@ class AxisItem(GraphicsWidget):
     def _updateLabel(self):
         self.label.setHtml(self.labelString())
         self._adjustSize()
-        self.picture = None
+        self.drawSpecs = None
         self.update()
 
     def labelString(self) -> str:
@@ -622,7 +622,7 @@ class AxisItem(GraphicsWidget):
 
         self.setMaximumHeight(h)
         self.setMinimumHeight(h)
-        self.picture = None
+        self.drawSpecs = None
 
     def setWidth(self, w: int | None=None):
         """
@@ -658,7 +658,7 @@ class AxisItem(GraphicsWidget):
 
         self.setMaximumWidth(w)
         self.setMinimumWidth(w)
-        self.picture = None
+        self.drawSpecs = None
 
     def pen(self) -> QtGui.QPen:
         """
@@ -694,7 +694,7 @@ class AxisItem(GraphicsWidget):
         :func:`setConfigOption <pyqtgraph.setConfigOption>`
             Option to change the default foreground color.
         """        
-        self.picture = None
+        self.drawSpecs = None
         if args or kwargs:
             self._pen = fn.mkPen(*args, **kwargs)
         else:
@@ -736,7 +736,7 @@ class AxisItem(GraphicsWidget):
         :func:`setConfigOption <pyqtgraph.setConfigOption>`
             Option to change the default foreground color.
         """     
-        self.picture = None
+        self.drawSpecs = None
         if args or kwargs:
             self._textPen = fn.mkPen(*args, **kwargs)
         else:
@@ -776,7 +776,7 @@ class AxisItem(GraphicsWidget):
         :func:`setConfigOption <pyqtgraph.setConfigOption>`
             Option to change the default foreground color.
         """   
-        self.picture = None
+        self.drawSpecs = None
         self._tickPen = fn.mkPen(*args, **kwargs) if args or kwargs else None
         self._updateLabel()
 
@@ -861,7 +861,7 @@ class AxisItem(GraphicsWidget):
             # XXX: Will already update once!
             self.updateAutoSIPrefix()
         else:
-            self.picture = None
+            self.drawSpecs = None
             self.update()
 
     def linkedView(self):
@@ -980,23 +980,16 @@ class AxisItem(GraphicsWidget):
         path.addRect(rect)
         return path
 
-    def paint(self, p, opt, widget):
+    def paint(self, painter, opt, widget):
         profiler = debug.Profiler()
-        if self.picture is None:
-            try:
-                picture = QtGui.QPicture()
-                painter = QtGui.QPainter(picture)
-                if self.style["tickFont"]:
-                    painter.setFont(self.style["tickFont"])
-                specs = self.generateDrawSpecs(painter)
-                profiler('generate specs')
-                if specs is not None:
-                    self.drawPicture(painter, *specs)
-                    profiler('draw picture')
-            finally:
-                painter.end()
-            self.picture = picture
-        self.picture.play(p)
+        if self.drawSpecs is None:
+            if self.style["tickFont"]:
+                painter.setFont(self.style["tickFont"])
+            self.drawSpecs = self.generateDrawSpecs(painter)
+            profiler('generate specs')
+        if self.drawSpecs is not None:
+            self.drawPicture(painter, *self.drawSpecs)
+            profiler('draw picture')
 
 
     def setTickDensity(self, density=1.0):
@@ -1013,7 +1006,7 @@ class AxisItem(GraphicsWidget):
             Density of ticks to display, by default 1.0.
         """
         self._tickDensity = density
-        self.picture = None
+        self.drawSpecs = None
         self.update()
 
 
@@ -1064,7 +1057,7 @@ class AxisItem(GraphicsWidget):
         """        
 
         self._tickLevels = ticks
-        self.picture = None
+        self.drawSpecs = None
         self.update()
 
     def setTickSpacing(
@@ -1106,7 +1099,7 @@ class AxisItem(GraphicsWidget):
         if levels is None:
             levels = None if major is None else [(major, 0.), (minor, 0.)]
         self._tickSpacing = levels
-        self.picture = None
+        self.drawSpecs = None
         self.update()
 
     def tickSpacing(self, minVal: float, maxVal: float, size: float):

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -15,8 +15,10 @@ from .GraphicsObject import GraphicsObject
 
 if QtVersionInfo[0] >= 6:
     QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
+    QtOpenGLWidgets = importlib.import_module(f"{QT_LIB}.QtOpenGLWidgets")
 else:
     QtOpenGL = QtGui
+    QtOpenGLWidgets = QtWidgets
 
 __all__ = ['PlotCurveItem']
 
@@ -875,7 +877,7 @@ class PlotCurveItem(GraphicsObject):
         #     Note: when OpenGL mode is enabled, we should normally be using the
         #     'paintGL' method, and should not even reach here.
         # Values were found using 'PlotSpeedTest.py' example, see #2257.
-        chunksize = 50 if not isinstance(widget, QtWidgets.QOpenGLWidget) else 5000
+        chunksize = 50 if not isinstance(widget, QtOpenGLWidgets.QOpenGLWidget) else 5000
 
         connect_kind = self.opts['connect']
         if isinstance(connect_kind, np.ndarray):

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -211,6 +211,10 @@ class GLViewMixin:
         return [self._itemNames[i[1]] for i in items]
     
     def paintGL(self):
+        # Qt may have triggered some OpenGL errors, drain those errors away.
+        while GL.glGetError() != GL.GL_NO_ERROR:
+            pass
+
         # when called by Qt, glViewport has already been called
         # with device pixel ratio taken of
         region = self.getViewport()

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -12,8 +12,10 @@ from ..Qt import QtCore, QtGui, QtWidgets, QT_LIB, QtVersionInfo
 
 if QtVersionInfo[0] >= 6:
     QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
+    QtOpenGLWidgets = importlib.import_module(f"{QT_LIB}.QtOpenGLWidgets")
 else:
     QtOpenGL = QtGui
+    QtOpenGLWidgets = QtWidgets
 
 class GLViewMixin:
     def __init__(self, *args, rotationMethod='euler', **kwargs):
@@ -551,7 +553,7 @@ class GLViewMixin:
         return output
 
 
-class GLViewWidget(GLViewMixin, QtWidgets.QOpenGLWidget):
+class GLViewWidget(GLViewMixin, QtOpenGLWidgets.QOpenGLWidget):
     def __init__(self, *args, devicePixelRatio=None, **kwargs):
         """
         Basic widget for displaying 3D data


### PR DESCRIPTION
This is a pre-emptive fix for the pre-release Qt 6.11.
The issue occurs on Wayland, but not on X11 nor Windows.

reported at https://qt-project.atlassian.net/browse/QTBUG-144549

The following screenshot shows that `AxisItem` is not rendered correctly. The most visually obvious errors can be seen at Y=0.0 and Y=-1.0.
<img width="1292" height="1026" alt="image" src="https://github.com/user-attachments/assets/540953dd-eee4-4dfb-b41c-f7a067482b32" />

A pyqtgraph-free MRE:
```python
# misalignment occurs under the following conditions:
# - PySide6 6.11
# - Wayland
# - rendering through a QPicture

from PySide6 import QtCore, QtGui, QtWidgets

class SimpleWidget(QtWidgets.QGraphicsWidget):
    def paint(self, painter, option, widget):
        self.render(painter, QtCore.Qt.GlobalColor.darkRed)

        pic = QtGui.QPicture()
        with QtGui.QPainter(pic) as p:
            self.render(p, QtCore.Qt.GlobalColor.darkGreen)
        pic.play(painter)

    def render(self, painter, color):
        pen = QtGui.QPen(QtGui.QColor(color))
        painter.setPen(pen)
        painter.drawRect(self.rect())

app = QtWidgets.QApplication([])
scene = QtWidgets.QGraphicsScene()
view = QtWidgets.QGraphicsView(scene)
layout = QtWidgets.QGraphicsGridLayout()
container = QtWidgets.QGraphicsWidget()
container.setLayout(layout)

for row in range(3):
    for col in range(3):
        item = SimpleWidget()
        layout.addItem(item, row, col)

# issue occurs when we set the stretch factor 
layout.setRowStretchFactor(1, 10)
layout.setColumnStretchFactor(1, 10)

container.setGeometry(0, 0, 600, 400)
scene.addItem(container)
view.show()
app.exec()
```
<img width="1216" height="870" alt="image" src="https://github.com/user-attachments/assets/8b0b10ef-3a9e-4713-9679-c21d91ffd8d4" />


The fix is to not use `QPicture` to draw the axes. Using `PYQTGRAPHPROFILE` shows that `AxisItem` doesn't take so much time to render to begin with. (1 to 2 millisecs). In any case, generation of the "drawSpecs" is still cached.
