### PR TITLE
BugFix: Add check for None data in Matplotlib exporter

### DIFF
--- a/pyqtgraph/exporters/Matplotlib.py
+++ b/pyqtgraph/exporters/Matplotlib.py
@@ -109,6 +109,8 @@ class MatplotlibExporter(Exporter):
         self.cleanAxes(ax)
         for item in self.item.curves:
             x, y = item.getData()
+            if x is None or y is None:
+                continue
             x = x * xscale
             y = y * yscale
 


### PR DESCRIPTION
Skip processing for curves with None data. Otherwise no other lines will be displayed.