### PR TITLE
Fix reset button state after setToDefault

### DIFF
--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -474,7 +474,11 @@ class Parameter(QtCore.QObject):
         """Set this parameter's value to the default. Raises ValueError if no default is set."""
         with self.treeChangeBlocker():
             self.setValue(self.defaultValue())
-            self._modifiedSinceReset = False
+            self._modifiedSinceReset = not self.valueIsDefault()
+            for item in list(self.items):
+                updateDefaultBtn = getattr(item, 'updateDefaultBtn', None)
+                if updateDefaultBtn is not None:
+                    updateDefaultBtn()
 
     def hasDefault(self):
         """Returns True if this parameter has a default value."""

--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -218,7 +218,6 @@ class WidgetParameterItem(ParameterItem):
 
     def defaultClicked(self):
         self.param.setToDefault()
-        self.updateDefaultBtn()
 
     def optsChanged(self, param, opts):
         """Called when any options are changed that are not

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -89,6 +89,12 @@ def test_parameter_defaults_and_pristineness():
     p.setDefault(7, updatePristineValues=True)
     assert p.value() == 7
 
+    # if the value is coerced away from the raw default, the parameter remains modified
+    p = Parameter.create(name="param", type='int', value=1, default=2.5)
+    p.setToDefault()
+    assert p.value() == 2
+    assert p.valueModifiedSinceResetToDefault() is True
+
     # init with neither value nor default
     p = Parameter.create(name="param", type='int')
     assert p.valueModifiedSinceResetToDefault() is False

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -155,6 +155,18 @@ def test_limits_enforcement(k, v_in, v_out):
     assert p[k] == v_out
 
 
+def test_set_to_default_updates_reset_button():
+    p = pt.Parameter.create(name='int', type='int', value=1, default=2)
+    tree = pt.ParameterTree()
+    tree.addParameters(p)
+
+    item = next(iter(p.items))
+    assert item.defaultBtn.isEnabled() is True
+
+    p.setToDefault()
+    assert item.defaultBtn.isEnabled() is False
+
+
 def test_data_race():
     # Ensure widgets don't override user setting of param values whether
     # they connect the signal before or after it's added to a tree


### PR DESCRIPTION
## Summary
- Recompute the reset-to-default modified flag from the final stored value after `setToDefault()`.
- Refresh attached parameter tree items so programmatic resets update the reset button state.
- Add coverage for the reset button state and a coerced-default edge case.

Fixes #3483.

## Testing
- `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest --no-qt-log tests/parametertree`