### PR TITLE
Fixes #3487 :  Restore backward compatibility for blockSignal=callable in Parameter.setValue()

### DIFF
--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -309,15 +309,22 @@ class Parameter(QtCore.QObject):
     def setValue(self, value, blockSignal=None):
         """
         Set the value of this Parameter; return the actual value that was set.
-        (this may be different from the value that was requested)
+        (this may be different from the value that was requested).
+        blockSignal specifies what to block during emission: a slot (callable) or the entire signal (True).
         """
         value = self._interpretValue(value)
         if fn.eq(self.opts.get('value', None), value):
             return value
         self._modifiedSinceReset = True
         self.opts['value'] = value
-        if not blockSignal:
-            self.sigValueChanged.emit(self, value)  # value might change after signal is received by tree item
+        if callable(blockSignal):
+            self.sigValueChanged.disconnect(blockSignal)
+            try:
+                self.sigValueChanged.emit(self, value)
+            finally:
+                self.sigValueChanged.connect(blockSignal)
+        elif not blockSignal:  # falsy: emit normally
+            self.sigValueChanged.emit(self, value)
 
         return self.opts['value']
 

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -564,3 +564,90 @@ def test_interact_existing_parent():
     assert outParam in parent.names.values()
     outParam.activate()
     assert lastValue == 5
+
+
+# ---------------------------------------------------------------------------
+# Tests for Parameter.setValue() blockSignal behaviour (regression for #3305)
+# ---------------------------------------------------------------------------
+
+def test_setValue_blockSignal_callable_blocks_only_that_slot():
+    """
+    blockSignal=<callable> must temporarily disconnect *only* that slot while
+    still emitting sigValueChanged to every other connected listener.
+    This exercises the backward-compatible `if callable(blockSignal)` branch.
+    """
+    p = Parameter.create(name="param", type="float", value=0.0)
+
+    blocked_received = []
+    other_received = []
+
+    def blocked_slot(param, value):
+        blocked_received.append(value)
+
+    def other_slot(param, value):
+        other_received.append(value)
+
+    p.sigValueChanged.connect(blocked_slot)
+    p.sigValueChanged.connect(other_slot)
+
+    # blockSignal=blocked_slot → blocked_slot should NOT fire, other_slot SHOULD
+    p.setValue(1.0, blockSignal=blocked_slot)
+
+    assert blocked_received == [], (
+        "Blocked slot must not receive the signal when passed as blockSignal"
+    )
+    assert other_received == [1.0], (
+        "Other connected slots must still receive sigValueChanged"
+    )
+
+    # After the call the slot must be reconnected; next plain setValue fires both
+    p.setValue(2.0)
+    assert blocked_received == [2.0], (
+        "Blocked slot must be reconnected after the setValue call"
+    )
+    assert other_received == [1.0, 2.0]
+
+
+def test_setValue_blockSignal_true_suppresses_signal_entirely():
+    """
+    blockSignal=True must prevent sigValueChanged from being emitted at all.
+    This preserves the behaviour introduced in #3305.
+    """
+    p = Parameter.create(name="param", type="float", value=0.0)
+
+    received = []
+
+    def slot(param, value):
+        received.append(value)
+
+    p.sigValueChanged.connect(slot)
+
+    p.setValue(99.0, blockSignal=True)
+
+    assert received == [], (
+        "sigValueChanged must not be emitted when blockSignal=True"
+    )
+    # Value must still be stored despite the signal being blocked
+    assert p.value() == 99.0
+
+
+def test_setValue_blockSignal_none_emits_normally():
+    """
+    The default blockSignal=None (falsy) must emit sigValueChanged as usual.
+    """
+    p = Parameter.create(name="param", type="float", value=0.0)
+
+    received = []
+
+    def slot(param, value):
+        received.append(value)
+
+    p.sigValueChanged.connect(slot)
+
+    p.setValue(42.0)          # blockSignal defaults to None
+    p.setValue(43.0, blockSignal=None)
+    p.setValue(44.0, blockSignal=False)
+
+    assert received == [42.0, 43.0, 44.0], (
+        "sigValueChanged must fire for all falsy blockSignal values"
+    )


### PR DESCRIPTION
Hi! This is my first contribution. 
Could a maintainer please approve the CI workflow so the tests can run? 
This PR fixes the regression introduced in #3487.
## Description
This PR addresses an unintended breaking change introduced in PR #3305. The previous change modified `Parameter.setValue()` such that setting `blockSignal` to a truthy value prevented `sigValueChanged` from being emitted entirely. However, this silently broke the old `blockSignal=callable` pattern used in both user code and `pyqtgraph`'s own examples (e.g., `examples/parametertree.py`).

Previously, `blockSignal` could be a callable, specifying a single slot to ignore during the value update. This is crucial for preventing recursion when a parameter reflects a model value, while still allowing the corresponding `ParameterItem`s to display the updated values in the UI.

## Changes Made
- Updated `Parameter.setValue()` to dispatch on the type of `blockSignal` to support both behaviors.
- **If `blockSignal` is a callable:** It temporarily disconnects only that specific slot, emits `sigValueChanged`, and then reconnects it. (Restores the pre-#3305 behavior)
- **If `blockSignal` is not callable (e.g., `True`):** It continues to block the entire signal from being emitted. (Retains the new behavior introduced in #3305)
- Updated the docstring to clarify the dual nature of the `blockSignal` argument.

## Motivation and Context
Resolves the issue where using `param.setValue(value, blockSignal=self.someSlot)` failed to update the parameter item in the UI because the signal was completely suppressed instead of just blocking the single recursive slot. This provides a clean, backward-compatible solution without needing to introduce new kwargs or cause further breaking changes.

## Related Issues
*(Note: If there is an open issue number for this, add it here like `Fixes #1234`)*
