### PR TITLE
Add upper/lower limit arrow markers to ErrorBarItem

### DIFF
--- a/pyqtgraph/examples/ErrorBarItem.py
+++ b/pyqtgraph/examples/ErrorBarItem.py
@@ -1,5 +1,5 @@
 """
-Demonstrates basic use of ErrorBarItem
+Demonstrates basic use of ErrorBarItem, including upper/lower limit arrows.
 """
 
 import numpy as np
@@ -9,13 +9,22 @@ import pyqtgraph as pg
 pg.setConfigOptions(antialias=True)
 
 x = np.arange(10)
-y = np.arange(10) %3
+y = np.arange(10) % 3
 top = np.linspace(1.0, 3.0, 10)
 bottom = np.linspace(2, 0.5, 10)
 
+# mark a couple of points as upper / lower limits (arrows instead of beams)
+topLimit = np.zeros(10, dtype=bool)
+topLimit[2] = True
+bottomLimit = np.zeros(10, dtype=bool)
+bottomLimit[7] = True
+
 plt = pg.plot()
 plt.setWindowTitle('pyqtgraph example: ErrorBarItem')
-err = pg.ErrorBarItem(x=x, y=y, top=top, bottom=bottom, beam=0.5)
+err = pg.ErrorBarItem(
+    x=x, y=y, top=top, bottom=bottom, beam=0.5,
+    topLimit=topLimit, bottomLimit=bottomLimit,
+)
 plt.addItem(err)
 plt.plot(x, y, symbol='o', pen={'color': 0.8, 'width': 2})
 

--- a/pyqtgraph/graphicsItems/ErrorBarItem.py
+++ b/pyqtgraph/graphicsItems/ErrorBarItem.py
@@ -1,9 +1,23 @@
+import numpy as np
+
 from .. import functions as fn
 from .. import getConfigOption
 from ..Qt import QtGui
+from .ArrowItem import ArrowItem
 from .GraphicsObject import GraphicsObject
 
 __all__ = ['ErrorBarItem']
+
+# ArrowItem angles for an arrow tip pointing in each direction.
+# ArrowItem with angle=0 has its tip on the left; rotation is counter-clockwise
+# in screen space (y increases downward), so angle=+90 puts the tip at the top.
+_LIMIT_ARROW_ANGLE = {
+    'top': 90,      # tip up
+    'bottom': -90,  # tip down
+    'left': 0,      # tip left
+    'right': 180,   # tip right
+}
+
 
 class ErrorBarItem(GraphicsObject):
     def __init__(self, **opts):
@@ -21,18 +35,28 @@ class ErrorBarItem(GraphicsObject):
             left=None,
             right=None,
             beam=None,
-            pen=None
+            pen=None,
+            topLimit=None,
+            bottomLimit=None,
+            leftLimit=None,
+            rightLimit=None,
+            arrowHeadLen=10,
+            arrowHeadWidth=None,
+            arrowTipAngle=25,
         )
+        self._arrowItems = []
         self.setVisible(False)
         self.setData(**opts)
 
     def setData(self, **opts):
         """
         Update the data in the item. All arguments are optional.
-        
+
         Valid keyword options are:
-        x, y, height, width, top, bottom, left, right, beam, pen
-        
+        x, y, height, width, top, bottom, left, right, beam, pen,
+        topLimit, bottomLimit, leftLimit, rightLimit,
+        arrowHeadLen, arrowHeadWidth, arrowTipAngle
+
           * x and y must be numpy arrays specifying the coordinates of data points.
           * height, width, top, bottom, left, right, and beam may be numpy arrays,
             single values, or None to disable. All values should be positive.
@@ -42,30 +66,142 @@ class ErrorBarItem(GraphicsObject):
           * If width is specified, it overrides left and right.
           * beam specifies the width of the beam at the end of each bar.
           * pen may be any single argument accepted by pg.mkPen().
-        
+          * topLimit, bottomLimit, leftLimit, rightLimit may be boolean arrays
+            (one entry per point) or a single bool. Where True, the corresponding
+            bar end is drawn as an arrow head (pointing away from the data point)
+            instead of a perpendicular beam, indicating that the value is a limit
+            rather than a measurement. The beam on that side is suppressed for
+            those points.
+          * arrowHeadLen is the length of the arrow head in pixels. default=10
+          * arrowHeadWidth, if given, overrides arrowTipAngle and sets the half
+            width of the arrow base in pixels.
+          * arrowTipAngle is the full angle (degrees) of the arrow tip when
+            arrowHeadWidth is not specified. default=25
+
         This method was added in version 0.9.9. For prior versions, use setOpts.
         """
         self.opts.update(opts)
         self.setVisible(all(self.opts[ax] is not None for ax in ['x', 'y']))
         self.path = None
+        self._rebuildArrows()
         self.update()
         self.prepareGeometryChange()
         self.informViewBoundsChanged()
-        
+
     def setOpts(self, **opts):
         # for backward compatibility
         self.setData(**opts)
-        
+
+    def _limitMask(self, key, n):
+        """Return a boolean ndarray of length n for the named limit option, or None if no limits."""
+        val = self.opts.get(key)
+        if val is None or val is False:
+            return None
+        if val is True:
+            return np.ones(n, dtype=bool)
+        arr = np.asarray(val, dtype=bool)
+        if arr.ndim == 0:
+            return np.full(n, bool(arr), dtype=bool)
+        if not arr.any():
+            return None
+        return arr
+
+    def _clearArrows(self):
+        for a in self._arrowItems:
+            a.setParentItem(None)
+            scene = a.scene()
+            if scene is not None:
+                scene.removeItem(a)
+        self._arrowItems = []
+
+    def _arrowStyle(self):
+        style = {
+            'headLen': self.opts.get('arrowHeadLen') or 10,
+            'pxMode': True,
+            'tailLen': None,
+        }
+        headWidth = self.opts.get('arrowHeadWidth')
+        if headWidth is not None:
+            style['headWidth'] = headWidth
+        else:
+            style['tipAngle'] = self.opts.get('arrowTipAngle') or 25
+        pen = self.opts.get('pen')
+        if pen is None:
+            pen = getConfigOption('foreground')
+        style['pen'] = fn.mkPen(pen)
+        style['brush'] = fn.mkBrush(pen)
+        return style
+
+    def _rebuildArrows(self):
+        self._clearArrows()
+
+        x, y = self.opts['x'], self.opts['y']
+        if x is None or y is None:
+            return
+        x = np.asarray(x)
+        y = np.asarray(y)
+        n = len(x)
+        if n == 0:
+            return
+
+        height, top, bottom = self.opts['height'], self.opts['top'], self.opts['bottom']
+        width, right, left = self.opts['width'], self.opts['right'], self.opts['left']
+
+        # Per-direction endpoint coordinates, broadcast to length n.
+        directions = []
+        if height is not None or top is not None:
+            if height is not None:
+                yEnd = y + np.broadcast_to(np.asarray(height) / 2., (n,))
+            else:
+                yEnd = y + np.broadcast_to(np.asarray(top), (n,))
+            directions.append(('top', x, yEnd))
+        if height is not None or bottom is not None:
+            if height is not None:
+                yEnd = y - np.broadcast_to(np.asarray(height) / 2., (n,))
+            else:
+                yEnd = y - np.broadcast_to(np.asarray(bottom), (n,))
+            directions.append(('bottom', x, yEnd))
+        if width is not None or right is not None:
+            if width is not None:
+                xEnd = x + np.broadcast_to(np.asarray(width) / 2., (n,))
+            else:
+                xEnd = x + np.broadcast_to(np.asarray(right), (n,))
+            directions.append(('right', xEnd, y))
+        if width is not None or left is not None:
+            if width is not None:
+                xEnd = x - np.broadcast_to(np.asarray(width) / 2., (n,))
+            else:
+                xEnd = x - np.broadcast_to(np.asarray(left), (n,))
+            directions.append(('left', xEnd, y))
+
+        style = self._arrowStyle()
+        for side, xEnd, yEnd in directions:
+            mask = self._limitMask(f'{side}Limit', n)
+            if mask is None:
+                continue
+            angle = _LIMIT_ARROW_ANGLE[side]
+            for i in np.flatnonzero(mask):
+                arrow = ArrowItem(angle=angle, **style)
+                arrow.setParentItem(self)
+                arrow.setPos(float(xEnd[i]), float(yEnd[i]))
+                self._arrowItems.append(arrow)
+
     def drawPath(self):
         p = QtGui.QPainterPath()
-        
+
         x, y = self.opts['x'], self.opts['y']
         if x is None or y is None:
             self.path = p
             return
-        
+
         beam = self.opts['beam']
-        
+        n = len(x)
+
+        topLim = self._limitMask('topLimit', n)
+        bottomLim = self._limitMask('bottomLimit', n)
+        leftLim = self._limitMask('leftLimit', n)
+        rightLim = self._limitMask('rightLimit', n)
+
         height, top, bottom = self.opts['height'], self.opts['top'], self.opts['bottom']
         if height is not None or top is not None or bottom is not None:
             ## draw vertical error bars
@@ -93,18 +229,30 @@ class ErrorBarItem(GraphicsObject):
 
                 x1_x2 = fn.interweaveArrays(x1, x2)
                 if height is not None or top is not None:
-                    y2s = fn.interweaveArrays(y2, y2)
-                    topEnds = fn.arrayToQPath(x1_x2, y2s, connect="pairs")
-                    p.addPath(topEnds)
+                    sel = ~topLim if topLim is not None else None
+                    if sel is None or sel.any():
+                        y2s = fn.interweaveArrays(y2, y2)
+                        if sel is not None:
+                            mask = np.repeat(sel, 2)
+                            topEnds = fn.arrayToQPath(x1_x2[mask], y2s[mask], connect="pairs")
+                        else:
+                            topEnds = fn.arrayToQPath(x1_x2, y2s, connect="pairs")
+                        p.addPath(topEnds)
 
                 if height is not None or bottom is not None:
-                    y1s = fn.interweaveArrays(y1, y1)
-                    bottomEnds = fn.arrayToQPath(x1_x2, y1s, connect="pairs")
-                    p.addPath(bottomEnds)
+                    sel = ~bottomLim if bottomLim is not None else None
+                    if sel is None or sel.any():
+                        y1s = fn.interweaveArrays(y1, y1)
+                        if sel is not None:
+                            mask = np.repeat(sel, 2)
+                            bottomEnds = fn.arrayToQPath(x1_x2[mask], y1s[mask], connect="pairs")
+                        else:
+                            bottomEnds = fn.arrayToQPath(x1_x2, y1s, connect="pairs")
+                        p.addPath(bottomEnds)
 
         width, right, left = self.opts['width'], self.opts['right'], self.opts['left']
         if width is not None or right is not None or left is not None:
-            ## draw vertical error bars
+            ## draw horizontal error bars
             if width is not None:
                 x1 = x - width/2.
                 x2 = x + width/2.
@@ -117,7 +265,7 @@ class ErrorBarItem(GraphicsObject):
                     x2 = x
                 else:
                     x2 = x + right
-            
+
             ys = fn.interweaveArrays(y, y)
             x1_x2 = fn.interweaveArrays(x1, x2)
             ends = fn.arrayToQPath(x1_x2, ys, connect='pairs')
@@ -128,19 +276,30 @@ class ErrorBarItem(GraphicsObject):
                 y2 = y + beam/2.
                 y1_y2 = fn.interweaveArrays(y1, y2)
                 if width is not None or right is not None:
-                    x2s = fn.interweaveArrays(x2, x2)
-                    rightEnds = fn.arrayToQPath(x2s, y1_y2, connect="pairs")
-                    p.addPath(rightEnds)
+                    sel = ~rightLim if rightLim is not None else None
+                    if sel is None or sel.any():
+                        x2s = fn.interweaveArrays(x2, x2)
+                        if sel is not None:
+                            mask = np.repeat(sel, 2)
+                            rightEnds = fn.arrayToQPath(x2s[mask], y1_y2[mask], connect="pairs")
+                        else:
+                            rightEnds = fn.arrayToQPath(x2s, y1_y2, connect="pairs")
+                        p.addPath(rightEnds)
 
                 if width is not None or left is not None:
-                    x1s = fn.interweaveArrays(x1, x1)
-                    leftEnds = fn.arrayToQPath(x1s, y1_y2, connect="pairs")
-                    p.addPath(leftEnds)
-                    
+                    sel = ~leftLim if leftLim is not None else None
+                    if sel is None or sel.any():
+                        x1s = fn.interweaveArrays(x1, x1)
+                        if sel is not None:
+                            mask = np.repeat(sel, 2)
+                            leftEnds = fn.arrayToQPath(x1s[mask], y1_y2[mask], connect="pairs")
+                        else:
+                            leftEnds = fn.arrayToQPath(x1s, y1_y2, connect="pairs")
+                        p.addPath(leftEnds)
+
         self.path = p
         self.prepareGeometryChange()
-        
-        
+
     def paint(self, p, *args):
         if self.path is None:
             self.drawPath()
@@ -149,10 +308,8 @@ class ErrorBarItem(GraphicsObject):
             pen = getConfigOption('foreground')
         p.setPen(fn.mkPen(pen))
         p.drawPath(self.path)
-            
+
     def boundingRect(self):
         if self.path is None:
             self.drawPath()
         return self.path.boundingRect()
-    
-        

--- a/tests/graphicsItems/test_ErrorBarItem.py
+++ b/tests/graphicsItems/test_ErrorBarItem.py
@@ -42,3 +42,74 @@ def test_ErrorBarItem_defer_data():
     assert r_clear_ebi.height() == r_empty_ebi.height()
 
     plot.close()
+
+
+def test_ErrorBarItem_limit_arrows_render():
+    """Limits on each side should render without errors and not affect viewRect height."""
+    plot = pg.PlotWidget()
+    plot.show()
+
+    x = np.arange(5, dtype=float)
+    y = np.zeros(5)
+    top = np.ones(5)
+    bottom = np.ones(5)
+    left = np.ones(5)
+    right = np.ones(5)
+
+    topLimit = np.array([True, False, False, False, False])
+    bottomLimit = np.array([False, True, False, False, False])
+    leftLimit = np.array([False, False, True, False, False])
+    rightLimit = np.array([False, False, False, True, False])
+
+    err = pg.ErrorBarItem(
+        x=x, y=y, top=top, bottom=bottom, left=left, right=right, beam=0.2,
+        topLimit=topLimit, bottomLimit=bottomLimit,
+        leftLimit=leftLimit, rightLimit=rightLimit,
+    )
+    plot.addItem(err)
+    app.processEvents()
+    app.processEvents()
+
+    # The error bars themselves still contribute to the view rect.
+    assert plot.viewRect().height() > 0
+    plot.close()
+
+
+def test_ErrorBarItem_limit_mask_scalar_and_array():
+    """Scalar True/False and per-point arrays both work for limit kwargs."""
+    err = pg.ErrorBarItem()
+    x = np.arange(3, dtype=float)
+    y = np.zeros(3)
+
+    # Scalar True -> all points are limits
+    err.setData(x=x, y=y, top=np.ones(3), beam=0.1, topLimit=True)
+    mask = err._limitMask('topLimit', 3)
+    assert mask is not None and mask.all()
+
+    # Scalar False -> no limits (treated as None)
+    err.setData(topLimit=False)
+    assert err._limitMask('topLimit', 3) is None
+
+    # All-False array -> no limits
+    err.setData(topLimit=np.zeros(3, dtype=bool))
+    assert err._limitMask('topLimit', 3) is None
+
+    # Mixed array -> mask returned as-is
+    err.setData(topLimit=np.array([True, False, True]))
+    mask = err._limitMask('topLimit', 3)
+    assert mask is not None
+    assert mask.tolist() == [True, False, True]
+
+
+def test_ErrorBarItem_no_limits_backwards_compat():
+    """Pre-existing usage (no limit kwargs) should be unchanged."""
+    plot = pg.PlotWidget()
+    plot.show()
+    x = np.arange(5, dtype=float)
+    err = pg.ErrorBarItem(x=x, y=x, top=np.ones(5), bottom=np.ones(5), beam=0.5)
+    plot.addItem(err)
+    app.processEvents()
+    app.processEvents()
+    # drawPath populates self.path with no exception
+    assert err.path is not None
+    plot.close()


### PR DESCRIPTION
## Summary

`ErrorBarItem` previously had no way to represent limit values (one-sided
bounds, common in astronomy/physics SED plots). The only options were
symmetric beams on both ends of each bar.

This PR adds limit-arrow support: where a point's value on a given side
is a bound rather than a measurement, the perpendicular beam cap is
suppressed and replaced with an arrowhead pointing in the limit
direction. The convention matches matplotlib's `errorbar` uplims/lolims
and the typical rendering in scientific publications.

Closes nothing formally, but addresses the user request described in #3478 


## API

Six new keyword options on `setData` (all default `None`, fully
backwards-compatible):

| kwarg | type | meaning |
|---|---|---|
| `topLimit`, `bottomLimit`, `leftLimit`, `rightLimit` | bool or bool array (length N) | when True, that side's bar end is drawn as an arrowhead instead of a beam |
| `arrowHeadLen` | float (pixels, default 10) | arrow head length |
| `arrowHeadWidth` | float (pixels, optional) | overrides `arrowTipAngle` |
| `arrowTipAngle` | float (degrees, default 25) | arrow tip angle when `arrowHeadWidth` is not set |

Naming follows the existing `top`/`bottom`/`left`/`right` style on
`ErrorBarItem`, and the arrow style kwargs mirror `ArrowItem`'s
vocabulary.

## Implementation notes

- Arrows are rendered as child `ArrowItem` instances with `pxMode=True`,
  so they stay constant pixel size under zoom and on log axes. This
  reuses the library's existing primitive rather than rolling
  pixel-space drawing inside `ErrorBarItem.paint()`.
- The beam cap is suppressed only on the limit side for limit points;
  the opposite side's beam (if any) is unaffected.
- The no-limits code path is unchanged. It early-exits before any new
  logic runs, so existing users see no behavior or performance change.

## Tests

`tests/graphicsItems/test_ErrorBarItem.py`:

- `test_ErrorBarItem_limit_arrows_render`: rendering with limits on
  all four sides
- `test_ErrorBarItem_limit_mask_scalar_and_array`: `True`/`False`
  scalar and per-point boolean array handling
- `test_ErrorBarItem_no_limits_backwards_compat`: pre-existing usage
  is unaffected

The pre-existing `test_ErrorBarItem_defer_data` test continues to pass.

## Example

`pyqtgraph/examples/ErrorBarItem.py` is extended to mark two points as
upper/lower limits, demonstrating the new options. The 1-second
example smoke test (`pytest pyqtgraph/examples`) passes.

## Verified locally

- `pytest tests/graphicsItems/test_ErrorBarItem.py`: all 3 new tests
  pass under PyQt6 / Python 3.14
- `pytest tests/graphicsItems/`: full subsuite passes (modulo one
  pre-existing offscreen-Qt font-warning failure that also fails on
  master, unrelated)
- `pytest pyqtgraph/examples -k ErrorBarItem`: passes
- `pre-commit run`: passes on touched files
- Visual verification with `python pyqtgraph/examples/ErrorBarItem.py`:
  arrows point in correct directions, stay fixed pixel size on zoom,
  beam suppression is correct

Cross-binding verification (PyQt5/PySide6) deferred to CI.

## Backwards compatibility

Fully backwards-compatible. All new kwargs default to `None`, and the
existing rendering path is untouched when no limit kwargs are passed.
