### PR TITLE
Fix legend not scaling on large exports

### DIFF
--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -67,7 +67,6 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         """
         GraphicsWidget.__init__(self)
         GraphicsWidgetAnchor.__init__(self)
-        self.setFlag(self.GraphicsItemFlag.ItemIgnoresTransformations)
         self.layout = QtWidgets.QGraphicsGridLayout()
         self.layout.setVerticalSpacing(verSpacing)
         self.layout.setHorizontalSpacing(horSpacing)


### PR DESCRIPTION
Removes the ItemIgnoresTransformations flag from LegendItem, which prevented the legend from scaling during high-resolution exports. The legend font and items now scale correctly with the rest of the plot.

Fixes #1552