### PR TITLE
image export: use recommended image format for rendering

### DIFF
--- a/pyqtgraph/exporters/ImageExporter.py
+++ b/pyqtgraph/exporters/ImageExporter.py
@@ -101,7 +101,7 @@ class ImageExporter(Exporter):
         targetRect = QtCore.QRect(0, 0, w, h)
         sourceRect = self.getSourceRect()
 
-        self.png = QtGui.QImage(w, h, QtGui.QImage.Format.Format_ARGB32)
+        self.png = QtGui.QImage(w, h, QtGui.QImage.Format.Format_ARGB32_Premultiplied)
         self.png.fill(self.params['background'])
         
         ## set resolution of image:


### PR DESCRIPTION
According to QImage docs https://doc.qt.io/qt-6/qimage.html,
`"Rendering is best optimized to the Format_RGB32 and Format_ARGB32_Premultiplied formats"`

Sample script demonstrating the difference:
master: 1.193568468093872
this PR: 0.09200310707092285
```python
import random
import time
import pyqtgraph as pg
import pyqtgraph.exporters as exp

random.seed(0)
xvals = [-1 + idx / 10000 for idx in range(2*10000+1)]
yvals = [2*(random.random() - 0.5) for x in xvals]

app = pg.mkQApp()
win = pg.PlotWidget()
win.plot(xvals, yvals)
app.processEvents()

exporter = exp.ImageExporter(win.getPlotItem())

t0 = time.time()
exporter.export(toBytes=True)
t1 = time.time()
print(t1 - t0)
```