### PR TITLE
ExampleApp: fix undefined app

### DIFF
--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -294,6 +294,7 @@ class PythonHighlighter(QSyntaxHighlighter):
         if not self.searchText:
             return
         expr = f'(?i){self.searchText}'
+        app = QtWidgets.QApplication.instance()
         palette: QtGui.QPalette = app.palette()
         color = palette.highlight().color()
         fgndColor = palette.color(palette.ColorGroup.Current,
@@ -441,6 +442,7 @@ class ExampleLoader(QtWidgets.QMainWindow):
             re.compile(text)
             self.ui.exampleFilter.setStyleSheet('')
         except re.error:
+            app = QtWidgets.QApplication.instance()
             colors = DarkThemeColors if app.property('darkMode') else LightThemeColors
             errorColor = pg.mkColor(colors.Red)
             validRegex = False

--- a/pyqtgraph/examples/syntax.py
+++ b/pyqtgraph/examples/syntax.py
@@ -279,6 +279,7 @@ class PythonHighlighter(QSyntaxHighlighter):
         if not self.searchText:
             return
         expr = f'(?i){self.searchText}'
+        app = QtWidgets.QApplication.instance()
         palette: QtGui.QPalette = app.palette()
         color = palette.highlight().color()
         fgndColor = palette.color(palette.ColorGroup.Current,


### PR DESCRIPTION
#3493 introduced a regression to `ExampleApp` when it removed the globally instantiated `app` because a couple of places assumed that `app` had been globally defined.

To trigger the regression:
- launch ExampleApp
- In the combo-box, change "Title Search" to "Content Search"
- Type something to search
- 