### PR TITLE
[codex] Accept Greek mu as SI micro prefix

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -61,15 +61,17 @@ Colors = {
 
 SI_PREFIXES = 'yzafpnµm kMGTPEZY'
 SI_PREFIXES_ASCII = 'yzafpnum kMGTPEZY'
+SI_PREFIXES_INPUT = 'uμ' + SI_PREFIXES
 SI_PREFIX_EXPONENTS = dict([(SI_PREFIXES[i], (i-8)*3) for i in range(len(SI_PREFIXES))])
 SI_PREFIX_EXPONENTS['u'] = -6
+SI_PREFIX_EXPONENTS['μ'] = -6
 
 #For comma as decimal separator
-FLOAT_REGEX_COMMA = re.compile(r'(?P<number>[+-]?((((\d+(,\d*)?)|(\d*,\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>\w.*))?$')
+FLOAT_REGEX_COMMA = re.compile(r'(?P<number>[+-]?((((\d+(,\d*)?)|(\d*,\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>\w.*))?$')
 #For period as decimal separator
-FLOAT_REGEX_PERIOD = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>\w.*))?$')
+FLOAT_REGEX_PERIOD = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>\w.*))?$')
 
-INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>.*)$')
+INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>.*)$')
 
 class HueKeywordArgs(TypedDict):
     hues: int
@@ -219,8 +221,8 @@ def siParse(s, regex=FLOAT_REGEX_PERIOD, suffix=None):
     Example:
         siParse('100 µV')  # returns ('100', 'µ', 'V')
 
-    Note that in the above example, the µ symbol is the "micro sign" (UTF-8
-    0xC2B5), as opposed to the Greek letter mu (UTF-8 0xCEBC).
+    Both the micro sign (UTF-8 0xC2B5) and Greek letter mu (UTF-8 0xCEBC)
+    are accepted as the micro prefix.
 
     Parameters
     ----------

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -231,6 +231,7 @@ def test_eq():
     # usual cases
     ("100 uV", "V", ("100", "u", "V")),
     ("100 µV", "V", ("100", "µ", "V")),
+    ("100 μV", "V", ("100", "μ", "V")),
     ("4.2 nV", None, ("4.2", "n", "V")),
     ("1.2 m", "m", ("1.2", "", "m")),
     ("1.2 m", None, ("1.2", "", "m")),
@@ -258,6 +259,7 @@ def test_siParse(s, suffix, expected):
     # usual cases
     ("100 uV", "V", 1, 1e-4),
     ("100 µV", "V", 1, 1e-4),
+    ("100 μV", "V", 1, 1e-4),
     ("4.2 nV", None, 1, 4.2e-9),
     ("1.2 m", "m", 1, 1.2),
     # siPrefix with explicit empty suffix


### PR DESCRIPTION
## Summary
- Accept the Greek small letter mu (`μ`, U+03BC) as an input spelling of the SI micro prefix.
- Keep `SI_PREFIXES` unchanged so formatted output continues to use the micro sign (`µ`, U+00B5).
- Update `siParse` documentation and tests for `siParse` / `siEval`.

Fixes #3498.

## Root cause
`siParse` only included ASCII `u` and the micro sign in its SI-prefix regex character class. When a Greek `μ` was supplied, it was parsed as part of the suffix instead of as the micro prefix, so `siEval` applied no `1e-6` scaling.

## Validation
- `python -m pytest tests/test_functions.py::test_siParse tests/test_functions.py::test_siEval -q`
- `python -m pytest tests/test_functions.py -q`
