### PR TITLE
Fix FFT autorange with auto downsampling

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -1441,6 +1441,48 @@ class PlotDataItem(GraphicsObject):
         dataset = self._dataset
         return (None, None) if dataset is None else (dataset.x, dataset.y)
 
+    def _getMappedDataset(self) -> PlotDataset | None:
+        if self._dataset is None:
+            return None
+
+        if self._datasetMapped is not None:
+            return self._datasetMapped
+
+        x = self._dataset.x
+        y = self._dataset.y
+        if y.dtype == bool:
+            y = y.astype(np.uint8)
+        if x.dtype == bool:
+            x = x.astype(np.uint8)
+        if self.opts['subtractMeanMode']:
+            y = y - np.mean(y)
+        if self.opts['fftMode']:
+            x, y = self._fourierTransform(x, y)
+            # Ignore the first bin for fft data if we have a logx scale
+            if self.opts['logMode'][0]:
+                x = x[1:]
+                y = y[1:]
+        if self.opts['derivativeMode']:  # plot dV/dt
+            y = np.diff(self._dataset.y) / np.diff(self._dataset.x)
+            x = x[:-1]
+        if self.opts['phasemapMode']:  # plot dV/dt vs V
+            x = self._dataset.y[:-1]
+            y = np.diff(self._dataset.y) / np.diff(self._dataset.x)
+
+        dataset = PlotDataset(
+            x,
+            y,
+            self._dataset.xAllFinite,
+            self._dataset.yAllFinite
+        )
+
+        if True in self.opts['logMode']:
+            # Apply log scaling for x and/or y-axis
+            dataset.applyLogMapping( self.opts['logMode'] )
+
+        self._datasetMapped = dataset
+        return dataset
+
     def _getDisplayDataset(self) -> PlotDataset | None:
         """
         Get data suitable for display as a :class:`PlotDataset`.
@@ -1466,41 +1508,8 @@ class PlotDataItem(GraphicsObject):
         ):
             return self._datasetDisplay
 
-        # Apply data mapping functions if mapped dataset is not yet available: 
-        if self._datasetMapped is None:
-            x = self._dataset.x
-            y = self._dataset.y
-            if y.dtype == bool:
-                y = y.astype(np.uint8)
-            if x.dtype == bool:
-                x = x.astype(np.uint8)
-            if self.opts['subtractMeanMode']:
-                y = y - np.mean(y)
-            if self.opts['fftMode']:
-                x, y = self._fourierTransform(x, y)
-                # Ignore the first bin for fft data if we have a logx scale
-                if self.opts['logMode'][0]:
-                    x = x[1:]
-                    y = y[1:]
-            if self.opts['derivativeMode']:  # plot dV/dt
-                y = np.diff(self._dataset.y) / np.diff(self._dataset.x)
-                x = x[:-1]
-            if self.opts['phasemapMode']:  # plot dV/dt vs V
-                x = self._dataset.y[:-1]
-                y = np.diff(self._dataset.y) / np.diff(self._dataset.x)
-
-            dataset = PlotDataset(
-                x,
-                y,
-                self._dataset.xAllFinite,
-                self._dataset.yAllFinite
-            )
-            
-            if True in self.opts['logMode']:
-                # Apply log scaling for x and/or y-axis
-                dataset.applyLogMapping( self.opts['logMode'] )
-
-            self._datasetMapped = dataset
+        if self._getMappedDataset() is None:
+            return None
         
         # apply processing that affects the on-screen display of data:
         x = self._datasetMapped.x
@@ -1689,6 +1698,71 @@ class PlotDataItem(GraphicsObject):
         """
         return None if self._dataset is None else self._dataset.dataRect()
 
+    def _mappedDataBounds(
+        self,
+        ax: int,
+        frac: float = 1.0,
+        orthoRange: tuple[float, float] | None = None
+    ) -> tuple[float, float] | tuple[None, None]:
+        dataset = self._getMappedDataset()
+        if dataset is None or len(dataset.x) == 0:
+            return (None, None)
+
+        if ax == 0:
+            d = dataset.x
+            d2 = dataset.y
+        elif ax == 1:
+            d = dataset.y
+            d2 = dataset.x
+        else:
+            raise ValueError("Invalid axis value")
+
+        if orthoRange is not None:
+            mask = (d2 >= orthoRange[0]) * (d2 <= orthoRange[1])
+            if self.opts.get("stepMode", None) == "center":
+                mask = mask[:-1]  # len(y) == len(x) - 1 when stepMode is center
+            d = d[mask]
+
+        if len(d) == 0:
+            return (None, None)
+
+        if frac >= 1.0:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                bounds = (float(np.nanmin(d)), float(np.nanmax(d)))
+            if math.isinf(bounds[0]) or math.isinf(bounds[1]):
+                finite = np.isfinite(d)
+                d = d[finite]
+                if len(d) == 0:
+                    return (None, None)
+                bounds = (float(d.min()), float(d.max()))
+        elif frac <= 0.0:
+            raise Exception("Value for parameter 'frac' must be > 0. (got %s)" % str(frac))
+        else:
+            finite = np.isfinite(d)
+            d = d[finite]
+            if len(d) == 0:
+                return (None, None)
+            bounds = np.percentile(d, [50 * (1 - frac), 50 * (1 + frac)])
+
+        curve_visible = self.curve.isVisible()
+
+        if curve_visible and ax == 1 and self.opts['fillLevel'] not in [None, 'enclosed']:
+            bounds = (
+                float(min(bounds[0], self.opts['fillLevel'])),
+                float(max(bounds[1], self.opts['fillLevel']))
+            )
+
+        if curve_visible:
+            pen = None if self.opts['pen'] is None else fn.mkPen(self.opts['pen'])
+            spen = None if self.opts['shadowPen'] is None else fn.mkPen(self.opts['shadowPen'])
+            if pen is not None and not pen.isCosmetic() and pen.style() != QtCore.Qt.PenStyle.NoPen:
+                bounds = (bounds[0] - pen.widthF()*0.7072, bounds[1] + pen.widthF()*0.7072)
+            if spen is not None and not spen.isCosmetic() and spen.style() != QtCore.Qt.PenStyle.NoPen:
+                bounds = (bounds[0] - spen.widthF()*0.7072, bounds[1] + spen.widthF()*0.7072)
+
+        return bounds
+
     def dataBounds(
         self,
         ax: int,
@@ -1725,6 +1799,9 @@ class PlotDataItem(GraphicsObject):
             The maximum end of the range that the data occupies along the specified
             axis. ``None`` if there is no data.
         """
+        if self.opts['autoDownsample'] and (self.curve.isVisible() or self.scatter.isVisible()):
+            return self._mappedDataBounds(ax, frac, orthoRange)
+
         bounds: tuple[None, None] | tuple[float, float] = (None, None)
         if self.curve.isVisible():
             bounds = self.curve.dataBounds(ax, frac, orthoRange)

--- a/tests/graphicsItems/test_PlotDataItem.py
+++ b/tests/graphicsItems/test_PlotDataItem.py
@@ -45,6 +45,36 @@ def test_fft():
     x, y = pd.getData()
     assert abs(x[np.argmax(y)] - np.log10(f)) < 0.01
 
+def test_fft_auto_downsample_autorange_with_implicit_x():
+    t = np.arange(1000.0)
+    y = np.zeros_like(t)
+    for f in (0.1, 0.2, 0.3, 0.4):
+        y += np.sin(2 * np.pi * f * t)
+
+    w = pg.PlotWidget(autoRange=True)
+    w.resize(640, 480)
+    w.show()
+    plotitem = w.getPlotItem()
+    plotitem.setDownsampling(auto=True)
+    curve = plotitem.plot(y)
+
+    app = pg.mkQApp()
+    app.processEvents()
+    plotitem.vb.updateAutoRange()
+    app.processEvents()
+
+    curve.setFftMode(True)
+    app.processEvents()
+    plotitem.vb.updateAutoRange()
+    app.processEvents()
+
+    x_range, _ = plotitem.vb.viewRange()
+    assert x_range[0] < 0
+    assert x_range[1] > 0.5
+    assert x_range[1] - x_range[0] < 2
+
+    w.close()
+
 def test_setData():
     pdi = pg.PlotDataItem()
 


### PR DESCRIPTION
## Summary
- Fix auto range for `PlotDataItem` when FFT mode and automatic downsampling are both enabled.
- Reuse the mapped dataset before display-only processing so `dataBounds()` is not calculated from a stale, downsampled FFT view.
- Add a regression test for FFT mode with implicit x-values and `PlotItem.setDownsampling(auto=True)`.

Fixes #438.

## Root cause
When `setFftMode(True)` was called after a y-only curve had already been auto-ranged, `updateItems()` recomputed display data using the previous wide x-range (`0..999`). With automatic downsampling enabled, that reduced the FFT display data to only a couple of points. The subsequent auto-range pass then asked `PlotDataItem.dataBounds()` for bounds, but it delegated to the already-downsampled `PlotCurveItem`, so the view could remain near the old pre-FFT range instead of shrinking to the FFT frequency range (`0..0.5` for implicit x-values).

## Validation
- `python -m pytest tests/graphicsItems/test_PlotDataItem.py::test_fft_auto_downsample_autorange_with_implicit_x -q`
- `python -m pytest tests/graphicsItems/test_PlotDataItem.py -q`
- `python -m pytest tests/graphicsItems/test_PlotCurveItem.py tests/graphicsItems/ViewBox/test_ViewBox.py tests/graphicsItems/ViewBox/test_ViewBoxZoom.py -q`
- `python -m pytest tests/graphicsItems -q`
- Manual reproduction of #438: after enabling FFT, the x view range now moves from roughly `[-542, 542]` to `[-0.021, 0.521]`.
