### PR TITLE
Use np.vstack instead of np.row_stack due to deprecation

### DIFF
--- a/pyqtgraph/examples/MultiDataPlot.py
+++ b/pyqtgraph/examples/MultiDataPlot.py
@@ -32,7 +32,7 @@ values = {
         *[sortedRandint(0, 20, 15) for _ in range(4)],
     ],
     # Convention 3 array form
-    "2D matrix": np.row_stack([sortedRandint(20, 40, 15) for _ in range(6)]),
+    "2D matrix": np.vstack([sortedRandint(20, 40, 15) for _ in range(6)]),
 }
 
 


### PR DESCRIPTION
NumPy 2.5 removed `np.row_stack` which was always an alias for `np.vstack`