### PR TITLE
Deprecation/direct icon attributes access

### DIFF
--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -1,7 +1,7 @@
 import math
 
 from .. import functions as fn
-from ..icons import invisibleEye
+from ..icons import getGraphPixmap
 from ..Point import Point
 from ..Qt import QtCore, QtGui, QtWidgets
 from .BarGraphItem import BarGraphItem
@@ -371,8 +371,7 @@ class ItemSample(GraphicsWidget):
 
         visible = self.item.isVisible()
         if not visible:
-            icon = invisibleEye.qicon
-            p.drawPixmap(QtCore.QPoint(1, 1), icon.pixmap(18, 18))
+            p.drawPixmap(QtCore.QPoint(1, 1), getGraphPixmap('invisibleEye', size=(18, 18)))
             return
 
         if not isinstance(self.item, ScatterPlotItem):

--- a/pyqtgraph/icons/__init__.py
+++ b/pyqtgraph/icons/__init__.py
@@ -60,8 +60,24 @@ def getGraphPixmap(name, size=(20, 20)):
 
 
 # Note: List all graph icons here ...
-auto = GraphIcon("auto.png")
-ctrl = GraphIcon("ctrl.png")
-default = GraphIcon("default.png")
-invisibleEye = GraphIcon("invisibleEye.svg")
-lock = GraphIcon("lock.png")
+GraphIcon("auto.png")
+GraphIcon("ctrl.png")
+GraphIcon("default.png")
+GraphIcon("invisibleEye.svg")
+GraphIcon("lock.png")
+
+
+def __getattr__(name):
+    # Deprecated: icons used to be exposed as module-level GraphIcon
+    # attributes (e.g. `pyqtgraph.icons.invisibleEye`). Use getGraphIcon()
+    # or getGraphPixmap() instead.
+    if name in _ICON_REGISTRY:
+        warnings.warn(
+            f"Accessing '{name}' as a module attribute of pyqtgraph.icons is "
+            f"deprecated and will be removed in a future version. Use "
+            f"getGraphIcon('{name}') or getGraphPixmap('{name}') instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getGraphIcon(name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Following up on the behavior of the github-advanced-security with the CodeQL / Unused global variable warning in PR #3479.
- I suggest we remove all global variables in /icons/__init__.py and replace it with a deprecation warning.
- I removed the only import (for invisibleEye) used in LegendItem to use the getGraphPixmap method instead 
