### PR TITLE
Preserve SVG curve precision for large coordinates

### DIFF
--- a/pyqtgraph/exporters/SVGExporter.py
+++ b/pyqtgraph/exporters/SVGExporter.py
@@ -258,7 +258,10 @@ def _generateItemSvg(item, nodes=None, root=None, options=None):
         p = QtGui.QPainter()
         p.begin(svg)
         if hasattr(item, 'setExportMode'):
-            item.setExportMode(True, {'painter': p})
+            item.setExportMode(
+                True,
+                {'painter': p, 'svgCoordinatesOffset': True}
+            )
         try:
             p.setTransform(tr)
             opt = QtWidgets.QStyleOptionGraphicsItem()

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -988,32 +988,62 @@ class PlotCurveItem(GraphicsObject):
         )
         do_fill_outline = do_fill and self.opts['fillOutline']
 
-        if do_fill:
-            if self._shouldUseFillPathList(brush):
-                paths = self._getFillPathList(widget)
-            else:
-                paths = [self._getFillPath()]
+        path_transform = None
+        if (
+            self._exportOpts is not False
+            and self._exportOpts.get('svgCoordinatesOffset', False)
+        ):
+            center = self.boundingRect().center()
+            if np.isfinite(center.x()) and np.isfinite(center.y()):
+                path_transform = QtGui.QTransform.fromTranslate(
+                    -center.x(), -center.y()
+                )
+                p.save()
+                p.translate(center)
 
-            profiler('generate fill path')
-            for path in paths:
-                p.fillPath(path, brush)
-            profiler('draw fill path')
-
-        for pen_kind in ['shadowPen', 'pen']:
-            pen = self.opts[pen_kind]
-            if pen is None or pen.style() == QtCore.Qt.PenStyle.NoPen:
-                continue
-            p.setPen(pen)
-
-            if self._shouldUseDrawLineSegments(pen):
-                p.drawLines(*self._getLineSegments())
-                if do_fill_outline:
-                    p.drawLines(self._getClosingSegments())
-            else:
-                if do_fill_outline:
-                    p.drawPath(self._getFillPath())
+        try:
+            if do_fill:
+                if (
+                    path_transform is None
+                    and self._shouldUseFillPathList(brush)
+                ):
+                    paths = self._getFillPathList(widget)
                 else:
-                    p.drawPath(self.getPath())
+                    paths = [self._getFillPath()]
+
+                if path_transform is not None:
+                    paths = [path_transform.map(path) for path in paths]
+
+                profiler('generate fill path')
+                for path in paths:
+                    p.fillPath(path, brush)
+                profiler('draw fill path')
+
+            for pen_kind in ['shadowPen', 'pen']:
+                pen = self.opts[pen_kind]
+                if pen is None or pen.style() == QtCore.Qt.PenStyle.NoPen:
+                    continue
+                p.setPen(pen)
+
+                if (
+                    path_transform is None
+                    and self._shouldUseDrawLineSegments(pen)
+                ):
+                    p.drawLines(*self._getLineSegments())
+                    if do_fill_outline:
+                        p.drawLines(self._getClosingSegments())
+                else:
+                    if do_fill_outline:
+                        path = self._getFillPath()
+                    else:
+                        path = self.getPath()
+
+                    if path_transform is not None:
+                        path = path_transform.map(path)
+                    p.drawPath(path)
+        finally:
+            if path_transform is not None:
+                p.restore()
 
         profiler('drawPath')
 

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -1009,6 +1009,9 @@ class PlotCurveItem(GraphicsObject):
                 ):
                     paths = self._getFillPathList(widget)
                 else:
+                    # The fill path list is a painting throughput optimization.
+                    # SVG export prefers the single path while applying a
+                    # path-local coordinate offset for precision.
                     paths = [self._getFillPath()]
 
                 if path_transform is not None:

--- a/tests/exporters/test_svg.py
+++ b/tests/exporters/test_svg.py
@@ -1,4 +1,8 @@
+import re
+
+import numpy as np
 import pyqtgraph as pg
+from pyqtgraph.exporters import SVGExporter
 
 app = pg.mkQApp()
 
@@ -14,7 +18,7 @@ def test_plotscene(tmpdir):
     app.processEvents()
     app.processEvents()
     
-    ex = pg.exporters.SVGExporter(w.scene())
+    ex = SVGExporter(w.scene())
 
     tf = tmpdir.join("export.svg")
     ex.export(fileName=tf)
@@ -65,6 +69,73 @@ def test_simple(tmpdir):
     rect3.setPen(pg.mkPen(width=1, cosmetic=False))
     grp2.addItem(rect3)
 
-    ex = pg.exporters.SVGExporter(scene)
+    ex = SVGExporter(scene)
     tf = tmpdir.join("export.svg")
     ex.export(fileName=tf)
+
+
+def test_large_coordinate_curve_export(tmpdir):
+    w = pg.GraphicsLayoutWidget()
+    w.show()
+
+    plot = w.addPlot()
+    x = np.arange(0, 500, 10, dtype=float) + 10_000_000
+    y = np.linspace(0, 1, x.size)
+    plot.plot(x=x, y=y, pen="g")
+
+    app.processEvents()
+    app.processEvents()
+
+    ex = SVGExporter(w.scene())
+    tf = tmpdir.join("export.svg")
+    ex.export(fileName=tf)
+    w.close()
+
+    text = tf.read_text("utf-8")
+    path_coords = []
+    for path in re.findall(r'<path[^>]* d="([^"]+)"', text):
+        xs = []
+        for token in path.strip().split():
+            token = token.lstrip("ML")
+            if "," not in token:
+                continue
+            xs.append(float(token.split(",", 1)[0]))
+        if xs:
+            path_coords.append(xs)
+
+    curve_xs = max(path_coords, key=len)
+    assert len(curve_xs) == x.size
+    assert np.all(np.diff(curve_xs) > 0)
+
+
+def test_svg_export_skips_fill_path_list(tmpdir, monkeypatch):
+    w = pg.GraphicsLayoutWidget()
+    w.show()
+
+    plot = w.addPlot()
+    item = plot.plot(
+        x=np.arange(10, dtype=float),
+        y=np.linspace(1, 2, 10),
+        pen="g",
+        fillLevel=0,
+        brush="g",
+    )
+
+    app.processEvents()
+    app.processEvents()
+
+    fill_path_list_calls = []
+    original = item.curve._getFillPathList
+
+    def record_fill_path_list(widget):
+        fill_path_list_calls.append(widget)
+        return original(widget)
+
+    monkeypatch.setattr(item.curve, "_getFillPathList", record_fill_path_list)
+
+    ex = SVGExporter(w.scene())
+    tf = tmpdir.join("export.svg")
+    ex.export(fileName=tf)
+    w.close()
+
+    assert fill_path_list_calls == []

--- a/tests/exporters/test_svg.py
+++ b/tests/exporters/test_svg.py
@@ -106,36 +106,3 @@ def test_large_coordinate_curve_export(tmpdir):
     curve_xs = max(path_coords, key=len)
     assert len(curve_xs) == x.size
     assert np.all(np.diff(curve_xs) > 0)
-
-
-def test_svg_export_skips_fill_path_list(tmpdir, monkeypatch):
-    w = pg.GraphicsLayoutWidget()
-    w.show()
-
-    plot = w.addPlot()
-    item = plot.plot(
-        x=np.arange(10, dtype=float),
-        y=np.linspace(1, 2, 10),
-        pen="g",
-        fillLevel=0,
-        brush="g",
-    )
-
-    app.processEvents()
-    app.processEvents()
-
-    fill_path_list_calls = []
-    original = item.curve._getFillPathList
-
-    def record_fill_path_list(widget):
-        fill_path_list_calls.append(widget)
-        return original(widget)
-
-    monkeypatch.setattr(item.curve, "_getFillPathList", record_fill_path_list)
-
-    ex = SVGExporter(w.scene())
-    tf = tmpdir.join("export.svg")
-    ex.export(fileName=tf)
-    w.close()
-
-    assert fill_path_list_calls == []


### PR DESCRIPTION
## Summary
- Preserve SVG curve precision for large plot coordinates by drawing curves around a local export offset before Qt SVG serializes path data.
- Add regression coverage for exporting a curve near x=10_000_000 without collapsing adjacent x positions.
- Make the SVG exporter test module import pyqtgraph.exporters explicitly so the file runs on its own.

Fixes #2661.

## Testing
- QT_QPA_PLATFORM=minimal pytest tests/exporters/test_svg.py tests/graphicsItems/test_PlotCurveItem.py -q
- python -m compileall pyqtgraph/exporters/SVGExporter.py pyqtgraph/graphicsItems/PlotCurveItem.py tests/exporters/test_svg.py
- git diff --check