### PR TITLE
fix: recognize Greek mu as SI prefix

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -61,15 +61,17 @@ Colors = {
 
 SI_PREFIXES = 'yzafpnµm kMGTPEZY'
 SI_PREFIXES_ASCII = 'yzafpnum kMGTPEZY'
+SI_PREFIXES_INPUT = SI_PREFIXES + 'uμ'
 SI_PREFIX_EXPONENTS = dict([(SI_PREFIXES[i], (i-8)*3) for i in range(len(SI_PREFIXES))])
 SI_PREFIX_EXPONENTS['u'] = -6
+SI_PREFIX_EXPONENTS['μ'] = -6
 
 #For comma as decimal separator
-FLOAT_REGEX_COMMA = re.compile(r'(?P<number>[+-]?((((\d+(,\d*)?)|(\d*,\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>\w.*))?$')
+FLOAT_REGEX_COMMA = re.compile(r'(?P<number>[+-]?((((\d+(,\d*)?)|(\d*,\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>\w.*))?$')
 #For period as decimal separator
-FLOAT_REGEX_PERIOD = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>\w.*))?$')
+FLOAT_REGEX_PERIOD = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>\w.*))?$')
 
-INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>.*)$')
+INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>.*)$')
 
 class HueKeywordArgs(TypedDict):
     hues: int
@@ -121,8 +123,8 @@ def siScale(x, minVal=1e-25, allowUnicode=True, power:int|float=1):
     Examples
     --------
     >>> siScale(0.0001)
-    (1000000.0, 'μ')
-    # This indicates that the number 0.0001 is best represented as 0.0001 * 1e6 = 100 μUnits
+    (1000000.0, 'µ')
+    # This indicates that the number 0.0001 is best represented as 0.0001 * 1e6 = 100 µUnits
     """
     
     if isinstance(x, decimal.Decimal):
@@ -189,7 +191,7 @@ def siFormat(x, precision=3, suffix='', space=True, error=None, minVal=1e-25, al
     Examples
     --------
     >>> siFormat(0.0001, suffix='V')
-    '100 μV'
+    '100 µV'
     """
     
     if space is True:
@@ -219,8 +221,8 @@ def siParse(s, regex=FLOAT_REGEX_PERIOD, suffix=None):
     Example:
         siParse('100 µV')  # returns ('100', 'µ', 'V')
 
-    Note that in the above example, the µ symbol is the "micro sign" (UTF-8
-    0xC2B5), as opposed to the Greek letter mu (UTF-8 0xCEBC).
+    Both the SI micro sign (UTF-8 0xC2B5) and Greek small letter mu (UTF-8
+    0xCEBC) are accepted as the micro prefix.
 
     Parameters
     ----------

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -71,7 +71,7 @@ FLOAT_REGEX_COMMA = re.compile(r'(?P<number>[+-]?((((\d+(,\d*)?)|(\d*,\d+))([eE]
 #For period as decimal separator
 FLOAT_REGEX_PERIOD = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>\w.*))?$')
 
-INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>.*)$')
+INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>.*)$')
 
 class HueKeywordArgs(TypedDict):
     hues: int

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -231,6 +231,7 @@ def test_eq():
     # usual cases
     ("100 uV", "V", ("100", "u", "V")),
     ("100 µV", "V", ("100", "µ", "V")),
+    ("100 μV", "V", ("100", "μ", "V")),
     ("4.2 nV", None, ("4.2", "n", "V")),
     ("1.2 m", "m", ("1.2", "", "m")),
     ("1.2 m", None, ("1.2", "", "m")),
@@ -258,6 +259,7 @@ def test_siParse(s, suffix, expected):
     # usual cases
     ("100 uV", "V", 1, 1e-4),
     ("100 µV", "V", 1, 1e-4),
+    ("100 μV", "V", 1, 1e-4),
     ("4.2 nV", None, 1, 4.2e-9),
     ("1.2 m", "m", 1, 1.2),
     # siPrefix with explicit empty suffix
@@ -280,6 +282,7 @@ def test_siEval(s, suffix, power, expected):
 @pytest.mark.parametrize("s,suffix,expected", [
     ("1,2 j", "", ("1,2", "", "")),
     ("1,2 j", None, ("1,2", "", "j")),
+    ("1,2 μV", "V", ("1,2", "μ", "V")),
     (",2 j", None, (",2", "", "j")),])
 def test_siParse_with_comma_as_decimal_separator(s, suffix, expected):
     assert pg.siParse(s, suffix=suffix, regex=pg.functions.FLOAT_REGEX_COMMA) == expected
@@ -531,6 +534,7 @@ def test_signal_block_unconnected():
     (0.123456789, 3, 'V', 1, "123 mV"),
     (0.0123456789, 3, 'V', 1, "12.3 mV"),
     (0.00123456789, 3, 'V', 1, "1.23 mV"),
+    (0.0001, 3, 'V', 1, "100 µV"),
     # Different power
     (0, 3, 'V²', 2, "0 V²"),
     (123.456, 3, 'V²', 2, "123 V²"),


### PR DESCRIPTION
### Summary
Accept Greek small letter mu as a micro prefix in SI parsing, alongside the existing SI micro sign and ASCII `u`.
Keep SI formatting examples and tests aligned with the formatter's micro-sign output.

### Testing
- `.venv/bin/python -m pytest tests/test_functions.py -q`

Closes #3498
