### PR TITLE
Respect LineSegmentROI resize flag

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -2165,6 +2165,9 @@ class LineSegmentROI(ROI):
     def listPoints(self):
         return [p['item'].pos() for p in self.handles]
 
+    def checkPointMove(self, handle, pos, modifiers):
+        return self.resizable
+
     def getState(self):
         state = ROI.getState(self)
         state['points'] = [Point(h.pos()) for h in self.getHandles()]

--- a/tests/graphicsItems/test_ROI.py
+++ b/tests/graphicsItems/test_ROI.py
@@ -469,3 +469,13 @@ def test_LineROI_coords(p1, p2):
         got = lineroi.mapSceneToParent(scenepos)
         assert math.isclose(got.x(), expected[0])
         assert math.isclose(got.y(), expected[1])
+
+
+def test_LineSegmentROI_resizable_controls_endpoint_handles():
+    locked = pg.LineSegmentROI(positions=((0, 0), (1, 1)), resizable=False)
+    locked.getHandles()[0].movePoint(pg.Point(5, 5))
+    assert locked.listPoints() == [pg.Point(0, 0), pg.Point(1, 1)]
+
+    unlocked = pg.LineSegmentROI(positions=((0, 0), (1, 1)), resizable=True)
+    unlocked.getHandles()[0].movePoint(pg.Point(5, 5))
+    assert unlocked.listPoints() == [pg.Point(5, 5), pg.Point(1, 1)]


### PR DESCRIPTION
## Summary

- Stop `LineSegmentROI` endpoint handles from moving when `resizable=False`.
- Keep endpoint handle resizing active when `resizable=True`.
- Add regression coverage for locked endpoint handles.

## Related issue

Closes #3222

## Tests

- `QT_QPA_PLATFORM=minimal .venv/bin/python -m pytest tests/graphicsItems/test_ROI.py -q`
- `QT_QPA_PLATFORM=minimal .venv/bin/python -m pytest tests/graphicsItems -q`