### PR TITLE
Restore DockArea QWidget close

### DIFF
--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -155,7 +155,10 @@ class DockArea(Container, QtWidgets.QWidget):
         new.containerChanged(self)
         self.topContainer = new
         self.dockdrop.raiseOverlay()
-        
+
+    def close(self):
+        return QtWidgets.QWidget.close(self)
+
     def count(self):
         if self.topContainer is None:
             return 0

--- a/tests/dockarea/test_dockarea.py
+++ b/tests/dockarea/test_dockarea.py
@@ -6,6 +6,25 @@ import pyqtgraph.dockarea as da
 pg.mkQApp()
 
 
+def test_dockarea_close():
+    class DockArea(da.DockArea):
+        def __init__(self):
+            super().__init__()
+            self.close_event_seen = False
+
+        def closeEvent(self, event):
+            self.close_event_seen = True
+            super().closeEvent(event)
+
+    a = DockArea()
+    a.addDock(da.Dock("dock 1"))
+
+    close_succeeded = a.close()
+    assert close_succeeded
+    pg.mkQApp().processEvents()
+    assert a.close_event_seen
+
+
 def test_dockarea():
     a = da.DockArea()
     d1 = da.Dock("dock 1")


### PR DESCRIPTION
## Summary

- Make `DockArea.close()` use QWidget close behavior instead of inherited container cleanup.
- Add regression coverage that `closeEvent` runs for `DockArea.close()`.
- Keep floating dock cleanup tests passing.

## Related issue

Closes #3234

## Tests

- `.venv/bin/python -m pytest tests/dockarea/test_dockarea.py::test_dockarea_close -q`
- `QT_QPA_PLATFORM=minimal .venv/bin/python -m pytest tests/dockarea/test_dockarea.py::test_dockarea_close tests/dockarea/test_dockarea.py::test_floating_and_closed_before_save_and_restore_state tests/dockarea/test_dockarea.py::test_floating_and_redock_by_dragging_back_before_save_and_restore_state tests/dockarea/test_dockarea.py::test_floating_dock_closed_by_restore_state_doesnt_error -q`