### PR TITLE
Keep ImageView histogram range setting

### DIFF
--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -135,6 +135,7 @@ class ImageView(QtWidgets.QWidget):
         self.ui = ui_template.Ui_Form()
         self.ui.setupUi(self)
         self.scene = self.ui.graphicsView.scene()
+        self._autoHistogramRange = True
         self.discreteTimeLine = discreteTimeLine
         self.ui.histogram.setLevelMode(levelMode)
         self.ignoreTimeLine = False
@@ -295,6 +296,7 @@ class ImageView(QtWidgets.QWidget):
             Set the transform of the displayed image. This option overrides *pos* and *scale*.
         autoHistogramRange : bool
             If True, the histogram y-range is automatically scaled to fit the image data.
+            The value is retained for later image updates.
         levelMode : str
             If specified, this sets the user interaction mode for setting image levels. Options are 'mono',
             which provides a single level control for all image channels, and 'rgb' or 'rgba', which provide
@@ -364,7 +366,8 @@ class ImageView(QtWidgets.QWidget):
         profiler()
 
         self.currentIndex = 0
-        self.updateImage(autoHistogramRange=autoHistogramRange)
+        self.setHistogramAutoRange(autoHistogramRange)
+        self.updateImage()
         if levels is None and autoLevels:
             self.autoLevels()
         if levels is not None:  ## this does nothing since getProcessedImage sets these values again.
@@ -454,6 +457,10 @@ class ImageView(QtWidgets.QWidget):
         if text == '':
             a.showLabel(False)
         self.ui.histogram.setMinimumWidth(135)
+
+    def setHistogramAutoRange(self, enabled=True):
+        """Set whether image updates automatically scale the histogram y-range."""
+        self._autoHistogramRange = bool(enabled)
 
     def nframes(self):
         """
@@ -820,12 +827,14 @@ class ImageView(QtWidgets.QWidget):
 
         self.sigTimeChanged.emit(ind, time)
 
-    def updateImage(self, autoHistogramRange=True):
+    def updateImage(self, autoHistogramRange=None):
         ## Redraw image on screen
         if self.image is None:
             return
     
         image = self.getProcessedImage()
+        if autoHistogramRange is None:
+            autoHistogramRange = self._autoHistogramRange
         if autoHistogramRange:
             self.ui.histogram.setHistogramRange(self.levelMin, self.levelMax)
         

--- a/tests/imageview/test_imageview.py
+++ b/tests/imageview/test_imageview.py
@@ -40,6 +40,31 @@ def test_timeslide_snap():
     assert iv.playRate == speed
 
 
+def test_auto_histogram_range_setting_persists_across_frames():
+    frames = np.zeros((2, 10, 10))
+    frames[1] = 10
+    iv = pg.ImageView()
+    calls = []
+    original = iv.ui.histogram.setHistogramRange
+
+    def record_histogram_range(*args, **kwargs):
+        calls.append(args)
+        return original(*args, **kwargs)
+
+    iv.ui.histogram.setHistogramRange = record_histogram_range
+
+    try:
+        iv.setImage(frames, autoHistogramRange=False)
+        iv.setCurrentIndex(1)
+        assert calls == []
+
+        iv.setHistogramAutoRange(True)
+        iv.setCurrentIndex(0)
+        assert calls == [(0.0, 10.0)]
+    finally:
+        iv.close()
+
+
 def test_init_with_mode_and_imageitem():
     data = np.random.randint(256, size=(256, 256, 3))
     imgitem = pg.ImageItem(data)


### PR DESCRIPTION
## Summary

- Retain ImageView's histogram auto-range preference after `setImage(..., autoHistogramRange=...)`.
- Add `setHistogramAutoRange()` so later image updates can opt in or out.
- Cover frame changes so `setCurrentIndex()` keeps a manual histogram range intact.

## Related issue

Closes #163

## Tests

- `QT_QPA_PLATFORM=minimal .venv/bin/python -m pytest tests/imageview/test_imageview.py::test_auto_histogram_range_setting_persists_across_frames -q`
- `QT_QPA_PLATFORM=minimal .venv/bin/python -m pytest tests/imageview -q -o qt_log_level_fail=CRITICAL`
- `QT_QPA_PLATFORM=minimal .venv/bin/python -m pytest tests/test_ref_cycles.py::test_ImageView -q`
- `git diff --check`