### PR TITLE
Fix addLine positions on log axes

### DIFF
--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -127,30 +127,26 @@ class InfiniteLine(GraphicsObject):
 
     def _getMappedViewPos(self, pos):
         mapped = list(pos)
-        axes = self._logMapAxes()
+        map_x, map_y = self._logMapAxes()
         with np.errstate(divide='ignore', invalid='ignore'):
-            if 0 in axes and self.logMode[0]:
+            if map_x and self.logMode[0]:
                 mapped[0] = np.log10(mapped[0])
-            if 1 in axes and self.logMode[1]:
+            if map_y and self.logMode[1]:
                 mapped[1] = np.log10(mapped[1])
         return mapped
 
     def _getDataPos(self, pos):
         data = [pos.x(), pos.y()] if isinstance(pos, QtCore.QPointF) else list(pos)
-        axes = self._logMapAxes()
-        if 0 in axes and self.logMode[0]:
+        map_x, map_y = self._logMapAxes()
+        if map_x and self.logMode[0]:
             data[0] = 10 ** data[0]
-        if 1 in axes and self.logMode[1]:
+        if map_y and self.logMode[1]:
             data[1] = 10 ** data[1]
         return data
 
     def _logMapAxes(self):
         angle = self.angle % 180
-        if angle == 0:
-            return (1,)
-        if angle == 90:
-            return (0,)
-        return (0, 1)
+        return angle != 0, angle != 90
 
     def setLogMode(self, xState: bool, yState: bool):
         """

--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -78,6 +78,7 @@ class InfiniteLine(GraphicsObject):
         else:
             self.maxRange = bounds
         self.moving = False
+        self.logMode = [False, False]
         self.setMovable(movable)
         self.mouseHovering = False
         self.p = [0, 0]
@@ -123,6 +124,48 @@ class InfiniteLine(GraphicsObject):
         """Set the (minimum, maximum) allowable values when dragging."""
         self.maxRange = bounds
         self.setValue(self.value())
+
+    def _getMappedViewPos(self, pos):
+        mapped = list(pos)
+        axes = self._logMapAxes()
+        with np.errstate(divide='ignore', invalid='ignore'):
+            if 0 in axes and self.logMode[0]:
+                mapped[0] = np.log10(mapped[0])
+            if 1 in axes and self.logMode[1]:
+                mapped[1] = np.log10(mapped[1])
+        return mapped
+
+    def _getDataPos(self, pos):
+        data = [pos.x(), pos.y()] if isinstance(pos, QtCore.QPointF) else list(pos)
+        axes = self._logMapAxes()
+        if 0 in axes and self.logMode[0]:
+            data[0] = 10 ** data[0]
+        if 1 in axes and self.logMode[1]:
+            data[1] = 10 ** data[1]
+        return data
+
+    def _logMapAxes(self):
+        angle = self.angle % 180
+        if angle == 0:
+            return (1,)
+        if angle == 90:
+            return (0,)
+        return (0, 1)
+
+    def setLogMode(self, xState: bool, yState: bool):
+        """
+        Enable log mapping per axis.
+
+        Log mode maps the stored data position to view coordinates for rendering while
+        preserving :meth:`value` and :meth:`getPos` in data coordinates.
+        """
+        logMode = [bool(xState), bool(yState)]
+        if self.logMode == logMode:
+            return
+        self.logMode = logMode
+        self.viewTransformChanged()
+        GraphicsObject.setPos(self, Point(self._getMappedViewPos(self.p)))
+        self.sigPositionChanged.emit(self)
         
     def bounds(self):
         """Return the (minimum, maximum) values allowed when dragging.
@@ -252,7 +295,7 @@ class InfiniteLine(GraphicsObject):
         if self.p != newPos:
             self.p = newPos
             self.viewTransformChanged()
-            GraphicsObject.setPos(self, Point(self.p))
+            GraphicsObject.setPos(self, Point(self._getMappedViewPos(self.p)))
             self.sigPositionChanged.emit(self)
 
     def getXPos(self):
@@ -395,7 +438,9 @@ class InfiniteLine(GraphicsObject):
             if not self.moving:
                 return
 
-            self.setPos(self.cursorOffset + self.mapToParent(ev.pos()))
+            self.setPos(
+                self._getDataPos(self.cursorOffset + self.mapToParent(ev.pos()))
+            )
             self.sigDragged.emit(self)
             if ev.isFinish():
                 self.moving = False

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -404,9 +404,8 @@ class PlotItem(GraphicsWidget):
         
         Notes
         -----
-        No other items, in the scene will be affected by this; there is (currently) 
-        no generic way to redisplay a :class:`~pyqtgraph.GraphicsItem` with log
-        coordinates.
+        This updates axes and items that implement ``setLogMode``. Other scene items
+        stay in view coordinates.
         """
         if x is not None:
             self.ctrl.logXCheck.setChecked(x)

--- a/tests/graphicsItems/test_InfiniteLine.py
+++ b/tests/graphicsItems/test_InfiniteLine.py
@@ -1,3 +1,5 @@
+import pytest
+
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui, QtTest
 from tests.ui_testing import mouseDrag, mouseMove
@@ -49,6 +51,55 @@ def test_InfiniteLine():
     px = pg.Point(-0.5, -1.0 / 3**0.5)
     assert br.containsPoint(pos + 1 * px, QtCore.Qt.FillRule.OddEvenFill)
     assert not br.containsPoint(pos + 3 * px, QtCore.Qt.FillRule.OddEvenFill)
+    plt.close()
+
+
+def test_InfiniteLine_setLogMode_maps_view_position():
+    plt = pg.PlotWidget()
+    vline = plt.addLine(x=10, label="{value:g}")
+    hline = plt.addLine(y=100)
+
+    plt.setLogMode(x=True, y=True)
+
+    assert vline.value() == 10
+    assert vline.label.toPlainText() == "10"
+    assert vline.getPos() == [10, 0]
+    assert vline.pos().x() == pytest.approx(1)
+    assert vline.pos().y() == pytest.approx(0)
+    assert hline.value() == 100
+    assert hline.getPos() == [0, 100]
+    assert hline.pos().x() == pytest.approx(0)
+    assert hline.pos().y() == pytest.approx(2)
+
+    vline.setValue(1000)
+    hline.setValue(10)
+
+    assert vline.value() == 1000
+    assert vline.label.toPlainText() == "1000"
+    assert vline.pos().x() == pytest.approx(3)
+    assert hline.value() == 10
+    assert hline.pos().y() == pytest.approx(1)
+
+    plt.setLogMode(x=False, y=False)
+
+    assert vline.value() == 1000
+    assert vline.pos().x() == pytest.approx(1000)
+    assert hline.value() == 10
+    assert hline.pos().y() == pytest.approx(10)
+    plt.close()
+
+
+def test_PlotItem_addLine_uses_log_mode_for_new_lines():
+    plt = pg.PlotWidget()
+    plt.setLogMode(x=True, y=True)
+
+    vline = plt.addLine(x=100)
+    hline = plt.addLine(y=1000)
+
+    assert vline.value() == 100
+    assert vline.pos().x() == pytest.approx(2)
+    assert hline.value() == 1000
+    assert hline.pos().y() == pytest.approx(3)
     plt.close()
 
 def test_mouseInteraction():


### PR DESCRIPTION
## Summary
- Map InfiniteLine positions through log-mode coordinates when a PlotItem toggles log axes.
- Keep InfiniteLine value and label data coordinates while rendering at log10 positions.
- Update PlotItem log-mode docs for item-level setLogMode hooks.

Fixes #1686.

## Testing
- QT_QPA_PLATFORM=minimal pytest tests/graphicsItems -q
- QT_QPA_PLATFORM=minimal pytest tests/graphicsItems/test_InfiniteLine.py -q
- QT_QPA_PLATFORM=minimal pytest tests/graphicsItems/PlotItem/test_PlotItem.py tests/graphicsItems/test_PlotDataItem.py -q
- python -m compileall pyqtgraph/graphicsItems/InfiniteLine.py pyqtgraph/graphicsItems/PlotItem/PlotItem.py tests/graphicsItems/test_InfiniteLine.py
- git diff --check