### PR TITLE
Fix filled log plot auto-connect

### DIFF
--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -1402,6 +1402,10 @@ class PlotDataItem(GraphicsObject):
                     # all points can be connected, and no further check is needed.
                     curveArgs['connect'] = 'all'
                     curveArgs['skipFiniteCheck'] = True
+                elif self.opts['fillLevel'] is not None:
+                    # Filled curves need one continuous outline across log(0) gaps.
+                    curveArgs['connect'] = 'all'
+                    curveArgs['skipFiniteCheck'] = False
                 else:   # True or None
                     # True: (we checked and found non-finites)
                     #   don't connect non-finites

--- a/tests/graphicsItems/test_PlotDataItem.py
+++ b/tests/graphicsItems/test_PlotDataItem.py
@@ -121,6 +121,40 @@ def test_nonfinite():
     _assert_equal_arrays( dataset.x, x_log )
     _assert_equal_arrays( dataset.y, y_log )
 
+def test_filled_log_plot_auto_connects_across_nonfinite_values(monkeypatch):
+    rng = np.random.default_rng(seed=0)
+    values = np.hstack([rng.normal(size=500), rng.normal(size=260, loc=4)])
+    y, x = np.histogram(values, bins=np.linspace(-3, 8, 40))
+
+    pdi = pg.PlotDataItem(
+        x,
+        y,
+        stepMode="center",
+        fillLevel=0,
+        fillOutline=True,
+        brush=(0, 0, 255, 150),
+    )
+
+    pdi.setLogMode(False, True)
+
+    segment_lengths = []
+    build_fill_paths = pdi.curve._construct_finite_segment_FillPathList
+
+    def record_fill_segment(x, y, baseline, chunksize):
+        segment_lengths.append(len(x))
+        return build_fill_paths(x, y, baseline, chunksize)
+
+    monkeypatch.setattr(
+        pdi.curve,
+        "_construct_finite_segment_FillPathList",
+        record_fill_segment,
+    )
+
+    assert pdi.curve.opts["connect"] == "all"
+    assert pdi.curve.opts["skipFiniteCheck"] is False
+    pdi.curve._getFillPathList(None)
+    assert len(segment_lengths) == 1
+
 def test_opts():
     # test that curve and scatter plot properties get updated from PlotDataItem methods
     y = list(np.random.normal(size=100))


### PR DESCRIPTION
## Summary
- keep filled `PlotDataItem` curves continuous when `connect="auto"` and log mode creates non-finite points
- add a seeded histogram regression for filled center-step plots in log Y mode

Fixes #2312.

## Tests
- `QT_QPA_PLATFORM=minimal .venv/bin/pytest tests/graphicsItems/test_PlotDataItem.py::test_filled_log_plot_auto_connects_across_nonfinite_values -q`
- `QT_QPA_PLATFORM=minimal .venv/bin/pytest tests/graphicsItems/test_PlotDataItem.py -q`
- `QT_QPA_PLATFORM=minimal .venv/bin/pytest tests/graphicsItems/test_PlotCurveItem.py -q`
- `QT_QPA_PLATFORM=minimal .venv/bin/pytest tests/graphicsItems -q`
- `.venv/bin/python -m compileall pyqtgraph/graphicsItems/PlotDataItem.py tests/graphicsItems/test_PlotDataItem.py`
- `git diff --check`