### PR TITLE
Update legend labels from plot item names

### DIFF
--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -73,6 +73,7 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
 
         self.setLayout(self.layout)
         self.items = []
+        self._labelUpdateSlots = {}
         self.size = size
         self.offset = offset
         self.frame = frame
@@ -224,8 +225,32 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         sample.sigClicked.connect(self.sigSampleClicked)
 
         self.items.append((sample, label))
+        self._connectLabelToPlotItem(sample.item, label)
         self._addItemToLayout(sample, label)
         self.updateSize()
+
+    def _connectLabelToPlotItem(self, plotItem, label):
+        item_name = getattr(plotItem, 'name', None)
+        if not hasattr(plotItem, 'sigPlotChanged') or not callable(item_name):
+            return
+
+        def updateLabel(*_):
+            label.setText(item_name())
+            self.updateSize()
+
+        plotItem.sigPlotChanged.connect(updateLabel)
+        self._labelUpdateSlots[label] = (plotItem, updateLabel)
+
+    def _disconnectLabelFromPlotItem(self, label):
+        label_update = self._labelUpdateSlots.pop(label, None)
+        if label_update is None:
+            return
+
+        plotItem, updateLabel = label_update
+        try:
+            plotItem.sigPlotChanged.disconnect(updateLabel)
+        except (TypeError, RuntimeError):
+            pass
 
     def _addItemToLayout(self, sample, label):
         col = self.layout.columnCount()
@@ -296,6 +321,7 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         for sample, label in self.items:
             if sample.item is item or label.text == item:
                 self.items.remove((sample, label))  # remove from itemlist
+                self._disconnectLabelFromPlotItem(label)
                 self._removeItemFromLayout(sample, label)
                 self.updateSize()  # redraw box
                 return  # return after first match
@@ -303,6 +329,7 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
     def clear(self):
         """Remove all items from the legend."""
         for sample, label in self.items:
+            self._disconnectLabelFromPlotItem(label)
             self._removeItemFromLayout(sample, label)
 
         self.items = []
@@ -408,4 +435,3 @@ class ItemSample(GraphicsWidget):
         event.accept()
         self.update()
         self.sigClicked.emit(self.item)
-

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -250,6 +250,7 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         try:
             plotItem.sigPlotChanged.disconnect(updateLabel)
         except (TypeError, RuntimeError):
+            # The signal can already be disconnected when Qt tears items down.
             pass
 
     def _addItemToLayout(self, sample, label):

--- a/tests/graphicsItems/test_LegendItem.py
+++ b/tests/graphicsItems/test_LegendItem.py
@@ -101,3 +101,28 @@ def test_legend_item_basics():
 
     legend.clear()
     assert legend.items == []
+
+
+def test_legend_label_updates_from_plot_data_item_name():
+
+    legend = pg.LegendItem()
+    first = pg.PlotDataItem([1, 2, 3], name="First")
+    second = pg.PlotDataItem([3, 2, 1], name="Second")
+
+    legend.addItem(first, name="First")
+    legend.addItem(second, name="Second")
+
+    first_label = legend.getLabel(first)
+    second_label = legend.getLabel(second)
+
+    first.setData([4, 5, 6], name="Renamed")
+
+    assert first_label.text == "Renamed"
+    assert second_label.text == "Second"
+    assert legend.items[0][1] is first_label
+    assert legend.items[1][1] is second_label
+
+    legend.removeItem(first)
+    first.setData([7, 8, 9], name="Removed")
+
+    assert first_label.text == "Renamed"


### PR DESCRIPTION
## Summary
- keep `LegendItem` labels in sync when a plot item's `name` changes through `setData`
- disconnect the label update slot when entries are removed or cleared
- add a regression test covering label updates, entry order, and removal cleanup

Fixes #1000

## Testing
- `/Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m mypy`
- `/Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests/graphicsItems/test_LegendItem.py tests/graphicsItems/test_PlotDataItem.py -vv`
- `/Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests/graphicsItems -vv`
- `/Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests -q`
- `/tmp/pyqtgraph-legend-pyqt6-venv/bin/python -m pytest pyqtgraph/examples -q -n 2`
