### PR TITLE
Fix AxisItem tick level and negative offset handling

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -620,6 +620,7 @@ class AxisItem(GraphicsWidget):
         else:
             h = self.fixedHeight
 
+        h = max(0, h)
         self.setMaximumHeight(h)
         self.setMinimumHeight(h)
         self.picture = None
@@ -656,6 +657,7 @@ class AxisItem(GraphicsWidget):
         else:
             w = self.fixedWidth
 
+        w = max(0, w)
         self.setMaximumWidth(w)
         self.setMinimumWidth(w)
         self.picture = None
@@ -1527,9 +1529,11 @@ class AxisItem(GraphicsWidget):
         ## compute coordinates to draw ticks
         ## draw three different intervals, long ticks first
         tickSpecs = []
+        drawnTickPositions = []
         for i in range(len(tickLevels)):
             tickPositions.append([])
             ticks = tickLevels[i][1]
+            drawLevel = i <= self.style['maxTickLevel']
 
             ## length of tick
             tickLength = self.style['tickLength'] / ((i*0.5)+1.0)
@@ -1569,20 +1573,22 @@ class AxisItem(GraphicsWidget):
                 p2[axis] = tickStop
                 if self.grid is False:
                     p2[axis] += tickLength*tickDir
-                tickSpecs.append((tickPen, Point(p1), Point(p2)))
+                if drawLevel:
+                    drawnTickPositions.append(x)
+                    tickSpecs.append((tickPen, Point(p1), Point(p2)))
         profiler('compute ticks')
 
 
-        if self.style['stopAxisAtTick'][0] is True:
-            minTickPosition = min(map(min, tickPositions))
+        if self.style['stopAxisAtTick'][0] is True and drawnTickPositions:
+            minTickPosition = min(drawnTickPositions)
             if axis == 0:
                 stop = max(span[0].y(), minTickPosition)
                 span[0].setY(stop)
             else:
                 stop = max(span[0].x(), minTickPosition)
                 span[0].setX(stop)
-        if self.style['stopAxisAtTick'][1] is True:
-            maxTickPosition = max(map(max, tickPositions))
+        if self.style['stopAxisAtTick'][1] is True and drawnTickPositions:
+            maxTickPosition = max(drawnTickPositions)
             if axis == 0:
                 stop = min(span[1].y(), maxTickPosition)
                 span[1].setY(stop)

--- a/tests/graphicsItems/test_AxisItem.py
+++ b/tests/graphicsItems/test_AxisItem.py
@@ -143,6 +143,51 @@ def test_AxisItem_tickFont(monkeypatch):
     plot.close()
 
 
+def test_AxisItem_maxTickLevel_limits_explicit_tick_lines(monkeypatch):
+    def check_ticks(p, axisSpec, tickSpecs, textSpecs):
+        viewPixelSize = view.viewPixelSize()
+        assert len(tickSpecs) == 2
+        assert isclose(
+            view.mapToView(axisSpec[1]).x(), 0.25, abs_tol=viewPixelSize[0]
+        )
+        assert isclose(
+            view.mapToView(axisSpec[2]).x(), 0.75, abs_tol=viewPixelSize[0]
+        )
+        assert "minor" in {spec[2] for spec in textSpecs}
+
+    plot = pg.PlotWidget()
+    view = plot.plotItem.getViewBox()
+    plot.resize(500, 300)
+    bottom = plot.getAxis("bottom")
+    bottom.setRange(0, 1)
+    bottom.setTicks([
+        [(0.25, "major-a"), (0.75, "major-b")],
+        [(0.1, "minor")],
+    ])
+    bottom.setStyle(maxTickLevel=0, maxTextLevel=1, stopAxisAtTick=(True, True))
+    monkeypatch.setattr(bottom, "drawPicture", check_ticks)
+
+    plot.show()
+    app.processEvents()
+    plot.close()
+
+
+@pytest.mark.parametrize(
+    "orientation, dimension_getter",
+    [
+        ("top", lambda axis: (axis.minimumHeight(), axis.maximumHeight())),
+        ("left", lambda axis: (axis.minimumWidth(), axis.maximumWidth())),
+    ],
+)
+def test_AxisItem_negative_text_offset_keeps_fixed_axis_space(
+    orientation, dimension_getter
+):
+    axis = pg.AxisItem(orientation, maxTickLength=-40)
+    axis.setStyle(tickTextOffset=-40)
+
+    assert dimension_getter(axis) == (0, 0)
+
+
 @pytest.mark.parametrize('orientation,label_kwargs,labelText,labelUnits', [
     ('left', {}, '', '',),
     ('left', dict(text='Position', units='mm'), 'Position', 'mm'),


### PR DESCRIPTION
## Summary
- Honor `maxTickLevel` when explicit `setTicks()` levels are supplied, while keeping label rendering under `maxTextLevel`.
- Clamp computed `AxisItem` width and height at zero so negative `tickTextOffset` values keep the axis constrained instead of letting Qt expand the layout.
- Keep `stopAxisAtTick` endpoints tied to the tick levels that draw lines.

Fixes #3386

## Tests
- `/Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests/graphicsItems/test_AxisItem.py -q`
- `/Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests/graphicsItems -q`
- `/Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests -q`