### PR TITLE
Restore GroupParameter getValues compatibility

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes/basetypes.py
+++ b/pyqtgraph/parametertree/parameterTypes/basetypes.py
@@ -441,6 +441,11 @@ class GroupParameter(Parameter):
 
     sigAddNew = QtCore.Signal(object, object)  # self, type
 
+    def value(self):
+        if not self.hasValue():
+            return None
+        return super().value()
+
     def addNew(self, typ=None):
         """
         This method is called when the user has requested to add a new item to the group.

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -140,6 +140,41 @@ def test_unpack_parameter():
     assert result["c"] == 3.0
 
 
+def test_get_values_nested_group_without_value():
+    children = [
+        Parameter.create(name=f"Child {child}", type="float", value=0.0)
+        for child in "abc"
+    ]
+    group = Parameter.create(name="New Group", type="group", children=children)
+    upper_group = Parameter.create(
+        name="Upper Group",
+        type="group",
+        children=[group],
+    )
+
+    assert group.hasValue() is False
+    assert group.value() is None
+    assert upper_group.getValues()["New Group"] == (
+        None,
+        {
+            "Child a": (0.0, {}),
+            "Child b": (0.0, {}),
+            "Child c": (0.0, {}),
+        },
+    )
+
+
+def test_get_values_raises_for_child_without_value():
+    parent = Parameter.create(
+        name="parent",
+        type="group",
+        children=[dict(name="child", type="float")],
+    )
+
+    with pytest.raises(ValueError, match="No Value has been set"):
+        parent.getValues()
+
+
 def test_interact():
     interactor = Interactor(runOptions=RunOptions.ON_ACTION)
     value = None


### PR DESCRIPTION
## Summary
- Return `None` from value-less `GroupParameter` instances so nested `getValues()` calls keep their previous group entry form.
- Keep value-less non-group children strict with a regression test that still raises `ValueError`.

Fixes #3378

## Tests
- `PYTHONPATH=$PWD /Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests/parametertree/test_Parameter.py -q`
- `PYTHONPATH=$PWD /Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests/parametertree -q`
- `PYTHONPATH=$PWD /Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests -q`