### PR TITLE
Handle BarGraphItem log mode

### DIFF
--- a/pyqtgraph/graphicsItems/BarGraphItem.py
+++ b/pyqtgraph/graphicsItems/BarGraphItem.py
@@ -57,6 +57,8 @@ class BarGraphItem(GraphicsObject):
         # the first call to _updateColors() will thus always be an update
 
         self._rectarray = Qt.internals.PrimitiveArray(QtCore.QRectF, 4)
+        self._rectIndices = np.array([], dtype=int)
+        self._logMode = [False, False]
         self._shape = None
         self.picture = None
         self.setOpts(**opts)
@@ -188,18 +190,56 @@ class BarGraphItem(GraphicsObject):
         if x0.size == 0 or y0.size == 0:
             self._dataBounds = (None, None), (None, None)
             self._rectarray.resize(0)
+            self._rectIndices = np.array([], dtype=int)
+            return
+
+        x0, y0, x1, y1 = np.broadcast_arrays(x0, y0, x1, y1)
+
+        if self._logMode[0]:
+            x0, x1 = self._mapLog(x0, x1)
+        if self._logMode[1]:
+            y0, y1 = self._mapLog(y0, y1)
+
+        valid = (
+            np.isfinite(x0) &
+            np.isfinite(x1) &
+            np.isfinite(y0) &
+            np.isfinite(y1)
+        )
+        if not valid.all():
+            self._rectIndices = np.nonzero(valid)[0]
+            x0 = x0[valid]
+            y0 = y0[valid]
+            x1 = x1[valid]
+            y1 = y1[valid]
+        else:
+            self._rectIndices = np.arange(x0.size)
+
+        if x0.size == 0:
+            self._dataBounds = (None, None), (None, None)
+            self._rectarray.resize(0)
             return
 
         xmn, xmx = np.min(x0), np.max(x1)
         ymn, ymx = np.min(y0), np.max(y1)
         self._dataBounds = (xmn, xmx), (ymn, ymx)
 
-        self._rectarray.resize(max(x0.size, y0.size))
+        self._rectarray.resize(x0.size)
         memory = self._rectarray.ndarray()
         memory[:, 0] = x0
         memory[:, 1] = y0
         memory[:, 2] = x1 - x0
         memory[:, 3] = y1 - y0
+
+    @staticmethod
+    def _mapLog(*coords):
+        mapped = []
+        with np.errstate(divide='ignore', invalid='ignore'):
+            for coord in coords:
+                coord = np.log10(coord)
+                coord = np.where(np.isfinite(coord), coord, np.nan)
+                mapped.append(coord)
+        return mapped
 
     def _render(self, painter):
         multi_pen = self._pens is not None
@@ -212,7 +252,7 @@ class BarGraphItem(GraphicsObject):
         rects = self._rectarray.instances()
 
         if no_pen and multi_brush:
-            for idx, rect in enumerate(rects):
+            for idx, rect in zip(self._rectIndices, rects):
                 painter.fillRect(rect, self._brushes[idx])
         else:
             if not multi_pen:
@@ -220,13 +260,20 @@ class BarGraphItem(GraphicsObject):
             if not multi_brush:
                 painter.setBrush(self._sharedBrush)
 
-            for idx, rect in enumerate(rects):
+            for idx, rect in zip(self._rectIndices, rects):
                 if multi_pen:
                     painter.setPen(self._pens[idx])
                 if multi_brush:
                     painter.setBrush(self._brushes[idx])
 
                 painter.drawRect(rect)
+
+    def setLogMode(self, xState: bool, yState: bool):
+        logMode = [bool(xState), bool(yState)]
+        if self._logMode == logMode:
+            return
+        self._logMode = logMode
+        self.setOpts()
 
     def drawPicture(self):
         self.picture = QtGui.QPicture()

--- a/tests/graphicsItems/test_BarGraphItem.py
+++ b/tests/graphicsItems/test_BarGraphItem.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+import pyqtgraph as pg
+
+pg.mkQApp()
+
+
+def test_log_mode_maps_bar_edges():
+    bar = pg.BarGraphItem(
+        x=[1, 2, 3],
+        y0=[0.1, 0.1, 0.1],
+        y1=[1, 10, 100],
+        width=1,
+    )
+
+    assert bar.dataBounds(1) == (0.1, 100)
+
+    bar.setLogMode(False, True)
+
+    np.testing.assert_allclose(bar.dataBounds(1), (-1, 2))
+    rects = bar._rectarray.ndarray()
+    np.testing.assert_allclose(rects[:, 1], [-1, -1, -1])
+    np.testing.assert_allclose(rects[:, 3], [1, 2, 3])
+
+
+@pytest.mark.qt_log_ignore("Populating font family aliases took .*")
+def test_plotitem_applies_log_mode_to_bar_graph_item():
+    plot = pg.PlotItem()
+    plot.setLogMode(y=True)
+    bar = pg.BarGraphItem(x=[1], y0=[1], y1=[10], width=1)
+
+    plot.addItem(bar)
+
+    assert bar.dataBounds(1) == (0, 1)
+
+
+def test_log_mode_skips_bars_with_non_positive_edges():
+    bar = pg.BarGraphItem(
+        x=[1, 2],
+        y0=[0, 1],
+        y1=[10, 100],
+        width=1,
+        brushes=["r", "g"],
+    )
+
+    bar.setLogMode(False, True)
+
+    assert bar._rectIndices.tolist() == [1]
+    np.testing.assert_allclose(bar.dataBounds(1), (0, 2))


### PR DESCRIPTION
## Summary
- Add `BarGraphItem.setLogMode()` so PlotItem log mode maps bar rectangle edges before drawing and bounds calculation.
- Drop bars with non-positive mapped edges, keeping per-bar pens and brushes aligned.
- Add regression coverage for direct bar log mode and PlotItem forwarding.

Fixes #2535

## Tests
- `PYTHONPATH=$PWD /Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests/graphicsItems/test_BarGraphItem.py -q`
- `PYTHONPATH=$PWD /Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests/graphicsItems -q`
- `PYTHONPATH=$PWD /Users/terry/Documents/gitproof/contrib/pyqtgraph/.venv/bin/python -m pytest tests -q`
