### PR TITLE
Fix auto-range with view limits

### DIFF
--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -719,12 +719,31 @@ class ViewBox(GraphicsWidget):
         ==============  =============================================================
         """
         if item is None:
-            bounds = self.childrenBoundingRect(items=items)
+            childRange = self.childrenBounds(items=items)
         else:
             bounds = self.mapFromItemToView(item, item.boundingRect()).boundingRect()
+            childRange = [
+                [bounds.left(), bounds.right()],
+                [bounds.top(), bounds.bottom()],
+            ]
 
-        if bounds is not None:
-            self.setRange(bounds, padding=padding)
+        if childRange is not None:
+            targetRange = self.targetRange()
+            for ax in (0, 1):
+                if childRange[ax] is None:
+                    childRange[ax] = targetRange[ax]
+                childRange[ax] = self._clipRangeToLimits(ax, childRange[ax])
+                axisPadding = self.suggestPadding(ax) if padding is None else padding
+                axisPad = (childRange[ax][1] - childRange[ax][0]) * axisPadding
+                childRange[ax][0] -= axisPad
+                childRange[ax][1] += axisPad
+                childRange[ax] = self._clipRangeToLimits(ax, childRange[ax])
+
+            self.setRange(
+                xRange=childRange[0],
+                yRange=childRange[1],
+                padding=0.0,
+            )
 
     def suggestPadding(self, axis):
         l = self.width() if axis==0 else self.height()
@@ -737,6 +756,17 @@ class ViewBox(GraphicsWidget):
         else:
             padding = def_pad
         return padding
+
+    def _clipRangeToLimits(self, axis, range):
+        range = list(range)
+        mn, mx = self._effectiveLimits()[axis]
+        if mn is not None:
+            range[0] = max(range[0], mn)
+            range[1] = max(range[1], mn)
+        if mx is not None:
+            range[0] = min(range[0], mx)
+            range[1] = min(range[1], mx)
+        return range
 
     def setLimits(self, **kwds):
         """
@@ -783,7 +813,10 @@ class ViewBox(GraphicsWidget):
                     update = True
 
         if update:
-            self.updateViewRange()
+            if any(self.state['autoRange']):
+                self.updateAutoRange()
+            else:
+                self.updateViewRange()
 
     def scaleBy(self, s=None, center=None, x=None, y=None):
         """
@@ -967,6 +1000,7 @@ class ViewBox(GraphicsWidget):
                 ## Make corrections to range
                 xr = childRange[ax]
                 if xr is not None:
+                    xr = self._clipRangeToLimits(ax, xr)
                     if self.state['autoPan'][ax]:
                         x = sum(xr) * 0.5
                         w2 = (targetRect[ax][1]-targetRect[ax][0]) / 2.
@@ -976,6 +1010,7 @@ class ViewBox(GraphicsWidget):
                         wp = (xr[1] - xr[0]) * padding
                         childRange[ax][0] -= wp
                         childRange[ax][1] += wp
+                        childRange[ax] = self._clipRangeToLimits(ax, childRange[ax])
                     targetRect[ax] = childRange[ax]
                     args['xRange' if ax == 0 else 'yRange'] = targetRect[ax]
 

--- a/tests/graphicsItems/ViewBox/test_ViewBox.py
+++ b/tests/graphicsItems/ViewBox/test_ViewBox.py
@@ -1,4 +1,5 @@
 #import PySide
+import numpy as np
 import pytest
 
 import pyqtgraph as pg
@@ -81,6 +82,23 @@ def test_ViewBox_setMenuEnabled():
     assert vb.menu is not None
     vb.setMenuEnabled(False)
     assert vb.menu is None
+
+
+def test_auto_range_intersects_limits():
+    win = pg.PlotWidget()
+    win.resize(400, 400)
+    win.show()
+    win.plot(np.linspace(-2000, 200, 10000))
+    qtest.qWaitForWindowExposed(win)
+    app.processEvents()
+
+    win.setLimits(yMin=0)
+    app.processEvents()
+
+    yRange = win.viewRange()[1]
+    assert yRange[0] == 0
+    assert 200 < yRange[1] < 300
+    win.close()
 
 
 


### PR DESCRIPTION
## Summary
- clamp auto-range child bounds to `ViewBox` limits before applying padding
- re-run auto-range when limits change while auto-range is active
- add regression coverage for `setLimits(yMin=0)` after plotting data that extends below the limit

Fixes #276.

## Tests
- `python -m pytest -q tests/graphicsItems/ViewBox/test_ViewBox.py tests/graphicsItems/ViewBox/test_ViewBoxZoom.py`
- `python -m pytest -q tests/graphicsItems/test_PlotDataItem.py`
- `python -m pytest -q tests`
- `python -m pytest -q pyqtgraph/examples -k 'not DateAxisItem_QtDesigner and not designerExample'`

The unfiltered examples run also passed 194 examples and 6 skips, then stopped on the two PySide6 Designer examples because `pyside6-uic` is not available locally.