### PR TITLE
Clip oblique InfiniteLine painting to the ViewBox

### DIFF
--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -295,6 +295,46 @@ class InfiniteLine(GraphicsObject):
             self.span = (mn, mx)
             self.update()
 
+    def _visibleLineBounds(self):
+        if self.angle % 90 == 0:
+            return None
+
+        view = self.getViewBox()
+        if view is None:
+            return None
+
+        viewRect = view.boundingRect()
+        if viewRect.isEmpty():
+            return None
+
+        corners = (
+            viewRect.topLeft(),
+            viewRect.topRight(),
+            viewRect.bottomRight(),
+            viewRect.bottomLeft(),
+        )
+        points = [self.mapFromItem(view, point) for point in corners]
+        intersections = []
+
+        for p1, p2 in zip(points, points[1:] + points[:1]):
+            y1 = p1.y()
+            y2 = p2.y()
+
+            if y1 == 0 and y2 == 0:
+                intersections.extend([p1.x(), p2.x()])
+                continue
+
+            if (y1 <= 0 <= y2) or (y2 <= 0 <= y1):
+                if y1 == y2:
+                    continue
+                ratio = -y1 / (y2 - y1)
+                intersections.append(p1.x() + ratio * (p2.x() - p1.x()))
+
+        if len(intersections) < 2:
+            return None
+
+        return min(intersections), max(intersections)
+
     def _computeBoundingRect(self):
         #br = UIGraphicsItem.boundingRect(self)
         vr = self.viewRect()  # bounds of containing ViewBox mapped to local coords.
@@ -311,6 +351,12 @@ class InfiniteLine(GraphicsObject):
         br = QtCore.QRectF(vr)
         br.setBottom(-w)
         br.setTop(w)
+
+        bounds = self._visibleLineBounds()
+        if bounds is not None:
+            left, right = bounds
+            br.setLeft(left)
+            br.setRight(right)
 
         length = br.width()
         left = br.left() + length * self.span[0]

--- a/tests/graphicsItems/test_InfiniteLine.py
+++ b/tests/graphicsItems/test_InfiniteLine.py
@@ -51,6 +51,34 @@ def test_InfiniteLine():
     assert not br.containsPoint(pos + 3 * px, QtCore.Qt.FillRule.OddEvenFill)
     plt.close()
 
+
+def test_oblique_infinite_line_clips_to_viewbox():
+    plt = pg.PlotWidget()
+    plt.resize(800, 600)
+    plt.show()
+
+    plot = plt.getPlotItem()
+    plot.plot(x=[0, 1], y=[0, 1e8], pen="r")
+    line = pg.InfiniteLine(
+        pos=pg.Point(0, 0),
+        angle=45,
+        pen=pg.mkPen("r", width=2, style=QtCore.Qt.PenStyle.DashLine),
+    )
+    plot.addItem(line)
+
+    QtTest.QTest.qWaitForWindowExposed(plt)
+    QtTest.QTest.qWait(100)
+
+    line.boundingRect()
+    left, right = line._endPoints
+    viewbox = plot.vb
+    viewRect = viewbox.boundingRect().adjusted(-1, -1, 1, 1)
+
+    assert viewRect.contains(line.mapToItem(viewbox, pg.Point(left, 0)))
+    assert viewRect.contains(line.mapToItem(viewbox, pg.Point(right, 0)))
+    plt.close()
+
+
 def test_mouseInteraction():
     # disable delay of mouse move events because events is called immediately in test
     pg.setConfigOption('mouseRateLimit', -1)


### PR DESCRIPTION
Fixes #1089.

## Summary
- Clip oblique `InfiniteLine` drawing bounds to the visible `ViewBox` intersection before applying `span`.
- This keeps dashed lines with extreme axis-range ratios from sending huge off-screen endpoints to Qt's painter.
- Add regression coverage for the large-range dashed-line case.

## Tests
- `PYTHONPATH=. python -m pytest tests/graphicsItems/test_InfiniteLine.py -q`
- `PYTHONPATH=. python -m pytest tests/graphicsItems/test_InfiniteLine.py tests/graphicsItems/PlotItem/test_PlotItem.py tests/graphicsItems/ViewBox/test_ViewBox.py -q`
- `PYTHONPATH=. python -m pytest tests/graphicsItems -q`
- `PYTHONPATH=. python -m pytest tests -q`
- `git diff --check`