### PR TITLE
Support callable action parameter values

### DIFF
--- a/pyqtgraph/parametertree/parameterTypes/action.py
+++ b/pyqtgraph/parametertree/parameterTypes/action.py
@@ -18,6 +18,7 @@ class ParameterControlledButton(QtWidgets.QPushButton):
         self.clicked.connect(parameter.activate)
         self.updateOpts(parameter, parameter.opts)
 
+    @QtCore.Slot(object, object)
     def updateOpts(self, param, opts):
         # Of the attributes that can be set on a QPushButton, only the text
         # and tooltip attributes are different from standard pushbutton names
@@ -41,6 +42,7 @@ class ParameterControlledButton(QtWidgets.QPushButton):
             setter = getattr(self, f"set{capitalized}")
             setter(opts[attr])
 
+    @QtCore.Slot(object, object)
     def onNameChange(self, param, name):
         self.updateOpts(param, dict(title=param.title()))
 
@@ -105,6 +107,7 @@ class ActionParameter(Parameter):
 
         return value
 
+    @QtCore.Slot()
     def activate(self):
         self.sigActivated.emit(self)
         self.emitStateChanged('activated', None)

--- a/pyqtgraph/parametertree/parameterTypes/action.py
+++ b/pyqtgraph/parametertree/parameterTypes/action.py
@@ -1,3 +1,4 @@
+from ... import functions as fn
 from ...Qt import QtCore, QtWidgets, QtGui
 from ..Parameter import Parameter
 from ..ParameterItem import ParameterItem
@@ -90,6 +91,19 @@ class ActionParameter(Parameter):
     """
     itemClass = ActionParameterItem
     sigActivated = QtCore.Signal(object)
+
+    def setValue(self, value, blockSignal=None):
+        old_value = self.opts.get('value', None)
+        if callable(old_value):
+            fn.disconnect(self.sigActivated, old_value)
+
+        value = super().setValue(value, blockSignal=blockSignal)
+
+        new_value = self.opts.get('value', None)
+        if callable(new_value):
+            self.sigActivated.connect(new_value)
+
+        return value
 
     def activate(self):
         self.sigActivated.emit(self)

--- a/tests/parametertree/test_parametertypes.py
+++ b/tests/parametertree/test_parametertypes.py
@@ -38,6 +38,54 @@ def test_opts():
     assert _getWidget(param.param('bool')).isEnabled() is False
 
 
+def test_action_parameter_value_callable_activates(qtbot):
+    callback = MagicMock()
+    param = pt.Parameter.create(name='run', type='action', value=callback)
+
+    with qtbot.waitSignal(param.sigActivated, timeout=1000):
+        param.activate()
+
+    callback.assert_called_once_with(param)
+
+
+def test_action_parameter_value_callable_replacement(qtbot):
+    first_callback = MagicMock()
+    second_callback = MagicMock()
+    param = pt.Parameter.create(name='run', type='action', value=first_callback)
+
+    assert param.setValue(first_callback) is first_callback
+    with qtbot.waitSignal(param.sigActivated, timeout=1000):
+        param.activate()
+    first_callback.assert_called_once_with(param)
+
+    assert param.setValue(second_callback) is second_callback
+    with qtbot.waitSignal(param.sigActivated, timeout=1000):
+        param.activate()
+
+    first_callback.assert_called_once_with(param)
+    second_callback.assert_called_once_with(param)
+
+    assert param.setValue(None) is None
+    with qtbot.waitSignal(param.sigActivated, timeout=1000):
+        param.activate()
+
+    second_callback.assert_called_once_with(param)
+
+
+@pytest.mark.qt_log_ignore("Registering dynamic slot")
+def test_action_parameter_value_callable_button_click(qtbot):
+    callback = MagicMock()
+    param = pt.Parameter.create(name='run', type='action', value=callback)
+    tree = pt.ParameterTree()
+    tree.setParameters(param)
+
+    item = next(iter(param.items.keys()))
+    with qtbot.waitSignal(param.sigActivated, timeout=1000):
+        item.button.click()
+
+    callback.assert_called_once_with(param)
+
+
 def test_types():
     paramSpec = [
         dict(name='float', type='float'),


### PR DESCRIPTION
## Summary
- connect callable `ActionParameter` values to `sigActivated`
- replace the signal connection when the value changes, and clear it for non-callable values
- add coverage for direct activation, replacing and removing callables, duplicate connection prevention, and button clicks

## Tests
- `python -m pytest tests/parametertree/test_parametertypes.py -q`
- `python -m pytest tests/parametertree -q`
- `PYQTGRAPH_QT_LIB=PySide6 python -m pytest tests/parametertree -q`
- `python -m pytest tests -q`
- `git diff --check`

Fixes #1421
