### PR TITLE
Fix VerticalLabel sizing with stylesheet margins

### DIFF
--- a/pyqtgraph/widgets/VerticalLabel.py
+++ b/pyqtgraph/widgets/VerticalLabel.py
@@ -31,6 +31,10 @@ class VerticalLabel(QtWidgets.QLabel):
         self.orientation = o
         self.update()
         self.updateGeometry()
+
+    def _textSize(self):
+        metrics = self.fontMetrics()
+        return QtCore.QSize(metrics.horizontalAdvance(self.text()), metrics.height())
         
     def paintEvent(self, ev):
         p = QtGui.QPainter(self)
@@ -40,43 +44,58 @@ class VerticalLabel(QtWidgets.QLabel):
         
         #p.setPen(QtGui.QPen(QtGui.QColor(255, 255, 255)))
         
+        contents = self.contentsRect()
         if self.orientation == 'vertical':
             p.rotate(-90)
-            rgn = QtCore.QRect(-self.height(), 0, self.height(), self.width())
+            rgn = QtCore.QRect(
+                -contents.y() - contents.height(),
+                contents.x(),
+                contents.height(),
+                contents.width()
+            )
         else:
-            rgn = self.contentsRect()
+            rgn = contents
         align = self.alignment()
         #align  = QtCore.Qt.AlignmentFlag.AlignTop|QtCore.Qt.AlignmentFlag.AlignHCenter
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            self.hint = p.drawText(rgn, align, self.text())
+            p.drawText(rgn, align, self.text())
+        self.hint = self._textSize()
         p.end()
+
+        margins = self.contentsMargins()
+        textWidth = self.hint.width()
+        textHeight = self.hint.height()
+        paddedWidth = textWidth + margins.left() + margins.right()
+        paddedHeight = textHeight + margins.top() + margins.bottom()
         
         if self.orientation == 'vertical':
-            self.setMaximumWidth(self.hint.height())
+            self.setMaximumWidth(textHeight + margins.left() + margins.right())
             self.setMinimumWidth(0)
             self.setMaximumHeight(16777215)
             if self.forceWidth:
-                self.setMinimumHeight(self.hint.width())
+                self.setMinimumHeight(textWidth + margins.top() + margins.bottom())
             else:
                 self.setMinimumHeight(0)
         else:
-            self.setMaximumHeight(self.hint.height())
+            self.setMaximumHeight(paddedHeight)
             self.setMinimumHeight(0)
             self.setMaximumWidth(16777215)
             if self.forceWidth:
-                self.setMinimumWidth(self.hint.width())
+                self.setMinimumWidth(paddedWidth)
             else:
                 self.setMinimumWidth(0)
 
     def sizeHint(self):
+        margins = self.contentsMargins()
+        hint = self._textSize()
         if self.orientation == 'vertical':
-            if hasattr(self, 'hint'):
-                return QtCore.QSize(self.hint.height(), self.hint.width())
-            else:
-                return QtCore.QSize(19, 50)
+            return QtCore.QSize(
+                hint.height() + margins.left() + margins.right(),
+                hint.width() + margins.top() + margins.bottom()
+            )
         else:
-            if hasattr(self, 'hint'):
-                return QtCore.QSize(self.hint.width(), self.hint.height())
-            else:
-                return QtCore.QSize(50, 19)
+            return QtCore.QSize(
+                hint.width() + margins.left() + margins.right(),
+                hint.height() + margins.top() + margins.bottom()
+            )

--- a/pyqtgraph/widgets/VerticalLabel.py
+++ b/pyqtgraph/widgets/VerticalLabel.py
@@ -35,6 +35,21 @@ class VerticalLabel(QtWidgets.QLabel):
     def _textSize(self):
         metrics = self.fontMetrics()
         return QtCore.QSize(metrics.horizontalAdvance(self.text()), metrics.height())
+
+    def _paddedTextSize(self, textSize=None):
+        if textSize is None:
+            textSize = self._textSize()
+
+        margins = self.contentsMargins()
+        if self.orientation == 'vertical':
+            return QtCore.QSize(
+                textSize.height() + margins.left() + margins.right(),
+                textSize.width() + margins.top() + margins.bottom()
+            )
+        return QtCore.QSize(
+            textSize.width() + margins.left() + margins.right(),
+            textSize.height() + margins.top() + margins.bottom()
+        )
         
     def paintEvent(self, ev):
         p = QtGui.QPainter(self)
@@ -63,39 +78,24 @@ class VerticalLabel(QtWidgets.QLabel):
         self.hint = self._textSize()
         p.end()
 
-        margins = self.contentsMargins()
-        textWidth = self.hint.width()
-        textHeight = self.hint.height()
-        paddedWidth = textWidth + margins.left() + margins.right()
-        paddedHeight = textHeight + margins.top() + margins.bottom()
+        paddedSize = self._paddedTextSize(self.hint)
         
         if self.orientation == 'vertical':
-            self.setMaximumWidth(textHeight + margins.left() + margins.right())
+            self.setMaximumWidth(paddedSize.width())
             self.setMinimumWidth(0)
             self.setMaximumHeight(16777215)
             if self.forceWidth:
-                self.setMinimumHeight(textWidth + margins.top() + margins.bottom())
+                self.setMinimumHeight(paddedSize.height())
             else:
                 self.setMinimumHeight(0)
         else:
-            self.setMaximumHeight(paddedHeight)
+            self.setMaximumHeight(paddedSize.height())
             self.setMinimumHeight(0)
             self.setMaximumWidth(16777215)
             if self.forceWidth:
-                self.setMinimumWidth(paddedWidth)
+                self.setMinimumWidth(paddedSize.width())
             else:
                 self.setMinimumWidth(0)
 
     def sizeHint(self):
-        margins = self.contentsMargins()
-        hint = self._textSize()
-        if self.orientation == 'vertical':
-            return QtCore.QSize(
-                hint.height() + margins.left() + margins.right(),
-                hint.width() + margins.top() + margins.bottom()
-            )
-        else:
-            return QtCore.QSize(
-                hint.width() + margins.left() + margins.right(),
-                hint.height() + margins.top() + margins.bottom()
-            )
+        return self._paddedTextSize()

--- a/tests/widgets/test_verticallabel.py
+++ b/tests/widgets/test_verticallabel.py
@@ -1,0 +1,48 @@
+import pytest
+
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtCore, QtGui
+from pyqtgraph.widgets.VerticalLabel import VerticalLabel
+
+
+pg.mkQApp()
+
+
+@pytest.mark.parametrize("orientation", ["horizontal", "vertical"])
+def test_size_hint_includes_stylesheet_contents_margins(orientation):
+    label = VerticalLabel("Dock", orientation=orientation)
+    label.setStyleSheet("""
+        QLabel {
+            padding-left: 4px;
+            padding-right: 6px;
+            padding-top: 3px;
+            padding-bottom: 5px;
+        }
+    """)
+    label.resize(label.sizeHint())
+    image = QtGui.QImage(label.size(), QtGui.QImage.Format.Format_ARGB32)
+    image.fill(0)
+    label.render(image)
+
+    margins = label.contentsMargins()
+    textSize = QtCore.QSize(
+        label.fontMetrics().horizontalAdvance(label.text()),
+        label.fontMetrics().height()
+    )
+
+    if orientation == "vertical":
+        expected = QtCore.QSize(
+            textSize.height() + margins.left() + margins.right(),
+            textSize.width() + margins.top() + margins.bottom()
+        )
+        assert label.maximumWidth() == expected.width()
+        assert label.minimumHeight() == expected.height()
+    else:
+        expected = QtCore.QSize(
+            textSize.width() + margins.left() + margins.right(),
+            textSize.height() + margins.top() + margins.bottom()
+        )
+        assert label.minimumWidth() == expected.width()
+        assert label.maximumHeight() == expected.height()
+
+    assert label.sizeHint() == expected


### PR DESCRIPTION
## Summary
- size `VerticalLabel` from font metrics plus stylesheet contents margins
- paint vertical text inside `contentsRect()` so dock labels account for stylesheet padding and borders
- add regression coverage for horizontal and vertical labels with stylesheet padding

Fixes #3447.

## Testing
- `QT_QPA_PLATFORM=minimal python -m pytest tests/widgets/test_verticallabel.py`
- `QT_QPA_PLATFORM=minimal python -m pytest --no-qt-log tests/widgets tests/dockarea`
- `QT_QPA_PLATFORM=minimal python -m pytest --no-qt-log tests`
- qdarkstyle repro audit: vertical dock label content width is at least the active font height