### PR TITLE
returning None if no value has been set on a parameter

### DIFF
--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -400,10 +400,7 @@ class Parameter(QtCore.QObject):
         """
         Return the value of this Parameter. Raises ValueError if no value has been set.
         """
-        try:
-            return self.opts['value']
-        except KeyError:
-            raise ValueError("No Value has been set")
+        return self.opts.get('value', None)
 
     def getValues(self):
         """

--- a/pyqtgraph/parametertree/Parameter.py
+++ b/pyqtgraph/parametertree/Parameter.py
@@ -398,7 +398,7 @@ class Parameter(QtCore.QObject):
 
     def value(self):
         """
-        Return the value of this Parameter. Raises ValueError if no value has been set.
+        Return the value of this Parameter or None if no value has been set.
         """
         return self.opts.get('value', None)
 

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -39,7 +39,14 @@ def test_parameter_hasdefault():
 
 
 def test_parameter_getValues():
-    from pyqtgraph.examples.parametertree import params
+    params = [
+        {"name": "a", "type": "int", "value": 1},
+        {"name": "b", "type": "float"},
+        {"name": "c", "type": "group", 'children': [
+            {"name": "d", "type": "bool"},
+            {"name": "e", "type": "int", "value": 2},
+        ]},
+    ]
     p = Parameter.create(name="param", type='group',
                          children=params)
     p.getValues()

--- a/tests/parametertree/test_Parameter.py
+++ b/tests/parametertree/test_Parameter.py
@@ -38,6 +38,21 @@ def test_parameter_hasdefault():
     assert p.defaultValue() == 2
 
 
+def test_parameter_getValues():
+    from pyqtgraph.examples.parametertree import params
+    p = Parameter.create(name="param", type='group',
+                         children=params)
+    p.getValues()
+
+
+def test_parameter_no_value():
+    p = Parameter.create(name="param", type='group',)
+    assert p.value() is None
+
+    p = Parameter.create(name='param', type='float',)
+    assert p.value() is None
+
+
 def test_parameter_defaults_and_pristineness():
     # init with identical value and default
     p = Parameter.create(name="param", type='int', value=1, default=1)


### PR DESCRIPTION
removing the ValueError recently introduced for no clear reason...

This PR solves #3378 by reverting the Value Error to just returning None if no value has bee set!

