### PR TITLE
docs: clarify graphicsItems varargs documentation

### DIFF
--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -41,7 +41,7 @@ class ImageItem(GraphicsObject):
     ----------
     image : np.ndarray or None, default None
         Image data.
-    **kargs : dict, optional
+    **kargs : keyword arguments, optional
         Arguments directed to `setImage` and `setOpts`, refer to each method for
         documentation for possible arguments.
 
@@ -376,7 +376,7 @@ class ImageItem(GraphicsObject):
         update : bool, default True
             Controls if image immediately updates to reflect the new options.
 
-        **kwargs : dict, optional
+        **kwargs : keyword arguments, optional
             Extra arguments that are directed to the respective methods.  Expected
             keys include:
 
@@ -465,7 +465,7 @@ class ImageItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args : positional arguments
             Contains one of :class:`QRectF`, :class:`QRect`, or arguments that can be
             used to construct :class:`QRectF`.
 
@@ -554,7 +554,7 @@ class ImageItem(GraphicsObject):
             maximum values, ImageItem only inspects a subset of pixels no larger than
             this number. Setting this larger than the total number of pixels considers
             all values. See `quickMinMax`.
-        **kwargs : dict, optional
+        **kwargs : keyword arguments, optional
             Extra arguments that are passed to `setOpts`.
 
         See Also
@@ -891,7 +891,7 @@ class ImageItem(GraphicsObject):
         ----------
         fileName : os.PathLike
             File path to save the image data to.
-        *args : tuple
+        *args : positional arguments
             Arguments that are passed to :meth:`QImage.save <QImage.save>`.
             
         See Also
@@ -937,8 +937,8 @@ class ImageItem(GraphicsObject):
         targetImageSize : int, default 200
             This parameter is used if ``step == 'auto'``, If so, the `step` size is
             calculated by ``step = ceil(image.shape[0] / targetImageSize)``.
-        **kwargs : dict, optional
-            Dictionary of arguments passed to :func:`numpy.histogram()`.
+        **kwargs : keyword arguments, optional
+            Keyword arguments passed to :func:`numpy.histogram()`.
         
         Returns
         -------

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -266,7 +266,7 @@ class PlotDataItem(GraphicsObject):
 
     Parameters
     ----------
-    *args : tuple, optional
+    *args : positional arguments, optional
         Arguments representing the `x` and `y` data to be drawn. The following are
         examples for initializing data.
 
@@ -294,7 +294,7 @@ class PlotDataItem(GraphicsObject):
         When using spot-style arguments, it is always possible to give coordinate data
         separately through the `x` and `y` keyword arguments.
     
-    **kwargs : dict, optional
+    **kwargs : keyword arguments, optional
         The supported keyword arguments can be grouped into several categories:
 
         *Point Style Keyword Arguments*, see
@@ -835,11 +835,11 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple or None
+        *args : positional arguments or None
             :class:`QPen`, or parameters for a QPen constructed by 
             :func:`mkPen <pyqtgraph.mkPen>`. Use ``None`` to disable drawing of lines.
-        **kwargs : dict
-            Alternative specification of arguments directed to
+        **kwargs : keyword arguments
+            Keyword arguments passed to
             :func:`mkPen <pyqtgraph.mkPen>`.
         """
         pen = fn.mkPen(*args, **kwargs)
@@ -856,11 +856,11 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple or None
+        *args : positional arguments or None
             :class:`QPen`, or parameters for a QPen constructed by 
             :func:`mkPen <pyqtgraph.mkPen>`. Use ``None`` to disable the shadow pen.
-        **kwargs : dict
-            Alternative specification of arguments directed to
+        **kwargs : keyword arguments
+            Keyword arguments passed to
             :func:`mkPen <pyqtgraph.mkPen>`.
         """
         if args and args[0] is None:
@@ -878,12 +878,12 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args : positional arguments
             :class:`QBrush`, or parameters for a QBrush constructed by
             :func:`mkBrush <pyqtgraph.mkBrush>`. Also accepts a color specifier
             understood by :func:`mkColor <pyqtgraph.mkColor>`.
-        **kwargs : dict
-            Alternative specification of arguments directed to
+        **kwargs : keyword arguments
+            Keyword arguments passed to
             :func:`mkBrush <pyqtgraph.mkBrush>`.
         """
         if args and args[0] is None:
@@ -901,12 +901,12 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args : positional arguments
             :class:`QBrush`, or parameters for a QBrush constructed by
             :func:`mkBrush <pyqtgraph.mkBrush>`. Also accepts a color specifier
             understood by :func:`mkColor <pyqtgraph.mkColor>`.
-        **kwargs : dict
-            Alternative specification of arguments directed to
+        **kwargs : keyword arguments
+            Keyword arguments passed to
             :func:`mkBrush <pyqtgraph.mkBrush>`.
         """
         self.setFillBrush(*args, **kwargs)
@@ -969,11 +969,11 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args : positional arguments
             :class:`QPen`, or parameters for a QPen constructed by 
             :func:`mkPen <pyqtgraph.mkPen>`.
-        **kwargs : dict
-            Alternative specification of arguments directed to
+        **kwargs : keyword arguments
+            Keyword arguments passed to
             :func:`mkPen <pyqtgraph.mkPen>`.
         """
         pen = fn.mkPen(*args, **kwargs)
@@ -990,12 +990,12 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args : positional arguments
             :class:`QBrush`, or parameters for a QBrush constructed by
             :func:`mkBrush <pyqtgraph.mkBrush>`. Also accepts a color specifier
             understood by :func:`mkColor <pyqtgraph.mkColor>`.
-        **kwargs : dict
-            Alternative specification of arguments directed to
+        **kwargs : keyword arguments
+            Keyword arguments passed to
             :func:`mkBrush <pyqtgraph.mkBrush>`.
         """
         brush = fn.mkBrush(*args, **kwargs)
@@ -1158,10 +1158,10 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args : positional arguments
             See :class:`PlotDataItem` description for supported arguments.
-        **kwargs : dict
-            See :class:`PlotDataItem` description for supported arguments.
+        **kwargs : keyword arguments
+            See :class:`PlotDataItem` description for supported keyword arguments.
 
         Raises
         ------

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -100,7 +100,7 @@ class PlotItem(GraphicsWidget):
         `left`, `bottom`, `right` or `top` axis.  Default is None.
     enableMenu : bool
         Toggle the enabling or disabling of the right-click context menu.
-    **kwargs : dict, optional
+    **kwargs : keyword arguments, optional
         Any extra keyword arguments are passed to
         :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>`.
     
@@ -591,10 +591,10 @@ class PlotItem(GraphicsWidget):
         ----------
         item : GraphicsItem
             Item to add to the ViewBox.
-        *args : tuple
+        *args : positional arguments
             Arguments relayed to :meth:`~pyqtgraph.ViewBox.addItem`.
-        **kwargs : dict
-            Keyword arguments for adding an item.  Supported arguments include.
+        **kwargs : keyword arguments
+            Keyword arguments for adding an item. Supported keyword arguments include:
 
             ============ ===============================================================
             Property     Description
@@ -744,12 +744,12 @@ class PlotItem(GraphicsWidget):
 
         Parameters
         ----------
-        *args : tuple, optional
+        *args : positional arguments, optional
             Arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
             constructor.
-        **kwargs : dict, optional
+        **kwargs : keyword arguments, optional
             Keyword arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
-            constructor.  In addition, the following keyword arguments are accepted.
+            constructor. In addition, the following keyword arguments are accepted:
 
             =========== ================================================================
             Property    Description
@@ -912,12 +912,12 @@ class PlotItem(GraphicsWidget):
 
         Parameters
         ----------
-        *args : tuple, optional
+        *args : positional arguments, optional
             Arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
             constructor.
-        **kwargs : dict, optional
+        **kwargs : keyword arguments, optional
             Keyword arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
-            constructor.  In addition, the following keyword arguments are accepted.
+            constructor. In addition, the following keyword arguments are accepted:
 
             =========== ================================================================
             Property    Description
@@ -1439,9 +1439,9 @@ class PlotItem(GraphicsWidget):
         ----------
         axis : {'left', 'bottom', 'right', 'top'}
             Specify which :class:`~pyqtgraph.AxisItem` to set the label for.
-        *args : tuple, optional
-            All extra arguments are passed to :meth:`~pyqtgraph.AxisItem.setLabel`.
-        **kwargs : dict, optional
+        *args : positional arguments, optional
+            All extra positional arguments are passed to :meth:`~pyqtgraph.AxisItem.setLabel`.
+        **kwargs : keyword arguments, optional
             Keyword arguments are passed to :meth:`~pyqtgraph.AxisItem.setLabel`.
         """
         self.getAxis(axis).setLabel(*args, **kwargs)
@@ -1453,8 +1453,8 @@ class PlotItem(GraphicsWidget):
 
         Parameters
         ----------
-        **kwargs : dict, optional
-            Keyword arguments are passed to  :meth:`~pyqtgraph.AxisItem.setLabel`.  The
+        **kwargs : keyword arguments, optional
+            Keyword arguments are passed to :meth:`~pyqtgraph.AxisItem.setLabel`. The
             special keyword ``title`` can be used to set the plot title using
             :meth:`~pyqtgraph.PlotItem.setTitle`.
         """


### PR DESCRIPTION
Partially addresses #3488.

This updates graphicsItems docstrings to describe caller-facing `*args` and `**kwargs` usage as positional and keyword arguments rather than as tuple/dict containers.

Scope:
- Clarifies `PlotItem`
- Clarifies `PlotDataItem`
- Clarifies `ImageItem`
- Leaves behavior unchanged

Validation:
- `pytest tests/graphicsItems -k PlotItem -vv`
- `pytest tests/graphicsItems -k PlotDataItem -vv`
- `pytest tests/graphicsItems -k ImageItem -vv`
- `git diff --check`