### PR TITLE
Preserve ImageView histogram range across frames

### DIFF
--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -132,6 +132,7 @@ class ImageView(QtWidgets.QWidget):
         self.image = None
         self.axes = {}
         self.imageDisp = None
+        self._autoHistogramRange = True
         self.ui = ui_template.Ui_Form()
         self.ui.setupUi(self)
         self.scene = self.ui.graphicsView.scene()
@@ -252,6 +253,10 @@ class ImageView(QtWidgets.QWidget):
         
         self.roiClicked() ## initialize roi plot to correct shape / visibility
 
+    def setHistogramAutoRange(self, enabled):
+        """Set whether image updates automatically adjust the histogram range."""
+        self._autoHistogramRange = bool(enabled)
+
     def setImage(
             self,
             img,
@@ -294,7 +299,8 @@ class ImageView(QtWidgets.QWidget):
         transform
             Set the transform of the displayed image. This option overrides *pos* and *scale*.
         autoHistogramRange : bool
-            If True, the histogram y-range is automatically scaled to fit the image data.
+            If True, the histogram y-range is automatically scaled to fit the image data
+            on this and subsequent image updates.
         levelMode : str
             If specified, this sets the user interaction mode for setting image levels. Options are 'mono',
             which provides a single level control for all image channels, and 'rgb' or 'rgba', which provide
@@ -364,7 +370,8 @@ class ImageView(QtWidgets.QWidget):
         profiler()
 
         self.currentIndex = 0
-        self.updateImage(autoHistogramRange=autoHistogramRange)
+        self.setHistogramAutoRange(autoHistogramRange)
+        self.updateImage()
         if levels is None and autoLevels:
             self.autoLevels()
         if levels is not None:  ## this does nothing since getProcessedImage sets these values again.
@@ -820,10 +827,13 @@ class ImageView(QtWidgets.QWidget):
 
         self.sigTimeChanged.emit(ind, time)
 
-    def updateImage(self, autoHistogramRange=True):
+    def updateImage(self, autoHistogramRange=None):
         ## Redraw image on screen
         if self.image is None:
             return
+
+        if autoHistogramRange is None:
+            autoHistogramRange = self._autoHistogramRange
     
         image = self.getProcessedImage()
         if autoHistogramRange:

--- a/tests/imageview/test_imageview.py
+++ b/tests/imageview/test_imageview.py
@@ -45,3 +45,35 @@ def test_init_with_mode_and_imageitem():
     imgitem = pg.ImageItem(data)
     pg.ImageView(imageItem=imgitem, levelMode="rgba")
     assert(pg.image is not None)
+
+
+def test_set_image_disables_histogram_auto_range_across_frames():
+    data = np.stack((np.arange(100).reshape(10, 10),
+                     np.arange(1000, 1100).reshape(10, 10)))
+    iv = pg.ImageView()
+    iv.setImage(data, autoHistogramRange=False)
+    iv.setHistogramRange(-10, 10, padding=0)
+
+    iv.setCurrentIndex(1)
+
+    assert iv.ui.histogram.getHistogramRange() == [-10, 10]
+    iv.close()
+
+
+def test_set_histogram_auto_range_controls_updates_across_frames():
+    data = np.stack((np.arange(100).reshape(10, 10),
+                     np.arange(1000, 1100).reshape(10, 10)))
+    iv = pg.ImageView()
+    iv.setImage(data)
+    iv.setHistogramRange(-10, 10, padding=0)
+
+    iv.setCurrentIndex(1)
+
+    assert iv.ui.histogram.getHistogramRange() != [-10, 10]
+
+    iv.setHistogramAutoRange(False)
+    iv.setHistogramRange(-10, 10, padding=0)
+    iv.setCurrentIndex(0)
+
+    assert iv.ui.histogram.getHistogramRange() == [-10, 10]
+    iv.close()


### PR DESCRIPTION
## Summary

- remember the `autoHistogramRange` choice supplied to `ImageView.setImage`
- add `setHistogramAutoRange(enabled)` so callers can change that behavior without threading flags through frame-navigation methods
- make parameterless image updates use the stored setting while preserving explicit one-call overrides
- add regression coverage for both the existing `setImage` argument and the new setter

## Root cause

`setCurrentIndex()` and other refresh paths call `updateImage()` without arguments. Its previous default of `autoHistogramRange=True` therefore replaced a manually selected histogram range even after `setImage(..., autoHistogramRange=False)`.

The default remains enabled, so existing callers retain the current behavior. When callers explicitly disable it, manual histogram bounds now survive frame changes and other parameterless refreshes.

## Tests

- `QT_QPA_PLATFORM=offscreen python -m pytest tests/imageview/test_imageview.py -q` (5 passed)
- `QT_QPA_PLATFORM=offscreen python -m pytest tests -q` (1088 passed, 723 skipped, 8 xfailed)
- repository pre-commit hooks for both changed files (all applicable hooks passed; the removed upstream `fix-encoding-pragma` hook was skipped)

Fixes #163