### PR TITLE
Keep subnormal plot ranges finite

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -1,5 +1,6 @@
+import sys
 import weakref
-from math import ceil, floor, frexp, isfinite, log10, sqrt
+from math import ceil, copysign, floor, frexp, isfinite, log10, sqrt
 
 import numpy as np
 
@@ -1509,12 +1510,17 @@ class AxisItem(GraphicsWidget):
         if dif == 0:
             xScale = 1
             offset = 0
-        elif axis == 0:
-            xScale = -bounds.height() / dif
-            offset = self.range[0] * xScale - bounds.height()
         else:
-            xScale = bounds.width() / dif
-            offset = self.range[0] * xScale
+            if axis == 0:
+                xScale = -bounds.height() / dif
+            else:
+                xScale = bounds.width() / dif
+            if not isfinite(xScale):
+                xScale = copysign(sys.float_info.max, xScale)
+            if axis == 0:
+                offset = self.range[0] * xScale - bounds.height()
+            else:
+                offset = self.range[0] * xScale
 
         xRange = [x * xScale - offset for x in self.range]
         xMin = min(xRange)

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -9,7 +9,7 @@ from ... import debug as debug
 from ... import functions as fn
 from ... import getConfigOption
 from ...Point import Point
-from ...Qt import QtCore, QtGui, QtWidgets, isQObjectAlive, QT_LIB
+from ...Qt import QT_LIB, QtCore, QtGui, QtWidgets, isQObjectAlive
 from ..GraphicsWidget import GraphicsWidget
 from ..ItemGroup import ItemGroup
 
@@ -1712,6 +1712,9 @@ class ViewBox(GraphicsWidget):
         if vr.height() == 0 or vr.width() == 0:
             return
         scale = Point(bounds.width()/vr.width(), bounds.height()/vr.height())
+        for axis in (0, 1):
+            if not math.isfinite(scale[axis]):
+                scale[axis] = math.copysign(sys.float_info.max, scale[axis])
         if not self.state['yInverted']:
             scale = scale * Point(1, -1)
         if self.state['xInverted']:

--- a/tests/graphicsItems/ViewBox/test_ViewBox.py
+++ b/tests/graphicsItems/ViewBox/test_ViewBox.py
@@ -1,3 +1,5 @@
+from math import isfinite
+
 #import PySide
 import pytest
 
@@ -81,6 +83,33 @@ def test_ViewBox_setMenuEnabled():
     assert vb.menu is not None
     vb.setMenuEnabled(False)
     assert vb.menu is None
+
+
+@pytest.mark.parametrize("data", (
+    [value * 1e-310 for value in range(1, 11)],
+    [-1e-310, 0, 1e-310],
+))
+@pytest.mark.parametrize("axis", ("x", "y"))
+def test_ViewBox_subnormal_range_transform_is_finite(data, axis):
+    plot = pg.PlotWidget()
+    plot.resize(640, 480)
+    indices = list(range(len(data)))
+    if axis == "x":
+        plot.plot(x=data, y=indices)
+    else:
+        plot.plot(x=indices, y=data)
+    plot.show()
+    app.processEvents()
+
+    transform = plot.getViewBox().childGroup.transform()
+    values = (
+        transform.m11(), transform.m12(), transform.m13(),
+        transform.m21(), transform.m22(), transform.m23(),
+        transform.m31(), transform.m32(), transform.m33(),
+    )
+
+    assert all(isfinite(value) for value in values)
+    plot.close()
 
 
 

--- a/tests/graphicsItems/test_AxisItem.py
+++ b/tests/graphicsItems/test_AxisItem.py
@@ -1,4 +1,4 @@
-from math import isclose
+from math import isclose, isfinite
 
 import pytest
 
@@ -46,6 +46,41 @@ def test_AxisItem_viewUnlink():
     assert axis.linkedView() == view
     axis.unlinkFromView()
     assert axis.linkedView() is None
+
+
+@pytest.mark.parametrize("data", (
+    [value * 1e-310 for value in range(1, 11)],
+    [-1e-310, 0, 1e-310],
+))
+@pytest.mark.parametrize("orientation", ("bottom", "left"))
+def test_AxisItem_subnormal_range_tick_coordinates_are_finite(data, orientation):
+    plot = pg.PlotWidget()
+    plot.resize(640, 480)
+    indices = list(range(len(data)))
+    if orientation == "bottom":
+        plot.plot(x=data, y=indices)
+    else:
+        plot.plot(x=indices, y=data)
+    plot.show()
+    app.processEvents()
+
+    axis = plot.getAxis(orientation)
+    picture = pg.Qt.QtGui.QPicture()
+    painter = pg.Qt.QtGui.QPainter(picture)
+    try:
+        _, tick_specs, _ = axis.generateDrawSpecs(painter)
+    finally:
+        painter.end()
+
+    coordinates = (
+        coordinate
+        for _, start, stop in tick_specs
+        for point in (start, stop)
+        for coordinate in (point.x(), point.y())
+    )
+    assert tick_specs
+    assert all(isfinite(coordinate) for coordinate in coordinates)
+    plot.close()
 
 
 class FakeSignal:


### PR DESCRIPTION
## Summary

- clamp only overflowed ViewBox scale factors to the signed maximum finite float
- apply the same finite-scale guard when AxisItem maps extremely small ranges to tick coordinates
- cover positive and zero-crossing subnormal ranges on both horizontal and vertical axes

## Root cause

For a nonzero range near `1e-310`, dividing a normal pixel width or height by that range overflows to infinity. The resulting Qt transform contains `inf`/`nan`, and AxisItem generates non-finite tick endpoints. This can cause platform-dependent rendering failures or crashes.

A fixed epsilon would change the visible scale of legitimate small-valued data. This change instead preserves the requested range and clamps only an already-overflowed ratio, retaining its sign. Ordinary scales and zero-range handling are unchanged.

## Tests

- focused ViewBox and AxisItem regression matrix: 8 passed
- `QT_QPA_PLATFORM=offscreen python -m pytest tests -q`: 1094 passed, 723 skipped, 8 xfailed
- repository pre-commit hooks for all four changed files: all applicable hooks passed; the removed upstream `fix-encoding-pragma` hook was skipped

Fixes #2370