### PR TITLE
Make makeARGB reference test platform independent

### DIFF
--- a/tests/test_makeARGB.py
+++ b/tests/test_makeARGB.py
@@ -59,9 +59,15 @@ def test_makeARGB_against_generated_references(acceleration, dtype, in_fmt, leve
         assert exc_info.type is expectation, f"makeARGB({key!r}) was supposed to raise {expectation}"
     else:
         output, alpha = _makeARGB(data, lut=lut, levels=levels, scale=scale, useRGBA=use_rgba)
-        assert (
-            output == expectation
-        ).all(), f"Incorrect _makeARGB({key!r}) output! Expected:\n{expectation!r}\n  Got:\n{output!r}"
+        matches = output == expectation
+        if data.dtype.kind == 'f':
+            nan_mask = np.isnan(data)
+            if data.ndim == 3:
+                nan_mask = np.any(nan_mask, axis=-1)
+            # NaN-to-integer conversion varies by platform. Only the alpha
+            # value of a NaN-containing pixel is defined by makeARGB.
+            matches[nan_mask, :3] = True
+        assert matches.all(), f"Incorrect _makeARGB({key!r}) output! Expected:\n{expectation!r}\n  Got:\n{output!r}"
     setConfigOptions(useCupy=False, useNumba=False)
 
 


### PR DESCRIPTION
NumPy's float-to-integer conversion of NaN varies by platform. On RISC-V, converting NaN to uint8 produces 255, while the generated reference arrays record the zero produced on x86_64. makeARGB already documents those color values as undefined and guarantees transparency by setting the alpha channel to zero, so comparing the RGB bytes rejects valid output.

Build a per-pixel NaN mask from the test input and exclude only the three color bytes at those pixels from the generated-reference comparison. The test continues to check alpha for NaN-containing pixels and every channel for all other pixels, including finite RGBA pixels whose alpha is zero.

Validated on Arch Linux x86_64 and RISC-V with:

    QT_QPA_PLATFORM=offscreen pytest -q tests/test_makeARGB.py::test_makeARGB_against_generated_references

Both runs completed with 594 passed and 702 skipped.