### PR TITLE
refactor: create QtOpenGL shim

### DIFF
--- a/pyqtgraph/Qt/QtOpenGL/__init__.py
+++ b/pyqtgraph/Qt/QtOpenGL/__init__.py
@@ -1,0 +1,11 @@
+import importlib
+from .. import QtVersionInfo, QT_LIB
+if QtVersionInfo[0] >= 6:
+    module = importlib.import_module(f'{QT_LIB}.QtOpenGL')
+else:
+    module = importlib.import_module(f'{QT_LIB}.QtGui')
+
+def __getattr__(name):
+    x = getattr(module, name)
+    globals()[name] = x
+    return x

--- a/pyqtgraph/graphicsItems/PColorMeshItem.py
+++ b/pyqtgraph/graphicsItems/PColorMeshItem.py
@@ -1,5 +1,4 @@
 import enum
-import importlib
 
 import numpy as np
 
@@ -8,13 +7,8 @@ from .. import functions as fn
 from ..Qt import compat
 from ..Qt import OpenGLConstants as GLC
 from ..Qt import OpenGLHelpers
-from ..Qt import QtCore, QtGui, QT_LIB, QtVersionInfo
+from ..Qt import QtCore, QtGui, QtOpenGL, QT_LIB
 from .GraphicsObject import GraphicsObject
-
-if QtVersionInfo[0] >= 6:
-    QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
-else:
-    QtOpenGL = QtGui
 
 __all__ = ['PColorMeshItem']
 
@@ -317,7 +311,7 @@ class PColorMeshItem(GraphicsObject):
             rng = 1
         norm = fn.rescaleData(valid_z, scale / rng, lo, dtype=int, clip=(0, len(lut)-1))
 
-        if Qt.QT_LIB.startswith('PyQt'):
+        if QT_LIB.startswith('PyQt'):
             drawConvexPolygon = lambda x : painter.drawConvexPolygon(*x)
         else:
             drawConvexPolygon = painter.drawConvexPolygon

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -1,6 +1,5 @@
-from ..Qt import QtCore, QtGui, QtWidgets, QtOpenGL, QT_LIB, QtVersionInfo
+from ..Qt import QtCore, QtGui, QtOpenGL
 
-import importlib
 import math
 import warnings
 
@@ -12,11 +11,6 @@ from .. import getConfigOption
 from ..Qt import OpenGLConstants as GLC
 from ..Qt import OpenGLHelpers
 from .GraphicsObject import GraphicsObject
-
-if QtVersionInfo[0] >= 6:
-    QtOpenGLWidgets = importlib.import_module(f"{QT_LIB}.QtOpenGLWidgets")
-else:
-    QtOpenGLWidgets = QtWidgets
 
 __all__ = ['PlotCurveItem']
 
@@ -875,8 +869,9 @@ class PlotCurveItem(GraphicsObject):
         #   * With OpenGL split in rather big chunks
         #     Note: when OpenGL mode is enabled, we should normally be using the
         #     'paintGL' method, and should not even reach here.
+        #     However, some oddball unsupported paint configurations may result in 'paintGL' not being used.
         # Values were found using 'PlotSpeedTest.py' example, see #2257.
-        chunksize = 50 if not isinstance(widget, QtOpenGLWidgets.QOpenGLWidget) else 5000
+        chunksize = 150 if not isinstance(widget, OpenGLHelpers.GraphicsViewGLWidget) else 5000
 
         connect_kind = self.opts['connect']
         if isinstance(connect_kind, np.ndarray):

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -1,4 +1,4 @@
-from ..Qt import QtCore, QtGui, QtWidgets, QT_LIB, QtVersionInfo
+from ..Qt import QtCore, QtGui, QtWidgets, QtOpenGL, QT_LIB, QtVersionInfo
 
 import importlib
 import math
@@ -14,10 +14,8 @@ from ..Qt import OpenGLHelpers
 from .GraphicsObject import GraphicsObject
 
 if QtVersionInfo[0] >= 6:
-    QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
     QtOpenGLWidgets = importlib.import_module(f"{QT_LIB}.QtOpenGLWidgets")
 else:
-    QtOpenGL = QtGui
     QtOpenGLWidgets = QtWidgets
 
 __all__ = ['PlotCurveItem']

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -8,13 +8,11 @@ import numpy as np
 from .. import Vector
 from .. import functions as fn
 from .. import getConfigOption
-from ..Qt import QtCore, QtGui, QtWidgets, QT_LIB, QtVersionInfo
+from ..Qt import QtCore, QtGui, QtWidgets, QtOpenGL, QT_LIB, QtVersionInfo
 
 if QtVersionInfo[0] >= 6:
-    QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
     QtOpenGLWidgets = importlib.import_module(f"{QT_LIB}.QtOpenGLWidgets")
 else:
-    QtOpenGL = QtGui
     QtOpenGLWidgets = QtWidgets
 
 class GLViewMixin:

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -1,16 +1,9 @@
-import importlib
-
 from OpenGL import GL
 from OpenGL.GL import shaders
 import numpy as np
 
-from ...Qt import QtGui, QT_LIB, QtVersionInfo
+from ...Qt import QtGui, QtOpenGL
 from ..GLGraphicsItem import GLGraphicsItem
-
-if QtVersionInfo[0] >= 6:
-    QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
-else:
-    QtOpenGL = QtGui
 
 __all__ = ['GLImageItem']
 

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -1,18 +1,12 @@
 import enum
-import importlib
 
 from OpenGL import GL
 from OpenGL.GL import shaders
 import numpy as np
 
-from ...Qt import QtGui, QT_LIB, QtVersionInfo
+from ...Qt import QtGui, QtOpenGL
 from ... import functions as fn
 from ..GLGraphicsItem import GLGraphicsItem
-
-if QtVersionInfo[0] >= 6:
-    QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
-else:
-    QtOpenGL = QtGui
 
 __all__ = ['GLLinePlotItem']
 

--- a/pyqtgraph/opengl/items/GLMeshItem.py
+++ b/pyqtgraph/opengl/items/GLMeshItem.py
@@ -1,18 +1,12 @@
 import enum
-import importlib
 
 from OpenGL import GL
 import numpy as np
 
-from ...Qt import QtGui, QT_LIB, QtVersionInfo
+from ...Qt import QtGui, QtOpenGL
 from .. import shaders
 from ..GLGraphicsItem import GLGraphicsItem
 from ..MeshData import MeshData
-
-if QtVersionInfo[0] >= 6:
-    QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
-else:
-    QtOpenGL = QtGui
 
 __all__ = ['GLMeshItem']
 

--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -1,18 +1,12 @@
 import enum
 import math
-import importlib
 
 from OpenGL import GL
 from OpenGL.GL import shaders
 import numpy as np
 
-from ...Qt import QtGui, QT_LIB, QtVersionInfo
+from ...Qt import QtGui, QtOpenGL
 from ..GLGraphicsItem import GLGraphicsItem
-
-if QtVersionInfo[0] >= 6:
-    QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
-else:
-    QtOpenGL = QtGui
 
 __all__ = ['GLScatterPlotItem']
 

--- a/pyqtgraph/opengl/items/GLVolumeItem.py
+++ b/pyqtgraph/opengl/items/GLVolumeItem.py
@@ -1,16 +1,9 @@
-import importlib
-
 from OpenGL import GL
 from OpenGL.GL import shaders
 import numpy as np
 
-from ...Qt import QtGui, QT_LIB, QtVersionInfo
+from ...Qt import QtGui, QtOpenGL
 from ..GLGraphicsItem import GLGraphicsItem
-
-if QtVersionInfo[0] >= 6:
-    QtOpenGL = importlib.import_module(f"{QT_LIB}.QtOpenGL")
-else:
-    QtOpenGL = QtGui
 
 __all__ = ['GLVolumeItem']
 

--- a/pyqtgraph/widgets/RawImageWidget.py
+++ b/pyqtgraph/widgets/RawImageWidget.py
@@ -11,15 +11,13 @@ import numpy as np
 from .. import functions as fn
 from .. import functions_qimage
 from .. import getConfigOption, getCupy
-from ..Qt import QtCore, QtGui, QtWidgets, QT_LIB, QtVersionInfo
+from ..Qt import QtCore, QtGui, QtWidgets, QtOpenGL, QT_LIB, QtVersionInfo
 from ..Qt import OpenGLConstants as GLC
 from ..Qt import OpenGLHelpers
 
 if QtVersionInfo[0] >= 6:
-    QtOpenGL = importlib.import_module(f'{QT_LIB}.QtOpenGL')
     QtOpenGLWidgets = importlib.import_module(f"{QT_LIB}.QtOpenGLWidgets")
 else:
-    QtOpenGL = QtGui
     QtOpenGLWidgets = QtWidgets
 
 # importing cuda python is fast


### PR DESCRIPTION
All code previously using Qt's built-in OpenGL functions had to import QtOpenGL for Qt6 and QtGui for Qt5. This localizes all that logic into a lazily-loaded QtOpenGL shim.

Some changes to `PlotCurveItem`:
1) Don't support user enabling OpenGL other than by `setConfigOption('useOpenGL', True)`
    * Previously, there was a user doing that (#2257) but apparently that is no longer the case (https://github.com/pyqtgraph/pyqtgraph/pull/3055#discussion_r1646051960)
2) bump the fill chunk size from 50 to 150
    * 150 performs slightly better, and should be more resistant to bad degradations in case we enter edge-case modes that prefer big chunks.
    