### PR TITLE
feat(AxisItem): expose labelOffset via setStyle() — Closes #986

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -94,6 +94,7 @@ class AxisItem(GraphicsWidget):
             'maxTickLevel': 2,
             'maxTextLevel': 2,
             'tickAlpha': None,  ## If not none, use this alpha for all ticks.
+            'labelOffset': 5,  ## offset in pixels between the axis label and the axis
         }
 
         self.textWidth = 30  ## Keeps track of maximum width / height of tick text
@@ -248,6 +249,13 @@ class AxisItem(GraphicsWidget):
                                   - 1: Show major ticks and one level of minor ticks
                                   - 2: Show major ticks and two levels of minor ticks
                                     (higher CPU usage)
+
+            labelOffset           ``int`` or ``float``
+                                  default: 5
+
+                                  Offset in pixels between the axis label and the axis
+                                  line. Adjust this to control how far the label sits
+                                  from the axis.
             ===================== ======================================================
 
         Raises
@@ -266,11 +274,14 @@ class AxisItem(GraphicsWidget):
                     'tickLength',
                     'tickTextOffset',
                     'tickTextWidth',
-                    'tickTextHeight'
+                    'tickTextHeight',
                 ) and 
                 not isinstance(value, int)
             ):
                 raise TypeError(f"Argument '{kwd}' must be int")
+
+            if kwd == 'labelOffset' and not isinstance(value, (int, float)):
+                raise TypeError(f"Argument 'labelOffset' must be int or float")
 
             if kwd == 'tickTextOffset':
                 if self.orientation in ('left', 'right'):
@@ -395,7 +406,7 @@ class AxisItem(GraphicsWidget):
 
     def resizeEvent(self, ev=None):
         # Set the position of the label
-        nudge = 5
+        nudge = self.style.get('labelOffset', 5)
         # self.label is set to None on close, but resize events can still occur.
         if self.label is None:
             self.picture = None
@@ -617,6 +628,7 @@ class AxisItem(GraphicsWidget):
             h += max(0, self.style['tickLength'])
             if self.label.isVisible():
                 h += self.label.boundingRect().height() * 0.8
+                h += max(0, self.style.get('labelOffset', 5) - 5)
         else:
             h = self.fixedHeight
 
@@ -653,6 +665,7 @@ class AxisItem(GraphicsWidget):
             w += max(0, self.style['tickLength'])
             if self.label.isVisible():
                 w += self.label.boundingRect().height() * 0.8  ## bounding rect is usually an overestimate
+                w += max(0, self.style.get('labelOffset', 5) - 5)
         else:
             w = self.fixedWidth
 
@@ -963,14 +976,15 @@ class AxisItem(GraphicsWidget):
         ## extend rect if ticks go in negative direction
         ## also extend to account for text that flows past the edges
         tl = self.style['tickLength']
+        labelOffset = self.style.get('labelOffset', 5)
         if self.orientation == 'left':
-            rect = rect.adjusted(0, -m, -min(0,tl), m)
+            rect = rect.adjusted(-labelOffset, -m, -min(0,tl), m)
         elif self.orientation == 'right':
-            rect = rect.adjusted(min(0,tl), -m, 0, m)
+            rect = rect.adjusted(min(0,tl), -m, labelOffset, m)
         elif self.orientation == 'top':
-            rect = rect.adjusted(-m, 0, m, -min(0,tl))
+            rect = rect.adjusted(-m, -labelOffset, m, -min(0,tl))
         elif self.orientation == 'bottom':
-            rect = rect.adjusted(-m, min(0,tl), m, 0)
+            rect = rect.adjusted(-m, min(0,tl), m, labelOffset)
         return rect
 
     def shape(self):

--- a/tests/graphicsItems/test_AxisItem.py
+++ b/tests/graphicsItems/test_AxisItem.py
@@ -189,3 +189,53 @@ def test_AxisItem_setLogMode_one_arg(orientation, log, expected):
     axis = pg.AxisItem(orientation)
     axis.setLogMode(log)
     assert axis.logMode == expected
+
+
+def test_AxisItem_labelOffset_default():
+    """Test that labelOffset defaults to 5."""
+    axis = pg.AxisItem('bottom')
+    assert axis.style['labelOffset'] == 5
+
+
+def test_AxisItem_labelOffset_setStyle():
+    """Test that labelOffset can be set via setStyle()."""
+    axis = pg.AxisItem('bottom')
+    axis.setStyle(labelOffset=10)
+    assert axis.style['labelOffset'] == 10
+
+    axis.setStyle(labelOffset=0)
+    assert axis.style['labelOffset'] == 0
+
+    axis.setStyle(labelOffset=3.5)
+    assert axis.style['labelOffset'] == 3.5
+
+
+def test_AxisItem_labelOffset_invalid_type():
+    """Test that setStyle raises TypeError for non-numeric labelOffset."""
+    axis = pg.AxisItem('bottom')
+    with pytest.raises(TypeError):
+        axis.setStyle(labelOffset="big")
+
+
+def test_AxisItem_labelOffset_boundingRect():
+    """Test that boundingRect accounts for labelOffset."""
+    plot = pg.PlotWidget()
+    plot.show()
+    app.processEvents()
+
+    axis = plot.getAxis('bottom')
+    axis.showLabel(True)
+    axis.setLabel(text='Test Label')
+
+    axis.setStyle(labelOffset=5)
+    app.processEvents()
+    br_small = axis.boundingRect()
+
+    axis.setStyle(labelOffset=20)
+    app.processEvents()
+    br_large = axis.boundingRect()
+
+    # larger labelOffset should produce a larger (or equal) bounding rect
+    assert br_large.height() >= br_small.height()
+
+    plot.close()


### PR DESCRIPTION
The axis label offset in AxisItem.resizeEvent() is hardcoded to nudge = 5 pixels. Users cannot adjust how far the axis label sits from the axis line without subclassing and overriding resizeEvent().

This has been requested in #986. A prior attempt (#1327) did not address layout sizing and boundingRect clipping properly.

This commit addresses:
1. 'labelOffset' as a style parameter for spacing.
2. Expands the AxisItem.boundingRect() by labelOffset so labels aren't clipped.
3. Fixes AxisItem._updateWidth() and _updateHeight() to properly negotiate space in the QGraphicsLayout so labels don't overlap neighboring plots.