### PR TITLE
Fix test_ErrorBarItem CI failures

### DIFF
--- a/tests/graphicsItems/test_ErrorBarItem.py
+++ b/tests/graphicsItems/test_ErrorBarItem.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import pyqtgraph as pg
+from pyqtgraph.Qt import QtTest
 
 app = pg.mkQApp()
 
@@ -8,12 +9,12 @@ app = pg.mkQApp()
 def test_ErrorBarItem_defer_data():
     plot = pg.PlotWidget()
     plot.show()
+    QtTest.QTest.qWaitForWindowExposed(plot)
 
     # plot some data away from the origin to set the view rect
     x = np.arange(5) + 10
     curve = pg.PlotCurveItem(x=x, y=x)
     plot.addItem(curve)
-    app.processEvents()
     app.processEvents()
     r_no_ebi = plot.viewRect()
 
@@ -21,13 +22,11 @@ def test_ErrorBarItem_defer_data():
     err = pg.ErrorBarItem()
     plot.addItem(err)
     app.processEvents()
-    app.processEvents()
     r_empty_ebi = plot.viewRect()
 
     assert r_no_ebi.height() == r_empty_ebi.height()
 
     err.setData(x=x, y=x, bottom=x, top=x)
-    app.processEvents()
     app.processEvents()
     r_ebi = plot.viewRect()
 
@@ -35,7 +34,6 @@ def test_ErrorBarItem_defer_data():
 
     # unset data, ErrorBarItem disappears and view rect goes back to original
     err.setData(x=None, y=None)
-    app.processEvents()
     app.processEvents()
     r_clear_ebi = plot.viewRect()
 


### PR DESCRIPTION
A plausible fix for the test_ErrorBarItem failures.
Window needs to be exposed (and not just show()-n before proceeding.)

Some previous failed attempts at fixing this issue: #2511, #2523