### PR TITLE
Fix ScatterPlotItem compositionMode handling

### DIFF
--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -561,6 +561,8 @@ class ScatterPlotItem(GraphicsObject):
             self.setPxMode(kargs['pxMode'])
         if 'antialias' in kargs:
             self.opts['antialias'] = kargs['antialias']
+        if 'compositionMode' in kargs:
+            self.opts['compositionMode'] = kargs['compositionMode']
         if 'hoverable' in kargs:
             self.opts['hoverable'] = bool(kargs['hoverable'])
         if 'tip' in kargs:

--- a/tests/graphicsItems/test_ScatterPlotItem.py
+++ b/tests/graphicsItems/test_ScatterPlotItem.py
@@ -67,6 +67,21 @@ def test_scatterplotitem():
     plot.close()
 
 
+def test_composition_mode():
+    pg.mkQApp()
+    source_over = QtGui.QPainter.CompositionMode.CompositionMode_SourceOver
+    plus = QtGui.QPainter.CompositionMode.CompositionMode_Plus
+
+    scatter = pg.ScatterPlotItem(x=[0], y=[0], compositionMode=plus)
+    assert scatter.opts['compositionMode'] == plus
+
+    scatter.setData(x=[1], y=[1], compositionMode=source_over)
+    assert scatter.opts['compositionMode'] == source_over
+
+    scatter.setData(x=[2], y=[2])
+    assert scatter.opts['compositionMode'] == source_over
+
+
 def test_init_spots():
     app = pg.mkQApp()
     plot = pg.PlotWidget()


### PR DESCRIPTION
## Summary

- honor `compositionMode` passed to `ScatterPlotItem` construction and `setData()`
- retain the selected mode when later data updates omit the option
- add regression coverage for construction and repeated `setData()` calls

Closes #3117

## Testing

- `python -m pytest tests/graphicsItems/test_ScatterPlotItem.py -q` — 3 passed
- `python -m pytest tests -q` — 1116 passed, 705 skipped, 8 xfailed
- `python -m pytest pyqtgraph/examples -q -n 2` — 98 passed, 3 skipped