### PR TITLE
Fix parsing of symbol-prefixed suffixes

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -11,7 +11,6 @@ import struct
 import sys
 import warnings
 from collections import OrderedDict
-
 from typing import TypeAlias, TypedDict
 
 import numpy as np
@@ -67,9 +66,9 @@ SI_PREFIX_EXPONENTS['u'] = -6
 SI_PREFIX_EXPONENTS['μ'] = -6
 
 #For comma as decimal separator
-FLOAT_REGEX_COMMA = re.compile(r'(?P<number>[+-]?((((\d+(,\d*)?)|(\d*,\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>\w.*))?$')
+FLOAT_REGEX_COMMA = re.compile(r'(?P<number>[+-]?((((\d+(,\d*)?)|(\d*,\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>\S.*))?$')
 #For period as decimal separator
-FLOAT_REGEX_PERIOD = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>\w.*))?$')
+FLOAT_REGEX_PERIOD = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>\S.*))?$')
 
 INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>.*)$')
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -6,7 +6,7 @@ import pytest
 from numpy.testing import assert_array_almost_equal
 
 import pyqtgraph as pg
-from pyqtgraph.functions import arrayToQPath, eq, SignalBlock
+from pyqtgraph.functions import SignalBlock, arrayToQPath, eq
 from pyqtgraph.Qt import QtCore, QtGui
 
 np.random.seed(12345)
@@ -235,6 +235,7 @@ def test_eq():
     ("4.2 nV", None, ("4.2", "n", "V")),
     ("1.2 m", "m", ("1.2", "", "m")),
     ("1.2 m", None, ("1.2", "", "m")),
+    ("451 °F", None, ("451", "", "°F")),
     ("5.0e9", None, ("5.0e9", "", "")),
     ("2 units", "units", ("2", "", "units")),
     # siPrefix with explicit empty suffix
@@ -262,6 +263,7 @@ def test_siParse(s, suffix, expected):
     ("100 μV", "V", 1, 1e-4),
     ("4.2 nV", None, 1, 4.2e-9),
     ("1.2 m", "m", 1, 1.2),
+    ("451 °F", None, 1, 451.0),
     # siPrefix with explicit empty suffix
     ("1.2 m", "", 1, 1.2e-3),
     ("5.0e-9 M", "", 1, 5.0e-3),
@@ -283,6 +285,7 @@ def test_siEval(s, suffix, power, expected):
     ("1,2 j", "", ("1,2", "", "")),
     ("1,2 j", None, ("1,2", "", "j")),
     ("1,2 μV", "V", ("1,2", "μ", "V")),
+    ("451,5 °F", None, ("451,5", "", "°F")),
     (",2 j", None, (",2", "", "j")),])
 def test_siParse_with_comma_as_decimal_separator(s, suffix, expected):
     assert pg.siParse(s, suffix=suffix, regex=pg.functions.FLOAT_REGEX_COMMA) == expected


### PR DESCRIPTION
Fixes #3115.

`FLOAT_REGEX_PERIOD` and `FLOAT_REGEX_COMMA` previously required suffixes to begin with a word character. For values such as `451 °F`, that made the regex backtrack and parse the number as `45` with a suffix of `1 °F`.

Allowing suffixes to begin with any non-whitespace character parses degree and percent symbols correctly while retaining the existing distinction between a bare unit (`100 m`) and an SI-prefixed unit (`100 mV`). Regression coverage includes period- and comma-decimal parsing and `siEval`.

Testing:
- `pytest tests/test_functions.py -q` — 178 passed
- `pytest tests -q` — 1118 passed, 705 skipped, 8 xfailed
- `pytest pyqtgraph/examples -q` — 98 passed, 3 skipped
- all applicable pre-commit hooks passed (`fix-encoding-pragma` skipped because that configured upstream hook has been removed)