### PR TITLE
Fix integer SpinBox text after coercion

### DIFF
--- a/pyqtgraph/widgets/SpinBox.py
+++ b/pyqtgraph/widgets/SpinBox.py
@@ -1,6 +1,5 @@
 import decimal
 import re
-import warnings
 from math import isinf, isnan
 
 from .. import functions as fn
@@ -610,6 +609,7 @@ class SpinBox(QtWidgets.QAbstractSpinBox):
         if val is False:
             return
         if val == self.val:
+            self.updateText()
             return
         self.setValue(val, delaySignal=False)  ## allow text update so that values are reformatted pretty-like
 

--- a/tests/widgets/test_spinbox.py
+++ b/tests/widgets/test_spinbox.py
@@ -90,6 +90,21 @@ def test_evalFunc():
     assert sb.value() == 100
 
 
+def test_SpinBox_reformats_unchanged_integer_value():
+    sb = pg.SpinBox(int=True)
+    sb.setValue(10)
+
+    sb.lineEdit().setText('2.5')
+    sb.editingFinishedEvent()
+    assert sb.value() == 2
+    assert sb.text() == '2'
+
+    sb.lineEdit().setText('2.1')
+    sb.editingFinishedEvent()
+    assert sb.value() == 2
+    assert sb.text() == '2'
+
+
 def spinBox_gui_set_value_test(expected, valueText, suffix, locale):
     sb = pg.SpinBox(suffix=suffix, locale=locale)
 


### PR DESCRIPTION
Fixes #3133.

When an integer `SpinBox` interprets edited text such as `2.1`, it coerces the value to `2`. If the stored value is already `2`, `editingFinishedEvent` returned without updating the line edit, leaving the displayed text inconsistent with the actual integer value.

The equal-value path now reformats the text without emitting a value-change signal. The regression test follows the reported sequence (`2.5`, then `2.1`) and verifies that both edits display the canonical integer text. The configured `pycln` hook also removed the module's unused `warnings` import.

Testing:
- `pytest tests/widgets/test_spinbox.py -q` — 45 passed
- `pytest tests -q` — 1116 passed, 705 skipped, 8 xfailed
- `pytest pyqtgraph/examples -q` — 98 passed, 3 skipped
- all applicable pre-commit hooks passed (`fix-encoding-pragma` skipped because that configured upstream hook has been removed)