### PR TITLE
pass clickEvent to other items if acceptedItem does not accept the event 

### DIFF
--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -368,7 +368,7 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
                     acceptedItem.mouseClickEvent(ev)
                 except:
                     debug.printExc("Error sending click event:")
-            if acceptedItem is None or not ev.isAccepted():
+            if not ev.isAccepted() or acceptedItem is None:
                 for item in self.itemsNearEvent(ev):
                     if not item.isVisible() or not item.isEnabled() or item is acceptedItem:
                         continue

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -370,7 +370,13 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
                     debug.printExc("Error sending click event:")
             if not ev.isAccepted() or acceptedItem is None:
                 for item in self.itemsNearEvent(ev):
-                    if not item.isVisible() or not item.isEnabled() or item is acceptedItem:
+                    if any(
+                        (
+                            not item.isVisible(),
+                            not item.isEnabled(),
+                            item is acceptedItem
+                        )
+                    ):
                         continue
                     if hasattr(item, 'mouseClickEvent'):
                         ev.currentItem = item

--- a/pyqtgraph/GraphicsScene/GraphicsScene.py
+++ b/pyqtgraph/GraphicsScene/GraphicsScene.py
@@ -368,9 +368,9 @@ class GraphicsScene(QtWidgets.QGraphicsScene):
                     acceptedItem.mouseClickEvent(ev)
                 except:
                     debug.printExc("Error sending click event:")
-            else:
+            if acceptedItem is None or not ev.isAccepted():
                 for item in self.itemsNearEvent(ev):
-                    if not item.isVisible() or not item.isEnabled():
+                    if not item.isVisible() or not item.isEnabled() or item is acceptedItem:
                         continue
                     if hasattr(item, 'mouseClickEvent'):
                         ev.currentItem = item


### PR DESCRIPTION
Currently, the `GraphicsScene` function `sendClickEvent` just silently swallows the click event if `lastHoverEvent` is not `None` and `acceptedItem` calls `ignore()` on the event. This patch changes the behavior such that if `acceptedItem` doesn't accept the event, the event will be passed on to any other `itemsNearEvent(ev)` (if any) to be handled.

Fixes #3549 