### PR TITLE
Fix JoystickButton move before press

### DIFF
--- a/pyqtgraph/widgets/JoystickButton.py
+++ b/pyqtgraph/widgets/JoystickButton.py
@@ -12,6 +12,7 @@ class JoystickButton(QtWidgets.QPushButton):
         self.radius = 200
         self.setCheckable(True)
         self.state = None
+        self.pressPos = None
         self.setState(0, 0)
         self.setFixedWidth(50)
         self.setFixedHeight(50)
@@ -24,12 +25,16 @@ class JoystickButton(QtWidgets.QPushButton):
         ev.accept()
         
     def mouseMoveEvent(self, ev):
+        if self.pressPos is None:
+            ev.ignore()
+            return
         lpos = ev.position() if hasattr(ev, 'position') else ev.localPos()
         dif = lpos - self.pressPos
         self.setState(dif.x(), -dif.y())
         
     def mouseReleaseEvent(self, ev):
         self.setChecked(False)
+        self.pressPos = None
         self.setState(0,0)
         
     def wheelEvent(self, ev):

--- a/tests/widgets/test_joystickbutton.py
+++ b/tests/widgets/test_joystickbutton.py
@@ -1,0 +1,20 @@
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtCore, QtGui
+
+
+def test_mouse_move_before_press_keeps_neutral_state():
+    pg.mkQApp()
+    button = pg.JoystickButton()
+    pos = QtCore.QPointF(10, 10)
+    event = QtGui.QMouseEvent(
+        QtCore.QEvent.Type.MouseMove,
+        pos,
+        pos,
+        QtCore.Qt.MouseButton.NoButton,
+        QtCore.Qt.MouseButton.NoButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+
+    button.mouseMoveEvent(event)
+
+    assert button.getState() == [0, 0]


### PR DESCRIPTION
## Summary

- initialize `JoystickButton.pressPos` when the widget is constructed
- ignore move events until a press establishes the drag origin
- clear the drag origin on release
- add a regression test for a mouse move arriving before the first press

## Root cause

`mouseMoveEvent` assumed that `mousePressEvent` had already assigned `pressPos`. With mouse tracking or bindings that deliver a hover move first, that assumption raises `AttributeError`.

## Validation

- `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/widgets/test_joystickbutton.py -q`
- `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest tests/widgets -q` (52 passed, 1 skipped)
- `git diff --check`

Fixes #3567.
