### PR TITLE
Fix locale-aware SI value parsing

### DIFF
--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -66,9 +66,9 @@ SI_PREFIX_EXPONENTS['u'] = -6
 SI_PREFIX_EXPONENTS['μ'] = -6
 
 #For comma as decimal separator
-FLOAT_REGEX_COMMA = re.compile(r'(?P<number>[+-]?((((\d+(,\d*)?)|(\d*,\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>\S.*))?$')
+FLOAT_REGEX_COMMA = re.compile(r'(?P<number>[+-]?((((\d+(,\d*)?)|(\d*,\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>[^\s\d.,].*))?$')
 #For period as decimal separator
-FLOAT_REGEX_PERIOD = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>\S.*))?$')
+FLOAT_REGEX_PERIOD = re.compile(r'(?P<number>[+-]?((((\d+(\.\d*)?)|(\d*\.\d+))([eE][+-]?\d+)?)|((?i:nan)|(inf))))\s*((?P<siPrefix>[' + SI_PREFIXES_INPUT + r']?)(?P<suffix>[^\s\d.,].*))?$')
 
 INT_REGEX = re.compile(r'(?P<number>[+-]?\d+)\s*(?P<siPrefix>[u' + SI_PREFIXES + r']?)(?P<suffix>.*)$')
 
@@ -277,6 +277,8 @@ def siEval(s, typ=float, regex=FLOAT_REGEX_PERIOD, suffix=None, unitPower=1):
         siEval("100 μV")  # returns 0.0001
     """
     val, siprefix, suffix = siParse(s, regex, suffix=suffix)
+    if regex is FLOAT_REGEX_COMMA:
+        val = val.replace(',', '.')
     v = typ(val)
     return siApply(v, siprefix, unitPower=unitPower)
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -315,15 +315,43 @@ def test_siEval_with_comma_as_decimal_separator(s, suffix, expected):
     assert np.isclose(result, expected)
 
 
-@pytest.mark.parametrize("s,regex", [
-    ("3,14 kB", pg.functions.FLOAT_REGEX_PERIOD),
-    ("31,4", pg.functions.FLOAT_REGEX_PERIOD),
-    ("3.14 kB", pg.functions.FLOAT_REGEX_COMMA),
-    ("31.4", pg.functions.FLOAT_REGEX_COMMA),
+@pytest.mark.parametrize("s,regex,expected", [
+    # period decimal separator
+    ("0", pg.functions.FLOAT_REGEX_PERIOD, ("0", "", "")),
+    ("+12", pg.functions.FLOAT_REGEX_PERIOD, ("+12", "", "")),
+    ("-0.5", pg.functions.FLOAT_REGEX_PERIOD, ("-0.5", "", "")),
+    (".5", pg.functions.FLOAT_REGEX_PERIOD, (".5", "", "")),
+    ("5.", pg.functions.FLOAT_REGEX_PERIOD, ("5.", "", "")),
+    ("1e3", pg.functions.FLOAT_REGEX_PERIOD, ("1e3", "", "")),
+    ("-2.5E-4", pg.functions.FLOAT_REGEX_PERIOD, ("-2.5E-4", "", "")),
+    ("3.14 kB", pg.functions.FLOAT_REGEX_PERIOD, ("3.14", "k", "B")),
+    ("100 µV", pg.functions.FLOAT_REGEX_PERIOD, ("100", "µ", "V")),
+    ("451.5 °F", pg.functions.FLOAT_REGEX_PERIOD, ("451.5", "", "°F")),
+    # comma decimal separator
+    ("0", pg.functions.FLOAT_REGEX_COMMA, ("0", "", "")),
+    ("+12", pg.functions.FLOAT_REGEX_COMMA, ("+12", "", "")),
+    ("-0,5", pg.functions.FLOAT_REGEX_COMMA, ("-0,5", "", "")),
+    (",5", pg.functions.FLOAT_REGEX_COMMA, (",5", "", "")),
+    ("5,", pg.functions.FLOAT_REGEX_COMMA, ("5,", "", "")),
+    ("1e3", pg.functions.FLOAT_REGEX_COMMA, ("1e3", "", "")),
+    ("-2,5E-4", pg.functions.FLOAT_REGEX_COMMA, ("-2,5E-4", "", "")),
+    ("3,14 kB", pg.functions.FLOAT_REGEX_COMMA, ("3,14", "k", "B")),
+    ("100 μV", pg.functions.FLOAT_REGEX_COMMA, ("100", "μ", "V")),
+    ("451,5 °F", pg.functions.FLOAT_REGEX_COMMA, ("451,5", "", "°F")),
+    # a decimal separator cannot be reinterpreted as a suffix
+    ("3,14 kB", pg.functions.FLOAT_REGEX_PERIOD, ValueError),
+    ("31,4", pg.functions.FLOAT_REGEX_PERIOD, ValueError),
+    ("1.2,3 V", pg.functions.FLOAT_REGEX_PERIOD, ValueError),
+    ("3.14 kB", pg.functions.FLOAT_REGEX_COMMA, ValueError),
+    ("31.4", pg.functions.FLOAT_REGEX_COMMA, ValueError),
+    ("1,2.3 V", pg.functions.FLOAT_REGEX_COMMA, ValueError),
 ])
-def test_siParse_rejects_mismatched_decimal_separator(s, regex):
-    with pytest.raises(ValueError):
-        pg.siParse(s, regex=regex)
+def test_siParse_decimal_separator_matrix(s, regex, expected):
+    if isinstance(expected, tuple):
+        assert pg.siParse(s, regex=regex) == expected
+    else:
+        with pytest.raises(expected):
+            pg.siParse(s, regex=regex)
 
 def test_CIELab_reconversion():
     color_list = [ pg.Qt.QtGui.QColor('#100235') ] # known problematic values

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -241,117 +241,69 @@ def test_eq():
     assert not eq(set(range(10)), set(range(9)))
 
 
-@pytest.mark.parametrize("s,suffix,expected", [
+@pytest.mark.parametrize("s,suffix,expected,sep", [
     # usual cases
-    ("100 uV", "V", ("100", "u", "V")),
-    ("100 µV", "V", ("100", "µ", "V")),
-    ("100 μV", "V", ("100", "μ", "V")),
-    ("4.2 nV", None, ("4.2", "n", "V")),
-    ("1.2 m", "m", ("1.2", "", "m")),
-    ("1.2 m", None, ("1.2", "", "m")),
-    ("451 °F", None, ("451", "", "°F")),
-    ("5.0e9", None, ("5.0e9", "", "")),
-    ("2 units", "units", ("2", "", "units")),
+    ("100 uV", "V", ("100", "u", "V"), pg.functions.FLOAT_REGEX_PERIOD),
+    ("100 µV", "V", ("100", "µ", "V"), pg.functions.FLOAT_REGEX_PERIOD),
+    ("100 μV", "V", ("100", "μ", "V"), pg.functions.FLOAT_REGEX_PERIOD),
+    ("4.2 nV", None, ("4.2", "n", "V"), pg.functions.FLOAT_REGEX_PERIOD),
+    ("1.2 m", "m", ("1.2", "", "m"), pg.functions.FLOAT_REGEX_PERIOD),
+    ("1.2 m", None, ("1.2", "", "m"), pg.functions.FLOAT_REGEX_PERIOD),
+    ("451 °F", None, ("451", "", "°F"), pg.functions.FLOAT_REGEX_PERIOD),
+    ("5.0e9", None, ("5.0e9", "", ""), pg.functions.FLOAT_REGEX_PERIOD),
+    ("2 units", "units", ("2", "", "units"), pg.functions.FLOAT_REGEX_PERIOD),
     # siPrefix with explicit empty suffix
-    ("1.2 m", "", ("1.2", "m", "")),
-    ("5.0e-9 M", "", ("5.0e-9", "M", "")),
+    ("1.2 m", "", ("1.2", "m", ""), pg.functions.FLOAT_REGEX_PERIOD),
+    ("5.0e-9 M", "", ("5.0e-9", "M", ""), pg.functions.FLOAT_REGEX_PERIOD),
     # weirder cases that should return the reasonable thing
-    ("4.2 nV", "nV", ("4.2", "", "nV")),
-    ("4.2 nV", "", ("4.2", "n", "")),
-    ("1.2 j", "", ("1.2", "", "")),
-    ("1.2 j", None, ("1.2", "", "j")),
+    ("4.2 nV", "nV", ("4.2", "", "nV"), pg.functions.FLOAT_REGEX_PERIOD),
+    ("4.2 nV", "", ("4.2", "n", ""), pg.functions.FLOAT_REGEX_PERIOD),
+    ("1.2 j", "", ("1.2", "", ""), pg.functions.FLOAT_REGEX_PERIOD),
+    ("1.2 j", None, ("1.2", "", "j"), pg.functions.FLOAT_REGEX_PERIOD),
     # expected error cases
-    ("100 uV", "v", ValueError),
-])
-def test_siParse(s, suffix, expected):
+    ("100 uV", "v", ValueError, pg.functions.FLOAT_REGEX_PERIOD),
+    ("1,2 j", "", ("1,2", "", ""), pg.functions.FLOAT_REGEX_COMMA),
+    ("1,2 j", None, ("1,2", "", "j"), pg.functions.FLOAT_REGEX_COMMA),
+    ("1,2 μV", "V", ("1,2", "μ", "V"), pg.functions.FLOAT_REGEX_COMMA),
+    ("451,5 °F", None, ("451,5", "", "°F"), pg.functions.FLOAT_REGEX_COMMA),
+    (",2 j", None, (",2", "", "j"), pg.functions.FLOAT_REGEX_COMMA),
+    ])
+def test_siParse(s, suffix, expected, sep):
     if isinstance(expected, tuple):
-        assert pg.siParse(s, suffix=suffix) == expected
+        assert pg.siParse(s, suffix=suffix, regex=sep) == expected
     else:
         with pytest.raises(expected):
-            pg.siParse(s, suffix=suffix)
+            pg.siParse(s, suffix=suffix, regex=sep)
 
-@pytest.mark.parametrize("s,suffix,power,expected", [
+
+@pytest.mark.parametrize("s,suffix,power,expected,sep", [
     # usual cases
-    ("100 uV", "V", 1, 1e-4),
-    ("100 µV", "V", 1, 1e-4),
-    ("100 μV", "V", 1, 1e-4),
-    ("4.2 nV", None, 1, 4.2e-9),
-    ("1.2 m", "m", 1, 1.2),
-    ("451 °F", None, 1, 451.0),
+    ("100 uV", "V", 1, 1e-4, pg.functions.FLOAT_REGEX_PERIOD),
+    ("100 µV", "V", 1, 1e-4, pg.functions.FLOAT_REGEX_PERIOD),
+    ("100 μV", "V", 1, 1e-4, pg.functions.FLOAT_REGEX_PERIOD),
+    ("4.2 nV", None, 1, 4.2e-9, pg.functions.FLOAT_REGEX_PERIOD),
+    ("1.2 m", "m", 1, 1.2, pg.functions.FLOAT_REGEX_PERIOD),
+    ("451 °F", None, 1, 451.0, pg.functions.FLOAT_REGEX_PERIOD),
     # siPrefix with explicit empty suffix
-    ("1.2 m", "", 1, 1.2e-3),
-    ("5.0e-9 M", "", 1, 5.0e-3),
+    ("1.2 m", "", 1, 1.2e-3, pg.functions.FLOAT_REGEX_PERIOD),
+    ("5.0e-9 M", "", 1, 5.0e-3, pg.functions.FLOAT_REGEX_PERIOD),
     # weirder cases that should return the reasonable thing    
-    ("4.2 nV", "", 1, 4.2e-9),
-    ("1.2 j", "", 1, 1.2),
-    ("1.2 j", None, 1, 1.2),
+    ("4.2 nV", "", 1, 4.2e-9, pg.functions.FLOAT_REGEX_PERIOD),
+    ("1.2 j", "", 1, 1.2, pg.functions.FLOAT_REGEX_PERIOD),
+    ("1.2 j", None, 1, 1.2, pg.functions.FLOAT_REGEX_PERIOD),
     # cases with power != 1
-    ("100 uV^2", "V^2", 2, 1e-10),
-    ("4.2 nV^2", None, 3, 4.2e-27),
-    ("100.2 um^(1/2)", "m^(1/2)", 0.5, 0.1002),
-    ("100 km^2", "m^2", 2, 1e+8),
+    ("100 uV^2", "V^2", 2, 1e-10, pg.functions.FLOAT_REGEX_PERIOD),
+    ("4.2 nV^2", None, 3, 4.2e-27, pg.functions.FLOAT_REGEX_PERIOD),
+    ("100.2 um^(1/2)", "m^(1/2)", 0.5, 0.1002, pg.functions.FLOAT_REGEX_PERIOD),
+    ("100 km^2", "m^2", 2, 1e+8, pg.functions.FLOAT_REGEX_PERIOD),
+    ("3,14", None, 1, 3.14, pg.functions.FLOAT_REGEX_COMMA),
+    ("3,14 kB", None, 1, 3140.0, pg.functions.FLOAT_REGEX_COMMA),
+    ("5,0e-9 M", "", 1, 5e-3, pg.functions.FLOAT_REGEX_COMMA),
 ])
-def test_siEval(s, suffix, power, expected):
-    result = pg.siEval(s, suffix=suffix, unitPower=power)
+def test_siEval(s, suffix, power, expected, sep):
+    result = pg.siEval(s, suffix=suffix, unitPower=power, regex=sep)
     assert np.isclose(result, expected)
 
-@pytest.mark.parametrize("s,suffix,expected", [
-    ("1,2 j", "", ("1,2", "", "")),
-    ("1,2 j", None, ("1,2", "", "j")),
-    ("1,2 μV", "V", ("1,2", "μ", "V")),
-    ("451,5 °F", None, ("451,5", "", "°F")),
-    (",2 j", None, (",2", "", "j")),])
-def test_siParse_with_comma_as_decimal_separator(s, suffix, expected):
-    assert pg.siParse(s, suffix=suffix, regex=pg.functions.FLOAT_REGEX_COMMA) == expected
-
-
-@pytest.mark.parametrize("s,suffix,expected", [
-    ("3,14", None, 3.14),
-    ("3,14 kB", None, 3140.0),
-    ("5,0e-9 M", "", 5e-3),
-])
-def test_siEval_with_comma_as_decimal_separator(s, suffix, expected):
-    result = pg.siEval(s, regex=pg.functions.FLOAT_REGEX_COMMA, suffix=suffix)
-    assert np.isclose(result, expected)
-
-
-@pytest.mark.parametrize("s,regex,expected", [
-    # period decimal separator
-    ("0", pg.functions.FLOAT_REGEX_PERIOD, ("0", "", "")),
-    ("+12", pg.functions.FLOAT_REGEX_PERIOD, ("+12", "", "")),
-    ("-0.5", pg.functions.FLOAT_REGEX_PERIOD, ("-0.5", "", "")),
-    (".5", pg.functions.FLOAT_REGEX_PERIOD, (".5", "", "")),
-    ("5.", pg.functions.FLOAT_REGEX_PERIOD, ("5.", "", "")),
-    ("1e3", pg.functions.FLOAT_REGEX_PERIOD, ("1e3", "", "")),
-    ("-2.5E-4", pg.functions.FLOAT_REGEX_PERIOD, ("-2.5E-4", "", "")),
-    ("3.14 kB", pg.functions.FLOAT_REGEX_PERIOD, ("3.14", "k", "B")),
-    ("100 µV", pg.functions.FLOAT_REGEX_PERIOD, ("100", "µ", "V")),
-    ("451.5 °F", pg.functions.FLOAT_REGEX_PERIOD, ("451.5", "", "°F")),
-    # comma decimal separator
-    ("0", pg.functions.FLOAT_REGEX_COMMA, ("0", "", "")),
-    ("+12", pg.functions.FLOAT_REGEX_COMMA, ("+12", "", "")),
-    ("-0,5", pg.functions.FLOAT_REGEX_COMMA, ("-0,5", "", "")),
-    (",5", pg.functions.FLOAT_REGEX_COMMA, (",5", "", "")),
-    ("5,", pg.functions.FLOAT_REGEX_COMMA, ("5,", "", "")),
-    ("1e3", pg.functions.FLOAT_REGEX_COMMA, ("1e3", "", "")),
-    ("-2,5E-4", pg.functions.FLOAT_REGEX_COMMA, ("-2,5E-4", "", "")),
-    ("3,14 kB", pg.functions.FLOAT_REGEX_COMMA, ("3,14", "k", "B")),
-    ("100 μV", pg.functions.FLOAT_REGEX_COMMA, ("100", "μ", "V")),
-    ("451,5 °F", pg.functions.FLOAT_REGEX_COMMA, ("451,5", "", "°F")),
-    # a decimal separator cannot be reinterpreted as a suffix
-    ("3,14 kB", pg.functions.FLOAT_REGEX_PERIOD, ValueError),
-    ("31,4", pg.functions.FLOAT_REGEX_PERIOD, ValueError),
-    ("1.2,3 V", pg.functions.FLOAT_REGEX_PERIOD, ValueError),
-    ("3.14 kB", pg.functions.FLOAT_REGEX_COMMA, ValueError),
-    ("31.4", pg.functions.FLOAT_REGEX_COMMA, ValueError),
-    ("1,2.3 V", pg.functions.FLOAT_REGEX_COMMA, ValueError),
-])
-def test_siParse_decimal_separator_matrix(s, regex, expected):
-    if isinstance(expected, tuple):
-        assert pg.siParse(s, regex=regex) == expected
-    else:
-        with pytest.raises(expected):
-            pg.siParse(s, regex=regex)
 
 def test_CIELab_reconversion():
     color_list = [ pg.Qt.QtGui.QColor('#100235') ] # known problematic values

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -304,6 +304,27 @@ def test_siEval(s, suffix, power, expected):
 def test_siParse_with_comma_as_decimal_separator(s, suffix, expected):
     assert pg.siParse(s, suffix=suffix, regex=pg.functions.FLOAT_REGEX_COMMA) == expected
 
+
+@pytest.mark.parametrize("s,suffix,expected", [
+    ("3,14", None, 3.14),
+    ("3,14 kB", None, 3140.0),
+    ("5,0e-9 M", "", 5e-3),
+])
+def test_siEval_with_comma_as_decimal_separator(s, suffix, expected):
+    result = pg.siEval(s, regex=pg.functions.FLOAT_REGEX_COMMA, suffix=suffix)
+    assert np.isclose(result, expected)
+
+
+@pytest.mark.parametrize("s,regex", [
+    ("3,14 kB", pg.functions.FLOAT_REGEX_PERIOD),
+    ("31,4", pg.functions.FLOAT_REGEX_PERIOD),
+    ("3.14 kB", pg.functions.FLOAT_REGEX_COMMA),
+    ("31.4", pg.functions.FLOAT_REGEX_COMMA),
+])
+def test_siParse_rejects_mismatched_decimal_separator(s, regex):
+    with pytest.raises(ValueError):
+        pg.siParse(s, regex=regex)
+
 def test_CIELab_reconversion():
     color_list = [ pg.Qt.QtGui.QColor('#100235') ] # known problematic values
     for _ in range(20):


### PR DESCRIPTION
## Summary

- normalize comma-decimal values before converting parsed SI values to numeric types
- prevent numeric, period, or comma characters from being accepted as the start of a unit suffix
- add coverage for comma-decimal SI evaluation
- add symmetric rejection coverage for mismatched decimal separators

## Root cause

The comma-aware regex returned the localized numeric token unchanged, so `float()` could not convert it. Separately, both locale regexes allowed any non-whitespace suffix start, which let a mismatched decimal separator and the remaining digits be treated as a suffix. That silently truncated the numeric value and could discard the intended SI prefix.

## Validation

- `pytest tests/test_functions.py tests/widgets/test_spinbox.py -q` (228 passed, 2 skipped)
- `git diff --check`

Fixes #3568.
Fixes #3569.
