### PR TITLE
Image Export: use QImage.invertPixels

### DIFF
--- a/pyqtgraph/exporters/ImageExporter.py
+++ b/pyqtgraph/exporters/ImageExporter.py
@@ -1,8 +1,3 @@
-import sys
-
-import numpy as np
-
-from .. import functions as fn
 from ..parametertree import Parameter
 from ..Qt import QtCore, QtGui, QtWidgets
 from .Exporter import Exporter
@@ -101,16 +96,16 @@ class ImageExporter(Exporter):
         targetRect = QtCore.QRect(0, 0, w, h)
         sourceRect = self.getSourceRect()
 
-        self.png = QtGui.QImage(w, h, QtGui.QImage.Format.Format_ARGB32_Premultiplied)
-        self.png.fill(self.params['background'])
+        qimg = QtGui.QImage(w, h, QtGui.QImage.Format.Format_ARGB32_Premultiplied)
+        qimg.fill(self.params['background'])
         
         ## set resolution of image:
         origTargetRect = self.getTargetRect()
         resolutionScale = targetRect.width() / origTargetRect.width()
-        #self.png.setDotsPerMeterX(self.png.dotsPerMeterX() * resolutionScale)
-        #self.png.setDotsPerMeterY(self.png.dotsPerMeterY() * resolutionScale)
+        #qimg.setDotsPerMeterX(qimg.dotsPerMeterX() * resolutionScale)
+        #qimg.setDotsPerMeterY(qimg.dotsPerMeterY() * resolutionScale)
         
-        painter = QtGui.QPainter(self.png)
+        painter = QtGui.QPainter(qimg)
         #dtr = painter.deviceTransform()
         try:
             self.setExportMode(True, {
@@ -125,21 +120,13 @@ class ImageExporter(Exporter):
         painter.end()
         
         if self.params['invertValue']:
-            bg = fn.ndarray_from_qimage(self.png)
-            if sys.byteorder == 'little':
-                cv = slice(0, 3)
-            else:
-                cv = slice(1, 4)
-            mn = bg[...,cv].min(axis=2)
-            mx = bg[...,cv].max(axis=2)
-            d = (255 - mx) - mn
-            bg[...,cv] += d[...,np.newaxis]
+            qimg.invertPixels()
         
         if copy:
-            QtWidgets.QApplication.clipboard().setImage(self.png)
+            QtWidgets.QApplication.clipboard().setImage(qimg)
         elif toBytes:
-            return self.png
+            return qimg
         else:
-            return self.png.save(fileName)
+            return qimg.save(fileName)
         
 ImageExporter.register()


### PR DESCRIPTION
#3499 changed to pre-multiplied format but the image inversion code wasn't changed to take that into account. Using `QImage`'s `invertPixels` method takes care of that. It also removes the need for the endian-dependent handling code.
