### PR TITLE
Refactor HDF5Exporter for better versatility and dataset naming

### DIFF
--- a/pyqtgraph/exporters/HDF5Exporter.py
+++ b/pyqtgraph/exporters/HDF5Exporter.py
@@ -69,8 +69,11 @@ class HDF5Exporter(Exporter):
         items = []
 
         if isinstance(item, GraphicsScene):
+            # why this order???
             items = [
-                _item for _item in item.items() if isinstance(_item, PlotItem)
+                _item
+                for _item in reversed(item.items())
+                if isinstance(_item, PlotItem)
             ]
         if isinstance(item, ViewBox):
             items = [

--- a/pyqtgraph/exporters/HDF5Exporter.py
+++ b/pyqtgraph/exporters/HDF5Exporter.py
@@ -96,14 +96,11 @@ class HDF5Exporter(Exporter):
 
         with h5py.File(fileName, "w") as fd:
             for index, item in enumerate(items, start=1):
-                if len(items) == 1:
-                    pd = fd
-                else:
-                    pd = fd.require_group(
-                        item.titleLabel.text
-                        if item.titleLabel.isVisible()
-                        else f"Plot {index}"
-                    )
+                pd = fd if len(items) == 1 else fd.require_group(
+                    item.titleLabel.text
+                    if item.titleLabel.isVisible()
+                    else f"Plot {index}"
+                )
                 if appendAllX:
                     for i, c in enumerate(item.curves):
                         d = (
@@ -115,7 +112,7 @@ class HDF5Exporter(Exporter):
                             continue
                         fdata = numpy.column_stack(d)
                         cname = c.name() or str(i)
-                        fd.require_dataset(
+                        pd.require_dataset(
                             name=cname,
                             shape=fdata.shape,
                             dtype=fdata.dtype,
@@ -142,7 +139,7 @@ class HDF5Exporter(Exporter):
                             else c.getData()
                         )
                         cname = c.name() or str(i)
-                        cg = fd.require_group(cname)
+                        cg = pd.require_group(cname)
                         if d[0] is not None:
                             cg.require_dataset(
                                 name=x_label,

--- a/pyqtgraph/exporters/HDF5Exporter.py
+++ b/pyqtgraph/exporters/HDF5Exporter.py
@@ -102,7 +102,7 @@ class HDF5Exporter(Exporter):
                     else f"Plot {index}"
                 )
                 if appendAllX:
-                    for i, c in enumerate(item.curves):
+                    for i, c in enumerate(item.curves, start=1):
                         d = (
                             c.getOriginalDataset()
                             if self.params["originalDataset"]
@@ -111,7 +111,7 @@ class HDF5Exporter(Exporter):
                         if d[0] is None or d[1] is None:
                             continue
                         fdata = numpy.column_stack(d)
-                        cname = c.name() or str(i)
+                        cname = c.name() or f"Curve {i}"
                         pd.require_dataset(
                             name=cname,
                             shape=fdata.shape,
@@ -132,13 +132,13 @@ class HDF5Exporter(Exporter):
                         else y_axis.labelText or "y"
                     )
 
-                    for i, c in enumerate(item.curves):
+                    for i, c in enumerate(item.curves, start=1):
                         d = (
                             c.getOriginalDataset()
                             if self.params["originalDataset"]
                             else c.getData()
                         )
-                        cname = c.name() or str(i)
+                        cname = c.name() or f"Curve {i}"
                         cg = pd.require_group(cname)
                         if d[0] is not None:
                             cg.require_dataset(

--- a/pyqtgraph/exporters/HDF5Exporter.py
+++ b/pyqtgraph/exporters/HDF5Exporter.py
@@ -5,7 +5,7 @@ import numpy
 from .. import PlotItem, ViewBox
 from ..parametertree import Parameter
 from ..GraphicsScene import GraphicsScene
-from ..Qt import QtCore, QtWidgets
+from ..Qt import QtCore
 from .Exporter import Exporter
 
 HAVE_HDF5 = importlib.util.find_spec("h5py") is not None
@@ -50,14 +50,6 @@ class HDF5Exporter(Exporter):
 
     def export(self, fileName=None):
         if not HAVE_HDF5:
-            QtWidgets.QMessageBox.critical(
-                self,
-                translate("Exporter", "HDF5 Export"),
-                translate(
-                    "This exporter requires the h5py package, "
-                    "but it was not importable."
-                ),
-            )
             raise RuntimeError(
                 "This exporter requires the h5py package, "
                 "but it was not importable."

--- a/pyqtgraph/exporters/HDF5Exporter.py
+++ b/pyqtgraph/exporters/HDF5Exporter.py
@@ -2,18 +2,19 @@ import importlib.util
 
 import numpy
 
-from .. import PlotItem
+from .. import PlotItem, ViewBox
 from ..parametertree import Parameter
-from ..Qt import QtCore
+from ..GraphicsScene import GraphicsScene
+from ..Qt import QtCore, QtWidgets
 from .Exporter import Exporter
 
 HAVE_HDF5 = importlib.util.find_spec("h5py") is not None
 
 translate = QtCore.QCoreApplication.translate
 
-__all__ = ['HDF5Exporter']
+__all__ = ["HDF5Exporter"]
 
-    
+
 class HDF5Exporter(Exporter):
     Name = "HDF5 Export: plot (x,y)"
     windows = []
@@ -21,55 +22,142 @@ class HDF5Exporter(Exporter):
 
     def __init__(self, item):
         Exporter.__init__(self, item)
-        self.params = Parameter.create(name='params', type='group', children=[
-            {'name': 'Name', 'title': translate("Exporter", 'Name'), 'type': 'str', 'value': 'Export', },
-            {'name': 'columnMode', 'title': translate("Exporter", 'columnMode'), 'type': 'list',
-             'limits': ['(x,y) per plot', '(x,y,y,y) for all plots'], 'value': '(x,y) per plot'},
-        ])
-        
+        self.params = Parameter.create(
+            name=translate("Exporter", "params"),
+            type="group",
+            children=[
+                {
+                    "name": "columnMode",
+                    "title": translate("Exporter", "columnMode"),
+                    "type": "list",
+                    "limits": [
+                        translate("Exporter", "2d (x,y) per plot"),
+                        translate("Exporter", "separate x and y"),
+                    ],
+                    "value": translate("Exporter", "2d (x,y) per plot"),
+                },
+                {
+                    "name": "originalDataset",
+                    "title": translate("Exporter", "originalDataset"),
+                    "type": "bool",
+                    "value": True,
+                },
+            ],
+        )
+
     def parameters(self):
         return self.params
-    
+
     def export(self, fileName=None):
         if not HAVE_HDF5:
-            raise RuntimeError("This exporter requires the h5py package, "
-                               "but it was not importable.")
-        
+            QtWidgets.QMessageBox.critical(
+                self,
+                translate("Exporter", "HDF5 Export"),
+                translate(
+                    "This exporter requires the h5py package, "
+                    "but it was not importable."
+                ),
+            )
+            raise RuntimeError(
+                "This exporter requires the h5py package, "
+                "but it was not importable."
+            )
+
         import h5py
 
-        if not isinstance(self.item, PlotItem):
-            raise Exception("Must have a PlotItem selected for HDF5 export.")
-        
+        item = self.item
+        items = []
+
+        if isinstance(item, GraphicsScene):
+            items = [
+                _item for _item in item.items() if isinstance(_item, PlotItem)
+            ]
+        if isinstance(item, ViewBox):
+            items = [
+                _item
+                for _item in [item.parentItem()]
+                if isinstance(_item, PlotItem)
+            ]
+        if isinstance(item, PlotItem):
+            items = [item]
+        if not items:
+            raise Exception("Must have a PlotItem for HDF5 export.")
+
         if fileName is None:
-            self.fileSaveDialog(filter=["*.h5", "*.hdf", "*.hd5"])
+            self.fileSaveDialog(
+                # see https://www.hdfgroup.org/solutions/hdf5/
+                filter=["*.h5", "*.hdf5"],
+            )
             return
-        dsname = self.params['Name']
-        fd = h5py.File(fileName, 'a')  # forces append to file... 'w' doesn't seem to "delete/overwrite"
-        data = []
 
-        appendAllX = self.params['columnMode'] == '(x,y) per plot'
-        # Check if the arrays are ragged
-        len_first = len(self.item.curves[0].getData()[0]) if self.item.curves[0] else None
-        ragged = any(len(i.getData()[0]) != len_first for i in self.item.curves)
+        appendAllX = self.params["columnMode"] == translate(
+            "Exporter", "2d (x,y) per plot"
+        )
 
-        if ragged:
-            dgroup = fd.create_group(dsname)
-            for i, c in enumerate(self.item.curves):
-                d = c.getData()
-                fdata = numpy.array([d[0], d[1]]).astype('double')
-                cname = c.name() if c.name() is not None else str(i)
-                dgroup.create_dataset(cname, data=fdata)
-        else:
-            for i, c in enumerate(self.item.curves):
-                d = c.getData()
-                if appendAllX or i == 0:
-                    data.append(d[0])
-                data.append(d[1])
+        with h5py.File(fileName, "w") as fd:
+            for index, item in enumerate(items, start=1):
+                if len(items) == 1:
+                    pd = fd
+                else:
+                    pd = fd.require_group(
+                        item.titleLabel.text
+                        if item.titleLabel.isVisible()
+                        else f"Plot {index}"
+                    )
+                if appendAllX:
+                    for i, c in enumerate(item.curves):
+                        d = (
+                            c.getOriginalDataset()
+                            if self.params["originalDataset"]
+                            else c.getData()
+                        )
+                        if d[0] is None or d[1] is None:
+                            continue
+                        fdata = numpy.column_stack(d)
+                        cname = c.name() or str(i)
+                        fd.require_dataset(
+                            name=cname,
+                            shape=fdata.shape,
+                            dtype=fdata.dtype,
+                            data=fdata,
+                        )
+                else:
+                    x_axis = item.getAxis("bottom")
+                    x_label = (
+                        f"{x_axis.labelText} ({x_axis.labelUnits})"
+                        if x_axis.labelUnits
+                        else x_axis.labelText or "x"
+                    )
+                    y_axis = item.getAxis("left")
+                    y_label = (
+                        f"{y_axis.labelText} ({y_axis.labelUnits})"
+                        if y_axis.labelUnits
+                        else y_axis.labelText or "y"
+                    )
 
-            fdata = numpy.array(data).astype('double')
-            fd.create_dataset(dsname, data=fdata)
+                    for i, c in enumerate(item.curves):
+                        d = (
+                            c.getOriginalDataset()
+                            if self.params["originalDataset"]
+                            else c.getData()
+                        )
+                        cname = c.name() or str(i)
+                        cg = fd.require_group(cname)
+                        if d[0] is not None:
+                            cg.require_dataset(
+                                name=x_label,
+                                shape=d[0].shape,
+                                dtype=d[0].dtype,
+                                data=d[0],
+                            )
+                        if d[1] is not None:
+                            cg.require_dataset(
+                                name=y_label,
+                                shape=d[1].shape,
+                                dtype=d[1].dtype,
+                                data=d[1],
+                            )
 
-        fd.close()
 
 if HAVE_HDF5:
     HDF5Exporter.register()

--- a/tests/exporters/test_hdf5.py
+++ b/tests/exporters/test_hdf5.py
@@ -59,33 +59,64 @@ def test_HDF5Exporter(tmp_h5, combine):
             assert_equal(y2, f["Curve 2"]["y"])
 
 
-def test_HDF5Exporter_unequal_lengths(tmp_h5):
-    # Test export with multiple curves of different size. The exporter should
-    # detect this and create multiple hdf5 datasets under a group.
+@pytest.mark.parametrize("combine", [False, True])
+def test_HDF5Exporter_2plots(tmp_h5, combine):
+    # Test export with multiple curves of different size on two plots.
+    # Tests both options for stacking the data (columnMode).
     x1 = np.linspace(0, 1, 10)
     y1 = np.sin(x1)
     x2 = np.linspace(0, 1, 100)
     y2 = np.cos(x2)
 
-    plt = pg.PlotWidget()
+    plt: pg.GraphicsLayoutWidget = pg.GraphicsLayoutWidget()
+    canvas1: pg.PlotItem = plt.ci.addPlot(row=0, col=0)
+    canvas2: pg.PlotItem = plt.ci.addPlot(row=1, col=0, title="Second plot")
     plt.show()
-    plt.plot(x=x1, y=y1, name='plot0')
-    plt.plot(x=x2, y=y2)
+    canvas1.plot(x=x1, y=y1)
+    canvas1.plot(x=x2, y=y2)
+    canvas2.plot(x=y1, y=x1)
+    canvas2.plot(x=y2, y=x2)
 
-    ex = HDF5Exporter(plt.plotItem)
+    ex = HDF5Exporter(plt.sceneObj)
+
+    if not combine:
+        ex.parameters()['columnMode'] = translate("Exporter", "separate x and y")
+
     ex.export(fileName=tmp_h5)
 
     with h5py.File(tmp_h5, 'r') as f:
-        # should be a group with the name of the curve
-        dset1 = f['plot0']
-        assert isinstance(dset1, h5py.Dataset)
-        # should be a group with the name by default
-        dset2 = f['Curve 2']
-        assert isinstance(dset2, h5py.Dataset)
-
-        # should be a dataset under the group with the name of the PlotItem
-        assert_equal(np.column_stack((x1, y1)), dset1)
-
-        # should be a dataset under the group with a default name that's the
-        # index of the curve in the PlotItem
-        assert_equal(np.column_stack((x2, y2)), dset2)
+        if combine:
+            # should be two datasets with default names
+            group1 = f["Plot 1"]
+            assert isinstance(group1, h5py.Group)
+            dset1 = group1["Curve 1"]
+            assert isinstance(dset1, h5py.Dataset)
+            dset2 = group1["Curve 2"]
+            assert isinstance(dset2, h5py.Dataset)
+            assert_equal(np.column_stack((x1, y1)), dset1)
+            assert_equal(np.column_stack((x2, y2)), dset2)
+            group1 = f["Second plot"]
+            assert isinstance(group1, h5py.Group)
+            dset1 = group1["Curve 1"]
+            assert isinstance(dset1, h5py.Dataset)
+            dset2 = group1["Curve 2"]
+            assert isinstance(dset2, h5py.Dataset)
+            assert_equal(np.column_stack((y1, x1)), dset1)
+            assert_equal(np.column_stack((y2, x2)), dset2)
+        else:
+            # should be two groups with default names,
+            # two datasets with default names in each
+            group1 = f["Plot 1"]
+            assert isinstance(group1, h5py.Group)
+            assert isinstance(group1["Curve 1"], h5py.Group)
+            assert_equal(x1, group1["Curve 1"]["x"])
+            assert_equal(y1, group1["Curve 1"]["y"])
+            assert_equal(x2, group1["Curve 2"]["x"])
+            assert_equal(y2, group1["Curve 2"]["y"])
+            group2 = f["Second plot"]
+            assert isinstance(group2, h5py.Group)
+            assert isinstance(group2["Curve 1"], h5py.Group)
+            assert_equal(x1, group2["Curve 1"]["y"])
+            assert_equal(y1, group2["Curve 1"]["x"])
+            assert_equal(x2, group2["Curve 2"]["y"])
+            assert_equal(y2, group2["Curve 2"]["x"])

--- a/tests/exporters/test_hdf5.py
+++ b/tests/exporters/test_hdf5.py
@@ -4,8 +4,13 @@ from numpy.testing import assert_equal
 
 import pyqtgraph as pg
 from pyqtgraph.exporters import HDF5Exporter
+from pyqtgraph.Qt import QtCore
+
 
 h5py = pytest.importorskip("h5py")
+
+
+translate = QtCore.QCoreApplication.translate
 
 
 @pytest.fixture
@@ -15,33 +20,43 @@ def tmp_h5(tmp_path):
 
 @pytest.mark.parametrize("combine", [False, True])
 def test_HDF5Exporter(tmp_h5, combine):
-    # Basic test of functionality: multiple curves with shared x array. Tests
-    # both options for stacking the data (columnMode).
-    x = np.linspace(0, 1, 100)
-    y1 = np.sin(x)
-    y2 = np.cos(x)
+    # Test export with multiple curves of different size.
+    # Tests both options for stacking the data (columnMode).
+    x1 = np.linspace(0, 1, 10)
+    y1 = np.sin(x1)
+    x2 = np.linspace(0, 1, 100)
+    y2 = np.cos(x2)
 
     plt = pg.PlotWidget()
     plt.show()
-    plt.plot(x=x, y=y1)
-    plt.plot(x=x, y=y2)
+    plt.plot(x=x1, y=y1)
+    plt.plot(x=x2, y=y2)
 
     ex = HDF5Exporter(plt.plotItem)
 
-    if combine:
-        ex.parameters()['columnMode'] = '(x,y,y,y) for all plots'
+    if not combine:
+        ex.parameters()['columnMode'] = translate("Exporter", "separate x and y")
 
     ex.export(fileName=tmp_h5)
 
     with h5py.File(tmp_h5, 'r') as f:
-        # should be a single dataset with the name of the exporter
-        dset = f[ex.parameters()['Name']]
-        assert isinstance(dset, h5py.Dataset)
-
         if combine:
-            assert_equal(np.array([x, y1, y2]), dset)
+            # should be two datasets with default names
+            dset1 = f["Curve 1"]
+            assert isinstance(dset1, h5py.Dataset)
+            dset2 = f["Curve 2"]
+            assert isinstance(dset2, h5py.Dataset)
+            assert_equal(np.column_stack((x1, y1)), dset1)
+            assert_equal(np.column_stack((x2, y2)), dset2)
         else:
-            assert_equal(np.array([x, y1, x, y2]), dset)
+            # should be two groups with default names,
+            # two datasets with default names in each
+            assert isinstance(f["Curve 1"], h5py.Group)
+            assert_equal(x1, f["Curve 1"]["x"])
+            assert_equal(y1, f["Curve 1"]["y"])
+            assert isinstance(f["Curve 2"], h5py.Group)
+            assert_equal(x2, f["Curve 2"]["x"])
+            assert_equal(y2, f["Curve 2"]["y"])
 
 
 def test_HDF5Exporter_unequal_lengths(tmp_h5):
@@ -61,13 +76,16 @@ def test_HDF5Exporter_unequal_lengths(tmp_h5):
     ex.export(fileName=tmp_h5)
 
     with h5py.File(tmp_h5, 'r') as f:
-        # should be a group with the name of the exporter
-        group = f[ex.parameters()['Name']]
-        assert isinstance(group, h5py.Group)
+        # should be a group with the name of the curve
+        dset1 = f['plot0']
+        assert isinstance(dset1, h5py.Dataset)
+        # should be a group with the name by default
+        dset2 = f['Curve 2']
+        assert isinstance(dset2, h5py.Dataset)
 
         # should be a dataset under the group with the name of the PlotItem
-        assert_equal(np.array([x1, y1]), group['plot0'])
+        assert_equal(np.column_stack((x1, y1)), dset1)
 
         # should be a dataset under the group with a default name that's the
         # index of the curve in the PlotItem
-        assert_equal(np.array([x2, y2]), group['1'])
+        assert_equal(np.column_stack((x2, y2)), dset2)


### PR DESCRIPTION
* Added saving original or displayed data.
* Added an option for saving x and y data as 1D arrays, naming them from the axes.
* Added naming datasets from the names of the curves if provided.
* Made more strings translatable.
* Fixed crash on rewriting an existing file.
* Fixed crash when not a `PlotItem` is selected.
* Removed global name selection as ambiguous.

This might resolve https://github.com/pyqtgraph/pyqtgraph/issues/3572.

But please add the translations. Other exporters might need to translate `'params'`, too.

Thank you, my dear OCD, for the PR.