### PR TITLE
Fix ColorButton dialog palette inheritance

### DIFF
--- a/pyqtgraph/widgets/ColorButton.py
+++ b/pyqtgraph/widgets/ColorButton.py
@@ -22,7 +22,8 @@ class ColorButton(QtWidgets.QPushButton):
         QtWidgets.QPushButton.__init__(self, parent)
         self.padding = (padding, padding, -padding, -padding) if isinstance(padding, (int, float)) else padding
         self.setColor(color)
-        self.colorDialog = QtWidgets.QColorDialog()
+        self.colorDialog = QtWidgets.QColorDialog(self)
+        self.colorDialog.setAttribute(QtCore.Qt.WidgetAttribute.WA_WindowPropagation, True)
         self.colorDialog.setOption(QtWidgets.QColorDialog.ColorDialogOption.ShowAlphaChannel, True)
         self.colorDialog.setOption(QtWidgets.QColorDialog.ColorDialogOption.DontUseNativeDialog, True)
         self.colorDialog.currentColorChanged.connect(self.dialogColorChanged)

--- a/tests/widgets/test_colorbutton.py
+++ b/tests/widgets/test_colorbutton.py
@@ -1,0 +1,18 @@
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtGui
+
+pg.mkQApp()
+
+
+def test_color_dialog_inherits_button_palette():
+    button = pg.ColorButton()
+    palette = button.palette()
+    window_color = QtGui.QColor("#123456")
+    palette.setColor(QtGui.QPalette.ColorRole.Window, window_color)
+    button.setPalette(palette)
+
+    assert button.colorDialog.parent() is button
+    assert (
+        button.colorDialog.palette().color(QtGui.QPalette.ColorRole.Window)
+        == window_color
+    )


### PR DESCRIPTION
## Summary

- parent the color dialog to `ColorButton`
- enable Qt window palette propagation so custom palettes remain inherited
- add regression coverage for dialog ownership and palette updates

## Testing

- focused regression on PyQt6, PySide6, and PyQt5
- `pytest tests/widgets -q` (52 passed, 1 skipped)
- `mypy` (350 source files clean)

Fixes #3312