### PR TITLE
Simplify file dialog life in `Exporter`

### DIFF
--- a/pyqtgraph/exporters/Exporter.py
+++ b/pyqtgraph/exporters/Exporter.py
@@ -29,7 +29,12 @@ class Exporter(object):
         """
         object.__init__(self)
         self.item = item
-        
+
+        self.fileDialog = FileDialog()
+        self.fileDialog.fileSelected.connect(self.fileSaveFinished)
+
+        self.exporterOpts = {}
+
     def parameters(self):
         """Return the parameters used to configure this exporter."""
         raise Exception("Abstract method must be overridden in subclass.")
@@ -46,7 +51,6 @@ class Exporter(object):
         ## Show a file dialog, call self.export(fileName) when finished.
         if opts is None:
             opts = {}
-        self.fileDialog = FileDialog()
         self.fileDialog.setFileMode(QtWidgets.QFileDialog.FileMode.AnyFile)
         self.fileDialog.setAcceptMode(QtWidgets.QFileDialog.AcceptMode.AcceptSave)
         if filter is not None:
@@ -54,15 +58,11 @@ class Exporter(object):
                 self.fileDialog.setNameFilter(filter)
             elif isinstance(filter, list):
                 self.fileDialog.setNameFilters(filter)
-        global LastExportDirectory
-        exportDir = LastExportDirectory
-        if exportDir is not None:
-            self.fileDialog.setDirectory(exportDir)
+        if LastExportDirectory is not None:
+            self.fileDialog.setDirectory(LastExportDirectory)
         self.fileDialog.show()
-        self.fileDialog.opts = opts
-        self.fileDialog.fileSelected.connect(self.fileSaveFinished)
-        return
-        
+        self.exporterOpts = opts
+
     def fileSaveFinished(self, fileName):
         global LastExportDirectory
         LastExportDirectory = os.path.split(fileName)[0]
@@ -73,10 +73,10 @@ class Exporter(object):
         if selectedExt is not None:
             selectedExt = selectedExt.groups()[0].lower()
             if ext != selectedExt:
-                fileName = fileName + '.' + selectedExt.lstrip('.')
-        
-        self.export(fileName=fileName, **self.fileDialog.opts)
-        
+                fileName += '.' + selectedExt.lstrip('.')
+
+        self.export(fileName=fileName, **self.exporterOpts)
+
     def getScene(self):
         if isinstance(self.item, GraphicsScene):
             return self.item

--- a/pyqtgraph/exporters/Exporter.py
+++ b/pyqtgraph/exporters/Exporter.py
@@ -1,3 +1,4 @@
+import abc
 import os
 import re
 
@@ -8,7 +9,7 @@ from ..widgets.FileDialog import FileDialog
 LastExportDirectory = None
 
 
-class Exporter(object):
+class Exporter(abc.ABC):
     """
     Abstract class used for exporting graphics to file / printer / whatever.
     """    
@@ -35,10 +36,12 @@ class Exporter(object):
 
         self.exporterOpts = {}
 
+    @abc.abstractmethod
     def parameters(self):
         """Return the parameters used to configure this exporter."""
         raise Exception("Abstract method must be overridden in subclass.")
         
+    @abc.abstractmethod
     def export(self, fileName=None, toBytes=False, copy=False):
         """
         If *fileName* is None, pop-up a file dialog.


### PR DESCRIPTION
While digging for the error handling, I stumbled upon the `Exporter` class. The IDE greeted me with a firework of warnings. So, I'm unsure whether the PR is worth it, but it's essentially up to you to evaluate.

Most of the IDE warnings were about `self.fileDialog`. So, the PR is mostly for it:

* Make it once, use it many times.
* Don't burden it with exporter-specific options.
* Use a global variable for the last directory instead of copying the value to a local var.

As a cosmetic change, I suggest making the `Exporter` class abstract not only in the description no one reads but also for Python.