### PR TITLE
Fix legend updates when plot data changes

### DIFF
--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -222,9 +222,21 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
             sample = self.sampleType(item)
 
         sample.sigClicked.connect(self.sigSampleClicked)
+        if hasattr(item, 'sigPlotChanged'):
+            item.sigPlotChanged.connect(
+                lambda _: self._updateItem(item, sample, label)
+            )
 
         self.items.append((sample, label))
         self._addItemToLayout(sample, label)
+        self.updateSize()
+
+    def _updateItem(self, item, sample, label):
+        """Update a legend entry after its plotted item changes."""
+        name = item.name()
+        if name is not None:
+            label.setText(name)
+        sample.update()
         self.updateSize()
 
     def _addItemToLayout(self, sample, label):

--- a/tests/graphicsItems/test_LegendItem.py
+++ b/tests/graphicsItems/test_LegendItem.py
@@ -101,3 +101,14 @@ def test_legend_item_basics():
 
     legend.clear()
     assert legend.items == []
+
+
+def test_legend_updates_when_plot_data_changes():
+    legend = pg.LegendItem()
+    plot = pg.PlotDataItem([1, 2], [3, 4], name='Old Name')
+    legend.addItem(plot, name='Old Name')
+
+    plot.setData([1, 2], [4, 5], name='New Name')
+
+    assert legend.getLabel(plot).text == 'New Name'
+    legend.clear()


### PR DESCRIPTION
Summary

Fix LegendItem labels not updating when a PlotDataItem name changes through setData().

Changes

•
Connect LegendItem entries to sigPlotChanged.

•
Update the legend label from PlotDataItem.name() when the plot changes.

•
Request a sample redraw and recalculate the legend size.

•
Add a regression test for dynamic name updates.

Testing

QT_QPA_PLATFORM=offscreen pytest -q tests/graphicsItems/test_LegendItem.py tests/graphicsItems/test_PlotDataItem.py

12 passed