### PR TITLE
Fix incorrect type annotations for *args/**kwargs in docstrings

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -323,8 +323,8 @@ class AxisItem(GraphicsWidget):
 
     def setLogMode(
         self,
-        *args: tuple[bool] | tuple[bool, bool] | None,
-        **kwargs: dict[str, bool] | None
+        *args: bool,
+        **kwargs: bool
     ):
         """
         Set log scaling for x and / or y axes.
@@ -340,11 +340,11 @@ class AxisItem(GraphicsWidget):
 
         Parameters
         ----------
-        *args : tuple of bool
+        *args : bool
             If length 1, sets log mode regardless of orientation.  If length 2, the
             first element toggles log mode for x-axis, and the second element toggles
             log mode for the y-axis.
-        **kwargs : dict
+        **kwargs : bool
             Pass a dictionary with keys `x` and `y`, where the values are ``bool`` to
             set the log mode for the respective `x` or `y` axis.  Trying to set the `y`
             axis log mode while this axis item is horizontal (or vice versa) will be

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -1158,9 +1158,9 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args : object
             See :class:`PlotDataItem` description for supported arguments.
-        **kwargs : dict
+        **kwargs : object
             See :class:`PlotDataItem` description for supported arguments.
 
         Raises


### PR DESCRIPTION
Fixes #3488

Corrected type annotations for *args/**kwargs that didn't match what the functions actually accept:

- `PlotDataItem.setData()`: docstring said `tuple`/`dict`, changed to `object`
- `AxisItem.setLogMode()`: signature and docstring said `tuple`/`dict`, changed to `bool` — the function actually accepts individual bool values (e.g. `setLogMode(x=True, y=False)`), not a tuple or dict