### PR TITLE
Fixup incorrect args and kwargs docstring types

### DIFF
--- a/benchmarks/renderImageItem.py
+++ b/benchmarks/renderImageItem.py
@@ -134,7 +134,7 @@ class TimeSuite:
             use_levels: bool,
             dtype: npt.DTypeLike,
             channels: int,
-            lut_length: typing.Optional[npt.DTypeLike]
+            lut_length: npt.DTypeLike | None
     ):
         xp = np
         if acceleration == "numba":

--- a/doc/source/api_reference/flowchart/index.rst
+++ b/doc/source/api_reference/flowchart/index.rst
@@ -152,8 +152,8 @@ control panel. A minimal Node subclass looks like::
                 'outputTerminalName': {'io': 'out'},
                 })
                 
-        def process(self, **kwds):
-            # kwds will have one keyword argument per input terminal.
+        def process(self, **kwargs):
+            # kwargs will have one keyword argument per input terminal.
             
             return {'outputTerminalName': result}
         

--- a/doc/source/dictionaries/pyqtgraph.dic
+++ b/doc/source/dictionaries/pyqtgraph.dic
@@ -3042,9 +3042,9 @@ isocurve
 isosurface
 itemCls
 itertools
-kargs
 kwargs
-kwds
+kwargs
+kwargs
 leftovers
 length
 level

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ reportIncompatibleMethodOverride = false # complains when argument names don't m
 reportUnannotatedClassAttribute = false
 reportAttributeAccessIssue = false
 reportUnusedCallResult = false
+reportPrivateLocalImportUsage = false
 
 [tool.mypy]
 packages = ["pyqtgraph"]

--- a/pyqtgraph/Qt/__init__.py
+++ b/pyqtgraph/Qt/__init__.py
@@ -186,8 +186,8 @@ if QT_LIB in [PYQT5, PYQT6]:
     # users), we install a global exception hook to override this behavior.
     if sys.excepthook == sys.__excepthook__:
         sys_excepthook = sys.excepthook
-        def pyqt_qabort_override(*args, **kwds):
-            return sys_excepthook(*args, **kwds)
+        def pyqt_qabort_override(*args, **kwargs):
+            return sys_excepthook(*args, **kwargs)
         sys.excepthook = pyqt_qabort_override
     
     def isQObjectAlive(obj):

--- a/pyqtgraph/Qt/__init__.pyi
+++ b/pyqtgraph/Qt/__init__.pyi
@@ -12,7 +12,7 @@ App: QtWidgets.QApplication
 VERSION_INFO: str
 QT_LIB: str
 QtVersion: str
-QtVersionInfo: tuple
+QtVersionInfo: tuple[int, int, int]
 
 def exec_() -> QtWidgets.QApplication: ...
 def mkQApp(name: str | None = None) -> QtWidgets.QApplication: ...

--- a/pyqtgraph/__init__.py
+++ b/pyqtgraph/__init__.py
@@ -5,7 +5,7 @@ www.pyqtgraph.org
 
 __version__ = '0.15.0.dev0'
 
-### import all the goodies and add some helper functions for easy CLI use
+# pyright: reportMissingImports=false, reportUnusedImport=false
 
 import importlib
 import os
@@ -60,8 +60,8 @@ def setConfigOptions(**opts):
 
     Each keyword argument sets one global option.
     """
-    for k,v in opts.items():
-        setConfigOption(k, v)
+    for key, value in opts.items():
+        setConfigOption(key, value)
 
 def getConfigOption(opt):
     """Return the value of a single global configuration option.
@@ -297,7 +297,7 @@ plots = []
 images = []
 QAPP = None
 
-def plot(*args, **kargs):
+def plot(*args, **kwargs):
     """
     Create and return a :class:`PlotWidget <pyqtgraph.PlotWidget>`
     Accepts a *title* argument to set the title of the window.
@@ -307,11 +307,11 @@ def plot(*args, **kargs):
     pwArgList = ['title', 'labels', 'name', 'left', 'right', 'top', 'bottom', 'background']
     pwArgs = {}
     dataArgs = {}
-    for k in kargs:
+    for k in kwargs:
         if k in pwArgList:
-            pwArgs[k] = kargs[k]
+            pwArgs[k] = kwargs[k]
         else:
-            dataArgs[k] = kargs[k]
+            dataArgs[k] = kwargs[k]
     windowTitle = pwArgs.pop("title", "PlotWidget")
     w = PlotWidget(**pwArgs)
     w.setWindowTitle(windowTitle)
@@ -321,7 +321,7 @@ def plot(*args, **kargs):
     w.show()
     return w
 
-def image(*args, **kargs):
+def image(*args, **kwargs):
     """
     Create and return an :class:`ImageView <pyqtgraph.ImageView>`
     Will show 2D or 3D image data.
@@ -330,16 +330,16 @@ def image(*args, **kargs):
     """
     mkQApp()
     w = ImageView()
-    windowTitle = kargs.pop("title", "ImageView")
+    windowTitle = kwargs.pop("title", "ImageView")
     w.setWindowTitle(windowTitle)
-    w.setImage(*args, **kargs)
+    w.setImage(*args, **kwargs)
     images.append(w)
     w.show()
     return w
 show = image  ## for backward compatibility
 
 
-def dbg(*args, **kwds):
+def dbg(*args, **kwargs):
     """
     Create a console window and begin watching for exceptions.
 
@@ -347,7 +347,7 @@ def dbg(*args, **kwds):
     """
     mkQApp()
     from . import console
-    c = console.ConsoleWidget(*args, **kwds)
+    c = console.ConsoleWidget(*args, **kwargs)
     c.catchAllExceptions()
     c.show()
     global consoles
@@ -358,7 +358,7 @@ def dbg(*args, **kwds):
     return c
 
 
-def stack(*args, **kwds):
+def stack(*args, **kwargs):
     """
     Create a console window and show the current stack trace.
 
@@ -366,7 +366,7 @@ def stack(*args, **kwds):
     """
     mkQApp()
     from . import console
-    c = console.ConsoleWidget(*args, **kwds)
+    c = console.ConsoleWidget(*args, **kwargs)
     c.setStack()
     c.show()
     global consoles
@@ -377,7 +377,7 @@ def stack(*args, **kwds):
     return c
 
 
-def setPalette(app, style):
+def setPalette(app: QtWidgets.QApplication, style: QtGui.QPalette | str):
     if isinstance(style, str):
         style = style.lower()
         if style == 'qdarkstylelight':

--- a/pyqtgraph/debug.py
+++ b/pyqtgraph/debug.py
@@ -45,13 +45,13 @@ def ftrace(func):
     """Decorator used for marking the beginning and end of function calls.
     Automatically indents nested calls.
     """
-    def w(*args, **kargs):
+    def w(*args, **kwargs):
         global __ftraceDepth
         pfx = "  " * __ftraceDepth
         print(pfx + func.__name__ + " start")
         __ftraceDepth += 1
         try:
-            rv = func(*args, **kargs)
+            rv = func(*args, **kwargs)
         finally:
             __ftraceDepth -= 1
         print(pfx + func.__name__ + " done")
@@ -112,9 +112,9 @@ class Tracer(object):
 
 def warnOnException(func):
     """Decorator that catches/ignores exceptions and prints a stack trace."""
-    def w(*args, **kwds):
+    def w(*args, **kwargs):
         try:
-            func(*args, **kwds)
+            func(*args, **kwargs)
         except:
             printExc('Ignored exception:')
     return w
@@ -516,7 +516,7 @@ class Profiler(object):
     disable = False  # set this flag to disable all or individual profilers at runtime
     
     class DisabledProfiler(object):
-        def __init__(self, *args, **kwds):
+        def __init__(self, *args, **kwargs):
             pass
         def __call__(self, *args):
             pass
@@ -725,7 +725,7 @@ class ObjTracker(object):
         #self.newRefs.clear()
         #self.newRefs.update(refs)
 
-    def diff(self, **kargs):
+    def diff(self, **kwargs):
         """
         Compute all differences between the current object set and the reference set.
         Print a set of reports for created, deleted, and persistent objects
@@ -785,11 +785,11 @@ class ObjTracker(object):
             print("  " + num + " "*(10-len(num)) + str(t))
             
         print("-----------  %d Deleted since last diff: ------------" % len(delRefs))
-        self.report(delRefs, objs, **kargs)
+        self.report(delRefs, objs, **kwargs)
         print("-----------  %d Created since last diff: ------------" % len(createRefs))
-        self.report(createRefs, objs, **kargs)
+        self.report(createRefs, objs, **kwargs)
         print("-----------  %d Created since start (persistent): ------------" % len(persistentRefs))
-        self.report(persistentRefs, objs, **kargs)
+        self.report(persistentRefs, objs, **kwargs)
         
         
     def __del__(self):
@@ -1223,7 +1223,7 @@ def threadName(threadId=None):
                 self._threadname = name
                 if not hasattr(Qt.QThread, '_names'):
                     Qt.QThread._names = {}
-                Qt.QThread.__init__(self, *args, **kwds)
+                Qt.QThread.__init__(self, *args, **kwargs)
             def run(self):
                 Qt.QThread._names[threading.current_thread().ident] = self._threadname
     """

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -10,7 +10,7 @@ class Dock(QtWidgets.QWidget):
     sigStretchChanged = QtCore.Signal()
     sigClosed = QtCore.Signal(object)
 
-    def __init__(self, name, area=None, size=(10, 10), widget=None, hideTitle=False, autoOrientation=True, label=None, **kargs):
+    def __init__(self, name, area=None, size=(10, 10), widget=None, hideTitle=False, autoOrientation=True, label=None, **kwargs):
         QtWidgets.QWidget.__init__(self)
         self.dockdrop = DockDrop(self)
         self._container = None
@@ -18,7 +18,7 @@ class Dock(QtWidgets.QWidget):
         self.area = area
         self.label = label
         if self.label is None:
-            self.label = DockLabel(name, **kargs)
+            self.label = DockLabel(name, **kwargs)
         self.label.dock = self
         if self.label.isClosable():
             self.label.sigCloseClicked.connect(self.close)

--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -26,7 +26,7 @@ class DockArea(Container, QtWidgets.QWidget):
     def type(self):
         return "top"
         
-    def addDock(self, dock=None, position='bottom', relativeTo=None, **kwds):
+    def addDock(self, dock=None, position='bottom', relativeTo=None, **kwargs):
         """Adds a dock to this area.
         
         ============== =================================================================
@@ -44,7 +44,7 @@ class DockArea(Container, QtWidgets.QWidget):
         None.        
         """
         if dock is None:
-            dock = Dock(**kwds)
+            dock = Dock(**kwargs)
             
         # store original area that the dock will return to when un-floated
         if not self.temporary:

--- a/pyqtgraph/examples/CustomGraphItem.py
+++ b/pyqtgraph/examples/CustomGraphItem.py
@@ -23,9 +23,9 @@ class Graph(pg.GraphItem):
         pg.GraphItem.__init__(self)
         self.scatter.sigClicked.connect(self.clicked)
         
-    def setData(self, **kwds):
-        self.text = kwds.pop('text', [])
-        self.data = kwds
+    def setData(self, **kwargs):
+        self.text = kwargs.pop('text', [])
+        self.data = kwargs
         if 'pos' in self.data:
             npts = self.data['pos'].shape[0]
             self.data['data'] = np.empty(npts, dtype=[('index', int)])

--- a/pyqtgraph/examples/ExampleApp.py
+++ b/pyqtgraph/examples/ExampleApp.py
@@ -6,7 +6,6 @@ import sys
 from argparse import Namespace
 from collections import OrderedDict
 from functools import lru_cache
-from typing import Optional
 
 import pyqtgraph as pg
 from pyqtgraph.Qt import QT_LIB, QtCore, QtGui, QtWidgets
@@ -92,7 +91,7 @@ class ExampleLoader(QtWidgets.QMainWindow):
         self.codeBtn.clicked.connect(self.runEditedCode)
         self.updateCodeViewTabWidth(self.ui.codeView.font())
 
-    def event(self, event: Optional[QtCore.QEvent]):
+    def event(self, event: QtCore.QEvent | None):
         if event is None:
             return super().event(None)
         if event.type() in [
@@ -333,10 +332,10 @@ class ExampleLoader(QtWidgets.QMainWindow):
         event.accept()
 
 def main():
-    app = pg.mkQApp()
+    _ = pg.mkQApp()
     loader = ExampleLoader()
     loader.ui.exampleTree.setCurrentIndex(
-        loader.ui.exampleTree.model().index(0,0)
+        loader.ui.exampleTree.model().index(0, 0)
     )
     pg.exec()
 

--- a/pyqtgraph/examples/GLPainterItem.py
+++ b/pyqtgraph/examples/GLPainterItem.py
@@ -9,9 +9,9 @@ from pyqtgraph.Qt import QtCore, QtGui
 SIZE = 32
 
 class GLPainterItem(GLGraphicsItem.GLGraphicsItem):
-    def __init__(self, **kwds):
+    def __init__(self, **kwargs):
         super().__init__()
-        glopts = kwds.pop('glOptions', 'additive')
+        glopts = kwargs.pop('glOptions', 'additive')
         self.setGLOptions(glopts)
 
     def compute_projection(self):

--- a/pyqtgraph/examples/PlotSpeedTest.py
+++ b/pyqtgraph/examples/PlotSpeedTest.py
@@ -46,8 +46,8 @@ QtGui.QSurfaceFormat.setDefaultFormat(sfmt)
 
 
 class MonkeyCurveItem(pg.PlotCurveItem):
-    def __init__(self, *args, **kwds):
-        super().__init__(*args, **kwds)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.monkey_mode = ''
 
     def setMethod(self, value):

--- a/pyqtgraph/examples/customPlot.py
+++ b/pyqtgraph/examples/customPlot.py
@@ -11,9 +11,9 @@ from pyqtgraph.Qt import QtCore
 
 
 class CustomViewBox(pg.ViewBox):
-    def __init__(self, *args, **kwds):
-        kwds['enableMenu'] = False
-        pg.ViewBox.__init__(self, *args, **kwds)
+    def __init__(self, *args, **kwargs):
+        kwargs['enableMenu'] = False
+        pg.ViewBox.__init__(self, *args, **kwargs)
         self.setMouseMode(self.RectMode)
         
     ## reimplement right-click to zoom out
@@ -29,8 +29,8 @@ class CustomViewBox(pg.ViewBox):
             pg.ViewBox.mouseDragEvent(self, ev, axis=axis)
 
 class CustomTickSliderItem(pg.TickSliderItem):
-    def __init__(self, *args, **kwds):
-        pg.TickSliderItem.__init__(self, *args, **kwds)
+    def __init__(self, *args, **kwargs):
+        pg.TickSliderItem.__init__(self, *args, **kwargs)
         
         self.all_ticks = {}
         self._range = [0,1]

--- a/pyqtgraph/examples/hdf5.py
+++ b/pyqtgraph/examples/hdf5.py
@@ -29,10 +29,10 @@ plt.enableAutoRange(False, False)
 plt.setXRange(0, 500)
 
 class HDF5Plot(pg.PlotCurveItem):
-    def __init__(self, *args, **kwds):
+    def __init__(self, *args, **kwargs):
         self.hdf5 = None
         self.limit = 10000 # maximum number of samples to be plotted
-        pg.PlotCurveItem.__init__(self, *args, **kwds)
+        pg.PlotCurveItem.__init__(self, *args, **kwargs)
         
     def setHDF5(self, data):
         self.hdf5 = data

--- a/pyqtgraph/examples/relativity/relativity.py
+++ b/pyqtgraph/examples/relativity/relativity.py
@@ -203,7 +203,7 @@ class ObjectGroupParam(pTypes.GroupParameter):
             self.addChild(GridParam())
 
 class ClockParam(pTypes.GroupParameter):
-    def __init__(self, **kwds):
+    def __init__(self, **kwargs):
         defs = dict(name="Clock", autoIncrementName=True, renamable=True, removable=True, children=[
             dict(name='Initial Position', type='float', value=0.0, step=0.1),
             #dict(name='V0', type='float', value=0.0, step=0.1),
@@ -214,9 +214,9 @@ class ClockParam(pTypes.GroupParameter):
             dict(name='Size', type='float', value=0.5),
             dict(name='Vertical Position', type='float', value=0.0, step=0.1),
             ])
-        #defs.update(kwds)
+        #defs.update(kwargs)
         pTypes.GroupParameter.__init__(self, **defs)
-        self.restoreState(kwds, removeChildren=False)
+        self.restoreState(kwargs, removeChildren=False)
             
     def buildClocks(self):
         x0 = self['Initial Position']
@@ -234,15 +234,15 @@ class ClockParam(pTypes.GroupParameter):
 pTypes.registerParameterType('Clock', ClockParam)
     
 class GridParam(pTypes.GroupParameter):
-    def __init__(self, **kwds):
+    def __init__(self, **kwargs):
         defs = dict(name="Grid", autoIncrementName=True, renamable=True, removable=True, children=[
             dict(name='Number of Clocks', type='int', value=5, limits=[1, None]),
             dict(name='Spacing', type='float', value=1.0, step=0.1),
             ClockParam(name='ClockTemplate'),
             ])
-        #defs.update(kwds)
+        #defs.update(kwargs)
         pTypes.GroupParameter.__init__(self, **defs)
-        self.restoreState(kwds, removeChildren=False)
+        self.restoreState(kwargs, removeChildren=False)
             
     def buildClocks(self):
         clocks = {}
@@ -260,10 +260,10 @@ class GridParam(pTypes.GroupParameter):
 pTypes.registerParameterType('Grid', GridParam)
 
 class AccelerationGroup(pTypes.GroupParameter):
-    def __init__(self, **kwds):
+    def __init__(self, **kwargs):
         defs = dict(name="Acceleration", addText="Add Command..")
         pTypes.GroupParameter.__init__(self, **defs)
-        self.restoreState(kwds, removeChildren=False)
+        self.restoreState(kwargs, removeChildren=False)
         
     def addNew(self):
         nextTime = 0.0

--- a/pyqtgraph/flowchart/Node.py
+++ b/pyqtgraph/flowchart/Node.py
@@ -169,7 +169,7 @@ class Node(QtCore.QObject):
         Warning: do not modify."""
         return self._outputs
         
-    def process(self, **kargs):
+    def process(self, **kwargs):
         """Process data through this node. This method is called any time the flowchart 
         wants the node to process data. It will be called with one keyword argument
         corresponding to each input terminal, and must return a dict mapping the name

--- a/pyqtgraph/flowchart/Terminal.py
+++ b/pyqtgraph/flowchart/Terminal.py
@@ -492,9 +492,9 @@ class ConnectionItem(GraphicsObject):
         self.target = target
         self.updateLine()
     
-    def setStyle(self, **kwds):
-        self.style.update(kwds)
-        if 'shape' in kwds:
+    def setStyle(self, **kwargs):
+        self.style.update(kwargs)
+        if 'shape' in kwargs:
             self.updateLine()
         else:
             self.update()

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -385,14 +385,14 @@ def mkColor(*args) -> QtGui.QColor:
     return QtGui.QColor(*args)
 
 
-def mkBrush(*args, **kwds):
+def mkBrush(*args, **kwargs):
     """
     | Convenience function for constructing Brush.
     | This function always constructs a solid brush and accepts the same arguments as :func:`mkColor() <pyqtgraph.mkColor>`
     | Calling mkBrush(None) returns an invisible brush.
     """
-    if 'color' in kwds:
-        color = kwds['color']
+    if 'color' in kwargs:
+        color = kwargs['color']
     elif len(args) == 1:
         arg = args[0]
         if arg is None:
@@ -406,7 +406,7 @@ def mkBrush(*args, **kwds):
     return QtGui.QBrush(mkColor(color))
 
 
-def mkPen(*args, **kargs) -> QtGui.QPen:
+def mkPen(*args, **kwargs) -> QtGui.QPen:
     """
     Convenience function for constructing QPen. 
     
@@ -419,12 +419,12 @@ def mkPen(*args, **kargs) -> QtGui.QPen:
         mkPen(None)   # (no pen)
     
     In these examples, *color* may be replaced with any arguments accepted by :func:`mkColor() <pyqtgraph.mkColor>`    """
-    color = kargs.get('color', None)
-    width = kargs.get('width', 1)
-    style = kargs.get('style', None)
-    dash = kargs.get('dash', None)
-    cosmetic = kargs.get('cosmetic', True)
-    hsv = kargs.get('hsv', None)
+    color = kwargs.get('color', None)
+    width = kwargs.get('width', 1)
+    style = kwargs.get('style', None)
+    dash = kwargs.get('dash', None)
+    cosmetic = kwargs.get('cosmetic', True)
+    hsv = kwargs.get('hsv', None)
     
     if len(args) == 1:
         arg = args[0]
@@ -655,12 +655,12 @@ def intColor(index, hues=9, values=1, maxValue=255, minValue=150, maxHue=360, mi
     return QtGui.QColor.fromHsv(h, sat, v, alpha)
 
 
-def glColor(*args, **kargs):
+def glColor(*args, **kwargs):
     """
     Convert a color to OpenGL color format (r,g,b,a) floats 0.0-1.0
     Accepts same arguments as :func:`mkColor <pyqtgraph.mkColor>`.
     """
-    c = mkColor(*args, **kargs)
+    c = mkColor(*args, **kwargs)
     return c.getRgbF()
 
     
@@ -813,7 +813,7 @@ def affineSliceCoords(shape, origin, vectors, axes):
     return x
 
     
-def affineSlice(data, shape, origin, vectors, axes, order=1, returnCoords=False, **kargs):
+def affineSlice(data, shape, origin, vectors, axes, order=1, returnCoords=False, **kwargs):
     """
     Take a slice of any orientation through an array. This is useful for extracting sections of multi-dimensional arrays
     such as MRI images for viewing as 1D or 2D data.
@@ -882,7 +882,7 @@ def affineSlice(data, shape, origin, vectors, axes, order=1, returnCoords=False,
         output = np.empty(tuple(shape) + extraShape, dtype=data.dtype)
         for inds in np.ndindex(*extraShape):
             ind = (Ellipsis,) + inds
-            output[ind] = scipy.ndimage.map_coordinates(data[ind], x, order=order, **kargs)
+            output[ind] = scipy.ndimage.map_coordinates(data[ind], x, order=order, **kwargs)
     else:
         # map_coordinates expects the indexes as the first axis, whereas
         # interpolateArray expects indexes at the last axis. 
@@ -1357,10 +1357,10 @@ def applyLookupTable(data, lut):
         return np.take(lut, data, axis=0, mode='clip')
     
 
-def makeRGBA(*args, **kwds):
+def makeRGBA(*args, **kwargs):
     """Equivalent to makeARGB(..., useRGBA=True)"""
-    kwds['useRGBA'] = True
-    return makeARGB(*args, **kwds)
+    kwargs['useRGBA'] = True
+    return makeARGB(*args, **kwargs)
 
 
 def makeARGB(data, lut=None, levels=None, scale=None, useRGBA=False, maskNans=True, output=None):

--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -154,7 +154,7 @@ class AxisItem(GraphicsWidget):
 
         Parameters
         ----------
-        **kwargs : dict, optional
+        **kwargs
             Here are a list of supported arguments.
 
             ===================== ======================================================
@@ -323,8 +323,8 @@ class AxisItem(GraphicsWidget):
 
     def setLogMode(
         self,
-        *args: tuple[bool] | tuple[bool, bool] | None,
-        **kwargs: dict[str, bool] | None
+        *args: bool,
+        **kwargs: bool
     ):
         """
         Set log scaling for x and / or y axes.
@@ -340,11 +340,11 @@ class AxisItem(GraphicsWidget):
 
         Parameters
         ----------
-        *args : tuple of bool
+        *args : bool
             If length 1, sets log mode regardless of orientation.  If length 2, the
             first element toggles log mode for x-axis, and the second element toggles
             log mode for the y-axis.
-        **kwargs : dict
+        **kwargs : bool
             Pass a dictionary with keys `x` and `y`, where the values are ``bool`` to
             set the log mode for the respective `x` or `y` axis.  Trying to set the `y`
             axis log mode while this axis item is horizontal (or vice versa) will be
@@ -458,7 +458,7 @@ class AxisItem(GraphicsWidget):
             prepended based on the range of data displayed.
         unitPrefix : str
             An extra prefix to prepend to the units.
-        siPrefixEnableRanges : tuple of tuple of float, float, Optional
+        siPrefixEnableRanges : tuple of tuple of float, float, optional
             The ranges in which automatic SI prefix scaling is enabled. Defaults to
             everywhere, unless units is empty, in which case it defaults to
             ``((0., 1.), (1e9, inf))``.
@@ -685,9 +685,9 @@ class AxisItem(GraphicsWidget):
 
         Parameters
         ----------
-        *args : tuple
+        *args
             Arguments relayed to :func:`~pyqtgraph.mkPen`.
-        **kwargs : dict
+        **kwargs
             Arguments relayed to `:func:`~pyqtgraph.mkPen`.
 
         See Also
@@ -727,9 +727,9 @@ class AxisItem(GraphicsWidget):
         
         Parameters
         ----------
-        *args : tuple
+        *args
             Arguments relayed to :func:`~pyqtgraph.mkPen`.
-        **kwargs : dict
+        **kwargs
             Arguments relayed to `:func:`~pyqtgraph.mkPen`.
 
         See Also
@@ -767,9 +767,9 @@ class AxisItem(GraphicsWidget):
         
         Parameters
         ----------
-        *args : tuple
+        *args
             Arguments relayed to :func:`~pyqtgraph.mkPen`.
-        **kwargs : dict
+        **kwargs
             Arguments relayed to `:func:`~pyqtgraph.mkPen`.
 
         See Also

--- a/pyqtgraph/graphicsItems/FillBetweenItem.py
+++ b/pyqtgraph/graphicsItems/FillBetweenItem.py
@@ -79,15 +79,15 @@ class FillBetweenItem(QtWidgets.QGraphicsPathItem):
         self._fillRule = fillRule
         self.updatePath()
         
-    def setBrush(self, *args, **kwds):
+    def setBrush(self, *args, **kwargs):
         """Change the fill brush. Accepts the same arguments as :func:`~pyqtgraph.mkBrush`
         """
-        QtWidgets.QGraphicsPathItem.setBrush(self, fn.mkBrush(*args, **kwds))
+        QtWidgets.QGraphicsPathItem.setBrush(self, fn.mkBrush(*args, **kwargs))
         
-    def setPen(self, *args, **kwds):
+    def setPen(self, *args, **kwargs):
         """Change the fill pen. Accepts the same arguments as :func:`~pyqtgraph.mkColor`
         """
-        QtWidgets.QGraphicsPathItem.setPen(self, fn.mkPen(*args, **kwds))
+        QtWidgets.QGraphicsPathItem.setPen(self, fn.mkPen(*args, **kwargs))
 
     def setCurves(
         self,

--- a/pyqtgraph/graphicsItems/GradientEditorItem.py
+++ b/pyqtgraph/graphicsItems/GradientEditorItem.py
@@ -36,7 +36,7 @@ class TickSliderItem(GraphicsWidget):
     sigTicksChanged = QtCore.Signal(object)
     sigTicksChangeFinished = QtCore.Signal(object)
     
-    def __init__(self, orientation='bottom', allowAdd=True, allowRemove=True, **kargs):
+    def __init__(self, orientation='bottom', allowAdd=True, allowRemove=True, **kwargs):
         """
         ==============  =================================================================================
         **Arguments:**
@@ -57,8 +57,8 @@ class TickSliderItem(GraphicsWidget):
         self.maxDim = 20
         self.allowAdd = allowAdd
         self.allowRemove = allowRemove
-        if 'tickPen' in kargs:
-            self.tickPen = fn.mkPen(kargs['tickPen'])
+        if 'tickPen' in kwargs:
+            self.tickPen = fn.mkPen(kwargs['tickPen'])
         else:
             self.tickPen = fn.mkPen('w')
             
@@ -392,7 +392,7 @@ class GradientEditorItem(TickSliderItem):
     sigGradientChanged = QtCore.Signal(object)
     sigGradientChangeFinished = QtCore.Signal(object)
     
-    def __init__(self, *args, **kargs):
+    def __init__(self, *args, **kwargs):
         """
         Create a new GradientEditorItem. 
         All arguments are passed to :func:`TickSliderItem.__init__ <pyqtgraph.TickSliderItem.__init__>`
@@ -414,7 +414,7 @@ class GradientEditorItem(TickSliderItem):
         self.backgroundRect.setBrush(QtGui.QBrush(QtCore.Qt.BrushStyle.DiagCrossPattern))
         self.colorMode = 'rgb'
         
-        TickSliderItem.__init__(self, *args, **kargs)
+        TickSliderItem.__init__(self, *args, **kwargs)
         
         self.colorDialog = QtWidgets.QColorDialog()
         self.colorDialog.setOption(QtWidgets.QColorDialog.ColorDialogOption.ShowAlphaChannel, True)

--- a/pyqtgraph/graphicsItems/GradientLegend.py
+++ b/pyqtgraph/graphicsItems/GradientLegend.py
@@ -34,17 +34,17 @@ class GradientLegend(UIGraphicsItem):
         """
         self.gradient = colormap.getGradient()
         
-    def setIntColorScale(self, minVal, maxVal, *args, **kargs):
-        colors = [fn.intColor(i, maxVal-minVal, *args, **kargs) for i in range(minVal, maxVal)]
+    def setIntColorScale(self, minVal, maxVal, *args, **kwargs):
+        colors = [fn.intColor(i, maxVal-minVal, *args, **kwargs) for i in range(minVal, maxVal)]
         g = QtGui.QLinearGradient()
         for i in range(len(colors)):
             x = float(i)/len(colors)
             g.setColorAt(x, colors[i])
         self.setGradient(g)
-        if 'labels' not in kargs:
+        if 'labels' not in kwargs:
             self.setLabels({str(minVal): 0, str(maxVal): 1})
         else:
-            self.setLabels({kargs['labels'][0]:0, kargs['labels'][1]:1})
+            self.setLabels({kwargs['labels'][0]:0, kwargs['labels'][1]:1})
         
     def setLabels(self, l):
         """Defines labels to appear next to the color scale. Accepts a dict of {text: value} pairs"""

--- a/pyqtgraph/graphicsItems/GraphItem.py
+++ b/pyqtgraph/graphicsItems/GraphItem.py
@@ -15,7 +15,7 @@ class GraphItem(GraphicsObject):
     Useful for drawing networks, trees, etc.
     """
 
-    def __init__(self, **kwds):
+    def __init__(self, **kwargs):
         GraphicsObject.__init__(self)
         self.scatter = ScatterPlotItem()
         self.scatter.setParentItem(self)
@@ -23,9 +23,9 @@ class GraphItem(GraphicsObject):
         self.pos = None
         self.picture = None
         self.pen = 'default'
-        self.setData(**kwds)
+        self.setData(**kwargs)
         
-    def setData(self, **kwds):
+    def setData(self, **kwargs):
         """
         Change the data displayed by the graph. 
         
@@ -54,25 +54,25 @@ class GraphItem(GraphicsObject):
                         etc.)
         ==============  =======================================================================
         """
-        if 'adj' in kwds:
-            self.adjacency = kwds.pop('adj')
+        if 'adj' in kwargs:
+            self.adjacency = kwargs.pop('adj')
             if hasattr(self.adjacency, '__len__') and len(self.adjacency) == 0:
                 self.adjacency = None
             elif self.adjacency is not None and self.adjacency.dtype.kind not in 'iu':
                 raise Exception("adjacency must be None or an array of either int or unsigned type.")
             self._update()
-        if 'pos' in kwds:
-            self.pos = kwds['pos']
+        if 'pos' in kwargs:
+            self.pos = kwargs['pos']
             self._update()
-        if 'pen' in kwds:
-            self.setPen(kwds.pop('pen'))
+        if 'pen' in kwargs:
+            self.setPen(kwargs.pop('pen'))
             self._update()
             
-        if 'symbolPen' in kwds:    
-            kwds['pen'] = kwds.pop('symbolPen')
-        if 'symbolBrush' in kwds:    
-            kwds['brush'] = kwds.pop('symbolBrush')
-        self.scatter.setData(**kwds)
+        if 'symbolPen' in kwargs:    
+            kwargs['pen'] = kwargs.pop('symbolPen')
+        if 'symbolBrush' in kwargs:    
+            kwargs['brush'] = kwargs.pop('symbolBrush')
+        self.scatter.setData(**kwargs)
         self.informViewBoundsChanged()
 
     def _update(self):
@@ -138,8 +138,8 @@ class GraphItem(GraphicsObject):
     def boundingRect(self):
         return self.scatter.boundingRect()
         
-    def dataBounds(self, *args, **kwds):
-        return self.scatter.dataBounds(*args, **kwds)
+    def dataBounds(self, *args, **kwargs):
+        return self.scatter.dataBounds(*args, **kwargs)
     
     def pixelPadding(self):
         return self.scatter.pixelPadding()

--- a/pyqtgraph/graphicsItems/GraphicsItem.py
+++ b/pyqtgraph/graphicsItems/GraphicsItem.py
@@ -5,13 +5,11 @@ import weakref
 from collections import OrderedDict
 from functools import reduce
 from math import hypot
-from typing import Optional
 from xml.etree.ElementTree import Element
 
 from .. import functions as fn
-from ..GraphicsScene import GraphicsScene
 from ..Point import Point
-from ..Qt import QtCore, QtWidgets, isQObjectAlive
+from ..Qt import QtCore, isQObjectAlive
 
 
 # Recipe from https://docs.python.org/3.8/library/collections.html#collections.OrderedDict
@@ -19,9 +17,9 @@ from ..Qt import QtCore, QtWidgets, isQObjectAlive
 class LRU(OrderedDict):
     'Limit size, evicting the least recently looked-up key when full'
 
-    def __init__(self, maxsize=128, *args, **kwds):
+    def __init__(self, maxsize=128, *args, **kwargs):
         self.maxsize = maxsize
-        super().__init__(*args, **kwds)
+        super().__init__(*args, **kwargs)
 
     def __getitem__(self, key):
         value = super().__getitem__(key)
@@ -37,7 +35,7 @@ class LRU(OrderedDict):
             del self[oldest]
 
 
-class GraphicsItem(object):
+class GraphicsItem:
     """
     **Bases:** :class:`object`
 
@@ -533,7 +531,7 @@ class GraphicsItem(object):
     def generateSvg(
             self,
             nodes: dict[str, Element]
-    ) -> Optional[tuple[Element, list[Element]]]:
+    ) -> tuple[Element, list[Element]] | None:
         """Method to override to manually specify the SVG writer mechanism.
 
         Parameters

--- a/pyqtgraph/graphicsItems/GraphicsLayout.py
+++ b/pyqtgraph/graphicsItems/GraphicsLayout.py
@@ -35,13 +35,13 @@ class GraphicsLayout(GraphicsWidget):
         #print self.pos(), self.mapToDevice(self.rect().topLeft())
         #return ret
 
-    def setBorder(self, *args, **kwds):
+    def setBorder(self, *args, **kwargs):
         """
         Set the pen used to draw border between cells.
         
         See :func:`mkPen <pyqtgraph.mkPen>` for arguments.        
         """
-        self.border = fn.mkPen(*args, **kwds)
+        self.border = fn.mkPen(*args, **kwargs)
 
         for borderRect in self.itemBorders.values():
             borderRect.setPen(self.border)
@@ -59,31 +59,31 @@ class GraphicsLayout(GraphicsWidget):
         while self.getItem(self.currentRow, self.currentCol) is not None:
             self.currentCol += 1
         
-    def nextCol(self, *args, **kargs):
+    def nextCol(self, *args, **kwargs):
         """Alias of nextColumn"""
-        return self.nextColumn(*args, **kargs)
+        return self.nextColumn(*args, **kwargs)
         
-    def addPlot(self, row=None, col=None, rowspan=1, colspan=1, **kargs):
+    def addPlot(self, row=None, col=None, rowspan=1, colspan=1, **kwargs):
         """
         Create a PlotItem and place it in the next available cell (or in the cell specified)
         All extra keyword arguments are passed to :func:`PlotItem.__init__ <pyqtgraph.PlotItem.__init__>`
         Returns the created item.
         """
-        plot = PlotItem(**kargs)
+        plot = PlotItem(**kwargs)
         self.addItem(plot, row, col, rowspan, colspan)
         return plot
         
-    def addViewBox(self, row=None, col=None, rowspan=1, colspan=1, **kargs):
+    def addViewBox(self, row=None, col=None, rowspan=1, colspan=1, **kwargs):
         """
         Create a ViewBox and place it in the next available cell (or in the cell specified)
         All extra keyword arguments are passed to :func:`ViewBox.__init__ <pyqtgraph.ViewBox.__init__>`
         Returns the created item.
         """
-        vb = ViewBox(**kargs)
+        vb = ViewBox(**kwargs)
         self.addItem(vb, row, col, rowspan, colspan)
         return vb
         
-    def addLabel(self, text=' ', row=None, col=None, rowspan=1, colspan=1, **kargs):
+    def addLabel(self, text=' ', row=None, col=None, rowspan=1, colspan=1, **kwargs):
         """
         Create a LabelItem with *text* and place it in the next available cell (or in the cell specified)
         All extra keyword arguments are passed to :func:`LabelItem.__init__ <pyqtgraph.LabelItem.__init__>`
@@ -91,17 +91,17 @@ class GraphicsLayout(GraphicsWidget):
         
         To create a vertical label, use *angle* = -90.
         """
-        text = LabelItem(text, **kargs)
+        text = LabelItem(text, **kwargs)
         self.addItem(text, row, col, rowspan, colspan)
         return text
         
-    def addLayout(self, row=None, col=None, rowspan=1, colspan=1, **kargs):
+    def addLayout(self, row=None, col=None, rowspan=1, colspan=1, **kwargs):
         """
         Create an empty GraphicsLayout and place it in the next available cell (or in the cell specified)
         All extra keyword arguments are passed to :func:`GraphicsLayout.__init__ <pyqtgraph.GraphicsLayout.__init__>`
         Returns the created item.
         """
-        layout = GraphicsLayout(**kargs)
+        layout = GraphicsLayout(**kwargs)
         self.addItem(layout, row, col, rowspan, colspan)
         return layout
         

--- a/pyqtgraph/graphicsItems/ImageItem.py
+++ b/pyqtgraph/graphicsItems/ImageItem.py
@@ -41,7 +41,7 @@ class ImageItem(GraphicsObject):
     ----------
     image : np.ndarray or None, default None
         Image data.
-    **kargs : dict, optional
+    **kwargs
         Arguments directed to `setImage` and `setOpts`, refer to each method for
         documentation for possible arguments.
 
@@ -63,7 +63,7 @@ class ImageItem(GraphicsObject):
     sigImageChanged = QtCore.Signal()
     sigRemoveRequested = QtCore.Signal(object) 
 
-    def __init__(self, image: np.ndarray | None=None, **kargs):
+    def __init__(self, image: np.ndarray | None=None, **kwargs):
         super().__init__()
         self.menu = None
         self.image = None   ## original image data
@@ -95,9 +95,9 @@ class ImageItem(GraphicsObject):
         self.removable = False
 
         if image is not None:
-            self.setImage(image, **kargs)
+            self.setImage(image, **kwargs)
         else:
-            self.setOpts(**kargs)
+            self.setOpts(**kwargs)
 
     def setCompositionMode(self, mode: QtGui.QPainter.CompositionMode):
         """
@@ -376,7 +376,7 @@ class ImageItem(GraphicsObject):
         update : bool, default True
             Controls if image immediately updates to reflect the new options.
 
-        **kwargs : dict, optional
+        **kwargs
             Extra arguments that are directed to the respective methods.  Expected
             keys include:
 
@@ -432,8 +432,8 @@ class ImageItem(GraphicsObject):
             self.setLookupTable(kwargs['lut'], update=update)
         if 'levels' in kwargs:
             self.setLevels(kwargs['levels'], update=update)
-        #if 'clipLevel' in kargs:
-            #self.setClipLevel(kargs['clipLevel'])
+        #if 'clipLevel' in kwargs:
+            #self.setClipLevel(kwargs['clipLevel'])
         if 'opacity' in kwargs:
             self.setOpacity(kwargs['opacity'])
         if 'compositionMode' in kwargs:
@@ -465,7 +465,7 @@ class ImageItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args : QRectF, QRect, QPointF, QSizeF, or float
             Contains one of :class:`QRectF`, :class:`QRect`, or arguments that can be
             used to construct :class:`QRectF`.
 
@@ -554,7 +554,7 @@ class ImageItem(GraphicsObject):
             maximum values, ImageItem only inspects a subset of pixels no larger than
             this number. Setting this larger than the total number of pixels considers
             all values. See `quickMinMax`.
-        **kwargs : dict, optional
+        **kwargs
             Extra arguments that are passed to `setOpts`.
 
         See Also
@@ -730,10 +730,10 @@ class ImageItem(GraphicsObject):
             data = data[::2, ::] if h > w else data[::, ::2]
         return self._xp.nanmin(data), self._xp.nanmax(data)
 
-    def updateImage(self, *args, **kargs):
+    def updateImage(self, *args, **kwargs):
         defaults = {
             'autoLevels': False,
-        } | kargs
+        } | kwargs
         return self.setImage(*args, **defaults)
 
     def render(self):
@@ -856,7 +856,7 @@ class ImageItem(GraphicsObject):
         self._renderRequired = False
         self._unrenderable = False
 
-    def paint(self, painter, *args):
+    def paint(self, painter: QtGui.QPainter, *args):
         profile = debug.Profiler()
         if self.image is None:
             return
@@ -874,13 +874,13 @@ class ImageItem(GraphicsObject):
             if self.axisOrder == 'col-major'
             else self.image.shape[:2][::-1]
         )
-        painter.drawImage(QtCore.QRectF(0,0,*shape), self.qimage)
+        painter.drawImage(QtCore.QRectF(0, 0, *shape), self.qimage)
         profile('p.drawImage')
         if self.border is not None:
             painter.setPen(self.border)
             painter.drawRect(self.boundingRect())
 
-    def save(self, fileName: str | pathlib.Path, *args) -> None:
+    def save(self, fileName: str | pathlib.Path, *args, **kwargs) -> None:
         """
         Save this image to file.
 
@@ -891,8 +891,10 @@ class ImageItem(GraphicsObject):
         ----------
         fileName : os.PathLike
             File path to save the image data to.
-        *args : tuple
+        *args
             Arguments that are passed to :meth:`QImage.save <QImage.save>`.
+        *kwargs
+            Keyword arguments that are passed to :meth:`QImage.save <QImage.save>`.
             
         See Also
         --------
@@ -937,7 +939,7 @@ class ImageItem(GraphicsObject):
         targetImageSize : int, default 200
             This parameter is used if ``step == 'auto'``, If so, the `step` size is
             calculated by ``step = ceil(image.shape[0] / targetImageSize)``.
-        **kwargs : dict, optional
+        **kwargs
             Dictionary of arguments passed to :func:`numpy.histogram()`.
         
         Returns

--- a/pyqtgraph/graphicsItems/InfiniteLine.py
+++ b/pyqtgraph/graphicsItems/InfiniteLine.py
@@ -474,7 +474,7 @@ class InfLineLabel(TextItem):
     option here is to use `rotateAxis=(1, 0)`, which will cause the text to
     be automatically rotated parallel to the line.
     """
-    def __init__(self, line, text="", movable=False, position=0.5, anchors=None, **kwds):
+    def __init__(self, line, text="", movable=False, position=0.5, anchors=None, **kwargs):
         self.line = line
         self.movable = movable
         self.moving = False
@@ -484,7 +484,7 @@ class InfLineLabel(TextItem):
         self._endpoints = (None, None)
         if anchors is None:
             # automatically pick sensible anchors
-            rax = kwds.get('rotateAxis', None)
+            rax = kwargs.get('rotateAxis', None)
             if rax is not None:
                 if tuple(rax) == (1,0):
                     anchors = [(0.5, 0), (0.5, 1)]
@@ -497,7 +497,7 @@ class InfLineLabel(TextItem):
                     anchors = [(0, 0.5), (1, 0.5)]
             
         self.anchors = anchors
-        TextItem.__init__(self, **kwds)
+        TextItem.__init__(self, **kwargs)
         self.setParentItem(line)
         self.valueChanged()
 

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -134,12 +134,12 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         """Get the QPen used to draw the border around the legend."""
         return self.opts['pen']
 
-    def setPen(self, *args, **kargs):
+    def setPen(self, *args, **kwargs):
         """Set the pen used to draw a border around the legend.
 
         Accepts the same arguments as :func:`~pyqtgraph.mkPen`.
         """
-        pen = fn.mkPen(*args, **kargs)
+        pen = fn.mkPen(*args, **kwargs)
         self.opts['pen'] = pen
 
         self.update()
@@ -148,12 +148,12 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         """Get the QBrush used to draw the legend background."""
         return self.opts['brush']
 
-    def setBrush(self, *args, **kargs):
+    def setBrush(self, *args, **kwargs):
         """Set the brush used to draw the legend background.
 
         Accepts the same arguments as :func:`~pyqtgraph.mkBrush`.
         """
-        brush = fn.mkBrush(*args, **kargs)
+        brush = fn.mkBrush(*args, **kwargs)
         if self.opts['brush'] == brush:
             return
         self.opts['brush'] = brush
@@ -164,12 +164,12 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         """Get the QColor used for the item labels."""
         return self.opts['labelTextColor']
 
-    def setLabelTextColor(self, *args, **kargs):
+    def setLabelTextColor(self, *args, **kwargs):
         """Set the color of the item labels.
 
         Accepts the same arguments as :func:`~pyqtgraph.mkColor`.
         """
-        self.opts['labelTextColor'] = fn.mkColor(*args, **kargs)
+        self.opts['labelTextColor'] = fn.mkColor(*args, **kwargs)
         for sample, label in self.items:
             label.setAttr('color', self.opts['labelTextColor'])
 

--- a/pyqtgraph/graphicsItems/LinearRegionItem.py
+++ b/pyqtgraph/graphicsItems/LinearRegionItem.py
@@ -162,19 +162,19 @@ class LinearRegionItem(GraphicsObject):
         self.lineMoved(1)
         self.lineMoveFinished()
 
-    def setBrush(self, *br, **kargs):
+    def setBrush(self, *br, **kwargs):
         """Set the brush that fills the region. Can have any arguments that are valid
         for :func:`mkBrush <pyqtgraph.mkBrush>`.
         """
-        self.brush = fn.mkBrush(*br, **kargs)
+        self.brush = fn.mkBrush(*br, **kwargs)
         self.currentBrush = self.brush
 
-    def setHoverBrush(self, *br, **kargs):
+    def setHoverBrush(self, *br, **kwargs):
         """Set the brush that fills the region when the mouse is hovering over.
         Can have any arguments that are valid
         for :func:`mkBrush <pyqtgraph.mkBrush>`.
         """
-        self.hoverBrush = fn.mkBrush(*br, **kargs)
+        self.hoverBrush = fn.mkBrush(*br, **kwargs)
 
     def setBounds(self, bounds):
         """Set ``(min, max)`` bounding values for the region.

--- a/pyqtgraph/graphicsItems/NonUniformImage.py
+++ b/pyqtgraph/graphicsItems/NonUniformImage.py
@@ -56,14 +56,14 @@ class NonUniformImage(GraphicsObject):
         self.setLookupTable(cmap.getLookupTable(nPts=256), update=True)
         self.cmap = cmap
 
-    def getHistogram(self, **kwds):
+    def getHistogram(self, **kwargs):
         """Returns x and y arrays containing the histogram values for the current image.
         For an explanation of the return format, see numpy.histogram().
         """
 
         z = self.data[2]
         z = z[np.isfinite(z)]
-        hist = np.histogram(z, **kwds)
+        hist = np.histogram(z, **kwargs)
 
         return hist[1][:-1], hist[0]
 

--- a/pyqtgraph/graphicsItems/PlotCurveItem.py
+++ b/pyqtgraph/graphicsItems/PlotCurveItem.py
@@ -226,7 +226,7 @@ class PlotCurveItem(GraphicsObject):
     sigPlotChanged = QtCore.Signal(object)
     sigClicked = QtCore.Signal(object, object)
 
-    def __init__(self, *args, **kargs):
+    def __init__(self, *args, **kwargs):
         """
         Forwards all arguments to :func:`setData <pyqtgraph.PlotCurveItem.setData>`.
 
@@ -239,7 +239,7 @@ class PlotCurveItem(GraphicsObject):
                         clicked on. Defaults to `False`.
         ==============  =======================================================
         """
-        GraphicsObject.__init__(self, kargs.get('parent', None))
+        GraphicsObject.__init__(self, kwargs.get('parent', None))
         self.clear()
 
         ## this is disastrous for performance.
@@ -260,10 +260,10 @@ class PlotCurveItem(GraphicsObject):
             'skipFiniteCheck': False,
             'segmentedLineMode': getConfigOption('segmentedLineMode'),
         }
-        if 'pen' not in kargs:
+        if 'pen' not in kwargs:
             self.opts['pen'] = fn.mkPen('w')
-        self.setClickable(kargs.get('clickable', False))
-        self.setData(*args, **kargs)
+        self.setClickable(kwargs.get('clickable', False))
+        self.setData(*args, **kwargs)
         self.glstate = None
 
     def implements(self, interface=None):
@@ -482,16 +482,16 @@ class PlotCurveItem(GraphicsObject):
         self._boundingRect = None
         self._boundsCache = [None, None]
 
-    def setPen(self, *args, **kargs):
+    def setPen(self, *args, **kwargs):
         """Set the pen used to draw the curve."""
         if args and args[0] is None:
             self.opts['pen'] = None
         else:
-            self.opts['pen'] = fn.mkPen(*args, **kargs)
+            self.opts['pen'] = fn.mkPen(*args, **kwargs)
         self.invalidateBounds()
         self.update()
 
-    def setShadowPen(self, *args, **kargs):
+    def setShadowPen(self, *args, **kwargs):
         """
         Set the shadow pen used to draw behind the primary pen.
         This pen must have a larger width than the primary
@@ -501,11 +501,11 @@ class PlotCurveItem(GraphicsObject):
         if args and args[0] is None:
             self.opts['shadowPen'] = None
         else:
-            self.opts['shadowPen'] = fn.mkPen(*args, **kargs)
+            self.opts['shadowPen'] = fn.mkPen(*args, **kwargs)
         self.invalidateBounds()
         self.update()
 
-    def setBrush(self, *args, **kargs):
+    def setBrush(self, *args, **kwargs):
         """
         Sets the brush used when filling the area under the curve. All 
         arguments are passed to :func:`mkBrush <pyqtgraph.mkBrush>`.
@@ -513,7 +513,7 @@ class PlotCurveItem(GraphicsObject):
         if args and args[0] is None:
             self.opts['brush'] = None
         else:
-            self.opts['brush'] = fn.mkBrush(*args, **kargs)
+            self.opts['brush'] = fn.mkBrush(*args, **kwargs)
         self.invalidateBounds()
         self.update()
 
@@ -534,7 +534,7 @@ class PlotCurveItem(GraphicsObject):
         """
         self.opts['skipFiniteCheck']  = bool(skipFiniteCheck)
 
-    def setData(self, *args, **kargs):
+    def setData(self, *args, **kwargs):
         """
         =============== =================================================================
         **Arguments:**
@@ -589,30 +589,30 @@ class PlotCurveItem(GraphicsObject):
         Line widths greater than 1 pixel affect the performance as discussed in 
         the documentation of :class:`PlotDataItem <pyqtgraph.PlotDataItem>`.
         """
-        self.updateData(*args, **kargs)
+        self.updateData(*args, **kwargs)
 
-    def updateData(self, *args, **kargs):
+    def updateData(self, *args, **kwargs):
         profiler = debug.Profiler()
 
-        if 'compositionMode' in kargs:
-            self.setCompositionMode(kargs['compositionMode'])
+        if 'compositionMode' in kwargs:
+            self.setCompositionMode(kwargs['compositionMode'])
 
         if len(args) == 1:
-            kargs['y'] = args[0]
+            kwargs['y'] = args[0]
         elif len(args) == 2:
-            kargs['x'] = args[0]
-            kargs['y'] = args[1]
+            kwargs['x'] = args[0]
+            kwargs['y'] = args[1]
 
-        if 'y' not in kargs or kargs['y'] is None:
-            kargs['y'] = np.array([])
-        if 'x' not in kargs or kargs['x'] is None:
-            kargs['x'] = np.arange(len(kargs['y']))
+        if 'y' not in kwargs or kwargs['y'] is None:
+            kwargs['y'] = np.array([])
+        if 'x' not in kwargs or kwargs['x'] is None:
+            kwargs['x'] = np.arange(len(kwargs['y']))
 
         for k in ['x', 'y']:
-            data = kargs[k]
+            data = kwargs[k]
             if isinstance(data, list):
                 data = np.array(data)
-                kargs[k] = data
+                kwargs[k] = data
             if not isinstance(data, np.ndarray) or data.ndim > 1:
                 raise Exception("Plot data must be 1D ndarray.")
             if data.dtype.kind == 'c':
@@ -623,8 +623,8 @@ class PlotCurveItem(GraphicsObject):
 
         #self.setCacheMode(QtWidgets.QGraphicsItem.CacheMode.NoCache)  ## Disabling and re-enabling the cache works around a bug in Qt 4.6 causing the cached results to display incorrectly
                                                         ##    Test this bug with test_PlotWidget and zoom in on the animated plot
-        self.yData = kargs['y'].view(np.ndarray)
-        self.xData = kargs['x'].view(np.ndarray)
+        self.yData = kwargs['y'].view(np.ndarray)
+        self.xData = kwargs['x'].view(np.ndarray)
         
         self.invalidateBounds()
         self.prepareGeometryChange()
@@ -632,8 +632,8 @@ class PlotCurveItem(GraphicsObject):
 
         profiler('copy')
 
-        if 'stepMode' in kargs:
-            self.opts['stepMode'] = kargs['stepMode']
+        if 'stepMode' in kwargs:
+            self.opts['stepMode'] = kwargs['stepMode']
 
         if self.opts['stepMode'] == "center":
             if len(self.xData) != len(self.yData)+1:  ## allow difference of 1 for step mode plots
@@ -648,24 +648,24 @@ class PlotCurveItem(GraphicsObject):
         self._mouseShape = None
         self._lineSegmentsRendered = False
 
-        if 'name' in kargs:
-            self.opts['name'] = kargs['name']
-        if 'connect' in kargs:
-            self.opts['connect'] = kargs['connect']
-        if 'pen' in kargs:
-            self.setPen(kargs['pen'])
-        if 'shadowPen' in kargs:
-            self.setShadowPen(kargs['shadowPen'])
-        if 'fillLevel' in kargs:
-            self.setFillLevel(kargs['fillLevel'])
-        if 'fillOutline' in kargs:
-            self.opts['fillOutline'] = kargs['fillOutline']
-        if 'brush' in kargs:
-            self.setBrush(kargs['brush'])
-        if 'antialias' in kargs:
-            self.opts['antialias'] = kargs['antialias']
-        if 'skipFiniteCheck' in kargs:
-            self.opts['skipFiniteCheck'] = kargs['skipFiniteCheck']
+        if 'name' in kwargs:
+            self.opts['name'] = kwargs['name']
+        if 'connect' in kwargs:
+            self.opts['connect'] = kwargs['connect']
+        if 'pen' in kwargs:
+            self.setPen(kwargs['pen'])
+        if 'shadowPen' in kwargs:
+            self.setShadowPen(kwargs['shadowPen'])
+        if 'fillLevel' in kwargs:
+            self.setFillLevel(kwargs['fillLevel'])
+        if 'fillOutline' in kwargs:
+            self.opts['fillOutline'] = kwargs['fillOutline']
+        if 'brush' in kwargs:
+            self.setBrush(kwargs['brush'])
+        if 'antialias' in kwargs:
+            self.opts['antialias'] = kwargs['antialias']
+        if 'skipFiniteCheck' in kwargs:
+            self.opts['skipFiniteCheck'] = kwargs['skipFiniteCheck']
 
         profiler('set')
         self.update()

--- a/pyqtgraph/graphicsItems/PlotDataItem.py
+++ b/pyqtgraph/graphicsItems/PlotDataItem.py
@@ -266,7 +266,7 @@ class PlotDataItem(GraphicsObject):
 
     Parameters
     ----------
-    *args : tuple, optional
+    *args
         Arguments representing the `x` and `y` data to be drawn. The following are
         examples for initializing data.
 
@@ -294,7 +294,7 @@ class PlotDataItem(GraphicsObject):
         When using spot-style arguments, it is always possible to give coordinate data
         separately through the `x` and `y` keyword arguments.
     
-    **kwargs : dict, optional
+    **kwargs
         The supported keyword arguments can be grouped into several categories:
 
         *Point Style Keyword Arguments*, see
@@ -835,10 +835,10 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple or None
+        *args
             :class:`QPen`, or parameters for a QPen constructed by 
             :func:`mkPen <pyqtgraph.mkPen>`. Use ``None`` to disable drawing of lines.
-        **kwargs : dict
+        **kwargs
             Alternative specification of arguments directed to
             :func:`mkPen <pyqtgraph.mkPen>`.
         """
@@ -856,10 +856,10 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple or None
+        *args
             :class:`QPen`, or parameters for a QPen constructed by 
             :func:`mkPen <pyqtgraph.mkPen>`. Use ``None`` to disable the shadow pen.
-        **kwargs : dict
+        **kwargs
             Alternative specification of arguments directed to
             :func:`mkPen <pyqtgraph.mkPen>`.
         """
@@ -878,11 +878,11 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args
             :class:`QBrush`, or parameters for a QBrush constructed by
             :func:`mkBrush <pyqtgraph.mkBrush>`. Also accepts a color specifier
             understood by :func:`mkColor <pyqtgraph.mkColor>`.
-        **kwargs : dict
+        **kwargs
             Alternative specification of arguments directed to
             :func:`mkBrush <pyqtgraph.mkBrush>`.
         """
@@ -901,11 +901,11 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args
             :class:`QBrush`, or parameters for a QBrush constructed by
             :func:`mkBrush <pyqtgraph.mkBrush>`. Also accepts a color specifier
             understood by :func:`mkColor <pyqtgraph.mkColor>`.
-        **kwargs : dict
+        **kwargs
             Alternative specification of arguments directed to
             :func:`mkBrush <pyqtgraph.mkBrush>`.
         """
@@ -969,10 +969,10 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args
             :class:`QPen`, or parameters for a QPen constructed by 
             :func:`mkPen <pyqtgraph.mkPen>`.
-        **kwargs : dict
+        **kwargs
             Alternative specification of arguments directed to
             :func:`mkPen <pyqtgraph.mkPen>`.
         """
@@ -990,11 +990,11 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args
             :class:`QBrush`, or parameters for a QBrush constructed by
             :func:`mkBrush <pyqtgraph.mkBrush>`. Also accepts a color specifier
             understood by :func:`mkColor <pyqtgraph.mkColor>`.
-        **kwargs : dict
+        **kwargs
             Alternative specification of arguments directed to
             :func:`mkBrush <pyqtgraph.mkBrush>`.
         """
@@ -1158,9 +1158,9 @@ class PlotDataItem(GraphicsObject):
 
         Parameters
         ----------
-        *args : tuple
+        *args
             See :class:`PlotDataItem` description for supported arguments.
-        **kwargs : dict
+        **kwargs
             See :class:`PlotDataItem` description for supported arguments.
 
         Raises

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -100,7 +100,7 @@ class PlotItem(GraphicsWidget):
         `left`, `bottom`, `right` or `top` axis.  Default is None.
     enableMenu : bool
         Toggle the enabling or disabling of the right-click context menu.
-    **kwargs : dict, optional
+    **kwargs
         Any extra keyword arguments are passed to
         :func:`PlotItem.plot() <pyqtgraph.PlotItem.plot>`.
     
@@ -591,9 +591,9 @@ class PlotItem(GraphicsWidget):
         ----------
         item : GraphicsItem
             Item to add to the ViewBox.
-        *args : tuple
+        *args
             Arguments relayed to :meth:`~pyqtgraph.ViewBox.addItem`.
-        **kwargs : dict
+        **kwargs
             Keyword arguments for adding an item.  Supported arguments include.
 
             ============ ===============================================================
@@ -681,7 +681,7 @@ class PlotItem(GraphicsWidget):
         z : int or None
             Z value to set the line to. This is used to determine which items are on top
             of the other.  See :meth:`~QtWidgets.QGraphicsItem.setZValue`.
-        **kwargs : dict
+        **kwargs
             Keyword arguments to pass to the :class:`~pyqtgraph.InfiniteLine` instance.
         
         Returns
@@ -744,10 +744,10 @@ class PlotItem(GraphicsWidget):
 
         Parameters
         ----------
-        *args : tuple, optional
+        *args
             Arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
             constructor.
-        **kwargs : dict, optional
+        **kwargs
             Keyword arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
             constructor.  In addition, the following keyword arguments are accepted.
 
@@ -795,7 +795,7 @@ class PlotItem(GraphicsWidget):
         ----------
         offset : tuple of int, int
             The distance to offset the LegendItem, defaults to ``(30, 30)``.
-        **kwargs : dict, optional
+        **kwargs
             Keyword argument passed to the :class:`~pyqtgraph.LegendItem` constructor.
         
         Returns
@@ -819,7 +819,7 @@ class PlotItem(GraphicsWidget):
         ----------
         image : ImageItem or list of ImageItem
             See :meth:`~pyqtgraph.ColorBarItem.setImageItem` for details.
-        **kwargs : dict, optional
+        **kwargs
             Keyword arguments passed to the :class:`~pyqtgraph.ColorBarItem`
             constructor.
         
@@ -854,7 +854,7 @@ class PlotItem(GraphicsWidget):
             or y are considered lists of curve data.
         constKwargs : dict, optional
             A dict of {str: value} passed to each curve during ``plot()``.
-        **kwargs : dict, optional
+        **kwargs
             A dict of {str: iterable} where the str is the name of a kwarg and the
             iterable is a list of values, one for each plotted curve.
         
@@ -912,10 +912,10 @@ class PlotItem(GraphicsWidget):
 
         Parameters
         ----------
-        *args : tuple, optional
+        *args
             Arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
             constructor.
-        **kwargs : dict, optional
+        **kwargs
             Keyword arguments that are passed to the :class:`~pyqtgraph.PlotDataItem`
             constructor.  In addition, the following keyword arguments are accepted.
 
@@ -1439,9 +1439,9 @@ class PlotItem(GraphicsWidget):
         ----------
         axis : {'left', 'bottom', 'right', 'top'}
             Specify which :class:`~pyqtgraph.AxisItem` to set the label for.
-        *args : tuple, optional
+        *args
             All extra arguments are passed to :meth:`~pyqtgraph.AxisItem.setLabel`.
-        **kwargs : dict, optional
+        **kwargs
             Keyword arguments are passed to :meth:`~pyqtgraph.AxisItem.setLabel`.
         """
         self.getAxis(axis).setLabel(*args, **kwargs)
@@ -1453,7 +1453,7 @@ class PlotItem(GraphicsWidget):
 
         Parameters
         ----------
-        **kwargs : dict, optional
+        **kwargs
             Keyword arguments are passed to  :meth:`~pyqtgraph.AxisItem.setLabel`.  The
             special keyword ``title`` can be used to set the plot title using
             :meth:`~pyqtgraph.PlotItem.setTitle`.
@@ -1479,7 +1479,7 @@ class PlotItem(GraphicsWidget):
         """
         self.getScale(axis).showLabel(show)
 
-    def setTitle(self, title=None, **args):
+    def setTitle(self, title=None, **kwargs):
         """
         Set the title of the plot.
 
@@ -1488,7 +1488,7 @@ class PlotItem(GraphicsWidget):
         title : str, optional
             The title text. If ``None``, the title will be hidden. The default is
             ``None``.
-        **args : dict
+        **kwargs
             Additional keyword arguments are passed to
             :meth:`~pyqtgraph.LabelItem.setText`.
         """
@@ -1500,7 +1500,7 @@ class PlotItem(GraphicsWidget):
             self.titleLabel.setMaximumHeight(30)
             self.layout.setRowFixedHeight(0, 30)
             self.titleLabel.setVisible(True)
-            self.titleLabel.setText(title, **args)
+            self.titleLabel.setText(title, **kwargs)
 
     def showAxis(self, axis: str, show: bool=True):
         """
@@ -1607,14 +1607,14 @@ class PlotItem(GraphicsWidget):
         except RuntimeError:
             pass  # this can happen if the plot has been deleted.
             
-    def _plotArray(self, arr, x=None, **kargs):
+    def _plotArray(self, arr, x=None, **kwargs):
         if arr.ndim != 1:
             raise ValueError(f"Array must be 1D to plot (shape is {arr.shape})")
         if x is None:
             x = np.arange(arr.shape[0])
         if x.ndim != 1:
             raise ValueError(f"X array must be 1D to plot (shape is {x.shape})")
-        return PlotCurveItem(arr, x=x, **kargs)
+        return PlotCurveItem(arr, x=x, **kwargs)
 
     def setExportMode(self, export: bool, opts=None):
         """

--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -18,7 +18,6 @@ import numpy as np
 
 from .. import functions as fn
 
-#from numpy.linalg import norm
 from ..Point import Point
 from ..Qt import QtCore, QtGui, QtWidgets
 from ..SRTTransform import SRTTransform
@@ -385,7 +384,7 @@ class ROI(GraphicsObject):
         newSize = self.state['size'] * s
         self.setSize(newSize, center=center, centerLocal=centerLocal, snap=snap, update=update, finish=finish)
    
-    def translate(self, *args, **kargs):
+    def translate(self, *args, **kwargs):
         """
         Move the ROI to a new position.
         Accepts either (x, y, snap) or ([x,y], snap) as arguments
@@ -412,7 +411,7 @@ class ROI(GraphicsObject):
         newState = self.stateCopy()
         newState['pos'] = newState['pos'] + pt
         
-        snap = kargs.get('snap', None)
+        snap = kwargs.get('snap', None)
         if snap is None:
             snap = self.translateSnap
         if snap is not False:
@@ -431,8 +430,8 @@ class ROI(GraphicsObject):
                 d[1] = self.maxBounds.bottom() - r.bottom()
             newState['pos'] += d
         
-        update = kargs.get('update', True)
-        finish = kargs.get('finish', True)
+        update = kwargs.get('update', True)
+        finish = kwargs.get('finish', True)
         self.setPos(newState['pos'], update=update, finish=finish)
 
     def rotate(self, angle, center=None, snap=False, update=True, finish=True):
@@ -1134,7 +1133,7 @@ class ROI(GraphicsObject):
         else:
             return bounds, tr
 
-    def getArrayRegion(self, data, img, axes=(0,1), returnMappedCoords=False, **kwds):
+    def getArrayRegion(self, data, img, axes=(0,1), returnMappedCoords=False, **kwargs):
         r"""Use the position and orientation of this ROI relative to an imageItem
         to pull a slice from an array.
 
@@ -1154,7 +1153,7 @@ class ROI(GraphicsObject):
         returnMappedCoords  (bool) If True, the array slice is returned along
                             with a corresponding array of coordinates that were
                             used to extract data from the original array.
-        \**kwds             All keyword arguments are passed to 
+        \**kwargs           All keyword arguments are passed to 
                             :func:`affineSlice <pyqtgraph.affineSlice>`.
         =================== ====================================================
         
@@ -1171,28 +1170,28 @@ class ROI(GraphicsObject):
         All extra keyword arguments are passed to :func:`affineSlice <pyqtgraph.affineSlice>`.
         """
         # this is a hidden argument for internal use
-        fromBR = kwds.pop('fromBoundingRect', False)
+        fromBR = kwargs.pop('fromBoundingRect', False)
         
         # Automatically compute missing parameters
         _shape, _vectors, _origin = self.getAffineSliceParams(data, img, axes, fromBoundingRect=fromBR)
         
         # Replace them with user defined parameters if defined
-        shape = kwds.pop('shape', _shape)
-        vectors = kwds.pop('vectors', _vectors)
-        origin = kwds.pop('origin', _origin)
+        shape = kwargs.pop('shape', _shape)
+        vectors = kwargs.pop('vectors', _vectors)
+        origin = kwargs.pop('origin', _origin)
         
         if not returnMappedCoords:
-            rgn = fn.affineSlice(data, shape=shape, vectors=vectors, origin=origin, axes=axes, **kwds)
+            rgn = fn.affineSlice(data, shape=shape, vectors=vectors, origin=origin, axes=axes, **kwargs)
             return rgn
         else:
-            kwds['returnCoords'] = True
-            result, coords = fn.affineSlice(data, shape=shape, vectors=vectors, origin=origin, axes=axes, **kwds)
+            kwargs['returnCoords'] = True
+            result, coords = fn.affineSlice(data, shape=shape, vectors=vectors, origin=origin, axes=axes, **kwargs)
             
             ### map coordinates and return
             mapped = fn.transformCoordinates(img.transform(), coords)
             return result, mapped
 
-    def _getArrayRegionForArbitraryShape(self, data, img, axes=(0,1), returnMappedCoords=False, **kwds):
+    def _getArrayRegionForArbitraryShape(self, data, img, axes=(0,1), returnMappedCoords=False, **kwargs):
         """
         Return the result of :meth:`~pyqtgraph.ROI.getArrayRegion`, masked by
         the shape of the ROI. Values outside the ROI shape are set to 0.
@@ -1202,10 +1201,10 @@ class ROI(GraphicsObject):
         """
         if returnMappedCoords:
             sliced, mappedCoords = ROI.getArrayRegion(
-                self, data, img, axes, returnMappedCoords, fromBoundingRect=True, **kwds)
+                self, data, img, axes, returnMappedCoords, fromBoundingRect=True, **kwargs)
         else:
             sliced = ROI.getArrayRegion(
-                self, data, img, axes, returnMappedCoords, fromBoundingRect=True, **kwds)
+                self, data, img, axes, returnMappedCoords, fromBoundingRect=True, **kwargs)
 
         if img.axisOrder == 'col-major':
             mask = self.renderShapeMask(sliced.shape[axes[0]], sliced.shape[axes[1]])
@@ -1742,7 +1741,7 @@ class MultiRectROI(QtWidgets.QGraphicsObject):
             pos.append(self.mapFromScene(l.getHandles()[1].scenePos()))
         return pos
         
-    def getArrayRegion(self, arr, img=None, axes=(0,1), **kwds):
+    def getArrayRegion(self, arr, img=None, axes=(0,1), **kwargs):
         """
         Return the result of :meth:`~pyqtgraph.ROI.getArrayRegion` for each rect
         in the chain concatenated into a single ndarray.
@@ -1754,7 +1753,7 @@ class MultiRectROI(QtWidgets.QGraphicsObject):
         """
         rgns = []
         for l in self.lines:
-            rgn = l.getArrayRegion(arr, img, axes=axes, **kwds)
+            rgn = l.getArrayRegion(arr, img, axes=axes, **kwargs)
             if rgn is None:
                 continue
             rgns.append(rgn)
@@ -1822,8 +1821,8 @@ class MultiRectROI(QtWidgets.QGraphicsObject):
         
         
 class MultiLineROI(MultiRectROI):
-    def __init__(self, *args, **kwds):
-        MultiRectROI.__init__(self, *args, **kwds)
+    def __init__(self, *args, **kwargs):
+        MultiRectROI.__init__(self, *args, **kwargs)
         print("Warning: MultiLineROI has been renamed to MultiRectROI. (and MultiLineROI may be redefined in the future)")
 
 
@@ -1866,7 +1865,7 @@ class EllipseROI(ROI):
         r = QtCore.QRectF(r.x()/r.width(), r.y()/r.height(), 1,1)
         p.drawEllipse(r)
         
-    def getArrayRegion(self, arr, img=None, axes=(0, 1), returnMappedCoords=False, **kwds):
+    def getArrayRegion(self, arr, img=None, axes=(0, 1), returnMappedCoords=False, **kwargs):
         """
         Return the result of :meth:`~pyqtgraph.ROI.getArrayRegion` masked by the
         elliptical shape of the ROI. Regions outside the ellipse are set to 0.
@@ -1880,10 +1879,10 @@ class EllipseROI(ROI):
         # implementation produces a nicer mask.
         if returnMappedCoords:
            arr, mappedCoords = ROI.getArrayRegion(self, arr, img, axes,
-                                                  returnMappedCoords, **kwds)
+                                                  returnMappedCoords, **kwargs)
         else:
            arr = ROI.getArrayRegion(self, arr, img, axes,
-                                    returnMappedCoords, **kwds)
+                                    returnMappedCoords, **kwargs)
         if arr is None or arr.shape[axes[0]] == 0 or arr.shape[axes[1]] == 0:
             if returnMappedCoords:
                 return arr, mappedCoords
@@ -2121,13 +2120,13 @@ class PolyLineROI(ROI):
         p.lineTo(self.handles[0]['item'].pos())
         return p
 
-    def getArrayRegion(self, *args, **kwds):
-        return self._getArrayRegionForArbitraryShape(*args, **kwds)
+    def getArrayRegion(self, *args, **kwargs):
+        return self._getArrayRegionForArbitraryShape(*args, **kwargs)
 
-    def setPen(self, *args, **kwds):
-        ROI.setPen(self, *args, **kwds)
+    def setPen(self, *args, **kwargs):
+        ROI.setPen(self, *args, **kwargs)
         for seg in self.segments:
-            seg.setPen(*args, **kwds)
+            seg.setPen(*args, **kwargs)
 
 
 
@@ -2217,7 +2216,7 @@ class LineSegmentROI(ROI):
       
         return p
     
-    def getArrayRegion(self, data, img, axes=(0,1), order=1, returnMappedCoords=False, **kwds):
+    def getArrayRegion(self, data, img, axes=(0,1), order=1, returnMappedCoords=False, **kwargs):
         """
         Use the position of this ROI relative to an imageItem to pull a slice 
         from an array.
@@ -2232,16 +2231,16 @@ class LineSegmentROI(ROI):
 
         d = Point(imgPts[1] - imgPts[0])
         o = Point(imgPts[0])
-        rgn = fn.affineSlice(data, shape=(int(d.length()),), vectors=[Point(d.norm())], origin=o, axes=axes, order=order, returnCoords=returnMappedCoords, **kwds)
+        rgn = fn.affineSlice(data, shape=(int(d.length()),), vectors=[Point(d.norm())], origin=o, axes=axes, order=order, returnCoords=returnMappedCoords, **kwargs)
 
         return rgn
         
 
 class _PolyLineSegment(LineSegmentROI):
     # Used internally by PolyLineROI
-    def __init__(self, *args, **kwds):
+    def __init__(self, *args, **kwargs):
         self._parentHovering = False
-        LineSegmentROI.__init__(self, *args, **kwds)
+        LineSegmentROI.__init__(self, *args, **kwargs)
         
     def setParentHover(self, hover):
         # set independently of own hover state
@@ -2266,13 +2265,13 @@ class _PolyLineSegment(LineSegmentROI):
 class CrosshairROI(ROI):
     """A crosshair ROI whose position is at the center of the crosshairs. By default, it is scalable, rotatable and translatable."""
     
-    def __init__(self, pos=None, size=None, **kargs):
+    def __init__(self, pos=None, size=None, **kwargs):
         if size is None:
             size=[1,1]
         if pos is None:
             pos = [0,0]
         self._shape = None
-        ROI.__init__(self, pos, size, aspectLocked=True, **kargs)
+        ROI.__init__(self, pos, size, aspectLocked=True, **kwargs)
         
         self.sigRegionChanged.connect(self.invalidate)
         self.addScaleRotateHandle(Point(1, 0), Point(0, 0))
@@ -2380,5 +2379,5 @@ class TriangleROI(ROI):
         self.path.addPolygon(self.poly)
         return t.map(self.path)
 
-    def getArrayRegion(self, *args, **kwds):
-        return self._getArrayRegionForArbitraryShape(*args, **kwds)
+    def getArrayRegion(self, *args, **kwargs):
+        return self._getArrayRegionForArbitraryShape(*args, **kwargs)

--- a/pyqtgraph/graphicsItems/ScatterPlotItem.py
+++ b/pyqtgraph/graphicsItems/ScatterPlotItem.py
@@ -356,7 +356,7 @@ class ScatterPlotItem(GraphicsObject):
     sigHovered = QtCore.Signal(object, object, object)
     sigPlotChanged = QtCore.Signal(object)
 
-    def __init__(self, *args, **kargs):
+    def __init__(self, *args, **kwargs):
         """
         Accepts the same arguments as setData()
         """
@@ -409,7 +409,7 @@ class ScatterPlotItem(GraphicsObject):
             {'hover' + opt.title(): _DEFAULT_STYLE[opt] for opt in ['symbol', 'size', 'pen', 'brush']}
         )
         profiler()
-        self.setData(*args, **kargs)
+        self.setData(*args, **kwargs)
         profiler('setData')
 
         #self.setCacheMode(self.DeviceCoordinateCache)
@@ -418,7 +418,7 @@ class ScatterPlotItem(GraphicsObject):
         # this allows another item in the VB to set the tooltip
         self._toolTipCleared = True
 
-    def setData(self, *args, **kargs):
+    def setData(self, *args, **kwargs):
         """
         **Ordered Arguments:**
 
@@ -468,9 +468,9 @@ class ScatterPlotItem(GraphicsObject):
         """
         oldData = self.data  ## this causes cached pixmaps to be preserved while new data is registered.
         self.clear()  ## clear out all old data
-        self.addPoints(*args, **kargs)
+        self.addPoints(*args, **kwargs)
 
-    def addPoints(self, *args, **kargs):
+    def addPoints(self, *args, **kwargs):
         """
         Add new points to the scatter plot.
         Arguments are the same as setData()
@@ -478,19 +478,19 @@ class ScatterPlotItem(GraphicsObject):
 
         ## deal with non-keyword arguments
         if len(args) == 1:
-            kargs['spots'] = args[0]
+            kwargs['spots'] = args[0]
         elif len(args) == 2:
-            kargs['x'] = args[0]
-            kargs['y'] = args[1]
+            kwargs['x'] = args[0]
+            kwargs['y'] = args[1]
         elif len(args) > 2:
             raise Exception('Only accepts up to two non-keyword arguments.')
 
         ## convert 'pos' argument to 'x' and 'y'
-        if 'pos' in kargs:
-            pos = kargs['pos']
+        if 'pos' in kwargs:
+            pos = kwargs['pos']
             if isinstance(pos, np.ndarray):
-                kargs['x'] = pos[:,0]
-                kargs['y'] = pos[:,1]
+                kwargs['x'] = pos[:,0]
+                kwargs['y'] = pos[:,1]
             else:
                 x = []
                 y = []
@@ -501,17 +501,17 @@ class ScatterPlotItem(GraphicsObject):
                     else:
                         x.append(p[0])
                         y.append(p[1])
-                kargs['x'] = x
-                kargs['y'] = y
+                kwargs['x'] = x
+                kwargs['y'] = y
 
         ## determine how many spots we have
-        if 'spots' in kargs:
-            numPts = len(kargs['spots'])
-        elif 'y' in kargs and kargs['y'] is not None:
-            numPts = len(kargs['y'])
+        if 'spots' in kwargs:
+            numPts = len(kwargs['spots'])
+        elif 'y' in kwargs and kwargs['y'] is not None:
+            numPts = len(kwargs['y'])
         else:
-            kargs['x'] = []
-            kargs['y'] = []
+            kwargs['x'] = []
+            kwargs['y'] = []
             numPts = 0
 
         ## Clear current SpotItems since the data references they contain will no longer be current
@@ -530,8 +530,8 @@ class ScatterPlotItem(GraphicsObject):
         newData['size'] = -1  ## indicates to use default size
         newData['visible'] = True
 
-        if 'spots' in kargs:
-            spots = kargs['spots']
+        if 'spots' in kwargs:
+            spots = kwargs['spots']
             for i in range(len(spots)):
                 spot = spots[i]
                 for k in spot:
@@ -551,40 +551,40 @@ class ScatterPlotItem(GraphicsObject):
                         newData[i][k] = spot[k]
                     else:
                         raise Exception("Unknown spot parameter: %s" % k)
-        elif 'y' in kargs:
-            newData['x'] = kargs['x']
-            newData['y'] = kargs['y']
+        elif 'y' in kwargs:
+            newData['x'] = kwargs['x']
+            newData['y'] = kwargs['y']
 
-        if 'name' in kargs:
-            self.opts['name'] = kargs['name']
-        if 'pxMode' in kargs:
-            self.setPxMode(kargs['pxMode'])
-        if 'antialias' in kargs:
-            self.opts['antialias'] = kargs['antialias']
-        if 'compositionMode' in kargs:
-            self.opts['compositionMode'] = kargs['compositionMode']
-        if 'hoverable' in kargs:
-            self.opts['hoverable'] = bool(kargs['hoverable'])
-        if 'tip' in kargs:
-            self.opts['tip'] = kargs['tip']
-        if 'useCache' in kargs:
-            self.opts['useCache'] = kargs['useCache']
+        if 'name' in kwargs:
+            self.opts['name'] = kwargs['name']
+        if 'pxMode' in kwargs:
+            self.setPxMode(kwargs['pxMode'])
+        if 'antialias' in kwargs:
+            self.opts['antialias'] = kwargs['antialias']
+        if 'compositionMode' in kwargs:
+            self.opts['compositionMode'] = kwargs['compositionMode']
+        if 'hoverable' in kwargs:
+            self.opts['hoverable'] = bool(kwargs['hoverable'])
+        if 'tip' in kwargs:
+            self.opts['tip'] = kwargs['tip']
+        if 'useCache' in kwargs:
+            self.opts['useCache'] = kwargs['useCache']
 
         ## Set any extra parameters provided in keyword arguments
         for k in ['pen', 'brush', 'symbol', 'size']:
-            if k in kargs:
+            if k in kwargs:
                 setMethod = getattr(self, 'set' + k[0].upper() + k[1:])
-                setMethod(kargs[k], update=False, dataSet=newData, mask=kargs.get('mask', None))
+                setMethod(kwargs[k], update=False, dataSet=newData, mask=kwargs.get('mask', None))
             kh = 'hover' + k.title()
-            if kh in kargs:
-                vh = kargs[kh]
+            if kh in kwargs:
+                vh = kwargs[kh]
                 if k == 'pen':
                     vh = _mkPen(vh)
                 elif k == 'brush':
                     vh = _mkBrush(vh)
                 self.opts[kh] = vh
-        if 'data' in kargs:
-            self.setPointData(kargs['data'], dataSet=newData)
+        if 'data' in kwargs:
+            self.setPointData(kwargs['data'], dataSet=newData)
 
         self.prepareGeometryChange()
         self.informViewBoundsChanged()
@@ -610,45 +610,45 @@ class ScatterPlotItem(GraphicsObject):
     def name(self):
         return self.opts.get('name', None)
 
-    def setPen(self, *args, **kargs):
+    def setPen(self, *args, **kwargs):
         """Set the pen(s) used to draw the outline around each spot.
         If a list or array is provided, then the pen for each spot will be set separately.
         Otherwise, the arguments are passed to pg.mkPen and used as the default pen for
         all spots which do not have a pen explicitly set."""
-        update = kargs.pop('update', True)
-        dataSet = kargs.pop('dataSet', self.data)
+        update = kwargs.pop('update', True)
+        dataSet = kwargs.pop('dataSet', self.data)
 
         if len(args) == 1 and (isinstance(args[0], np.ndarray) or isinstance(args[0], list)):
             pens = args[0]
-            if 'mask' in kargs and kargs['mask'] is not None:
-                pens = pens[kargs['mask']]
+            if 'mask' in kwargs and kwargs['mask'] is not None:
+                pens = pens[kwargs['mask']]
             if len(pens) != len(dataSet):
                 raise Exception("Number of pens does not match number of points (%d != %d)" % (len(pens), len(dataSet)))
             dataSet['pen'] = list(map(_mkPen, pens))
         else:
-            self.opts['pen'] = _mkPen(*args, **kargs)
+            self.opts['pen'] = _mkPen(*args, **kwargs)
 
         dataSet['sourceRect'] = 0
         if update:
             self.updateSpots(dataSet)
 
-    def setBrush(self, *args, **kargs):
+    def setBrush(self, *args, **kwargs):
         """Set the brush(es) used to fill the interior of each spot.
         If a list or array is provided, then the brush for each spot will be set separately.
         Otherwise, the arguments are passed to pg.mkBrush and used as the default brush for
         all spots which do not have a brush explicitly set."""
-        update = kargs.pop('update', True)
-        dataSet = kargs.pop('dataSet', self.data)
+        update = kwargs.pop('update', True)
+        dataSet = kwargs.pop('dataSet', self.data)
 
         if len(args) == 1 and (isinstance(args[0], np.ndarray) or isinstance(args[0], list)):
             brushes = args[0]
-            if 'mask' in kargs and kargs['mask'] is not None:
-                brushes = brushes[kargs['mask']]
+            if 'mask' in kwargs and kwargs['mask'] is not None:
+                brushes = brushes[kwargs['mask']]
             if len(brushes) != len(dataSet):
                 raise Exception("Number of brushes does not match number of points (%d != %d)" % (len(brushes), len(dataSet)))
             dataSet['brush'] = list(map(_mkBrush, brushes))
         else:
-            self.opts['brush'] = _mkBrush(*args, **kargs)
+            self.opts['brush'] = _mkBrush(*args, **kwargs)
 
         dataSet['sourceRect'] = 0
         if update:
@@ -933,8 +933,8 @@ class ScatterPlotItem(GraphicsObject):
         GraphicsObject.viewTransformChanged(self)
         self.bounds = [None, None]
 
-    def setExportMode(self, *args, **kwds):
-        GraphicsObject.setExportMode(self, *args, **kwds)
+    def setExportMode(self, *args, **kwargs):
+        GraphicsObject.setExportMode(self, *args, **kwargs)
         self.invalidate()
 
     @debug.warnOnException  ## raising an exception here causes crash
@@ -1199,9 +1199,9 @@ class SpotItem(object):
             pen = self._plot.opts['pen']
         return fn.mkPen(pen)
 
-    def setPen(self, *args, **kargs):
+    def setPen(self, *args, **kwargs):
         """Set the outline pen for this spot"""
-        self._data['pen'] = _mkPen(*args, **kargs)
+        self._data['pen'] = _mkPen(*args, **kwargs)
         self.updateItem()
 
     def resetPen(self):
@@ -1215,9 +1215,9 @@ class SpotItem(object):
             brush = self._plot.opts['brush']
         return fn.mkBrush(brush)
 
-    def setBrush(self, *args, **kargs):
+    def setBrush(self, *args, **kwargs):
         """Set the fill brush for this spot"""
-        self._data['brush'] = _mkBrush(*args, **kargs)
+        self._data['brush'] = _mkBrush(*args, **kwargs)
         self.updateItem()
 
     def resetBrush(self):

--- a/pyqtgraph/graphicsItems/TargetItem.py
+++ b/pyqtgraph/graphicsItems/TargetItem.py
@@ -38,7 +38,7 @@ class TargetItem(UIGraphicsItem):
         r"""
         Parameters
         ----------
-        pos : list, tuple, QPointF, QPoint, Optional
+        pos : list, tuple, QPointF, QPoint, optional
             Initial position of the symbol.  Default is (0, 0)
         size : int
             Size of the symbol in pixels.  Default is 10.
@@ -149,7 +149,7 @@ class TargetItem(UIGraphicsItem):
 
         Parameters
         ----------
-        args : tuple or list or QtCore.QPointF or QtCore.QPoint or Point or float
+        args : QtCore.QPointF or QtCore.QPoint or Point or float
             Two float values or a container that specifies ``(x, y)`` position where the
             TargetItem should be placed
 
@@ -358,7 +358,7 @@ class TargetLabel(TextItem):
     ----------
     target : TargetItem
         The TargetItem to which this label will be attached to.
-    text : str or callable, Optional
+    text : str or callable, optional
         Governs the text displayed, can be a fixed string or a format string
         that accepts the x, and y position of the target item; or be a callable
         method that accepts a tuple (x, y) and returns a string to be displayed.
@@ -369,7 +369,7 @@ class TargetLabel(TextItem):
     anchor : tuple or list or QPointF or QPoint
         Position to rotate the TargetLabel about, and position to set the
         offset value to see :class:`~pyqtgraph.TextItem` for more information.
-    kwargs : dict 
+    **kwargs
         kwargs contains arguments that are passed onto
         :class:`~pyqtgraph.TextItem` constructor, excluding text parameter
     """

--- a/pyqtgraph/graphicsItems/VTickGroup.py
+++ b/pyqtgraph/graphicsItems/VTickGroup.py
@@ -1,9 +1,3 @@
-if __name__ == '__main__':
-    import os
-    import sys
-    path = os.path.abspath(os.path.dirname(__file__))
-    sys.path.insert(0, os.path.join(path, '..', '..'))
-
 from .. import functions as fn
 from ..Qt import QtGui, QtWidgets
 from .UIGraphicsItem import UIGraphicsItem
@@ -71,7 +65,7 @@ class VTickGroup(UIGraphicsItem):
         self.yrange = vals
         self.rebuildTicks()
         
-    def dataBounds(self, *args, **kargs):
+    def dataBounds(self, *args, **kwargs):
         return None  ## item should never affect view autoscaling
             
     def yRange(self):

--- a/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
+++ b/pyqtgraph/graphicsItems/ViewBox/ViewBox.py
@@ -740,7 +740,7 @@ class ViewBox(GraphicsWidget):
             padding = def_pad
         return padding
 
-    def setLimits(self, **kwds):
+    def setLimits(self, **kwargs):
         """
         Set limits that constrain the possible view ranges.
 
@@ -768,20 +768,20 @@ class ViewBox(GraphicsWidget):
         """
         update = False
         allowed = ['xMin', 'xMax', 'yMin', 'yMax', 'minXRange', 'maxXRange', 'minYRange', 'maxYRange']
-        for kwd in kwds:
+        for kwd in kwargs:
             if kwd not in allowed:
                 raise ValueError("Invalid keyword argument '%s'." % kwd)
         for axis in [0,1]:
             for mnmx in [0,1]:
                 kwd = [['xMin', 'xMax'], ['yMin', 'yMax']][axis][mnmx]
                 lname = ['xLimits', 'yLimits'][axis]
-                if kwd in kwds and self.state['limits'][lname][mnmx] != kwds[kwd]:
-                    self.state['limits'][lname][mnmx] = kwds[kwd]
+                if kwd in kwargs and self.state['limits'][lname][mnmx] != kwargs[kwd]:
+                    self.state['limits'][lname][mnmx] = kwargs[kwd]
                     update = True
                 kwd = [['minXRange', 'maxXRange'], ['minYRange', 'maxYRange']][axis][mnmx]
                 lname = ['xRange', 'yRange'][axis]
-                if kwd in kwds and self.state['limits'][lname][mnmx] != kwds[kwd]:
-                    self.state['limits'][lname][mnmx] = kwds[kwd]
+                if kwd in kwargs and self.state['limits'][lname][mnmx] != kwargs[kwd]:
+                    self.state['limits'][lname][mnmx] = kwargs[kwd]
                     update = True
 
         if update:
@@ -1188,7 +1188,7 @@ class ViewBox(GraphicsWidget):
     def xInverted(self):
         return self.state['xInverted']
 
-    def setBorder(self, *args, **kwds):
+    def setBorder(self, *args, **kwargs):
         """
         Set the pen used to draw border around the view
 
@@ -1198,7 +1198,7 @@ class ViewBox(GraphicsWidget):
 
         See :func:`mkPen <pyqtgraph.mkPen>` for arguments.
         """
-        self.border = fn.mkPen(*args, **kwds)
+        self.border = fn.mkPen(*args, **kwargs)
         self.borderRect.setPen(self.border)
     
     def setDefaultPadding(self, padding=0.02):
@@ -1552,8 +1552,8 @@ class ViewBox(GraphicsWidget):
                 range[1][1] = max(range[1][1], bounds.bottom() + px*pxSize)
         return range
 
-    def childrenBoundingRect(self, *args, **kwds):
-        range = self.childrenBounds(*args, **kwds)
+    def childrenBoundingRect(self, *args, **kwargs):
+        range = self.childrenBounds(*args, **kwargs)
         tr = self.targetRange()
         if range[0] is None:
             range[0] = tr[0]

--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -472,12 +472,12 @@ class ImageView(QtWidgets.QWidget):
         """Set the min/max intensity levels automatically to match the image data."""
         self.setLevels(rgba=self._imageLevels)
 
-    def setLevels(self, *args, **kwds):
+    def setLevels(self, *args, **kwargs):
         """Set the min/max (bright and dark) levels.
         
         See :func:`HistogramLUTItem.setLevels <pyqtgraph.HistogramLUTItem.setLevels>`.
         """
-        self.ui.histogram.setLevels(*args, **kwds)
+        self.ui.histogram.setLevels(*args, **kwargs)
 
     def autoRange(self):
         """Auto scale and pan the view around the image such that the image fills the view."""

--- a/pyqtgraph/jupyter/GraphicsView.py
+++ b/pyqtgraph/jupyter/GraphicsView.py
@@ -54,8 +54,8 @@ class GraphicsView(jupyter_rfb.RemoteFrameBuffer):
     :class:`GraphicsLayoutWidget <pyqtgraph.jupyter.GraphicsLayoutWidget>` and
     :class:`PlotWidget <pyqtgraph.jupyter.PlotWidget>` should be used instead."""
 
-    def __init__(self, **kwds):
-        super().__init__(**kwds)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.gfxView = widgets.GraphicsView.GraphicsView()
         self.logical_size = int(self.css_width[:-2]), int(self.css_height[:-2])
         self.pixel_ratio = 1.0
@@ -128,8 +128,8 @@ class GraphicsLayoutWidget(GraphicsView):
     """jupyter_rfb analogue of
     :class:`GraphicsLayoutWidget <pyqtgraph.GraphicsLayoutWidget>`."""
 
-    def __init__(self, **kwds):
-        super().__init__(**kwds)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         self.gfxLayout = graphicsItems.GraphicsLayout.GraphicsLayout()
         for n in [
@@ -139,15 +139,15 @@ class GraphicsLayoutWidget(GraphicsView):
             setattr(self, n, getattr(self.gfxLayout, n))
         self.gfxView.setCentralItem(self.gfxLayout)
 
-    def addPlot(self, *args, **kwds):
-        kwds["enableMenu"] = False
-        plotItem = self.gfxLayout.addPlot(*args, **kwds)
+    def addPlot(self, *args, **kwargs):
+        kwargs["enableMenu"] = False
+        plotItem = self.gfxLayout.addPlot(*args, **kwargs)
         connect_viewbox_redraw(plotItem.getViewBox(), self.request_draw)
         return plotItem
 
-    def addViewBox(self, *args, **kwds):
-        kwds["enableMenu"] = False
-        vb = self.gfxLayout.addViewBox(*args, **kwds)
+    def addViewBox(self, *args, **kwargs):
+        kwargs["enableMenu"] = False
+        vb = self.gfxLayout.addViewBox(*args, **kwargs)
         connect_viewbox_redraw(vb, self.request_draw)
         return vb
 
@@ -156,8 +156,8 @@ class PlotWidget(GraphicsView):
     """jupyter_rfb analogue of
     :class:`PlotWidget <pyqtgraph.PlotWidget>`."""
 
-    def __init__(self, **kwds):
-        super().__init__(**kwds)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         plotItem = graphicsItems.PlotItem.PlotItem(enableMenu=False)
         self.gfxView.setCentralItem(plotItem)
         connect_viewbox_redraw(plotItem.getViewBox(), self.request_draw)

--- a/pyqtgraph/multiprocess/parallelizer.py
+++ b/pyqtgraph/multiprocess/parallelizer.py
@@ -43,7 +43,7 @@ class Parallelize(object):
     since it is automatically sent via pipe back to the parent process.
     """
 
-    def __init__(self, tasks=None, workers=None, block=True, progressDialog=None, randomReseed=True, **kwds):
+    def __init__(self, tasks=None, workers=None, block=True, progressDialog=None, randomReseed=True, **kwargs):
         """
         ===============  ===================================================================
         **Arguments:**
@@ -57,7 +57,7 @@ class Parallelize(object):
         randomReseed     If True, each forked process will reseed its random number generator
                          to ensure independent results. Works with the built-in random
                          and numpy.random.
-        kwds             objects to be shared by proxy with child processes (they will 
+        kwargs             objects to be shared by proxy with child processes (they will 
                          appear as attributes of the tasker)
         ===============  ===================================================================
         """
@@ -81,8 +81,8 @@ class Parallelize(object):
             tasks = range(workers)
         self.tasks = list(tasks)
         self.reseed = randomReseed
-        self.kwds = kwds.copy()
-        self.kwds['_taskStarted'] = self._taskStarted
+        self.kwargs = kwargs.copy()
+        self.kwargs['_taskStarted'] = self._taskStarted
         
     def __enter__(self):
         self.proc = None
@@ -115,7 +115,7 @@ class Parallelize(object):
             self.progressDlg.__enter__()
             self.progressDlg.setMaximum(len(self.tasks))
         self.progress = {os.getpid(): []}
-        return Tasker(self, None, self.tasks, self.kwds)
+        return Tasker(self, None, self.tasks, self.kwargs)
 
     
     def runParallel(self):
@@ -130,7 +130,7 @@ class Parallelize(object):
         
         ## fork and assign tasks to each worker
         for i in range(workers):
-            proc = ForkedProcess(target=None, preProxy=self.kwds, randomReseed=self.reseed)
+            proc = ForkedProcess(target=None, preProxy=self.kwargs, randomReseed=self.reseed)
             if not proc.isParent:
                 self.proc = proc
                 return Tasker(self, proc, chunks[i], proc.forkedProxies)
@@ -232,7 +232,7 @@ class Parallelize(object):
         else:
             return multiprocessing.cpu_count()
         
-    def _taskStarted(self, pid, i, **kwds):
+    def _taskStarted(self, pid, i, **kwargs):
         ## called remotely by tasker to indicate it has started working on task i
         #print pid, 'reported starting task', i
         if self.showProgress:
@@ -245,11 +245,11 @@ class Parallelize(object):
     
     
 class Tasker(object):
-    def __init__(self, parallelizer, process, tasks, kwds):
+    def __init__(self, parallelizer, process, tasks, kwargs):
         self.proc = process
         self.par = parallelizer
         self.tasks = tasks
-        for k, v in kwds.items():
+        for k, v in kwargs.items():
             setattr(self, k, v)
         
     def __iter__(self):

--- a/pyqtgraph/multiprocess/processes.py
+++ b/pyqtgraph/multiprocess/processes.py
@@ -389,8 +389,8 @@ class ForkedProcess(RemoteEventHandler):
 ##Special set of subclasses that implement a Qt event loop instead.
         
 class RemoteQtEventHandler(RemoteEventHandler):
-    def __init__(self, *args, **kwds):
-        RemoteEventHandler.__init__(self, *args, **kwds)
+    def __init__(self, *args, **kwargs):
+        RemoteEventHandler.__init__(self, *args, **kwargs)
         
     def startEventTimer(self):
         from ..Qt import QtCore
@@ -432,16 +432,16 @@ class QtProcess(Process):
         btn.clicked.connect(proxy(slot))   # be sure to send a proxy of the slot
     """
     
-    def __init__(self, **kwds):
-        if 'target' not in kwds:
-            kwds['target'] = startQtEventLoop
+    def __init__(self, **kwargs):
+        if 'target' not in kwargs:
+            kwargs['target'] = startQtEventLoop
         from ..Qt import (  # # avoid module-level import to keep bootstrap snappy.
             QtWidgets,
         )
-        self._processRequests = kwds.pop('processRequests', True)
+        self._processRequests = kwargs.pop('processRequests', True)
         if self._processRequests and QtWidgets.QApplication.instance() is None:
             raise Exception("Must create QApplication before starting QtProcess, or use QtProcess(processRequests=False)")
-        Process.__init__(self, **kwds)
+        Process.__init__(self, **kwargs)
         self.startEventTimer()
         
     def startEventTimer(self):

--- a/pyqtgraph/multiprocess/remoteproxy.py
+++ b/pyqtgraph/multiprocess/remoteproxy.py
@@ -114,13 +114,13 @@ class RemoteEventHandler(object):
         with self.optsLock:
             return self.proxyOptions[opt]
         
-    def setProxyOptions(self, **kwds):
+    def setProxyOptions(self, **kwargs):
         """
         Set the default behavior options for object proxies.
         See ObjectProxy._setProxyOptions for more info.
         """
         with self.optsLock:
-            self.proxyOptions.update(kwds)
+            self.proxyOptions.update(kwargs)
     
     def processRequests(self):
         """Process all pending requests from the pipe, return
@@ -171,7 +171,7 @@ class RemoteEventHandler(object):
         result = None
         while True:
             try:
-                ## args, kwds are double-pickled to ensure this recv() call never fails                
+                ## args, kwargs are double-pickled to ensure this recv() call never fails                
                 cmd, reqId, nByteMsgs, optStr = self.conn.recv() 
                 break
             except EOFError:
@@ -231,7 +231,7 @@ class RemoteEventHandler(object):
             elif cmd == 'callObj':
                 obj = opts['obj']
                 fnargs = opts['args']
-                fnkwds = opts['kwds']
+                fnkwargs = opts['kwargs']
                 
                 ## If arrays were sent as byte messages, they must be re-inserted into the 
                 ## arguments
@@ -241,20 +241,20 @@ class RemoteEventHandler(object):
                             ind = arg[1]
                             dtype, shape = arg[2]
                             fnargs[i] = np.frombuffer(byteData[ind], dtype=dtype).reshape(shape)
-                    for k,arg in fnkwds.items():
+                    for k,arg in fnkwargs.items():
                         if isinstance(arg, tuple) and len(arg) > 0 and arg[0] == '__byte_message__':
                             ind = arg[1]
                             dtype, shape = arg[2]
-                            fnkwds[k] = np.frombuffer(byteData[ind], dtype=dtype).reshape(shape)
+                            fnkwargs[k] = np.frombuffer(byteData[ind], dtype=dtype).reshape(shape)
                 
-                if len(fnkwds) == 0:  ## need to do this because some functions do not allow keyword arguments.
+                if len(fnkwargs) == 0:  ## need to do this because some functions do not allow keyword arguments.
                     try:
                         result = obj(*fnargs)
                     except:
                         print("Failed to call object %s: %d, %s" % (obj, len(fnargs), fnargs[1:]))
                         raise
                 else:
-                    result = obj(*fnargs, **fnkwds)
+                    result = obj(*fnargs, **fnkwargs)
                     
             elif cmd == 'getObjValue':
                 result = opts['obj']  ## has already been unpickled into its local value
@@ -338,7 +338,7 @@ class RemoteEventHandler(object):
         except:
             self.send(request='error', reqId=reqId, callSync='off', opts=dict(exception=None, excString=excStr))
     
-    def send(self, request, opts=None, reqId=None, callSync='sync', timeout=10, returnType=None, byteData=None, **kwds):
+    def send(self, request, opts=None, reqId=None, callSync='sync', timeout=10, returnType=None, byteData=None, **kwargs):
         """Send a request or return packet to the remote process.
         Generally it is not necessary to call this method directly; it is for internal use.
         (The docstring has information that is nevertheless useful to the programmer
@@ -382,7 +382,7 @@ class RemoteEventHandler(object):
                                       function)
                        obj            the (reference to) object to call
                        args           tuple of arguments to pass to callable
-                       kwds           dict of keyword arguments to pass to callable
+                       kwargs           dict of keyword arguments to pass to callable
                        returnValue    bool or 'auto' indicating whether to return a proxy or
                                       the actual value. 
                        
@@ -425,8 +425,8 @@ class RemoteEventHandler(object):
             raise ClosedError()
         
         with self.sendLock:
-            #if len(kwds) > 0:
-                #print "Warning: send() ignored args:", kwds
+            #if len(kwargs) > 0:
+                #print "Warning: send() ignored args:", kwargs
                 
             if opts is None:
                 opts = {}
@@ -480,9 +480,9 @@ class RemoteEventHandler(object):
         if callSync == 'sync':
             return req.result()
         
-    def close(self, callSync='off', noCleanup=False, **kwds):
+    def close(self, callSync='off', noCleanup=False, **kwargs):
         try:
-            self.send(request='close', opts=dict(noCleanup=noCleanup), callSync=callSync, **kwds)
+            self.send(request='close', opts=dict(noCleanup=noCleanup), callSync=callSync, **kwargs)
             self.exited = True
         except ClosedError:
             pass
@@ -526,7 +526,7 @@ class RemoteEventHandler(object):
         else:
             raise Exception("Internal error.")
     
-    def _import(self, mod, **kwds):
+    def _import(self, mod, **kwargs):
         """
         Request the remote process import a module (or symbols from a module)
         and return the proxied results. Uses built-in __import__() function, but 
@@ -539,15 +539,15 @@ class RemoteEventHandler(object):
                                              (this also differs from behavior of __import__)
             
         """
-        return self.send(request='import', callSync='sync', opts=dict(module=mod), **kwds)
+        return self.send(request='import', callSync='sync', opts=dict(module=mod), **kwargs)
         
-    def getObjAttr(self, obj, attr, **kwds):
-        return self.send(request='getObjAttr', opts=dict(obj=obj, attr=attr), **kwds)
+    def getObjAttr(self, obj, attr, **kwargs):
+        return self.send(request='getObjAttr', opts=dict(obj=obj, attr=attr), **kwargs)
         
-    def getObjValue(self, obj, **kwds):
-        return self.send(request='getObjValue', opts=dict(obj=obj), **kwds)
+    def getObjValue(self, obj, **kwargs):
+        return self.send(request='getObjValue', opts=dict(obj=obj), **kwargs)
         
-    def callObj(self, obj, args, kwds, **opts):
+    def callObj(self, obj, args, kwargs, **opts):
         opts = opts.copy()
         args = list(args)
         
@@ -561,7 +561,7 @@ class RemoteEventHandler(object):
         
         if autoProxy is True:
             args = [self.autoProxy(v, noProxyTypes) for v in args]
-            for k, v in kwds.items():
+            for k, v in kwargs.items():
                 opts[k] = self.autoProxy(v, noProxyTypes)
         
         byteMsgs = []
@@ -572,12 +572,12 @@ class RemoteEventHandler(object):
             if arg.__class__ == np.ndarray:
                 args[i] = ("__byte_message__", len(byteMsgs), (arg.dtype, arg.shape))
                 byteMsgs.append(arg)
-        for k,v in kwds.items():
+        for k,v in kwargs.items():
             if v.__class__ == np.ndarray:
-                kwds[k] = ("__byte_message__", len(byteMsgs), (v.dtype, v.shape))
+                kwargs[k] = ("__byte_message__", len(byteMsgs), (v.dtype, v.shape))
                 byteMsgs.append(v)
         
-        return self.send(request='callObj', opts=dict(obj=obj, args=args, kwds=kwds), byteData=byteMsgs, **opts)
+        return self.send(request='callObj', opts=dict(obj=obj, args=args, kwargs=kwargs), byteData=byteMsgs, **opts)
 
     def registerProxy(self, proxy):
         with self.proxyLock:
@@ -597,16 +597,16 @@ class RemoteEventHandler(object):
         except ClosedError:  ## if remote process has closed down, there is no need to send delete requests anymore
             pass
 
-    def transfer(self, obj, **kwds):
+    def transfer(self, obj, **kwargs):
         """
         Transfer an object by value to the remote host (the object must be picklable) 
         and return a proxy for the new remote object.
         """
         if obj.__class__ is np.ndarray:
             opts = {'dtype': obj.dtype, 'shape': obj.shape}
-            return self.send(request='transferArray', opts=opts, byteData=[obj], **kwds)            
+            return self.send(request='transferArray', opts=opts, byteData=[obj], **kwargs)            
         else:
-            return self.send(request='transfer', opts=dict(obj=obj), **kwds)
+            return self.send(request='transfer', opts=dict(obj=obj), **kwargs)
         
     def autoProxy(self, obj, noProxyTypes):
         ## Return object wrapped in LocalObjectProxy _unless_ its type is in noProxyTypes.
@@ -814,7 +814,7 @@ class ObjectProxy(object):
         self.__dict__['_handler'] = RemoteEventHandler.getHandler(processId)
         self.__dict__['_handler'].registerProxy(self)  ## handler will watch proxy; inform remote process when the proxy is deleted.
     
-    def _setProxyOptions(self, **kwds):
+    def _setProxyOptions(self, **kwargs):
         """
         Change the behavior of this proxy. For all options, a value of None
         will cause the proxy to instead use the default behavior defined
@@ -862,10 +862,10 @@ class ObjectProxy(object):
                        sent to the remote process.
         =============  =============================================================
         """
-        for k in kwds:
+        for k in kwargs:
             if k not in self._proxyOptions:
                 raise KeyError("Unrecognized proxy option '%s'" % k)
-        self._proxyOptions.update(kwds)
+        self._proxyOptions.update(kwargs)
     
     def _getValue(self):
         """
@@ -891,7 +891,7 @@ class ObjectProxy(object):
         return "<ObjectProxy for process %d, object 0x%x: %s >" % (self._processId, self._proxyId, self._typeStr)
         
         
-    def __getattr__(self, attr, **kwds):
+    def __getattr__(self, attr, **kwargs):
         """
         Calls __getattr__ on the remote object and returns the attribute
         by value or by proxy depending on the options set (see
@@ -905,8 +905,8 @@ class ObjectProxy(object):
         """
         opts = self._getProxyOptions()
         for k in opts:
-            if '_'+k in kwds:
-                opts[k] = kwds.pop('_'+k)
+            if '_'+k in kwargs:
+                opts[k] = kwargs.pop('_'+k)
         if opts['deferGetattr'] is True:
             return self._deferredAttr(attr)
         else:
@@ -916,7 +916,7 @@ class ObjectProxy(object):
     def _deferredAttr(self, attr):
         return DeferredObjectProxy(self, attr)
     
-    def __call__(self, *args, **kwds):
+    def __call__(self, *args, **kwargs):
         """
         Attempts to call the proxied object from the remote process.
         Accepts extra keyword arguments:
@@ -930,9 +930,9 @@ class ObjectProxy(object):
         """
         opts = self._getProxyOptions()
         for k in opts:
-            if '_'+k in kwds:
-                opts[k] = kwds.pop('_'+k)
-        return self._handler.callObj(obj=self, args=args, kwds=kwds, **opts)
+            if '_'+k in kwargs:
+                opts[k] = kwargs.pop('_'+k)
+        return self._handler.callObj(obj=self, args=args, kwargs=kwargs, **opts)
     
     
     ## Explicitly proxy special methods. Is there a better way to do this??

--- a/pyqtgraph/opengl/GLViewWidget.py
+++ b/pyqtgraph/opengl/GLViewWidget.py
@@ -126,12 +126,12 @@ class GLViewMixin:
             if not item.isInitialized():
                 item.initialize()
         
-    def setBackgroundColor(self, *args, **kwds):
+    def setBackgroundColor(self, *args, **kwargs):
         """
         Set the background color of the widget. Accepts the same arguments as
         :func:`~pyqtgraph.mkColor`.
         """
-        self.opts['bgcolor'] = fn.mkColor(*args, **kwds).getRgbF()
+        self.opts['bgcolor'] = fn.mkColor(*args, **kwargs).getRgbF()
         self.update()
         
     def getViewport(self):
@@ -320,16 +320,16 @@ class GLViewMixin:
             )
         return pos
 
-    def setCameraParams(self, **kwds):
+    def setCameraParams(self, **kwargs):
         valid_keys = {'center', 'rotation', 'distance', 'fov', 'elevation', 'azimuth'}
-        if not valid_keys.issuperset(kwds):
+        if not valid_keys.issuperset(kwargs):
             raise ValueError(f'valid keywords are {valid_keys}')
 
-        self.setCameraPosition(pos=kwds.get('center'), distance=kwds.get('distance'),
-                               elevation=kwds.get('elevation'), azimuth=kwds.get('azimuth'),
-                               rotation=kwds.get('rotation'))
-        if 'fov' in kwds:
-            self.opts['fov'] = kwds['fov']
+        self.setCameraPosition(pos=kwargs.get('center'), distance=kwargs.get('distance'),
+                               elevation=kwargs.get('elevation'), azimuth=kwargs.get('azimuth'),
+                               rotation=kwargs.get('rotation'))
+        if 'fov' in kwargs:
+            self.opts['fov'] = kwargs['fov']
 
     def cameraParams(self):
         valid_keys = ['center', 'distance', 'fov']

--- a/pyqtgraph/opengl/items/GLGradientLegendItem.py
+++ b/pyqtgraph/opengl/items/GLGradientLegendItem.py
@@ -10,7 +10,7 @@ class GLGradientLegendItem(GLGraphicsItem):
     Displays legend colorbar on the screen.
     """
 
-    def __init__(self, parentItem=None, **kwds):
+    def __init__(self, parentItem=None, **kwargs):
         """
         Arguments:
             pos: position of the colorbar on the screen, from the top left corner, in pixels
@@ -25,7 +25,7 @@ class GLGradientLegendItem(GLGraphicsItem):
                 legend title
         """
         super().__init__(parentItem=parentItem)
-        glopts = kwds.pop("glOptions", "additive")
+        glopts = kwargs.pop("glOptions", "additive")
         self.setGLOptions(glopts)
         self.pos = (10, 10)
         self.size = (10, 100)
@@ -35,11 +35,11 @@ class GLGradientLegendItem(GLGraphicsItem):
         self.gradient = ColorMap(pos=stops, color=(0.0, 1.0))
         self._gradient = None
         self.labels = {str(x) : x for x in stops}
-        self.setData(**kwds)
+        self.setData(**kwargs)
 
-    def setData(self, **kwds):
+    def setData(self, **kwargs):
         args = ["size", "pos", "gradient", "labels", "fontColor"]
-        for k in kwds.keys():
+        for k in kwargs.keys():
             if k not in args:
                 raise Exception(
                     "Invalid keyword argument: %s (allowed arguments are %s)"
@@ -48,8 +48,8 @@ class GLGradientLegendItem(GLGraphicsItem):
 
         self.antialias = False
 
-        for key in kwds:
-            value = kwds[key]
+        for key in kwargs:
+            value = kwargs[key]
             if key == 'fontColor':
                 value = fn.mkColor(value)
             elif key == 'gradient':

--- a/pyqtgraph/opengl/items/GLGraphItem.py
+++ b/pyqtgraph/opengl/items/GLGraphItem.py
@@ -14,9 +14,9 @@ class GLGraphItem(GLGraphicsItem):
     Useful for drawing networks, trees, etc.
     """
 
-    def __init__(self, parentItem=None, **kwds):
+    def __init__(self, parentItem=None, **kwargs):
         super().__init__()
-        glopts = kwds.pop('glOptions', 'translucent')
+        glopts = kwargs.pop('glOptions', 'translucent')
 
         self.edges = None
         self.edgeColor = QtGui.QColor(QtCore.Qt.GlobalColor.white)
@@ -25,9 +25,9 @@ class GLGraphItem(GLGraphicsItem):
         self.lineplot = GLLinePlotItem(parentItem=self, glOptions=glopts, mode='lines')
         self.scatter = GLScatterPlotItem(parentItem=self, glOptions=glopts)
         self.setParentItem(parentItem)
-        self.setData(**kwds)
+        self.setData(**kwargs)
 
-    def setData(self, **kwds):
+    def setData(self, **kwargs):
         """
         Change the data displayed by the graph. 
 
@@ -54,7 +54,7 @@ class GLGraphItem(GLGraphicsItem):
         nodeSize : np.ndarray or float or int
             Either 2D numpy array of shape (N, 1) where each row represents the
             size of each node, or if a scalar, apply the same size to all nodes
-        **kwds
+        **kwargs
             All other keyword arguments are given to
             :meth:`GLScatterPlotItem.setData() <pyqtgraph.opengl.GLScatterPlotItem.setData>`
             to affect the appearance of nodes (pos, color, size, pxMode, etc.)
@@ -65,23 +65,23 @@ class GLGraphItem(GLGraphicsItem):
             When dtype of edges dtype is not unsigned or integer dtype
         """
 
-        if 'edges' in kwds:
-            self.edges = kwds.pop('edges')
+        if 'edges' in kwargs:
+            self.edges = kwargs.pop('edges')
             if self.edges.dtype.kind not in 'iu':
                 raise TypeError("edges array must have int or unsigned dtype.")
-        if 'edgeColor' in kwds:
-            edgeColor = kwds.pop('edgeColor')
+        if 'edgeColor' in kwargs:
+            edgeColor = kwargs.pop('edgeColor')
             self.edgeColor = fn.mkColor(edgeColor) if edgeColor is not None else None
-        if 'edgeWidth' in kwds:
-            self.edgeWidth = kwds.pop('edgeWidth')
-        if 'nodePositions' in kwds:
-            kwds['pos'] = kwds.pop('nodePositions')
-        if 'nodeColor' in kwds:
-            kwds['color'] = kwds.pop('nodeColor')
-        if 'nodeSize' in kwds:
-            kwds['size'] = kwds.pop('nodeSize')
+        if 'edgeWidth' in kwargs:
+            self.edgeWidth = kwargs.pop('edgeWidth')
+        if 'nodePositions' in kwargs:
+            kwargs['pos'] = kwargs.pop('nodePositions')
+        if 'nodeColor' in kwargs:
+            kwargs['color'] = kwargs.pop('nodeColor')
+        if 'nodeSize' in kwargs:
+            kwargs['size'] = kwargs.pop('nodeSize')
 
-        self.scatter.setData(**kwds)
+        self.scatter.setData(**kwargs)
 
         kwdLines = dict(width=self.edgeWidth)
         if self.scatter.pos is None or self.edges is None or self.edgeColor is None:

--- a/pyqtgraph/opengl/items/GLLinePlotItem.py
+++ b/pyqtgraph/opengl/items/GLLinePlotItem.py
@@ -21,10 +21,10 @@ class GLLinePlotItem(GLGraphicsItem):
 
     _shaderProgram = None
 
-    def __init__(self, parentItem=None, **kwds):
+    def __init__(self, parentItem=None, **kwargs):
         """All keyword arguments are passed to setData()"""
         super().__init__()
-        glopts = kwds.pop('glOptions', 'additive')
+        glopts = kwargs.pop('glOptions', 'additive')
         self.setGLOptions(glopts)
         self.pos = None
         self.mode = 'line_strip'
@@ -37,9 +37,9 @@ class GLLinePlotItem(GLGraphicsItem):
         self.dirty_bits = DirtyFlag(0)
 
         self.setParentItem(parentItem)
-        self.setData(**kwds)
+        self.setData(**kwargs)
     
-    def setData(self, **kwds):
+    def setData(self, **kwargs):
         """
         Update the data displayed by this item. All arguments are optional; 
         for example it is allowed to update vertex positions while leaving 
@@ -61,15 +61,15 @@ class GLLinePlotItem(GLGraphicsItem):
         ====================  ==================================================
         """
         args = ['pos', 'color', 'width', 'mode', 'antialias']
-        for k in kwds.keys():
+        for k in kwargs.keys():
             if k not in args:
                 raise Exception('Invalid keyword argument: %s (allowed arguments are %s)' % (k, str(args)))
-        if 'pos' in kwds:
-            pos = kwds.pop('pos')
+        if 'pos' in kwargs:
+            pos = kwargs.pop('pos')
             self.pos = np.ascontiguousarray(pos, dtype=np.float32)
             self.dirty_bits |= DirtyFlag.POSITION
-        if 'color' in kwds:
-            color = kwds.pop('color')
+        if 'color' in kwargs:
+            color = kwargs.pop('color')
             if isinstance(color, np.ndarray):
                 color = np.ascontiguousarray(color, dtype=np.float32)
                 self.dirty_bits |= DirtyFlag.COLOR
@@ -78,7 +78,7 @@ class GLLinePlotItem(GLGraphicsItem):
             if isinstance(color, QtGui.QColor):
                 color = color.getRgbF()
             self.color = color
-        for k, v in kwds.items():
+        for k, v in kwargs.items():
             setattr(self, k, v)
 
         if self.mode not in ['line_strip', 'lines']:

--- a/pyqtgraph/opengl/items/GLMeshItem.py
+++ b/pyqtgraph/opengl/items/GLMeshItem.py
@@ -26,7 +26,7 @@ class GLMeshItem(GLGraphicsItem):
     
     Displays a 3D triangle mesh. 
     """
-    def __init__(self, parentItem=None, **kwds):
+    def __init__(self, parentItem=None, **kwargs):
         """
         ============== =====================================================
         **Arguments:**
@@ -63,12 +63,12 @@ class GLMeshItem(GLGraphicsItem):
         }
         
         super().__init__(parentItem=parentItem)
-        glopts = kwds.pop('glOptions', 'opaque')
+        glopts = kwargs.pop('glOptions', 'opaque')
         self.setGLOptions(glopts)
-        shader = kwds.pop('shader', None)
+        shader = kwargs.pop('shader', None)
         self.setShader(shader)
         
-        self.setMeshData(**kwds)
+        self.setMeshData(**kwargs)
         
         ## storage for data compiled from MeshData object
         self.vertexes = None
@@ -105,25 +105,25 @@ class GLMeshItem(GLGraphicsItem):
         self.opts['polygonOffset'] = enable
         self.update()
 
-    def setMeshData(self, **kwds):
+    def setMeshData(self, **kwargs):
         """
         Set mesh data for this item. This can be invoked two ways:
         
         1. Specify *meshdata* argument with a new MeshData object
         2. Specify keyword arguments to be passed to MeshData(..) to create a new instance.
         """
-        md = kwds.get('meshdata', None)
+        md = kwargs.get('meshdata', None)
         if md is None:
             opts = {}
             for k in ['vertexes', 'faces', 'edges', 'vertexColors', 'faceColors']:
                 try:
-                    opts[k] = kwds.pop(k)
+                    opts[k] = kwargs.pop(k)
                 except KeyError:
                     pass
             md = MeshData(**opts)
         
         self.opts['meshdata'] = md
-        self.opts.update(kwds)
+        self.opts.update(kwargs)
         self.meshDataChanged()
         self.update()
         

--- a/pyqtgraph/opengl/items/GLScatterPlotItem.py
+++ b/pyqtgraph/opengl/items/GLScatterPlotItem.py
@@ -22,9 +22,9 @@ class GLScatterPlotItem(GLGraphicsItem):
     
     _shaderProgram = None
 
-    def __init__(self, parentItem=None, **kwds):
+    def __init__(self, parentItem=None, **kwargs):
         super().__init__()
-        glopts = kwds.pop('glOptions', 'additive')
+        glopts = kwargs.pop('glOptions', 'additive')
         self.setGLOptions(glopts)
         self.pos = None
         self.size = 10
@@ -37,9 +37,9 @@ class GLScatterPlotItem(GLGraphicsItem):
         self.dirty_bits = DirtyFlag(0)
 
         self.setParentItem(parentItem)
-        self.setData(**kwds)
+        self.setData(**kwargs)
 
-    def setData(self, **kwds):
+    def setData(self, **kwargs):
         """
         Update the data displayed by this item. All arguments are optional; 
         for example it is allowed to update spot positions while leaving 
@@ -58,30 +58,30 @@ class GLScatterPlotItem(GLGraphicsItem):
         ====================  ==================================================
         """
         args = ['pos', 'color', 'size', 'pxMode']
-        for k in kwds.keys():
+        for k in kwargs.keys():
             if k not in args:
                 raise Exception('Invalid keyword argument: %s (allowed arguments are %s)' % (k, str(args)))
             
-        if 'pos' in kwds:
-            pos = kwds.pop('pos')
+        if 'pos' in kwargs:
+            pos = kwargs.pop('pos')
             self.pos = np.ascontiguousarray(pos, dtype=np.float32)
             self.dirty_bits |= DirtyFlag.POSITION
-        if 'color' in kwds:
-            color = kwds.pop('color')
+        if 'color' in kwargs:
+            color = kwargs.pop('color')
             if isinstance(color, np.ndarray):
                 color = np.ascontiguousarray(color, dtype=np.float32)
                 self.dirty_bits |= DirtyFlag.COLOR
             if isinstance(color, QtGui.QColor):
                 color = color.getRgbF()
             self.color = color
-        if 'size' in kwds:
-            size = kwds.pop('size')
+        if 'size' in kwargs:
+            size = kwargs.pop('size')
             if isinstance(size, np.ndarray):
                 size = np.ascontiguousarray(size, dtype=np.float32)
                 self.dirty_bits |= DirtyFlag.SIZE
             self.size = size
                 
-        self.pxMode = kwds.get('pxMode', self.pxMode)
+        self.pxMode = kwargs.get('pxMode', self.pxMode)
         self.update()
 
     def upload_vbo(self, vbo, arr):

--- a/pyqtgraph/opengl/items/GLSurfacePlotItem.py
+++ b/pyqtgraph/opengl/items/GLSurfacePlotItem.py
@@ -17,7 +17,7 @@ class GLSurfacePlotItem(GLMeshItem):
     mesh_keys = ('x', 'y', 'z', 'colors')
     grid_keys = ('showGrid', 'lineColor', 'lineWidth', 'lineAntialias')
 
-    def __init__(self, parentItem=None, **kwds):
+    def __init__(self, parentItem=None, **kwargs):
         """
         The x, y, z, colors, showGrid, lineColor, lineWidth and lineAntialias
         arguments are passed to setData().
@@ -34,14 +34,14 @@ class GLSurfacePlotItem(GLMeshItem):
         self._vertexes = None
         self._meshdata = MeshData()
 
-        # splitout GLSurfacePlotItem from kwds
+        # splitout GLSurfacePlotItem from kwargs
         surface_keys = self.mesh_keys + self.grid_keys
-        surface_kwds = {}
+        surface_kwargs = {}
         for arg in surface_keys:
-            if arg in kwds:
-                surface_kwds[arg] = kwds.pop(arg)
+            if arg in kwargs:
+                surface_kwargs[arg] = kwargs.pop(arg)
 
-        super().__init__(meshdata=self._meshdata, **kwds)
+        super().__init__(meshdata=self._meshdata, **kwargs)
 
         self.lineplot = GLLinePlotItem(parentItem=self, mode='lines', glOptions='translucent')
         # in GLViewWidget.drawItemTree(), at the same depth value, child items
@@ -50,9 +50,9 @@ class GLSurfacePlotItem(GLMeshItem):
         self.lineplot.setDepthValue(self.depthValue() + 1)
         self.setParentItem(parentItem)
 
-        self.setData(**surface_kwds)
+        self.setData(**surface_kwargs)
         
-    def setData(self, **kwds):
+    def setData(self, **kwargs):
         """
         Update the data in this surface plot. 
         
@@ -78,10 +78,10 @@ class GLSurfacePlotItem(GLMeshItem):
         """
 
         for arg in self.grid_keys:
-            if arg in kwds:
-                setattr(self, '_' + arg, kwds[arg])
+            if arg in kwargs:
+                setattr(self, '_' + arg, kwargs[arg])
 
-        x, y, z, colors = map(kwds.get, self.mesh_keys)
+        x, y, z, colors = map(kwargs.get, self.mesh_keys)
 
         if x is not None:
             if self._x is None or len(x) != len(self._x):

--- a/pyqtgraph/opengl/items/GLTextItem.py
+++ b/pyqtgraph/opengl/items/GLTextItem.py
@@ -9,10 +9,10 @@ __all__ = ['GLTextItem']
 class GLTextItem(GLGraphicsItem):
     """Draws text in 3D."""
 
-    def __init__(self, parentItem=None, **kwds):
+    def __init__(self, parentItem=None, **kwargs):
         """All keyword arguments are passed to setData()"""
         super().__init__(parentItem=parentItem)
-        glopts = kwds.pop('glOptions', 'additive')
+        glopts = kwargs.pop('glOptions', 'additive')
         self.setGLOptions(glopts)
 
         self.items = []
@@ -22,9 +22,9 @@ class GLTextItem(GLGraphicsItem):
         self.font = QtGui.QFont('Helvetica', 16)
         self.alignment = QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignBottom
 
-        self.setData(**kwds)
+        self.setData(**kwargs)
 
-    def setData(self, **kwds):
+    def setData(self, **kwargs):
         """
         Update the data displayed by this item. All arguments are optional;
         for example it is allowed to update text while leaving colors unchanged, etc.
@@ -43,12 +43,12 @@ class GLTextItem(GLGraphicsItem):
         ====================  ==================================================
         """
         args = ['pos', 'text', 'color', 'font', 'alignment', 'items']
-        for k in kwds.keys():
+        for k in kwargs.keys():
             if k not in args:
                 raise ValueError('Invalid keyword argument: %s (allowed arguments are %s)' % (k, str(args)))
         for arg in args:
-            if arg in kwds:
-                value = kwds[arg]
+            if arg in kwargs:
+                value = kwargs[arg]
                 if arg == 'pos':
                     if isinstance(value, np.ndarray):
                         if value.shape != (3,):

--- a/pyqtgraph/parametertree/ParameterSystem.py
+++ b/pyqtgraph/parametertree/ParameterSystem.py
@@ -16,11 +16,11 @@ class ParameterSystem(GroupParameter):
     NOTE: This API is experimental and may change substantially across minor 
     version numbers. 
     """
-    def __init__(self, *args, **kwds):
-        GroupParameter.__init__(self, *args, **kwds)
+    def __init__(self, *args, **kwargs):
+        GroupParameter.__init__(self, *args, **kwargs)
         self._system = None
         self._fixParams = []  # all auto-generated 'fixed' params
-        sys = kwds.pop('system', None)
+        sys = kwargs.pop('system', None)
         if sys is not None:
             self.setSystem(sys)
         self._ignoreChange = [] # params whose changes should be ignored temporarily

--- a/pyqtgraph/util/cprint.py
+++ b/pyqtgraph/util/cprint.py
@@ -50,7 +50,7 @@ ANSI[RESET] = "\033[0m"
 WIN[RESET] =  {'reset': True}
 
 
-def cprint(stream, *args, **kwds):
+def cprint(stream, *args, **kwargs):
     """
     Print with color. Examples::
 
@@ -69,19 +69,19 @@ def cprint(stream, *args, **kwds):
 
     """
     if isinstance(stream, str):
-        stream = kwds.get('stream', 'stdout')
+        stream = kwargs.get('stream', 'stdout')
         err = stream == 'stderr'
         stream = getattr(sys, stream)
     else:
-        err = kwds.get('stderr', False)
+        err = kwargs.get('stderr', False)
 
     if hasattr(stream, 'isatty') and stream.isatty():
         for arg in args:
             if isinstance(arg, str):
                 stream.write(arg)
             elif _WIN:
-                kwds = WIN[arg]
-                winset(stderr=err, **kwds)
+                kwargs = WIN[arg]
+                winset(stderr=err, **kwargs)
             else:
                 stream.write(ANSI[arg])
     else:

--- a/pyqtgraph/util/cupy_helper.py
+++ b/pyqtgraph/util/cupy_helper.py
@@ -1,18 +1,20 @@
 import os
 from warnings import warn
+from types import ModuleType
 
 from .. import getConfigOption
 
 
-def getCupy():
+def getCupy() -> ModuleType | None:
     if getConfigOption("useCupy"):
         try:
-            import cupy
+            import cupy  # pyright: ignore[reportMissingImports]
         except ImportError:
             warn("cupy library could not be loaded, but 'useCupy' is set.")
             return None
-        if os.name == "nt" and cupy.cuda.runtime.runtimeGetVersion() < 11000:
-            warn("In Windows, CUDA toolkit should be version 11 or higher, or some functions may misbehave.")
+        else:
+            if os.name == "nt" and cupy.cuda.runtime.runtimeGetVersion() < 11000:  # pyright: ignore[reportUnknownMemberType]
+                warn("In Windows, CUDA toolkit should be version 11 or higher, or some functions may misbehave.")
         return cupy
     else:
         return None

--- a/pyqtgraph/util/mutex.py
+++ b/pyqtgraph/util/mutex.py
@@ -12,13 +12,13 @@ class Mutex(QtCore.QMutex):
     
     Also provides __enter__ and __exit__ methods for use in "with" statements.
     """    
-    def __init__(self, *args, **kargs):
-        if kargs.get('recursive', False):
+    def __init__(self, *args, **kwargs):
+        if kwargs.get('recursive', False):
             args = (QtCore.QMutex.Recursive,)
         QtCore.QMutex.__init__(self, *args)
         self.l = QtCore.QMutex()  ## for serializing access to self.tb
         self.tb = []
-        self.debug = kargs.pop('debug', False) ## True to enable debugging functions
+        self.debug = kwargs.pop('debug', False) ## True to enable debugging functions
 
     def tryLock(self, timeout=None, id=None):
         if timeout is None:
@@ -108,6 +108,6 @@ class Mutex(QtCore.QMutex):
 class RecursiveMutex(Mutex):
     """Mimics threading.RLock class.
     """
-    def __init__(self, **kwds):
-        kwds['recursive'] = True
-        Mutex.__init__(self, **kwds)
+    def __init__(self, **kwargs):
+        kwargs['recursive'] = True
+        Mutex.__init__(self, **kwargs)

--- a/pyqtgraph/widgets/ComboBox.py
+++ b/pyqtgraph/widgets/ComboBox.py
@@ -68,11 +68,11 @@ class ComboBox(QtWidgets.QComboBox):
     
     def ignoreIndexChange(func):
         # Decorator that prevents updates to self._chosenText
-        def fn(self, *args, **kwds):
+        def fn(self, *args, **kwargs):
             prev = self._ignoreIndexChange
             self._ignoreIndexChange = True
             try:
-                ret = func(self, *args, **kwds)
+                ret = func(self, *args, **kwargs)
             finally:
                 self._ignoreIndexChange = prev
             return ret
@@ -82,12 +82,12 @@ class ComboBox(QtWidgets.QComboBox):
         # decorator that blocks signal emission during complex operations
         # and emits currentIndexChanged only if the value has actually
         # changed at the end.
-        def fn(self, *args, **kwds):
+        def fn(self, *args, **kwargs):
             prevVal = self.value()
             blocked = self.signalsBlocked()
             self.blockSignals(True)
             try:
-                ret = func(self, *args, **kwds)
+                ret = func(self, *args, **kwargs)
             finally:
                 self.blockSignals(blocked)
                 
@@ -147,7 +147,7 @@ class ComboBox(QtWidgets.QComboBox):
         #self.itemsChanged()
     
     @ignoreIndexChange
-    def addItem(self, *args, **kwds):
+    def addItem(self, *args, **kwargs):
         # Need to handle two different function signatures for QComboBox.addItem
         try:
             if isinstance(args[0], str):
@@ -155,13 +155,13 @@ class ComboBox(QtWidgets.QComboBox):
                 if len(args) == 2:
                     value = args[1]
                 else:
-                    value = kwds.get('value', text)
+                    value = kwargs.get('value', text)
             else:
                 text = args[1]
                 if len(args) == 3:
                     value = args[2]
                 else:
-                    value = kwds.get('value', text)
+                    value = kwargs.get('value', text)
         
         except IndexError:
             raise TypeError("First or second argument of addItem must be a string.")

--- a/pyqtgraph/widgets/GradientWidget.py
+++ b/pyqtgraph/widgets/GradientWidget.py
@@ -14,7 +14,7 @@ class GradientWidget(GraphicsView):
     sigGradientChanged = QtCore.Signal(object)
     sigGradientChangeFinished = QtCore.Signal(object)
     
-    def __init__(self, parent=None, orientation='bottom',  *args, **kargs):
+    def __init__(self, parent=None, orientation='bottom',  *args, **kwargs):
         """
         The *orientation* argument may be 'bottom', 'top', 'left', or 'right' 
         indicating whether the gradient is displayed horizontally (top, bottom)
@@ -29,8 +29,8 @@ class GradientWidget(GraphicsView):
         """
         GraphicsView.__init__(self, parent, useOpenGL=False, background=None)
         self.maxDim = 31
-        kargs['tickPen'] = 'k'
-        self.item = GradientEditorItem(*args, **kargs)
+        kwargs['tickPen'] = 'k'
+        self.item = GradientEditorItem(*args, **kwargs)
         self.item.sigGradientChanged.connect(self.sigGradientChanged)
         self.item.sigGradientChangeFinished.connect(self.sigGradientChangeFinished)
         self.setCentralItem(self.item)

--- a/pyqtgraph/widgets/GraphicsLayoutWidget.py
+++ b/pyqtgraph/widgets/GraphicsLayoutWidget.py
@@ -4,7 +4,7 @@ from .GraphicsView import GraphicsView
 
 __all__ = ['GraphicsLayoutWidget']
 class GraphicsLayoutWidget(GraphicsView):
-    """
+    r"""
     Convenience class consisting of a :class:`GraphicsView 
     <pyqtgraph.GraphicsView>` with a single :class:`GraphicsLayout
     <pyqtgraph.GraphicsLayout>` as its central item. 
@@ -27,8 +27,7 @@ class GraphicsLayoutWidget(GraphicsView):
                effect.
     title      (str or None) If specified, then set the window title for this
                widget.
-    kargs      All extra arguments are passed to
-               :meth:`GraphicsLayout.__init__
+    \**kwargs  All extra arguments are passed to :meth:`GraphicsLayout.__init__
                <pyqtgraph.GraphicsLayout.__init__>`
     =========  =================================================================
         
@@ -46,10 +45,10 @@ class GraphicsLayoutWidget(GraphicsView):
     :func:`itemIndex <pyqtgraph.GraphicsLayout.itemIndex>`
     :func:`clear <pyqtgraph.GraphicsLayout.clear>`
     """
-    def __init__(self, parent=None, show=False, size=None, title=None, **kargs):
+    def __init__(self, parent=None, show=False, size=None, title=None, **kwargs):
         mkQApp()
         GraphicsView.__init__(self, parent)
-        self.ci = GraphicsLayout(**kargs)
+        self.ci = GraphicsLayout(**kwargs)
         for n in ['nextRow', 'nextCol', 'nextColumn', 'addPlot', 'addViewBox', 'addItem', 'getItem', 'addLayout', 'addLabel', 'removeItem', 'itemIndex', 'clear']:
             setattr(self, n, getattr(self.ci, n))
         self.setCentralItem(self.ci)

--- a/pyqtgraph/widgets/GraphicsView.py
+++ b/pyqtgraph/widgets/GraphicsView.py
@@ -137,9 +137,9 @@ class GraphicsView(QtWidgets.QGraphicsView):
         self.scene().prepareForPaint()
         return super().paintEvent(ev)
     
-    def render(self, *args, **kwds):
+    def render(self, *args, **kwargs):
         self.scene().prepareForPaint()
-        return super().render(*args, **kwds)
+        return super().render(*args, **kwargs)
         
     
     def close(self):

--- a/pyqtgraph/widgets/GroupBox.py
+++ b/pyqtgraph/widgets/GroupBox.py
@@ -69,9 +69,9 @@ class GroupBox(QtWidgets.QGroupBox):
         self._collapsed = c
         self.sigCollapseChanged.emit(c)
 
-    def setSizePolicy(self, *args, **kwds):
+    def setSizePolicy(self, *args, **kwargs):
         QtWidgets.QGroupBox.setSizePolicy(self, *args)
-        if kwds.pop('closing', False) is True:
+        if kwargs.pop('closing', False) is True:
             self._lastSizePolicy = self.sizePolicy()
 
     def setHorizontalPolicy(self, *args):

--- a/pyqtgraph/widgets/HistogramLUTWidget.py
+++ b/pyqtgraph/widgets/HistogramLUTWidget.py
@@ -16,13 +16,13 @@ class HistogramLUTWidget(GraphicsView):
     All parameters are passed along in creating the HistogramLUTItem.
     """
 
-    def __init__(self, parent=None, *args, **kargs):
-        background = kargs.pop('background', 'default')
+    def __init__(self, parent=None, *args, **kwargs):
+        background = kwargs.pop('background', 'default')
         GraphicsView.__init__(self, parent, useOpenGL=False, background=background)
-        self.item = HistogramLUTItem(*args, **kargs)
+        self.item = HistogramLUTItem(*args, **kwargs)
         self.setCentralItem(self.item)
 
-        self.orientation = kargs.get('orientation', 'vertical')
+        self.orientation = kwargs.get('orientation', 'vertical')
         if self.orientation == 'vertical':
             self.setSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Expanding)
             self.setMinimumWidth(95)

--- a/pyqtgraph/widgets/LayoutWidget.py
+++ b/pyqtgraph/widgets/LayoutWidget.py
@@ -27,28 +27,28 @@ class LayoutWidget(QtWidgets.QWidget):
         self.currentCol += colspan
         return self.currentCol-colspan
         
-    def nextCol(self, *args, **kargs):
+    def nextCol(self, *args, **kwargs):
         """Alias of nextColumn"""
-        return self.nextColumn(*args, **kargs)
+        return self.nextColumn(*args, **kwargs)
         
         
-    def addLabel(self, text=' ', row=None, col=None, rowspan=1, colspan=1, **kargs):
+    def addLabel(self, text=' ', row=None, col=None, rowspan=1, colspan=1, **kwargs):
         """
         Create a QLabel with *text* and place it in the next available cell (or in the cell specified)
         All extra keyword arguments are passed to QLabel().
         Returns the created widget.
         """
-        text = QtWidgets.QLabel(text, **kargs)
+        text = QtWidgets.QLabel(text, **kwargs)
         self.addWidget(text, row, col, rowspan, colspan)
         return text
         
-    def addLayout(self, row=None, col=None, rowspan=1, colspan=1, **kargs):
+    def addLayout(self, row=None, col=None, rowspan=1, colspan=1, **kwargs):
         """
         Create an empty LayoutWidget and place it in the next available cell (or in the cell specified)
         All extra keyword arguments are passed to :func:`LayoutWidget.__init__ <pyqtgraph.LayoutWidget.__init__>`
         Returns the created widget.
         """
-        layout = LayoutWidget(**kargs)
+        layout = LayoutWidget(**kwargs)
         self.addWidget(layout, row, col, rowspan, colspan)
         return layout
         

--- a/pyqtgraph/widgets/PlotWidget.py
+++ b/pyqtgraph/widgets/PlotWidget.py
@@ -41,7 +41,7 @@ class PlotWidget(GraphicsView):
     sigRangeChanged = QtCore.Signal(object, object)
     sigTransformChanged = QtCore.Signal(object)
 
-    def __init__(self, parent=None, background='default', plotItem=None, **kargs):
+    def __init__(self, parent=None, background='default', plotItem=None, **kwargs):
         ## start by instantiating the plotItem attribute in order to avoid recursive 
         ## calls of PlotWidget.__getattr__ - which access self.plotItem!
         self.plotItem = None
@@ -53,7 +53,7 @@ class PlotWidget(GraphicsView):
         self.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding)
         self.enableMouse(False)
         if plotItem is None:
-            self.plotItem = PlotItem(**kargs)
+            self.plotItem = PlotItem(**kwargs)
         else:
             self.plotItem = plotItem
         self.setCentralItem(self.plotItem)

--- a/pyqtgraph/widgets/RawImageWidget.py
+++ b/pyqtgraph/widgets/RawImageWidget.py
@@ -47,14 +47,14 @@ class RawImageWidget(QtWidgets.QWidget):
         self.image = None
         self._cp = getCupy()
 
-    def setImage(self, img, *args, **kargs):
+    def setImage(self, img, *args, **kwargs):
         """
         img must be ndarray of shape (x,y), (x,y,3), or (x,y,4).
         Extra arguments are sent to functions.makeARGB
         """
         if getConfigOption('imageAxisOrder') == 'col-major':
             img = img.swapaxes(0, 1)
-        self.opts = (img, args, kargs)
+        self.opts = (img, args, kwargs)
         self.image = None
         self.update()
 
@@ -142,14 +142,14 @@ class RawImageGLWidget(QtOpenGLWidgets.QOpenGLWidget):
 
         self.try_cuda = cudart is not None
 
-    def setImage(self, img, *args, **kargs):
+    def setImage(self, img, *args, **kwargs):
         """
         img must be ndarray of shape (x,y), (x,y,3), or (x,y,4).
         Extra arguments are sent to functions.makeARGB
         """
         if getConfigOption('imageAxisOrder') == 'col-major':
             img = img.swapaxes(0, 1)
-        self.opts = (img, args, kargs)
+        self.opts = (img, args, kwargs)
         self.image = None
         self.uploaded = False
         self.update()
@@ -250,8 +250,8 @@ class RawImageGLWidget(QtOpenGLWidgets.QOpenGLWidget):
         if self.image is None:
             if self.opts is None:
                 return
-            img, args, kwds = self.opts
-            self.image, _ = fn.makeRGBA(img, *args, **kwds)
+            img, args, kwargs = self.opts
+            self.image, _ = fn.makeRGBA(img, *args, **kwargs)
 
         if not self.uploaded:
             # mark as uploaded whether or not it succeeds so that we don't retry and refail

--- a/pyqtgraph/widgets/RemoteGraphicsView.py
+++ b/pyqtgraph/widgets/RemoteGraphicsView.py
@@ -139,7 +139,7 @@ class RemoteGraphicsView(QtWidgets.QWidget):
     GraphicsItems must be created by proxy to the remote process.
     
     """
-    def __init__(self, parent=None, *args, **kwds):
+    def __init__(self, parent=None, *args, **kwargs):
         """
         The keyword arguments 'useOpenGL' and 'background', if specified, are passed to the remote
         GraphicsView.__init__(). All other keyword arguments are passed to multiprocess.QtProcess.__init__().
@@ -153,10 +153,10 @@ class RemoteGraphicsView(QtWidgets.QWidget):
         # separate local keyword arguments from remote.
         remoteKwds = {}
         for kwd in ['useOpenGL', 'background']:
-            if kwd in kwds:
-                remoteKwds[kwd] = kwds.pop(kwd)
+            if kwd in kwargs:
+                remoteKwds[kwd] = kwargs.pop(kwd)
 
-        self._proc = mp.QtProcess(**kwds)
+        self._proc = mp.QtProcess(**kwargs)
         self.pg = self._proc._import('pyqtgraph')
         self.pg.setConfigOptions(**CONFIG_OPTIONS)
         rpgRemote = self._proc._import('pyqtgraph.widgets.RemoteGraphicsView')
@@ -250,7 +250,7 @@ class Renderer(GraphicsView):
     
     sceneRendered = QtCore.Signal(object)
     
-    def __init__(self, *args, **kwds):
+    def __init__(self, *args, **kwargs):
         ## Create shared memory for rendered image
         self.shmFile = tempfile.NamedTemporaryFile(prefix='pyqtgraph_shmem_')
         size = mmap.PAGESIZE
@@ -259,7 +259,7 @@ class Renderer(GraphicsView):
         self.shm = mmap.mmap(self.shmFile.fileno(), size, access=mmap.ACCESS_WRITE)
         atexit.register(self.close)
         
-        GraphicsView.__init__(self, *args, **kwds)
+        GraphicsView.__init__(self, *args, **kwargs)
         self.scene().changed.connect(self.update)
         self.img = None
         self.renderTimer = QtCore.QTimer()

--- a/pyqtgraph/widgets/TableWidget.py
+++ b/pyqtgraph/widgets/TableWidget.py
@@ -8,7 +8,7 @@ __all__ = ['TableWidget']
 
 
 def _defersort(fn):
-    def defersort(self, *args, **kwds):
+    def defersort(self, *args, **kwargs):
         # may be called recursively; only the first call needs to block sorting
         setSorting = False
         if self._sorting is None:
@@ -16,7 +16,7 @@ def _defersort(fn):
             setSorting = True
             self.setSortingEnabled(False)
         try:
-            return fn(self, *args, **kwds)
+            return fn(self, *args, **kwargs)
         finally:
             if setSorting:
                 self.setSortingEnabled(self._sorting)
@@ -32,7 +32,7 @@ class TableWidget(QtWidgets.QTableWidget):
     information.
     """
     
-    def __init__(self, *args, **kwds):
+    def __init__(self, *args, **kwargs):
         """
         All positional arguments are passed to QTableWidget.__init__().
         
@@ -57,13 +57,13 @@ class TableWidget(QtWidgets.QTableWidget):
         self.setSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred)
         self.clear()
         
-        kwds.setdefault('sortable', True)
-        kwds.setdefault('editable', False)
-        self.setEditable(kwds.pop('editable'))
-        self.setSortingEnabled(kwds.pop('sortable'))
+        kwargs.setdefault('sortable', True)
+        kwargs.setdefault('editable', False)
+        self.setEditable(kwargs.pop('editable'))
+        self.setSortingEnabled(kwargs.pop('sortable'))
         
-        if len(kwds) > 0:
-            raise TypeError("Invalid keyword arguments '%s'" % list(kwds.keys()))
+        if len(kwargs) > 0:
+            raise TypeError("Invalid keyword arguments '%s'" % list(kwargs.keys()))
         
         self._sorting = None  # used when temporarily disabling sorting
         

--- a/tests/image_testing.py
+++ b/tests/image_testing.py
@@ -475,10 +475,10 @@ def indent(s, pfx):
 class TransposedImageItem(ImageItem):
     # used for testing image axis order; we can test row-major and col-major using
     # the same test images
-    def __init__(self, *args, **kwds):
-        self.__transpose = kwds.pop('transpose', False)
-        ImageItem.__init__(self, *args, **kwds)
-    def setImage(self, image=None, **kwds):
+    def __init__(self, *args, **kwargs):
+        self.__transpose = kwargs.pop('transpose', False)
+        ImageItem.__init__(self, *args, **kwargs)
+    def setImage(self, image=None, **kwargs):
         if image is not None and self.__transpose is True:
             image = np.swapaxes(image, 0, 1)
-        return ImageItem.setImage(self, image, **kwds)
+        return ImageItem.setImage(self, image, **kwargs)

--- a/tests/makeARGB_test_data.py
+++ b/tests/makeARGB_test_data.py
@@ -1,5 +1,4 @@
 import sys
-from typing import Optional, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -166,8 +165,8 @@ LEVELS = {
 }
 
 EXPECTED_OUTPUTS: dict[
-    tuple[npt.DTypeLike, str, Optional[str], Optional[npt.DTypeLike], Optional[int], bool],
-    Union[type(Exception), np.ndarray]
+    tuple[npt.DTypeLike, str, str | None, npt.DTypeLike | None, int | None, bool],
+    type[Exception] | np.ndarray
 ] = {
     (np.uint8, "2D", None, None, None, True): np.array(
         [
@@ -4222,9 +4221,9 @@ EXPECTED_OUTPUTS: dict[
 }
 
 
-def _makeARGB(*args, **kwds):
-    img, alpha = makeARGB(*args, **kwds)
-    if kwds.get('useRGBA'):  # endian independent
+def _makeARGB(*args, **kwargs):
+    img, alpha = makeARGB(*args, **kwargs)
+    if kwargs.get('useRGBA'):  # endian independent
         out = img
     elif sys.byteorder == 'little':  # little-endian ARGB32 to B,G,R,A
         out = img

--- a/tests/test_makeARGB.py
+++ b/tests/test_makeARGB.py
@@ -15,9 +15,9 @@ except ImportError:
     pass
 
 
-def _makeARGB(*args, **kwds):
-    img, alpha = real_makeARGB(*args, **kwds)
-    if kwds.get('useRGBA'):  # endian independent
+def _makeARGB(*args, **kwargs):
+    img, alpha = real_makeARGB(*args, **kwargs)
+    if kwargs.get('useRGBA'):  # endian independent
         out = img
     elif sys.byteorder == 'little':  # little-endian ARGB32 to B,G,R,A
         out = img

--- a/tests/test_ref_cycles.py
+++ b/tests/test_ref_cycles.py
@@ -35,10 +35,10 @@ def mkrefs(*objs):
 
 
 def test_PlotWidget():
-    def mkobjs(*args, **kwds):
+    def mkobjs(*args, **kwargs):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            w = pg.PlotWidget(*args, **kwds)
+            w = pg.PlotWidget(*args, **kwargs)
         data = np.array([1,5,2,4,3])
         c = w.plot(data, name='stuff')
         w.addLegend()


### PR DESCRIPTION
Fixes #3488

A number of other PRs attempted to fix that PR, but all the other PRs only aimed at the examples cited in the issues instead of fixing the issue that was common throughout the entire library.

In addition to those changes, I introduced a small handful of in-line typing fixes, removed the use of `typing.Optional` and `typing.Union`, and migrated `kargs` to `kwargs` to follow general convention better.