### PR TITLE
Fix packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.dynamic]
 version = { attr = "pyqtgraph.__version__" }
 
-[tool.setuptools]
-packages = ["pyqtgraph"]
+[tool.setuptools.packages.find]
+include = ["pyqtgraph", "pyqtgraph.*"]
 
 [tool.setuptools.package-data]
 pyqtgraph = [


### PR DESCRIPTION
#3583 broke some packaging, see for example [this run](https://github.com/mne-tools/mne-python/actions/runs/32598912252/job/97094126289?pr=14187#step:23:12893) from MNE-Python:
```
==================================== ERRORS ====================================
___________________ ERROR at setup of test_merge_annotations ___________________
[gw0] linux -- Python 3.14.7 /opt/hostedtoolcache/Python/3.14.7/x64/bin/python
/opt/hostedtoolcache/Python/3.14.7/x64/lib/python3.14/site-packages/pytestqt/plugin.py:178: in pytest_runtest_setup
    result = yield
             ^^^^^
mne/conftest.py:689: in pg_backend
    from mne_qt_browser._pg_figure import MNEQtBrowser
/opt/hostedtoolcache/Python/3.14.7/x64/lib/python3.14/site-packages/mne_qt_browser/_pg_figure.py:37: in <module>
    from pyqtgraph import (
/opt/hostedtoolcache/Python/3.14.7/x64/lib/python3.14/site-packages/pyqtgraph/__init__.py:18: in <module>
    from .colors import palette
E   ImportError: cannot import name 'palette' from 'pyqtgraph.colors' (unknown location)
=============================== warnings summary ===============================
```
This change should fix it.

Longer-term, might be good to have a little CI run that does something minimal with the packaged version (full tests would be great, but at least some smoke test for some packages being available).