### PR TITLE
Update legend entries automatically when setData() changes name/style

### DIFF
--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -222,10 +222,24 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
             sample = self.sampleType(item)
 
         sample.sigClicked.connect(self.sigSampleClicked)
+        if hasattr(item, 'sigPlotChanged'):
+            item.sigPlotChanged.connect(self._plotChanged)
 
         self.items.append((sample, label))
         self._addItemToLayout(sample, label)
         self.updateSize()
+
+    def _plotChanged(self, item):
+        # Keep a legend entry in sync with its plot item after setData()
+        # changes the name, pen, symbol or brush of an already-added item.
+        for sample, label in self.items:
+            if sample.item is item:
+                name = item.opts.get('name')
+                if name is not None and label.text != name:
+                    label.setText(name)
+                    self.updateSize()
+                sample.update()
+                return
 
     def _addItemToLayout(self, sample, label):
         col = self.layout.columnCount()
@@ -295,14 +309,23 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         """
         for sample, label in self.items:
             if sample.item is item or label.text == item:
+                self._disconnectPlotChanged(sample.item)
                 self.items.remove((sample, label))  # remove from itemlist
                 self._removeItemFromLayout(sample, label)
                 self.updateSize()  # redraw box
                 return  # return after first match
 
+    def _disconnectPlotChanged(self, item):
+        if hasattr(item, 'sigPlotChanged'):
+            try:
+                item.sigPlotChanged.disconnect(self._plotChanged)
+            except (TypeError, RuntimeError):
+                pass  # already disconnected
+
     def clear(self):
         """Remove all items from the legend."""
         for sample, label in self.items:
+            self._disconnectPlotChanged(sample.item)
             self._removeItemFromLayout(sample, label)
 
         self.items = []
@@ -408,4 +431,3 @@ class ItemSample(GraphicsWidget):
         event.accept()
         self.update()
         self.sigClicked.emit(self.item)
-

--- a/tests/graphicsItems/test_LegendItem.py
+++ b/tests/graphicsItems/test_LegendItem.py
@@ -101,3 +101,24 @@ def test_legend_item_basics():
 
     legend.clear()
     assert legend.items == []
+
+
+def test_legend_item_updates_on_setdata():
+    # https://github.com/pyqtgraph/pyqtgraph/issues/1000
+    # Legend entries should reflect name/style changes made via setData()
+    # on an item that is already in the legend.
+    legend = pg.LegendItem()
+
+    curve = pg.PlotDataItem([0, 1, 2], [0, 1, 4], name="Original Name")
+    legend.addItem(curve, name="Original Name")
+
+    label = legend.getLabel(curve)
+    assert label.text == "Original Name"
+
+    curve.setData([0, 1, 2], [1, 2, 3], name="New Name")
+    assert label.text == "New Name"
+
+    # Removing the item from the legend should disconnect the update
+    # handler so later setData() calls do not raise or leak connections.
+    legend.removeItem(curve)
+    curve.setData([0, 1], [5, 6], name="Should Not Raise")


### PR DESCRIPTION
## Summary
Fixes #1000.

`PlotDataItem.setData()` already emits `sigPlotChanged`, but `LegendItem` never listened for it, so a legend entry's label text and sample glyph went stale after `setData()` changed the item's name, pen, symbol, or brush.

- `LegendItem.addItem()` now connects to the item's `sigPlotChanged` signal (when present) and keeps the label text and sample glyph in sync when the underlying data/style changes.
- `LegendItem.removeItem()` and `clear()` disconnect this signal to avoid stale callbacks/leaks.

## Test plan
- Added `test_legend_item_updates_on_setdata` in `tests/graphicsItems/test_LegendItem.py`, covering both the name-update case and that `removeItem()` followed by another `setData()` call does not raise.
- Ran `tests/graphicsItems/` locally: all passing except one pre-existing, unrelated failure (`test_PlotItem_shared_axis_items`) confirmed to also fail on `master` without this change (a local offscreen-Qt font-cache warning, unrelated to this fix).
- Manually reproduced the exact behavior described in #1000 (legend label stuck on old name after `setData(name=...)`), confirmed the fix resolves it, and confirmed reverting the fix reproduces the bug again.