### PR TITLE
GLImageItem and GLVolumeItem: use QOpenGLTexture

### DIFF
--- a/.github/workflows/etc/environment-pyqt.yml
+++ b/.github/workflows/etc/environment-pyqt.yml
@@ -4,6 +4,5 @@ dependencies:
   - numpy
   - nomkl
   - scipy
-  - pyopengl
   - colorama
   - pip

--- a/.github/workflows/etc/environment-pyside.yml
+++ b/.github/workflows/etc/environment-pyside.yml
@@ -4,6 +4,5 @@ dependencies:
   - numpy
   - nomkl
   - scipy
-  - pyopengl
   - colorama
   - pip

--- a/.github/workflows/etc/requirements.txt
+++ b/.github/workflows/etc/requirements.txt
@@ -10,9 +10,6 @@ scipy==1.18.1
 # optional high performance paths
 numba==0.67.0; python_version == '3.12'
 
-# optional 3D
-pyopengl==3.1.10
-
 # supplimental tools
 matplotlib==3.11.1
 h5py==3.16.0

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ the table below for a summary.
 | Library        | Added functionality |
 | -------------- | - |
 | [`scipy`]      | <ul><li> Image processing through [`ndimage`]</li><li> Data array filtering through [`signal`] </li><ul> |
-| [`pyopengl`]   | <ul><li> 3D graphics </li></ul> |
 | [`h5py`]       | <ul><li> Export in hdf5 format </li></ul> |
 | [`colorcet`]   | <ul><li> Add a collection of perceptually uniform colormaps </li></ul> |
 | [`matplotlib`] | <ul><li> Export of PlotItem in matplotlib figure </li><li> Add matplotlib collection of colormaps </li></ul> |
@@ -57,7 +56,6 @@ the table below for a summary.
 [`scipy`]: https://github.com/scipy/scipy
 [`ndimage`]: https://docs.scipy.org/doc/scipy/reference/ndimage.html
 [`signal`]: https://docs.scipy.org/doc/scipy/reference/signal.html
-[`pyopengl`]: https://github.com/mcfletch/pyopengl
 [`h5py`]: https://github.com/h5py/h5py
 [`colorcet`]: https://github.com/holoviz/colorcet
 [`matplotlib`]: https://github.com/matplotlib/matplotlib

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,5 +8,4 @@ sphinx-autodoc-typehints
 sphinx-qt-documentation
 sphinxext-rediraffe
 numpy
-pyopengl
 colorama

--- a/pyqtgraph/Qt/OpenGLHelpers.py
+++ b/pyqtgraph/Qt/OpenGLHelpers.py
@@ -1,7 +1,8 @@
 import ctypes
 import importlib
+import sys
 
-from . import QT_LIB, QtGui, QtWidgets, QtVersionInfo
+from . import QT_LIB, QtCore, QtGui, QtWidgets, QtVersionInfo
 from . import OpenGLConstants as GLC
 
 if QtVersionInfo[0] >= 6:
@@ -107,3 +108,26 @@ def get_gl_uniform_1fv():
     context = QtGui.QOpenGLContext.currentContext()
     func_ptr = context.getProcAddress(b"glUniform1fv")
     return GLUNIFORM1FV_TYPE(int(func_ptr))
+
+
+_handler_installed = False
+_prev_handler = None
+
+def message_handler(msg_type, context, message):
+    if msg_type == QtCore.QtMsgType.QtWarningMsg:
+        if "QOpenGLTexture" in message and "has not been destroyed" in message:
+            return
+
+    if _prev_handler is not None:
+        _prev_handler(msg_type, context, message)
+    else:
+        sys.stderr.write(f"{message}\n")
+
+
+def suppress_texture_warning():
+    global _handler_installed, _prev_handler
+    if _handler_installed:
+        return
+
+    _prev_handler = QtCore.qInstallMessageHandler(message_handler)
+    _handler_installed = True

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -1,13 +1,8 @@
-from ...Qt import FailedImport
-
-try:
-    from OpenGL import GL
-except ImportError as err:
-    GL = FailedImport(err)
-
 import numpy as np
 
 from ...Qt import QtGui, QtOpenGL
+from ...Qt import OpenGLConstants as GLC
+from ...Qt import OpenGLHelpers
 from ..GLGraphicsItem import GLGraphicsItem
 
 __all__ = ['GLImageItem']
@@ -33,10 +28,11 @@ class GLImageItem(GLGraphicsItem):
         """
         
         super().__init__()
+        OpenGLHelpers.suppress_texture_warning()
         self.setGLOptions(glOptions)
         self.smooth = smooth
         self._needUpdate = False
-        self.texture = None
+        self.m_texture = QtOpenGL.QOpenGLTexture(QtOpenGL.QOpenGLTexture.Target.Target2D)
         self.m_vbo_position = QtOpenGL.QOpenGLBuffer(QtOpenGL.QOpenGLBuffer.Type.VertexBuffer)
         self.setParentItem(parentItem)
         self.setData(data)
@@ -45,30 +41,33 @@ class GLImageItem(GLGraphicsItem):
         self.data = data
         self._needUpdate = True
         self.update()
-        
-    def _updateTexture(self):
-        if self.texture is None:
-            self.texture = GL.glGenTextures(1)
-        GL.glBindTexture(GL.GL_TEXTURE_2D, self.texture)
-        filt = GL.GL_LINEAR if self.smooth else GL.GL_NEAREST
-        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, filt)
-        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, filt)
-        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_BORDER)
-        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_BORDER)
-        shape = self.data.shape
-        
-        context = QtGui.QOpenGLContext.currentContext()
-        if not context.isOpenGLES():
-            ## Test texture dimensions first
-            GL.glTexImage2D(GL.GL_PROXY_TEXTURE_2D, 0, GL.GL_RGBA, shape[0], shape[1], 0, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, None)
-            if GL.glGetTexLevelParameteriv(GL.GL_PROXY_TEXTURE_2D, 0, GL.GL_TEXTURE_WIDTH) == 0:
-                raise Exception("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % shape[:2])
-        
-        data = np.ascontiguousarray(self.data.transpose((1,0,2)))
-        GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_RGBA, shape[0], shape[1], 0, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, data)
-        GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
 
-        x, y = shape[:2]
+    def _updateTexture(self):
+        tex = self.m_texture
+
+        data = np.ascontiguousarray(self.data.transpose((1,0,2)))
+        h, w = data.shape[:2]
+
+        if tex.isCreated() and (w != tex.width() or h != tex.height()):
+            tex.destroy()
+
+        if not tex.isCreated():
+            tex.setFormat(QtOpenGL.QOpenGLTexture.TextureFormat.RGBA8_UNorm)
+            tex.setSize(w, h)
+            tex.allocateStorage()
+            if not tex.isStorageAllocated():
+                raise RuntimeError("OpenGL failed to create 2D texture (%dx%d); too large for this hardware." % (w, h))
+
+        filt = QtOpenGL.QOpenGLTexture.Filter.Linear if self.smooth else QtOpenGL.QOpenGLTexture.Filter.Nearest
+        tex.setMinMagFilters(filt, filt)
+        tex.setWrapMode(QtOpenGL.QOpenGLTexture.WrapMode.ClampToBorder)
+
+        tex.setData(
+            QtOpenGL.QOpenGLTexture.PixelFormat.RGBA,
+            QtOpenGL.QOpenGLTexture.PixelType.UInt8,
+            data)
+
+        x, y = self.data.shape[:2]
         pos = np.array([
             [0, 0, 0, 0],
             [x, 0, 1, 0],
@@ -129,15 +128,18 @@ class GLImageItem(GLGraphicsItem):
 
         mat_mvp = self.mvpMatrix()
 
+        context = QtGui.QOpenGLContext.currentContext()
+        glfn = OpenGLHelpers.getFunctions(context)
+
         program = self.getShaderProgram()
         loc_pos, loc_tex = 0, 1
         self.m_vbo_position.bind()
-        program.setAttributeBuffer(loc_pos, GL.GL_FLOAT, 0*4, 2, 4*4)
-        program.setAttributeBuffer(loc_tex, GL.GL_FLOAT, 2*4, 2, 4*4)
+        program.setAttributeBuffer(loc_pos, GLC.GL_FLOAT, 0*4, 2, 4*4)
+        program.setAttributeBuffer(loc_tex, GLC.GL_FLOAT, 2*4, 2, 4*4)
         self.m_vbo_position.release()
         enabled_locs = [loc_pos, loc_tex]
 
-        GL.glBindTexture(GL.GL_TEXTURE_2D, self.texture)
+        self.m_texture.bind()
 
         for loc in enabled_locs:
             program.enableAttributeArray(loc)
@@ -145,14 +147,14 @@ class GLImageItem(GLGraphicsItem):
         program.bind()
         program.setUniformValue("u_mvp", mat_mvp)
 
-        GL.glDrawArrays(GL.GL_TRIANGLE_STRIP, 0, 4)
+        glfn.glDrawArrays(GLC.GL_TRIANGLE_STRIP, 0, 4)
 
         program.release()
 
         for loc in enabled_locs:
             program.disableAttributeArray(loc)
 
-        GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+        self.m_texture.release()
 
 
 SHADER_LEGACY = {

--- a/pyqtgraph/opengl/items/GLVolumeItem.py
+++ b/pyqtgraph/opengl/items/GLVolumeItem.py
@@ -1,13 +1,8 @@
-from ...Qt import FailedImport
-
-try:
-    from OpenGL import GL
-except ImportError as err:
-    GL = FailedImport(err)
-
 import numpy as np
 
 from ...Qt import QtGui, QtOpenGL
+from ...Qt import OpenGLConstants as GLC
+from ...Qt import OpenGLHelpers
 from ..GLGraphicsItem import GLGraphicsItem
 
 __all__ = ['GLVolumeItem']
@@ -32,12 +27,13 @@ class GLVolumeItem(GLGraphicsItem):
         """
         
         super().__init__()
+        OpenGLHelpers.suppress_texture_warning()
         self.setGLOptions(glOptions)
         self.sliceDensity = sliceDensity
         self.smooth = smooth
         self.data = None
         self._needUpload = False
-        self.texture = None
+        self.m_texture = QtOpenGL.QOpenGLTexture(QtOpenGL.QOpenGLTexture.Target.Target3D)
         self.m_vbo_position = QtOpenGL.QOpenGLBuffer(QtOpenGL.QOpenGLBuffer.Type.VertexBuffer)
         self.setParentItem(parentItem)
         self.setData(data)
@@ -46,29 +42,31 @@ class GLVolumeItem(GLGraphicsItem):
         self.data = data
         self._needUpload = True
         self.update()
-        
-    def _uploadData(self):
-        if self.texture is None:
-            self.texture = GL.glGenTextures(1)
-        GL.glBindTexture(GL.GL_TEXTURE_3D, self.texture)
-        filt = GL.GL_LINEAR if self.smooth else GL.GL_NEAREST
-        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_MIN_FILTER, filt)
-        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_MAG_FILTER, filt)
-        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_BORDER)
-        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_BORDER)
-        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_WRAP_R, GL.GL_CLAMP_TO_BORDER)
-        shape = self.data.shape
 
-        context = QtGui.QOpenGLContext.currentContext()
-        if not context.isOpenGLES():
-            ## Test texture dimensions first
-            GL.glTexImage3D(GL.GL_PROXY_TEXTURE_3D, 0, GL.GL_RGBA, shape[0], shape[1], shape[2], 0, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, None)
-            if GL.glGetTexLevelParameteriv(GL.GL_PROXY_TEXTURE_3D, 0, GL.GL_TEXTURE_WIDTH) == 0:
-                raise Exception("OpenGL failed to create 3D texture (%dx%dx%d); too large for this hardware." % shape[:3])
-        
+    def _uploadData(self):
+        tex = self.m_texture
+
         data = np.ascontiguousarray(self.data.transpose((2,1,0,3)))
-        GL.glTexImage3D(GL.GL_TEXTURE_3D, 0, GL.GL_RGBA, shape[0], shape[1], shape[2], 0, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, data)
-        GL.glBindTexture(GL.GL_TEXTURE_3D, 0)
+        d, h, w = data.shape[:3]
+
+        if tex.isCreated() and (w != tex.width() or h != tex.height() or d != tex.depth()):
+            tex.destroy()
+
+        if not tex.isCreated():
+            tex.setFormat(QtOpenGL.QOpenGLTexture.TextureFormat.RGBA8_UNorm)
+            tex.setSize(w, h, d)
+            tex.allocateStorage()
+            if not tex.isStorageAllocated():
+                raise RuntimeError("OpenGL failed to create 3D texture (%dx%dx%d); too large for this hardware." % (w, h, d))
+
+        filt = QtOpenGL.QOpenGLTexture.Filter.Linear if self.smooth else QtOpenGL.QOpenGLTexture.Filter.Nearest
+        tex.setMinMagFilters(filt, filt)
+        tex.setWrapMode(QtOpenGL.QOpenGLTexture.WrapMode.ClampToBorder)
+
+        tex.setData(
+            QtOpenGL.QOpenGLTexture.PixelFormat.RGBA,
+            QtOpenGL.QOpenGLTexture.PixelType.UInt8,
+            data)
         
         all_vertices = []
 
@@ -151,16 +149,19 @@ class GLVolumeItem(GLGraphicsItem):
         d = 1 if cam[ax] > 0 else -1
         offset, num_vertices = self.lists[(ax,d)]
 
+        context = QtGui.QOpenGLContext.currentContext()
+        glfn = OpenGLHelpers.getFunctions(context)
+
         program = self.getShaderProgram()
 
         loc_pos, loc_tex = 0, 1
         self.m_vbo_position.bind()
-        program.setAttributeBuffer(loc_pos, GL.GL_FLOAT, 0*4, 3, 6*4)
-        program.setAttributeBuffer(loc_tex, GL.GL_FLOAT, 3*4, 3, 6*4)
+        program.setAttributeBuffer(loc_pos, GLC.GL_FLOAT, 0*4, 3, 6*4)
+        program.setAttributeBuffer(loc_tex, GLC.GL_FLOAT, 3*4, 3, 6*4)
         self.m_vbo_position.release()
         enabled_locs = [loc_pos, loc_tex]
 
-        GL.glBindTexture(GL.GL_TEXTURE_3D, self.texture)
+        self.m_texture.bind()
 
         for loc in enabled_locs:
             program.enableAttributeArray(loc)
@@ -168,14 +169,14 @@ class GLVolumeItem(GLGraphicsItem):
         program.bind()
         program.setUniformValue("u_mvp", mat_mvp)
 
-        GL.glDrawArrays(GL.GL_TRIANGLES, offset, num_vertices)
+        glfn.glDrawArrays(GLC.GL_TRIANGLES, offset, num_vertices)
 
         program.release()
 
         for loc in enabled_locs:
             program.disableAttributeArray(loc)
 
-        GL.glBindTexture(GL.GL_TEXTURE_3D, 0)
+        self.m_texture.release()
 
     def drawVolume(self, ax, d):
         imax = [0,1,2]

--- a/tests/opengl/items/test_GLAxisItem.py
+++ b/tests/opengl/items/test_GLAxisItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLAxisItem
 

--- a/tests/opengl/items/test_GLBarGraphItem.py
+++ b/tests/opengl/items/test_GLBarGraphItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 import numpy as np
 
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem

--- a/tests/opengl/items/test_GLBoxItem.py
+++ b/tests/opengl/items/test_GLBoxItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLBoxItem
 

--- a/tests/opengl/items/test_GLGradientLegendItem.py
+++ b/tests/opengl/items/test_GLGradientLegendItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLGradientLegendItem
 

--- a/tests/opengl/items/test_GLGraphItem.py
+++ b/tests/opengl/items/test_GLGraphItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLGraphItem
 

--- a/tests/opengl/items/test_GLGridItem.py
+++ b/tests/opengl/items/test_GLGridItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLGridItem
 

--- a/tests/opengl/items/test_GLImageItem.py
+++ b/tests/opengl/items/test_GLImageItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLAxisItem
 

--- a/tests/opengl/items/test_GLLinePlotItem.py
+++ b/tests/opengl/items/test_GLLinePlotItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLLinePlotItem
 

--- a/tests/opengl/items/test_GLMeshItem.py
+++ b/tests/opengl/items/test_GLMeshItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLMeshItem
 

--- a/tests/opengl/items/test_GLScatterPlotItem.py
+++ b/tests/opengl/items/test_GLScatterPlotItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLScatterPlotItem
 

--- a/tests/opengl/items/test_GLSurfacePlotItem.py
+++ b/tests/opengl/items/test_GLSurfacePlotItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLSurfacePlotItem
 

--- a/tests/opengl/items/test_GLTextItem.py
+++ b/tests/opengl/items/test_GLTextItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLTextItem
 

--- a/tests/opengl/items/test_GLVolumeItem.py
+++ b/tests/opengl/items/test_GLVolumeItem.py
@@ -1,6 +1,3 @@
-import pytest
-pytest.importorskip('OpenGL')
-
 from pyqtgraph.opengl.GLGraphicsItem import GLGraphicsItem
 from pyqtgraph.opengl import GLVolumeItem
 


### PR DESCRIPTION
fixes #3590

As the warning about the texture not being cleaned up occurring at program termination could not be adequately resolved, this PR opts to suppress the warning.
The message handler to suppress the warning is only installed if `GLImageItem` or `GLVolumeItem` is used, this minimizes the impact to applications that don't use these objects.

Note that `PColorMeshItem` doesn't have such an issue, where it does manage to perform the cleanup.
The issue arises from GLViewWidget being used as a top-level window. In such a case, the `QOpenGLContext.aboutToBeDestroyed` signal slot machinery doesn't get activated. (Or the signal got emitted but the slot just doesn't get called)
