### PR TITLE
Fix ROI handling maxBounds being a QRect

### DIFF
--- a/pyqtgraph/graphicsItems/ROI.py
+++ b/pyqtgraph/graphicsItems/ROI.py
@@ -186,6 +186,9 @@ class ROI(GraphicsObject):
         
         self.handleSize = 5
         self.invertible = invertible
+
+        if maxBounds is not None:
+            maxBounds = QtCore.QRectF(maxBounds)
         self.maxBounds = maxBounds
         
         self.snapSize = snapSize


### PR DESCRIPTION
Fixes #3201 

## Summary

Passing ROI `maxBounds` as `QRect` fails as it gets checked against the ROI bounds which is computed as a `QRectF`, so convert maxBounds to a `QRectF`.

## Testing

Existing ROI tests pass and manually testing the example from the issue no longer raises the error when resizing the ROI