### PR TITLE
Fixup OpenGL

### DIFF
--- a/pyqtgraph/opengl/GLGraphicsItem.py
+++ b/pyqtgraph/opengl/GLGraphicsItem.py
@@ -39,6 +39,8 @@ class GLGraphicsItem(QtCore.QObject):
         self.__transform = Transform3D()
         self.__visible = True
         self.__initialized = False
+        self.__glctx: QtGui.QOpenGLContext | None = None
+        self.__glfns = None
         self.setParentItem(parentItem)
         self.setDepthValue(0)
         self.__glOpts = {}
@@ -330,4 +332,8 @@ class GLGraphicsItem(QtCore.QObject):
     def glFunctions(self):
         if (view := self.view()) is None:
             return None
-        return OpenGLHelpers.getFunctions(view.context())
+        glctx = view.context()
+        if self.__glfns is None or self.__glctx is not glctx:
+            self.__glctx = glctx
+            self.__glfns = OpenGLHelpers.getFunctions(glctx)
+        return self.__glfns

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -18,12 +18,11 @@ class GLImageItem(GLGraphicsItem):
     
     def __init__(self, data, smooth=False, glOptions='translucent', parentItem=None):
         """
-        
         ==============  =======================================================================================
         **Arguments:**
-        data            Volume data to be rendered. *Must* be 3D numpy array (x, y, RGBA) with dtype=ubyte.
+        data            Image data to be rendered. *Must* be 3D numpy array (x, y, RGBA) with dtype=ubyte.
                         (See functions.makeRGBA)
-        smooth          (bool) If True, the volume slices are rendered with linear interpolation 
+        smooth          (bool) If True, the image is rendered with linear interpolation
         ==============  =======================================================================================
         """
         

--- a/pyqtgraph/opengl/items/GLImageItem.py
+++ b/pyqtgraph/opengl/items/GLImageItem.py
@@ -52,7 +52,13 @@ class GLImageItem(GLGraphicsItem):
             tex.destroy()
 
         if not tex.isCreated():
-            tex.setFormat(QtOpenGL.QOpenGLTexture.TextureFormat.RGBA8_UNorm)
+            context = QtGui.QOpenGLContext.currentContext()
+            if context.isOpenGLES() and context.format().version() <= (2, 0):
+                # PyQt5 on Windows with QT_OPENGL=angle emulates OpenGL ES 2.0
+                texfmt = QtOpenGL.QOpenGLTexture.TextureFormat.RGBAFormat
+            else:
+                texfmt = QtOpenGL.QOpenGLTexture.TextureFormat.RGBA8_UNorm
+            tex.setFormat(texfmt)
             tex.setSize(w, h)
             tex.allocateStorage()
             if not tex.isStorageAllocated():
@@ -128,8 +134,7 @@ class GLImageItem(GLGraphicsItem):
 
         mat_mvp = self.mvpMatrix()
 
-        context = QtGui.QOpenGLContext.currentContext()
-        glfn = OpenGLHelpers.getFunctions(context)
+        glfn = self.glFunctions()
 
         program = self.getShaderProgram()
         loc_pos, loc_tex = 0, 1

--- a/pyqtgraph/opengl/items/GLVolumeItem.py
+++ b/pyqtgraph/opengl/items/GLVolumeItem.py
@@ -149,8 +149,7 @@ class GLVolumeItem(GLGraphicsItem):
         d = 1 if cam[ax] > 0 else -1
         offset, num_vertices = self.lists[(ax,d)]
 
-        context = QtGui.QOpenGLContext.currentContext()
-        glfn = OpenGLHelpers.getFunctions(context)
+        glfn = self.glFunctions()
 
         program = self.getShaderProgram()
 


### PR DESCRIPTION
1) In the original code, `GL_RGBA` (what Qt calls RGBAFormat) was used as the format. This worked for both Desktop OpenGL and OpenGL ES 2.0.

GL_RGBA was considered obsolete and was supposed to be replaced with `GL_RGBA8` (what Qt calls RGBA8_UNorm).

OpenGL ES 2.0 does not support GL_RGBA8.

2) Cache retrieval of OpenGLFunctions