### PR TITLE
fix: move __all__ declarations to top of files

### DIFF
--- a/pyqtgraph/ThreadsafeTimer.py
+++ b/pyqtgraph/ThreadsafeTimer.py
@@ -1,6 +1,6 @@
 from .Qt import QtCore
-
 __all__ = ['ThreadsafeTimer']
+
 
 class ThreadsafeTimer(QtCore.QObject):
     """

--- a/pyqtgraph/WidgetGroup.py
+++ b/pyqtgraph/WidgetGroup.py
@@ -11,8 +11,8 @@ import inspect
 import weakref
 
 from .Qt import QtCore, QtWidgets
-
 __all__ = ['WidgetGroup']
+
 
 def splitterState(w):
     s = w.saveState().toPercentEncoding().data().decode()

--- a/pyqtgraph/algorithms.py
+++ b/pyqtgraph/algorithms.py
@@ -1,7 +1,7 @@
 import numpy as np
 from .Qt import QtGui
-
 __all__ = ['isocurve', 'isosurface', 'pseudoScatter', 'toposort']
+
 
 # isocurve is used by:
 # - IsocurveItem

--- a/pyqtgraph/colormap.py
+++ b/pyqtgraph/colormap.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from .functions import clip_array, clip_scalar, colorDistance, eq, mkColor
 from .Qt import QtCore, QtGui
-
 __all__ = ['ColorMap']
+
 
 _mapCache = {}
 

--- a/pyqtgraph/functions.py
+++ b/pyqtgraph/functions.py
@@ -18,10 +18,10 @@ import numpy as np
 from . import Qt, debug, getConfigOption, reload
 from .Qt import QT_LIB, QtCore, QtGui
 from .util.cupy_helper import getCupy
+__all__ = [
 
 # in order of appearance in this file.
 # add new functions to this list only if they are to reside in pg namespace.
-__all__ = [
     'siScale', 'siFormat', 'siParse', 'siEval', 'siApply',
     'Color', 'mkColor', 'mkBrush', 'mkPen', 'hsvColor',
     'CIELabColor', 'colorCIELab', 'colorDistance',

--- a/pyqtgraph/widgets/TableWidget.py
+++ b/pyqtgraph/widgets/TableWidget.py
@@ -2,9 +2,9 @@ import numpy as np
 
 from ..Qt import QtCore, QtGui, QtWidgets
 
-translate = QtCore.QCoreApplication.translate
-
 __all__ = ['TableWidget']
+
+translate = QtCore.QCoreApplication.translate
 
 
 def _defersort(fn):


### PR DESCRIPTION
## Problem

`__all__` statements were placed after other code in several files, violating Python convention that `__all__` should be at the top of a module, immediately after imports.

## Fix

Moved `__all__` declarations to immediately after the last import statement in 6 files:

- `pyqtgraph/widgets/TableWidget.py`
- `pyqtgraph/functions.py`
- `pyqtgraph/colormap.py`
- `pyqtgraph/algorithms.py`
- `pyqtgraph/WidgetGroup.py`
- `pyqtgraph/ThreadsafeTimer.py`

Resolves #2373