### PR TITLE
Fix clobbering of layout method of QWidget

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,11 @@ exclude = '(Template|__init__.py)'
 [tool.pyright]
 pythonVersion = "3.12"
 include = ["pyqtgraph"]
+strictListInference = true
+strictDictionaryInference = true
+strictSetInference = true
+useLibraryCodeForTypes = true
+enableExperimentalFeatures = true
 reportImplicitOverride = false           # qt methods intended to be overridden
 reportMissingTypeStubs = false
 reportIncompatibleMethodOverride = false # complains when argument names don't match up

--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -74,13 +74,13 @@ class ConsoleWidget(QtWidgets.QWidget):
         self.currentTraceback = None
 
     def _setupUi(self):
-        self.layout = QtWidgets.QGridLayout(self)
-        self.setLayout(self.layout)
-        self.layout.setContentsMargins(0, 0, 0, 0)
-        self.layout.setSpacing(0)
+        self.layout_ = QtWidgets.QGridLayout()
+        self.setLayout(self.layout_)
+        self.layout_.setContentsMargins(0, 0, 0, 0)
+        self.layout_.setSpacing(0)
 
         self.splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical, self)
-        self.layout.addWidget(self.splitter, 0, 0)
+        self.layout_.addWidget(self.splitter, 0, 0)
 
         self.repl = ReplWidget(self.globals, self.locals, self, allowNonGuiExecution=self._allowNonGuiExecution)
         self.splitter.addWidget(self.repl)

--- a/pyqtgraph/console/exception_widget.py
+++ b/pyqtgraph/console/exception_widget.py
@@ -17,48 +17,50 @@ class ExceptionHandlerWidget(QtWidgets.QGroupBox):
         self.filterString = ''
         self._inSystrace = False
 
+
         # send exceptions raised in non-gui threads back to the main thread by signal.
         self._threadException.connect(self._threadExceptionHandler)
 
     def _setupUi(self):
         self.setTitle("Exception Handling")
 
-        self.layout = QtWidgets.QGridLayout(self)
-        self.layout.setContentsMargins(0, 0, 0, 0)
-        self.layout.setHorizontalSpacing(2)
-        self.layout.setVerticalSpacing(0)
+        self.layout_ = QtWidgets.QGridLayout()
+        self.setLayout(self.layout_)
+        self.layout_.setContentsMargins(0, 0, 0, 0)
+        self.layout_.setHorizontalSpacing(2)
+        self.layout_.setVerticalSpacing(0)
 
         self.clearExceptionBtn = QtWidgets.QPushButton("Clear Stack", self)
         self.clearExceptionBtn.setEnabled(False)
-        self.layout.addWidget(self.clearExceptionBtn, 0, 6, 1, 1)
+        self.layout_.addWidget(self.clearExceptionBtn, 0, 6, 1, 1)
 
         self.catchAllExceptionsBtn = QtWidgets.QPushButton("Show All Exceptions", self)
         self.catchAllExceptionsBtn.setCheckable(True)
-        self.layout.addWidget(self.catchAllExceptionsBtn, 0, 1, 1, 1)
+        self.layout_.addWidget(self.catchAllExceptionsBtn, 0, 1, 1, 1)
 
         self.catchNextExceptionBtn = QtWidgets.QPushButton("Show Next Exception", self)
         self.catchNextExceptionBtn.setCheckable(True)
-        self.layout.addWidget(self.catchNextExceptionBtn, 0, 0, 1, 1)
+        self.layout_.addWidget(self.catchNextExceptionBtn, 0, 0, 1, 1)
 
         self.onlyUncaughtCheck = QtWidgets.QCheckBox("Only Uncaught Exceptions", self)
         self.onlyUncaughtCheck.setChecked(True)
-        self.layout.addWidget(self.onlyUncaughtCheck, 0, 4, 1, 1)
+        self.layout_.addWidget(self.onlyUncaughtCheck, 0, 4, 1, 1)
 
         self.stackTree = StackWidget(self)
-        self.layout.addWidget(self.stackTree, 2, 0, 1, 7)
+        self.layout_.addWidget(self.stackTree, 2, 0, 1, 7)
 
         self.runSelectedFrameCheck = QtWidgets.QCheckBox("Run commands in selected stack frame", self)
         self.runSelectedFrameCheck.setChecked(True)
-        self.layout.addWidget(self.runSelectedFrameCheck, 3, 0, 1, 7)
+        self.layout_.addWidget(self.runSelectedFrameCheck, 3, 0, 1, 7)
 
         spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum)
-        self.layout.addItem(spacerItem, 0, 5, 1, 1)
+        self.layout_.addItem(spacerItem, 0, 5, 1, 1)
 
         self.filterLabel = QtWidgets.QLabel("Filter (regex):", self)
-        self.layout.addWidget(self.filterLabel, 0, 2, 1, 1)
+        self.layout_.addWidget(self.filterLabel, 0, 2, 1, 1)
 
         self.filterText = QtWidgets.QLineEdit(self)
-        self.layout.addWidget(self.filterText, 0, 3, 1, 1)
+        self.layout_.addWidget(self.filterText, 0, 3, 1, 1)
 
         self.catchAllExceptionsBtn.toggled.connect(self.catchAllExceptions)
         self.catchNextExceptionBtn.toggled.connect(self.catchNextException)

--- a/pyqtgraph/console/repl_widget.py
+++ b/pyqtgraph/console/repl_widget.py
@@ -62,10 +62,10 @@ class ReplWidget(QtWidgets.QWidget):
             _ = thread.wait(5_000)
 
     def _setupUi(self):
-        self.layout = QtWidgets.QVBoxLayout()
-        self.layout.setContentsMargins(0, 0, 0, 0)
-        self.layout.setSpacing(0)
-        self.setLayout(self.layout)
+        self.layout_ = QtWidgets.QVBoxLayout()
+        self.layout_.setContentsMargins(0, 0, 0, 0)
+        self.layout_.setSpacing(0)
+        self.setLayout(self.layout_)
 
         self.output = QtWidgets.QTextEdit(self)
         font = QtGui.QFont("monospace")
@@ -75,11 +75,11 @@ class ReplWidget(QtWidgets.QWidget):
         )
         self.output.setFont(font)
         self.output.setReadOnly(True)
-        self.layout.addWidget(self.output)
+        self.layout_.addWidget(self.output)
         
-        # put input box in a horizontal layout so we can easily place buttons at the end
+        # put input box in a horizontal layout_ so we can easily place buttons at the end
         self.inputWidget = QtWidgets.QWidget(self)
-        self.layout.addWidget(self.inputWidget)
+        self.layout_.addWidget(self.inputWidget)
         self.inputLayout = QtWidgets.QHBoxLayout()
         self.inputWidget.setLayout(self.inputLayout)
         self.inputLayout.setContentsMargins(0, 0, 0, 0)

--- a/pyqtgraph/dockarea/Container.py
+++ b/pyqtgraph/dockarea/Container.py
@@ -224,23 +224,22 @@ class TContainer(Container, QtWidgets.QWidget):
     def __init__(self, area):
         QtWidgets.QWidget.__init__(self)
         Container.__init__(self, area)
-        self.layout = QtWidgets.QGridLayout()
-        self.layout.setSpacing(0)
-        self.layout.setContentsMargins(0,0,0,0)
-        self.setLayout(self.layout)
+        self.layout_ = QtWidgets.QGridLayout()
+        self.layout_.setSpacing(0)
+        self.layout_.setContentsMargins(0,0,0,0)
         
         self.hTabLayout = QtWidgets.QHBoxLayout()
         self.hTabBox = QtWidgets.QWidget()
         self.hTabBox.setLayout(self.hTabLayout)
         self.hTabLayout.setSpacing(2)
         self.hTabLayout.setContentsMargins(0,0,0,0)
-        self.layout.addWidget(self.hTabBox, 0, 1)
+        self.layout_.addWidget(self.hTabBox, 0, 1)
 
         self.stack = StackedWidget(container=self)
-        self.layout.addWidget(self.stack, 1, 1)
+        self.layout_.addWidget(self.stack, 1, 1)
+        self.setLayout(self.layout_)
 
 
-        self.setLayout(self.layout)
         for n in ['count', 'widget', 'indexOf']:
             setattr(self, n, getattr(self.stack, n))
 

--- a/pyqtgraph/dockarea/Dock.py
+++ b/pyqtgraph/dockarea/Dock.py
@@ -43,10 +43,10 @@ class Dock(QtWidgets.QWidget):
         self.topLayout.addWidget(self.label, 0, 1)
         self.widgetArea = QtWidgets.QWidget()
         self.topLayout.addWidget(self.widgetArea, 1, 1)
-        self.layout = QtWidgets.QGridLayout()
-        self.layout.setContentsMargins(0, 0, 0, 0)
-        self.layout.setSpacing(0)
-        self.widgetArea.setLayout(self.layout)
+        self.layout_ = QtWidgets.QGridLayout()
+        self.layout_.setContentsMargins(0, 0, 0, 0)
+        self.layout_.setSpacing(0)
+        self.widgetArea.setLayout(self.layout_)
         self.widgetArea.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Expanding,
             QtWidgets.QSizePolicy.Policy.Expanding
@@ -201,7 +201,7 @@ class Dock(QtWidgets.QWidget):
             row = self.currentRow
         self.currentRow = max(row+1, self.currentRow)
         self.widgets.append(widget)
-        self.layout.addWidget(widget, row, col, rowspan, colspan)
+        self.layout_.addWidget(widget, row, col, rowspan, colspan)
         self.dockdrop.raiseOverlay()
         
     def startDrag(self):
@@ -238,7 +238,9 @@ class Dock(QtWidgets.QWidget):
 
     def raiseDock(self):
         """If this Dock is stacked underneath others, raise it to the top."""
-        self.container().raiseDock(self)
+        container = self.container()
+        if container is not None:
+            container.raiseDock(self)
 
     def close(self):
         """Remove this dock from the DockArea it lives inside."""

--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -12,10 +12,10 @@ class DockArea(Container, QtWidgets.QWidget):
         QtWidgets.QWidget.__init__(self, parent=parent)
         self.dockdrop = DockDrop(self)
         self.dockdrop.removeAllowedArea('center')
-        self.layout = QtWidgets.QVBoxLayout()
-        self.layout.setContentsMargins(0,0,0,0)
-        self.layout.setSpacing(0)
-        self.setLayout(self.layout)
+        self.layout_ = QtWidgets.QVBoxLayout()
+        self.layout_.setContentsMargins(0,0,0,0)
+        self.layout_.setSpacing(0)
+        self.setLayout(self.layout_)
         self.docks = weakref.WeakValueDictionary()
         self.topContainer = None
         self.dockdrop.raiseOverlay()
@@ -157,7 +157,7 @@ class DockArea(Container, QtWidgets.QWidget):
             # Adding new top-level container; addContainer() should
             # take care of giving the old top container a new home.
             self.topContainer.containerChanged(None)
-        self.layout.addWidget(new)
+        self.layout_.addWidget(new)
         new.containerChanged(self)
         self.topContainer = new
         self.dockdrop.raiseOverlay()
@@ -387,13 +387,14 @@ class DockArea(Container, QtWidgets.QWidget):
 
 
 class TempAreaWindow(QtWidgets.QWidget):
+    
     def __init__(self, area, **kwargs):
         QtWidgets.QWidget.__init__(self, **kwargs)
-        self.layout = QtWidgets.QGridLayout()
-        self.setLayout(self.layout)
-        self.layout.setContentsMargins(0, 0, 0, 0)
+        self.layout_ = QtWidgets.QGridLayout()
+        self.layout_.setContentsMargins(0, 0, 0, 0)
+        self.layout_.addWidget(area)
+        self.setLayout(self.layout_)
         self.dockarea = area
-        self.layout.addWidget(area)
 
     def closeEvent(self, *args):
         # restore docks to their original area

--- a/pyqtgraph/examples/MultiplePlotAxes.py
+++ b/pyqtgraph/examples/MultiplePlotAxes.py
@@ -27,7 +27,7 @@ p1.getAxis('right').setLabel('axis2', color='#0000ff')
 ## this time we need to create a new axis as well.
 p3 = pg.ViewBox()
 ax3 = pg.AxisItem('right')
-p1.layout.addItem(ax3, 2, 3)
+p1.layout().addItem(ax3, 2, 3)
 p1.scene().addItem(p3)
 ax3.linkToView(p3)
 p3.setXLink(p1)

--- a/pyqtgraph/examples/customPlot.py
+++ b/pyqtgraph/examples/customPlot.py
@@ -79,7 +79,7 @@ pw.plot(x=dates, y=[1,6,2,4,3,5,6,8], symbol='o')
 # Using allowAdd and allowRemove to limit user interaction
 tickViewer = CustomTickSliderItem(allowAdd=False, allowRemove=False)
 vb.sigXRangeChanged.connect(tickViewer.updateRange)
-pw.plotItem.layout.addItem(tickViewer, 4, 1)
+pw.plotItem.layout().addItem(tickViewer, 4, 1)
 
 tickViewer.setTicks( [dates[0], dates[2], dates[-1]] )
 

--- a/pyqtgraph/examples/relativity/relativity.py
+++ b/pyqtgraph/examples/relativity/relativity.py
@@ -51,17 +51,15 @@ class RelativityGUI(QtWidgets.QWidget):
         if os.path.exists(presetDir):
             presets = [os.path.splitext(p)[0] for p in os.listdir(presetDir)]
             self.params.param('Load Preset..').setLimits(['']+presets)
-        
-        
-        
-        
+
     def setupGUI(self):
-        self.layout = QtWidgets.QVBoxLayout()
-        self.layout.setContentsMargins(0,0,0,0)
-        self.setLayout(self.layout)
+        self.layout_ = QtWidgets.QVBoxLayout()
+        self.layout_.setContentsMargins(0,0,0,0)
+        
         self.splitter = QtWidgets.QSplitter()
         self.splitter.setOrientation(QtCore.Qt.Orientation.Horizontal)
-        self.layout.addWidget(self.splitter)
+        self.layout_.addWidget(self.splitter)
+        self.setLayout(self.layout_)
         
         self.tree = ParameterTree(showHeader=False)
         self.splitter.addWidget(self.tree)

--- a/pyqtgraph/flowchart/library/Data.py
+++ b/pyqtgraph/flowchart/library/Data.py
@@ -187,12 +187,12 @@ class EvalNode(Node):
             allowAddInput=True, allowAddOutput=True)
         
         self.ui = QtWidgets.QWidget()
-        self.layout = QtWidgets.QGridLayout()
+        self.layout_ = QtWidgets.QGridLayout()
         self.text = TextEdit(self.update)
         self.text.setTabStopDistance(30)
         self.text.setPlainText("# Access inputs as args['input_name']\nreturn {'output': None} ## one key per output terminal")
-        self.layout.addWidget(self.text, 1, 0, 1, 2)
-        self.ui.setLayout(self.layout)
+        self.layout_.addWidget(self.text, 1, 0, 1, 2)
+        self.ui.setLayout(self.layout_)
         
     def ctrlWidget(self):
         return self.ui
@@ -260,16 +260,16 @@ class ColumnJoinNode(Node):
         #self.items = []
         
         self.ui = QtWidgets.QWidget()
-        self.layout = QtWidgets.QGridLayout()
-        self.ui.setLayout(self.layout)
+        self.layout_ = QtWidgets.QGridLayout()
+        self.ui.setLayout(self.layout_)
         
         self.tree = TreeWidget()
         self.addInBtn = QtWidgets.QPushButton('+ Input')
         self.remInBtn = QtWidgets.QPushButton('- Input')
         
-        self.layout.addWidget(self.tree, 0, 0, 1, 2)
-        self.layout.addWidget(self.addInBtn, 1, 0)
-        self.layout.addWidget(self.remInBtn, 1, 1)
+        self.layout_.addWidget(self.tree, 0, 0, 1, 2)
+        self.layout_.addWidget(self.addInBtn, 1, 0)
+        self.layout_.addWidget(self.remInBtn, 1, 1)
 
         self.addInBtn.clicked.connect(self.addInput)
         self.remInBtn.clicked.connect(self.remInput)

--- a/pyqtgraph/flowchart/library/Display.py
+++ b/pyqtgraph/flowchart/library/Display.py
@@ -180,8 +180,6 @@ class PlotCurve(CtrlNode):
         
         self.item.setData(x, y, pen=self.ctrls['color'].color())
         return {'plot': self.item}
-        
-        
 
 
 class ScatterPlot(CtrlNode):
@@ -200,21 +198,12 @@ class ScatterPlot(CtrlNode):
     ]
     
     def __init__(self, name):
-        CtrlNode.__init__(self, name, terminals={
+        super().__init__(name, terminals={
             'input': {'io': 'in'},
             'plot': {'io': 'out'}
         })
         self.item = ScatterPlotItem()
         self.keys = []
-        
-        #self.ui = QtWidgets.QWidget()
-        #self.layout = QtWidgets.QGridLayout()
-        #self.ui.setLayout(self.layout)
-        
-        #self.xCombo = QtWidgets.QComboBox()
-        #self.yCombo = QtWidgets.QComboBox()
-        
-        
     
     def process(self, input, display=True):
         #print "scatterplot process"

--- a/pyqtgraph/graphicsItems/ColorBarItem.py
+++ b/pyqtgraph/graphicsItems/ColorBarItem.py
@@ -115,10 +115,10 @@ class ColorBarItem(PlotItem):
 
         if self.horizontal:
             self.setRange( xRange=(0,256), yRange=(0,1), padding=0 )
-            self.layout.setRowFixedHeight(2, width)
+            self.layout().setRowFixedHeight(2, width)
         else:
             self.setRange( xRange=(0,1), yRange=(0,256), padding=0 )
-            self.layout.setColumnFixedWidth(1, width) # width of color bar
+            self.layout().setColumnFixedWidth(1, width) # width of color bar
 
         for key in ['left','right','top','bottom']:
             self.showAxis(key)
@@ -219,11 +219,11 @@ class ColorBarItem(PlotItem):
 
         if insert_in is not None:
             if self.horizontal:
-                insert_in.layout.addItem( self, 5, 1 ) # insert in layout below bottom axis
-                insert_in.layout.setRowFixedHeight(4, 10) # enforce some space to axis above
+                insert_in.layout().addItem( self, 5, 1 ) # insert in layout below bottom axis
+                insert_in.layout().setRowFixedHeight(4, 10) # enforce some space to axis above
             else:
-                insert_in.layout.addItem( self, 2, 5 ) # insert in layout after right-hand axis
-                insert_in.layout.setColumnFixedWidth(4, 5) # enforce some space to axis on the left
+                insert_in.layout().addItem( self, 2, 5 ) # insert in layout after right-hand axis
+                insert_in.layout().setColumnFixedWidth(4, 5) # enforce some space to axis on the left
         self._update_items( update_cmap = True )
 
     def setColorMap(self, colorMap):

--- a/pyqtgraph/graphicsItems/GraphicsLayout.py
+++ b/pyqtgraph/graphicsItems/GraphicsLayout.py
@@ -1,3 +1,5 @@
+__all__ = ['GraphicsLayout']
+
 from .. import functions as fn
 from ..Qt import QtCore, QtWidgets
 from .GraphicsWidget import GraphicsWidget
@@ -7,28 +9,34 @@ from .PlotItem import PlotItem
 ## Must be imported at the end to avoid cyclic-dependency hell:
 from .ViewBox import ViewBox
 
-__all__ = ['GraphicsLayout']
 class GraphicsLayout(GraphicsWidget):
     """
     Used for laying out GraphicsWidgets in a grid.
     This is usually created automatically as part of a :class:`GraphicsLayoutWidget <pyqtgraph.GraphicsLayoutWidget>`.
     """
 
-    def __init__(self, parent=None, border=None):
-        GraphicsWidget.__init__(self, parent)
+    def __init__(
+        self,
+        parent: QtWidgets.QGraphicsItem | None=None,
+        border: tuple[int, int, int] | bool | None=None
+    ):
+        super().__init__(parent)
         if border is True:
-            border = (100,100,100)
+            border = (100, 100, 100)
         elif border is False:
             border = None  
-        self.border = border
-        self.layout = QtWidgets.QGraphicsGridLayout()
-        self.setLayout(self.layout)
+        self.border: tuple[int, int, int] | None = border
+        self.layout_ = QtWidgets.QGraphicsGridLayout(self)
         self.items = {}  ## item: [(row, col), (row, col), ...]  lists all cells occupied by the item
         self.rows = {}   ## row: {col1: item1, col2: item2, ...}    maps cell location to item
         self.itemBorders = {}  ## {item1: QtWidgets.QGraphicsRectItem, ...} border rects
         self.currentRow = 0
         self.currentCol = 0
-        self.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding))
+        self.setSizePolicy(
+            QtWidgets.QSizePolicy(
+                QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding
+            )
+        )
     
     #def resizeEvent(self, ev):
         #ret = GraphicsWidget.resizeEvent(self, ev)
@@ -135,8 +143,8 @@ class GraphicsLayout(GraphicsWidget):
 
         item.geometryChanged.connect(self._updateItemBorder)
 
-        self.layout.addItem(item, row, col, rowspan, colspan)
-        self.layout.activate() # Update layout, recalculating bounds.
+        self.layout_.addItem(item, row, col, rowspan, colspan)
+        self.layout_.activate() # Update layout, recalculating bounds.
                                # Allows some PyQtGraph features to also work without Qt event loop.
         
         self.nextColumn()
@@ -166,8 +174,8 @@ class GraphicsLayout(GraphicsWidget):
         ValueError
             Raised if item could not be found inside the GraphicsLayout instance.
         """
-        for i in range(self.layout.count()):
-            if self.layout.itemAt(i).graphicsItem() is item:
+        for i in range(self.layout_.count()):
+            if self.layout_.itemAt(i).graphicsItem() is item:
                 return i
         raise ValueError(f"Could not determine index of item {item}")
     
@@ -176,7 +184,7 @@ class GraphicsLayout(GraphicsWidget):
         ind = self.itemIndex(item)
         
         # Remove the item from the layout and scene
-        self.layout.removeAt(ind)
+        self.layout_.removeAt(ind)
         self.scene().removeItem(item)
         
         # Clear the row and column where the item was
@@ -192,7 +200,7 @@ class GraphicsLayout(GraphicsWidget):
         self.scene().removeItem(itemBorder)
         
         # Recalculate the layout to reclaim the space
-        self.layout.updateGeometry()
+        self.layout_.updateGeometry()
         self.update()
 
     
@@ -208,10 +216,10 @@ class GraphicsLayout(GraphicsWidget):
         # Wrap calls to layout. This should happen automatically, but there
         # seems to be a Qt bug:
         # http://stackoverflow.com/questions/27092164/margins-in-pyqtgraphs-graphicslayout
-        self.layout.setContentsMargins(*args)
+        self.layout_.setContentsMargins(*args)
 
     def setSpacing(self, *args):
-        self.layout.setSpacing(*args)
+        self.layout_.setSpacing(*args)
 
     @QtCore.Slot()
     def _updateItemBorder(self):

--- a/pyqtgraph/graphicsItems/GraphicsWidget.py
+++ b/pyqtgraph/graphicsItems/GraphicsWidget.py
@@ -1,9 +1,9 @@
+__all__ = ['GraphicsWidget']
+
 from ..Qt import QtWidgets
 from .GraphicsItem import GraphicsItem
 from ..GraphicsScene.GraphicsScene import GraphicsScene
 from typing import TYPE_CHECKING
-
-__all__ = ['GraphicsWidget']
 
 
 class GraphicsWidget(GraphicsItem, QtWidgets.QGraphicsWidget):

--- a/pyqtgraph/graphicsItems/HistogramLUTItem.py
+++ b/pyqtgraph/graphicsItems/HistogramLUTItem.py
@@ -89,10 +89,16 @@ class HistogramLUTItem(GraphicsWidget):
     sigLevelsChanged = QtCore.Signal(object)
     sigLevelChangeFinished = QtCore.Signal(object)
 
-    def __init__(self, image=None, fillHistogram=True, levelMode='mono',
-                 gradientPosition='right', orientation='vertical',
-                 colorMapMenu=None):
-        GraphicsWidget.__init__(self)
+    def __init__(
+        self,
+        image=None,
+        fillHistogram=True,
+        levelMode='mono',
+        gradientPosition='right',
+        orientation='vertical',
+        colorMapMenu=None
+    ):
+        super().__init__()
         self.lut = None
         self.imageItem = lambda: None  # fake a dead weakref
         self.levelMode = levelMode
@@ -104,10 +110,10 @@ class HistogramLUTItem(GraphicsWidget):
         elif orientation == 'horizontal' and gradientPosition not in {'top', 'bottom'}:
             self.gradientPosition = 'bottom'
 
-        self.layout = QtWidgets.QGraphicsGridLayout()
-        self.setLayout(self.layout)
-        self.layout.setContentsMargins(1, 1, 1, 1)
-        self.layout.setSpacing(0)
+        self.layout_ = QtWidgets.QGraphicsGridLayout()
+        self.layout_.setContentsMargins(1, 1, 1, 1)
+        self.layout_.setSpacing(0)
+        self.setLayout(self.layout_)
 
         self.vb = ViewBox(parent=self)
         if self.orientation == 'vertical':
@@ -158,13 +164,13 @@ class HistogramLUTItem(GraphicsWidget):
         # axis / viewbox / gradient order in the grid
         avg = (0, 1, 2) if self.gradientPosition in {'right', 'bottom'} else (2, 1, 0)
         if self.orientation == 'vertical':
-            self.layout.addItem(self.axis, 0, avg[0])
-            self.layout.addItem(self.vb, 0, avg[1])
-            self.layout.addItem(self.gradient, 0, avg[2])
+            self.layout_.addItem(self.axis, 0, avg[0])
+            self.layout_.addItem(self.vb, 0, avg[1])
+            self.layout_.addItem(self.gradient, 0, avg[2])
         else:
-            self.layout.addItem(self.axis, avg[0], 0)
-            self.layout.addItem(self.vb, avg[1], 0)
-            self.layout.addItem(self.gradient, avg[2], 0)
+            self.layout_.addItem(self.axis, avg[0], 0)
+            self.layout_.addItem(self.vb, avg[1], 0)
+            self.layout_.addItem(self.gradient, avg[2], 0)
 
         self.gradient.setFlag(QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemStacksBehindParent)
         self.vb.setFlag(QtWidgets.QGraphicsItem.GraphicsItemFlag.ItemStacksBehindParent)

--- a/pyqtgraph/graphicsItems/LegendItem.py
+++ b/pyqtgraph/graphicsItems/LegendItem.py
@@ -67,11 +67,11 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         """
         GraphicsWidget.__init__(self)
         GraphicsWidgetAnchor.__init__(self)
-        self.layout = QtWidgets.QGraphicsGridLayout()
-        self.layout.setVerticalSpacing(verSpacing)
-        self.layout.setHorizontalSpacing(horSpacing)
+        self.layout_ = QtWidgets.QGraphicsGridLayout()
+        self.layout_.setVerticalSpacing(verSpacing)
+        self.layout_.setHorizontalSpacing(horSpacing)
 
-        self.setLayout(self.layout)
+        self.setLayout(self.layout_)
         self.items = []
         self.size = size
         self.offset = offset
@@ -228,8 +228,8 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         self.updateSize()
 
     def _addItemToLayout(self, sample, label):
-        col = self.layout.columnCount()
-        row = self.layout.rowCount()
+        col = self.layout_.columnCount()
+        row = self.layout_.rowCount()
         if row:
             row -= 1
         nCol = self.columnCount * 2
@@ -237,15 +237,15 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
         if col == nCol:
             for col in range(0, nCol, 2):
                 # FIND RIGHT COLUMN
-                if not self.layout.itemAt(row, col):
+                if not self.layout_.itemAt(row, col):
                     break
             else:
                 if col + 2 == nCol:
                     # MAKE NEW ROW
                     col = 0
                     row += 1
-        self.layout.addItem(sample, row, col, alignment=QtCore.Qt.AlignmentFlag.AlignVCenter)
-        self.layout.addItem(label, row, col + 1)
+        self.layout_.addItem(sample, row, col, alignment=QtCore.Qt.AlignmentFlag.AlignVCenter)
+        self.layout_.addItem(label, row, col + 1)
         # Keep rowCount in sync with the number of rows if items are added
         self.rowCount = max(self.rowCount, row + 1)
 
@@ -256,8 +256,8 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
             self.columnCount = columnCount
 
             self.rowCount = math.ceil(len(self.items) / columnCount)
-            for i in range(self.layout.count() - 1, -1, -1):
-                self.layout.removeAt(i)  # clear layout
+            for i in range(self.layout_.count() - 1, -1, -1):
+                self.layout_.removeAt(i)  # clear layout
             for sample, label in self.items:
                 self._addItemToLayout(sample, label)
             self.updateSize()
@@ -275,7 +275,7 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
 
     def _removeItemFromLayout(self, *args):
         for item in args:
-            self.layout.removeItem(item)
+            self.layout_.removeItem(item)
             item.close()
             # Normally, the item is automatically removed from
             # its scene when it gets destroyed.
@@ -313,11 +313,11 @@ class LegendItem(GraphicsWidgetAnchor, GraphicsWidget):
             return
         height = 0
         width = 0
-        for row in range(self.layout.rowCount()):
+        for row in range(self.layout_.rowCount()):
             row_height = 0
             col_width = 0
-            for col in range(self.layout.columnCount()):
-                item = self.layout.itemAt(row, col)
+            for col in range(self.layout_.columnCount()):
+                item = self.layout_.itemAt(row, col)
                 if item:
                     col_width += item.width() + 3
                     row_height = max(row_height, item.height())

--- a/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
+++ b/pyqtgraph/graphicsItems/PlotItem/PlotItem.py
@@ -152,11 +152,12 @@ class PlotItem(GraphicsWidget):
         self.buttonsHidden = False  # has the user has requested buttons to be hidden?
         self.mouseHovering = False
 
-        self.layout = QtWidgets.QGraphicsGridLayout()
-        self.layout.setContentsMargins(1,1,1,1)
-        self.setLayout(self.layout)
-        self.layout.setHorizontalSpacing(0)
-        self.layout.setVerticalSpacing(0)
+        self.layout_ = QtWidgets.QGraphicsGridLayout()
+        self.layout_.setContentsMargins(1,1,1,1)
+        self.layout_.setHorizontalSpacing(0)
+        self.layout_.setVerticalSpacing(0)
+        self.setLayout(self.layout_)
+
 
         if viewBox is None:
             viewBox = ViewBox(parent=self, enableMenu=enableMenu)
@@ -173,7 +174,7 @@ class PlotItem(GraphicsWidget):
         self.vb.sigYRangeChanged.connect(self.sigYRangeChanged)
         self.vb.sigRangeChangedManually.connect(self.sigRangeChangedManually)
 
-        self.layout.addItem(self.vb, 2, 1)
+        self.layout_.addItem(self.vb, 2, 1)
         self.alpha = 1.0
         self.autoAlpha = True
         self.spectrumMode = False
@@ -185,22 +186,22 @@ class PlotItem(GraphicsWidget):
         self.setAxisItems(axisItems)
 
         self.titleLabel = LabelItem('', size='11pt', parent=self)
-        self.layout.addItem(self.titleLabel, 0, 1)
+        self.layout_.addItem(self.titleLabel, 0, 1)
         self.setTitle(None)  ## hide
 
         for i in range(4):
-            self.layout.setRowPreferredHeight(i, 0)
-            self.layout.setRowMinimumHeight(i, 0)
-            self.layout.setRowSpacing(i, 0)
-            self.layout.setRowStretchFactor(i, 1)
+            self.layout_.setRowPreferredHeight(i, 0)
+            self.layout_.setRowMinimumHeight(i, 0)
+            self.layout_.setRowSpacing(i, 0)
+            self.layout_.setRowStretchFactor(i, 1)
 
         for i in range(3):
-            self.layout.setColumnPreferredWidth(i, 0)
-            self.layout.setColumnMinimumWidth(i, 0)
-            self.layout.setColumnSpacing(i, 0)
-            self.layout.setColumnStretchFactor(i, 1)
-        self.layout.setRowStretchFactor(2, 100)
-        self.layout.setColumnStretchFactor(1, 100)
+            self.layout_.setColumnPreferredWidth(i, 0)
+            self.layout_.setColumnMinimumWidth(i, 0)
+            self.layout_.setColumnSpacing(i, 0)
+            self.layout_.setColumnStretchFactor(i, 1)
+        self.layout_.setRowStretchFactor(2, 100)
+        self.layout_.setColumnStretchFactor(1, 100)
 
 
         self.items = []
@@ -355,7 +356,7 @@ class PlotItem(GraphicsWidget):
                 
                 # Remove old axis
                 oldAxis = self.axes[k]['item']
-                self.layout.removeItem(oldAxis)
+                self.layout_.removeItem(oldAxis)
                 if oldAxis.scene() is not None:
                     oldAxis.scene().removeItem(oldAxis)
                 oldAxis.unlinkFromView()
@@ -378,7 +379,7 @@ class PlotItem(GraphicsWidget):
             # Set up new axis
             axis.linkToView(self.vb)
             self.axes[k] = {'item': axis, 'pos': pos}
-            self.layout.addItem(axis, *pos)
+            self.layout_.addItem(axis, *pos)
             # place axis above images at z=0, items that want to draw over the axes 
             # should be placed at z>=1
             axis.setZValue(0.5) 
@@ -1494,11 +1495,11 @@ class PlotItem(GraphicsWidget):
         """
         if title is None:
             self.titleLabel.setVisible(False)
-            self.layout.setRowFixedHeight(0, 0)
+            self.layout_.setRowFixedHeight(0, 0)
             self.titleLabel.setMaximumHeight(0)
         else:
             self.titleLabel.setMaximumHeight(30)
-            self.layout.setRowFixedHeight(0, 30)
+            self.layout_.setRowFixedHeight(0, 30)
             self.titleLabel.setVisible(True)
             self.titleLabel.setText(title, **kwargs)
 

--- a/pyqtgraph/parametertree/parameterTypes/action.py
+++ b/pyqtgraph/parametertree/parameterTypes/action.py
@@ -52,13 +52,13 @@ class ActionParameterItem(ParameterItem):
     def __init__(self, param, depth):
         ParameterItem.__init__(self, param, depth)
         self.layoutWidget = QtWidgets.QWidget()
-        self.layout = QtWidgets.QHBoxLayout()
-        self.layout.setContentsMargins(0, 0, 0, 0)
-        self.layoutWidget.setLayout(self.layout)
+        self.layout_ = QtWidgets.QHBoxLayout()
+        self.layout_.setContentsMargins(0, 0, 0, 0)
         self.button = ParameterControlledButton(param, self.layoutWidget)
         #self.layout.addSpacing(100)
-        self.layout.addWidget(self.button)
-        self.layout.addStretch()
+        self.layout_.addWidget(self.button)
+        self.layout_.addStretch()
+        self.layoutWidget.setLayout(self.layout_)
         self.titleChanged()
 
     def treeWidgetChanged(self):

--- a/pyqtgraph/widgets/CheckTable.py
+++ b/pyqtgraph/widgets/CheckTable.py
@@ -1,24 +1,24 @@
+__all__ = ['CheckTable']
+
 from ..Qt import QtCore, QtWidgets
 from . import VerticalLabel
-
-__all__ = ['CheckTable']
 
 class CheckTable(QtWidgets.QWidget):
     
     sigStateChanged = QtCore.Signal(object, object, object) # (row, col, state)
     
     def __init__(self, columns):
-        QtWidgets.QWidget.__init__(self)
-        self.layout = QtWidgets.QGridLayout()
-        self.layout.setSpacing(0)
-        self.setLayout(self.layout)
+        super().__init__()
+        self.layout_ = QtWidgets.QGridLayout()
+        self.layout_.setSpacing(0)
+        self.setLayout(self.layout_)
         self.headers = []
         self.columns = columns
         col = 1
         for c in columns:
             label = VerticalLabel.VerticalLabel(c, orientation='vertical')
             self.headers.append(label)
-            self.layout.addWidget(label, 0, col)
+            self.layout_.addWidget(label, 0, col)
             col += 1
         
         self.rowNames = []
@@ -37,14 +37,14 @@ class CheckTable(QtWidgets.QWidget):
     def addRow(self, name):
         label = QtWidgets.QLabel(name)
         row = len(self.rowNames)+1
-        self.layout.addWidget(label, row, 0)
+        self.layout_.addWidget(label, row, 0)
         checks = []
         col = 1
         for c in self.columns:
             check = QtWidgets.QCheckBox('')
             check.col = c
             check.row = name
-            self.layout.addWidget(check, row, col)
+            self.layout_.addWidget(check, row, col)
             checks.append(check)
             if name in self.oldRows:
                 check.setChecked(self.oldRows[name][col])
@@ -68,7 +68,7 @@ class CheckTable(QtWidgets.QWidget):
             widgets = self.rowWidgets[i]
             for j in range(len(widgets)):
                 widgets[j].setParent(None)
-                self.layout.addWidget(widgets[j], i+1, j)
+                self.layout_.addWidget(widgets[j], i+1, j)
 
     def checkChanged(self, state):
         check = QtCore.QObject.sender(self)

--- a/pyqtgraph/widgets/DiffTreeWidget.py
+++ b/pyqtgraph/widgets/DiffTreeWidget.py
@@ -13,12 +13,12 @@ class DiffTreeWidget(QtWidgets.QWidget):
     (eg, nested dicts, lists, and arrays)
     """
     def __init__(self, parent=None, a=None, b=None):
-        QtWidgets.QWidget.__init__(self, parent)
-        self.layout = QtWidgets.QHBoxLayout()
-        self.setLayout(self.layout)
+        super().__init__(parent)
+        self.layout_ = QtWidgets.QHBoxLayout()
+        self.setLayout(self.layout_)
         self.trees = [DataTreeWidget(self), DataTreeWidget(self)]
         for t in self.trees:
-            self.layout.addWidget(t)
+            self.layout_.addWidget(t)
         if a is not None:
             self.setData(a, b)
     

--- a/pyqtgraph/widgets/LayoutWidget.py
+++ b/pyqtgraph/widgets/LayoutWidget.py
@@ -9,8 +9,8 @@ class LayoutWidget(QtWidgets.QWidget):
 
     def __init__(self, parent=None):
         QtWidgets.QWidget.__init__(self, parent)
-        self.layout = QtWidgets.QGridLayout()
-        self.setLayout(self.layout)
+        self.layout_ = QtWidgets.QGridLayout()
+        self.setLayout(self.layout_)
         self.items = {}
         self.rows = {}
         self.currentRow = 0
@@ -71,7 +71,7 @@ class LayoutWidget(QtWidgets.QWidget):
         self.rows[row][col] = item
         self.items[item] = (row, col)
         
-        self.layout.addWidget(item, row, col, rowspan, colspan)
+        self.layout_.addWidget(item, row, col, rowspan, colspan)
 
     def getWidget(self, row, col):
         """Return the widget in (*row*, *col*)"""

--- a/pyqtgraph/widgets/ProgressDialog.py
+++ b/pyqtgraph/widgets/ProgressDialog.py
@@ -247,15 +247,14 @@ class ProgressWidget(QtWidgets.QWidget):
     to be hidden without changing size.
     """
     def __init__(self, label, bar):
-        QtWidgets.QWidget.__init__(self)
+        super().__init__()
         self.hidden = False
-        self.layout = QtWidgets.QVBoxLayout()
-        self.setLayout(self.layout)
-        
+        self.layout_ = QtWidgets.QVBoxLayout()
         self.label = label
         self.bar = bar
-        self.layout.addWidget(label)
-        self.layout.addWidget(bar)
+        self.layout_.addWidget(label)
+        self.layout_.addWidget(bar)
+        self.setLayout(self.layout_)
         
     def eventFilter(self, obj, ev):
         return ev.type() == QtCore.QEvent.Type.Paint

--- a/tests/graphicsItems/ViewBox/test_ViewBox.py
+++ b/tests/graphicsItems/ViewBox/test_ViewBox.py
@@ -21,7 +21,7 @@ def init_viewbox():
     global win, vb
     
     win = pg.GraphicsLayoutWidget()
-    win.ci.layout.setContentsMargins(0,0,0,0)
+    win.ci.layout().setContentsMargins(0,0,0,0)
     win.resize(200, 200)
     win.show()
     vb = win.addViewBox()

--- a/tests/graphicsItems/test_LegendItem.py
+++ b/tests/graphicsItems/test_LegendItem.py
@@ -76,26 +76,26 @@ def test_legend_item_basics():
     legend.addItem(scrabble, name="Scrabble")
     assert len(legend.items) == 4
 
-    assert legend.layout.rowCount() == 4
+    assert legend.layout().rowCount() == 4
     assert legend.rowCount == 4
     legend.setColumnCount(2)
     assert legend.columnCount == 2
     assert legend.rowCount == 2
 
-    assert legend.layout.rowCount() == 2
+    assert legend.layout().rowCount() == 2
 
     # Remove items
     # ----------------------------------------------------
 
     legend.removeItem(scrabble)
     assert legend.rowCount == 2
-    assert legend.layout.rowCount() == 2
+    assert legend.layout().rowCount() == 2
     assert scrabble not in legend.items
     assert len(legend.items) == 3
 
     legend.removeItem(curve)
     assert legend.rowCount == 2 # rowCount will never decrease when removing
-    assert legend.layout.rowCount() == 1
+    assert legend.layout().rowCount() == 1
     assert curve not in legend.items
     assert len(legend.items) == 2
 

--- a/tests/image_testing.py
+++ b/tests/image_testing.py
@@ -304,18 +304,18 @@ class ImageTester(QtWidgets.QWidget):
     def __init__(self):
         self.lastKey = None
         
-        QtWidgets.QWidget.__init__(self)
+        super().__init__()
         self.resize(1200, 800)
         self.setWindowTitle("ImageTester")
         
-        self.layout = QtWidgets.QGridLayout()
-        self.setLayout(self.layout)
+        self.layout_ = QtWidgets.QGridLayout()
+        self.setLayout(self.layout_)
         
         self.view = GraphicsLayoutWidget()
-        self.layout.addWidget(self.view, 0, 0, 1, 2)
+        self.layout_.addWidget(self.view, 0, 0, 1, 2)
 
         self.label = QtWidgets.QLabel()
-        self.layout.addWidget(self.label, 1, 0, 1, 2)
+        self.layout_.addWidget(self.label, 1, 0, 1, 2)
         self.label.setWordWrap(True)
         font = QtGui.QFont("monospace", 14)
         font.setStyleHint(QtGui.QFont.StyleHint.Monospace)
@@ -332,7 +332,7 @@ class ImageTester(QtWidgets.QWidget):
         self.passBtn.clicked.connect(self.passTest)
         self.failBtn.clicked.connect(self.failTest)
         self.saveBtn.clicked.connect(self.saveImage)
-        self.layout.addWidget(self.btnBox, 2, 0, 1, -1)
+        self.layout_.addWidget(self.btnBox, 2, 0, 1, -1)
 
         self.plots = (
             self.view.addPlot(title="Result", row=0, col=0),


### PR DESCRIPTION
While experimenting with pyright, I noticed it was giving a funky error about `self.layout = ...`. On further investigation I realized that this variable assignment was clobbering the `QWidget.layout()` method, which we really should not be doing.

There is an argument to be made that we should not store the layout as an attribute of each class, and just reference it via `self.layout()` as needed, but I'm going to go with the smaller change for now.