### PR TITLE
can instanciate an ImageView() with ImageItem() with image that is None

### DIFF
--- a/pyqtgraph/imageview/ImageView.py
+++ b/pyqtgraph/imageview/ImageView.py
@@ -181,7 +181,8 @@ class ImageView(QtWidgets.QWidget):
             self.imageItem = ImageItem()
         else:
             self.imageItem = imageItem
-            self.setImage(imageItem.image, autoRange=False, autoLevels=False, transform=imageItem.transform())
+            if imageItem.image is not None:
+                self.setImage(imageItem.image, autoRange=False, autoLevels=False, transform=imageItem.transform())
         self.view.addItem(self.imageItem)
         self.currentIndex = 0
         


### PR DESCRIPTION
When doing this

```python
import pyqtgraph

image_view = pyqtgraph.ImageView(imageItem=pyqtgraph.ImageItem())
```

it would fail, because in ``ImageView.__init__``, there is a condition that if the parameter ``imageItem`` is not None the code would try to call ``self.setImage(imageItem.image,, ...)``. 

But if ``imageItem.image`` is None, it would fail. ``ImageItem()`` can be initialized with``image = None`` so this feels like a bug. 

I fixed it by adding a condition that ``self.setImage(...)`` is called only if ``imageItem.image`` is not None