### PR TITLE
Add native Windows ARM64 CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,6 +157,14 @@ jobs:
           - python-version: "3.14"
             qt-lib: "pyside"
             qt-version: "PySide6-Essentials"
+          - os: windows-11-arm
+            python-version: "3.14"
+            qt-lib: "pyqt"
+            qt-version: "PyQt6"
+          - os: windows-11-arm
+            python-version: "3.14"
+            qt-lib: "pyside"
+            qt-version: "PySide6-Essentials"
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -166,11 +174,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: "Install Windows-Mesa OpenGL DLL"
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.os != 'windows-11-arm'
         run: |
           curl -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/24.3.4/mesa3d-24.3.4-release-msvc.7z
           7z x mesa.7z -o*
           powershell.exe mesa\systemwidedeploy.cmd 1
+      - name: Verify Native ARM64
+        if: matrix.os == 'windows-11-arm'
+        run: |
+          python -c "import platform; assert platform.machine().lower() in {'arm64', 'aarch64'}, platform.machine()"
       - name: Install Dependencies
         run: |
           python -m pip install -r .github/workflows/etc/requirements.txt ${{ matrix.qt-version }} . "coverage[toml]"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,6 +179,22 @@ jobs:
           curl -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/24.3.4/mesa3d-24.3.4-release-msvc.7z
           7z x mesa.7z -o*
           powershell.exe mesa\systemwidedeploy.cmd 1
+      - name: Install ARM64 Mesa llvmpipe
+        if: matrix.os == 'windows-11-arm'
+        shell: pwsh
+        run: |
+          $archive = Join-Path $env:RUNNER_TEMP "mesa-llvmpipe-arm64.7z"
+          $mesaDir = Join-Path $env:RUNNER_TEMP "mesa-llvmpipe-arm64"
+          Invoke-WebRequest -Uri "https://github.com/mmozeiko/build-mesa/releases/download/26.2.1/mesa-llvmpipe-arm64-26.2.1.7z" -OutFile $archive
+          $actualHash = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+          $expectedHash = "0f2d64be56f0c5421772b394e0fc8a0b83401bd4672f78bd9aeace981d30d100"
+          if ($actualHash -ne $expectedHash) {
+            throw "Mesa archive SHA256 mismatch: $actualHash"
+          }
+          7z x $archive "-o$mesaDir" -y
+          Copy-Item (Join-Path $mesaDir "opengl32.dll") (Join-Path $env:pythonLocation "opengl32sw.dll")
+          Add-Content -Path $env:GITHUB_ENV -Value "QT_OPENGL=software"
+          Add-Content -Path $env:GITHUB_ENV -Value "QT_OPENGL_DLL=opengl32sw.dll"
       - name: Verify Native ARM64
         if: matrix.os == 'windows-11-arm'
         run: |
@@ -186,6 +202,22 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install -r .github/workflows/etc/requirements.txt ${{ matrix.qt-version }} . "coverage[toml]"
+      - name: Verify ARM64 Software OpenGL
+        if: matrix.os == 'windows-11-arm'
+        shell: pwsh
+        run: |
+          $output = python -m pyqtgraph.util.glinfo 2>&1
+          $exitCode = $LASTEXITCODE
+          $output | ForEach-Object { Write-Host $_ }
+          if ($exitCode -ne 0) {
+            throw "glinfo exited with code $exitCode"
+          }
+          $glinfo = $output -join "`n"
+          foreach ($expected in @("VENDOR: Mesa", "RENDERER: llvmpipe", "VERSION:", "GLSL_VERSION:")) {
+            if (-not $glinfo.Contains($expected)) {
+              throw "glinfo did not report $expected"
+            }
+          }
       - name: "Install Linux VirtualDisplay"
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
Adds native Python 3.14 Windows ARM64 jobs for PyQt6 and PySide6.

The hosted ARM runner does not expose usable OpenGL by default. These jobs install a version-pinned ARM64 Mesa llvmpipe build as Qt software OpenGL and fail unless `glinfo` identifies Mesa and llvmpipe. The existing Windows x64 Mesa setup is unchanged.

Original implementation validated in [fork run 33470131307](https://github.com/ClayWarren/pyqtgraph/actions/runs/33470131307):

- `platform.machine()` reports ARM64.
- Mesa 26.2.1 reports llvmpipe, OpenGL 4.6, and GLSL 4.60.
- PyQt6: 1,141 core tests passed; 98 examples passed.
- PySide6: 1,141 core tests passed; 98 examples passed.
- `MouseSelection.py`, which forces an OpenGL render and reparents the widget, passes under both bindings.
