### PR TITLE
Fix console history double click handling

### DIFF
--- a/pyqtgraph/console/Console.py
+++ b/pyqtgraph/console/Console.py
@@ -159,13 +159,11 @@ class ConsoleWidget(QtWidgets.QWidget):
             return self.localNamespace
 
     def cmdSelected(self, item):
-        index = -(self.historyList.row(item)+1)
-        self.input.setHistory(index)
+        self.input.setText(item.text())
         self.input.setFocus()
         
     def cmdDblClicked(self, item):
-        index = -(self.historyList.row(item)+1)
-        self.input.setHistory(index)
+        self.input.setText(item.text())
         self.input.execCmd()
         
     def _stackItemDblClicked(self, handler, item):


### PR DESCRIPTION
Fixes #2155 

`ConsoleWidget` was mapping clicked `historyList` rows back into `CmdInput.history` using negative indexing which would cause an IndexError if the last item in the history was double clicked since the two list indexing isn't aligned. The fix uses the clicked list item text directly when selecting or double clicking history rows.

Tested the steps outlined in the original issue to reproduce the error, the error no longer occurs and double clicking items in the history behaves as expected.