### PR TITLE
fix: stop ConsoleWidget help() entering interactive mode

### DIFF
--- a/pyqtgraph/console/repl_widget.py
+++ b/pyqtgraph/console/repl_widget.py
@@ -1,4 +1,5 @@
 import code
+import pydoc
 import queue
 import sys
 import traceback
@@ -232,6 +233,12 @@ class ReplThread(QtCore.QThread):
                 return
 
             self._commandBuffer = []
+
+            if fullcmd.strip() == "help()":
+                with self._stdoutInterceptor:
+                    pydoc.Helper(output=sys.stdout).intro()
+                    self.sigCommandExecuted.emit()
+                return
 
             # run command
             try:


### PR DESCRIPTION
Fixes #3247 

The ConsoleWidget would become unresponsive if `help()` was entered as it would try to enter interactive help mode but the console disables input while execution is active. The PR is a bit of a hack and just prints pydoc's intro text on `help()` instead of trying to enter an interactive session. Entering `help(object)` still works unchanged.

A fix to allow properly entering the interactive help would need to add command execution handling in a way that doesn't block the Qt event loop while it's being executed.

In the original issue discussion it was mentioned that the QtConsole is favoured over the ConsoleWidget so i feel this simple fix is probably fine? But happy to reconsider