### PR TITLE
Add test coverage for float_regex_for_locale

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -305,6 +305,27 @@ def test_siEval(s, suffix, power, expected, sep):
     assert np.isclose(result, expected)
 
 
+@pytest.mark.parametrize("locale_name,expected", [
+    # period as decimal separator
+    ("en_US", pg.functions.FLOAT_REGEX_PERIOD),
+    ("en_GB", pg.functions.FLOAT_REGEX_PERIOD),
+    ("ja_JP", pg.functions.FLOAT_REGEX_PERIOD),
+    # comma as decimal separator
+    ("de_DE", pg.functions.FLOAT_REGEX_COMMA),
+    ("fr_FR", pg.functions.FLOAT_REGEX_COMMA),
+    ("pt_BR", pg.functions.FLOAT_REGEX_COMMA),
+    # neither: ar_EG uses U+066B, so it falls through to the period pattern
+    ("ar_EG", pg.functions.FLOAT_REGEX_PERIOD),
+])
+def test_float_regex_for_locale(locale_name, expected):
+    locale = QtCore.QLocale(locale_name)
+    assert pg.functions.float_regex_for_locale(locale) is expected
+
+
+def test_float_regex_for_locale_c_locale():
+    assert pg.functions.float_regex_for_locale(QtCore.QLocale.c()) is pg.functions.FLOAT_REGEX_PERIOD
+
+
 def test_CIELab_reconversion():
     color_list = [ pg.Qt.QtGui.QColor('#100235') ] # known problematic values
     for _ in range(20):


### PR DESCRIPTION
## Summary

- Adds test coverage for `float_regex_for_locale()` in `pyqtgraph/functions.py`, which previously had none.
- This function selects between the two module-level `FLOAT_REGEX_COMMA` / `FLOAT_REGEX_PERIOD` patterns based on a locale's decimal separator, and that choice feeds directly into `siParse`/`siEval` (see the fixes for #3568 / #3569). Locking down its behavior with tests protects against regressions in that dispatch logic.
- Covers: locales using `.` as the decimal separator, locales using `,`, and `ar_EG` — which uses neither ASCII character (its `QLocale` reports U+066B) and so exercises the fallback branch. Also covers the explicit `QLocale.c()` case.
- Assertions use `is`, not `==`, because the function's actual contract (relied on by `siEval`) is returning one of the two specific singleton pattern objects, not merely a pattern with equivalent regex text.

## Notes

- This is intentionally test-only. The zero-argument default (`float_regex_for_locale()` with no locale passed) evaluates `QtCore.QLocale()` once at import time, so its result depends on the machine's locale — testing it would be flaky in CI. That's a real latent bug but belongs in a separate follow-up issue, to keep this PR focused per the contributing guide.

## Test plan

- [x] `python -m pytest tests/test_functions.py -k float_regex -v` — 8 passed (PyQt6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)